### PR TITLE
fix: add DB_RENAME_LOCK to test_restraint_report_december

### DIFF
--- a/tests/dtako_test.rs
+++ b/tests/dtako_test.rs
@@ -5754,6 +5754,8 @@ async fn test_restraint_report_invalid_year_month() {
 
 #[tokio::test]
 async fn test_restraint_report_december() {
+    let _db = common::DB_RENAME_LOCK.lock().unwrap();
+    let _flock = common::db_rename_flock();
     test_group!("拘束時間レポート: エッジケース");
     test_case!("month=12 → 年越し処理 (L224)", {
         let state = common::setup_app_state().await;


### PR DESCRIPTION
## Summary
- `test_restraint_report_december` が `test_restraint_report_db_error_internal_err` (RENAME dtako_daily_work_segments) と並列実行時に競合 → flaky failure
- `DB_RENAME_LOCK` + `db_rename_flock()` を追加して直列化

🤖 Generated with [Claude Code](https://claude.com/claude-code)