### PR TITLE
refactor: introduce EmployeeRepository trait (Phase 0)

### DIFF
--- a/coverage_100.toml
+++ b/coverage_100.toml
@@ -224,3 +224,18 @@ test_file = "tests/coverage/main.rs"
 path = "src/routes/guidance_records.rs"
 type = "integration"
 test_file = "tests/coverage/main.rs"
+
+[[files]]
+path = "src/routes/devices.rs"
+type = "integration"
+test_file = "tests/devices_test.rs"
+
+[[files]]
+path = "src/routes/tenko_sessions.rs"
+type = "both"
+test_file = "tests/coverage/main.rs"
+
+[[files]]
+path = "src/routes/dtako_restraint_report.rs"
+type = "integration"
+test_file = "tests/dtako_test.rs"

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,2 +1,3 @@
 pub mod models;
+pub mod repository;
 pub mod tenant;

--- a/src/db/repository/employees.rs
+++ b/src/db/repository/employees.rs
@@ -1,0 +1,333 @@
+use async_trait::async_trait;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use crate::db::models::{CreateEmployee, Employee, FaceDataEntry, UpdateEmployee, UpdateFace};
+
+use super::TenantConn;
+
+#[async_trait]
+pub trait EmployeeRepository: Send + Sync {
+    async fn create(
+        &self,
+        tenant_id: Uuid,
+        input: &CreateEmployee,
+    ) -> Result<Employee, sqlx::Error>;
+
+    async fn list(&self, tenant_id: Uuid) -> Result<Vec<Employee>, sqlx::Error>;
+
+    async fn get(&self, tenant_id: Uuid, id: Uuid) -> Result<Option<Employee>, sqlx::Error>;
+
+    async fn get_by_nfc(
+        &self,
+        tenant_id: Uuid,
+        nfc_id: &str,
+    ) -> Result<Option<Employee>, sqlx::Error>;
+
+    async fn get_by_code(
+        &self,
+        tenant_id: Uuid,
+        code: &str,
+    ) -> Result<Option<Employee>, sqlx::Error>;
+
+    async fn update(
+        &self,
+        tenant_id: Uuid,
+        id: Uuid,
+        input: &UpdateEmployee,
+    ) -> Result<Option<Employee>, sqlx::Error>;
+
+    /// Soft-delete. Returns true if a row was affected.
+    async fn delete(&self, tenant_id: Uuid, id: Uuid) -> Result<bool, sqlx::Error>;
+
+    async fn update_face(
+        &self,
+        tenant_id: Uuid,
+        id: Uuid,
+        input: &UpdateFace,
+    ) -> Result<Option<Employee>, sqlx::Error>;
+
+    async fn list_face_data(&self, tenant_id: Uuid) -> Result<Vec<FaceDataEntry>, sqlx::Error>;
+
+    async fn update_license(
+        &self,
+        tenant_id: Uuid,
+        id: Uuid,
+        issue_date: Option<chrono::NaiveDate>,
+        expiry_date: Option<chrono::NaiveDate>,
+    ) -> Result<Option<Employee>, sqlx::Error>;
+
+    async fn update_nfc_id(
+        &self,
+        tenant_id: Uuid,
+        id: Uuid,
+        nfc_id: &str,
+    ) -> Result<Option<Employee>, sqlx::Error>;
+
+    async fn approve_face(
+        &self,
+        tenant_id: Uuid,
+        id: Uuid,
+    ) -> Result<Option<Employee>, sqlx::Error>;
+
+    async fn reject_face(&self, tenant_id: Uuid, id: Uuid)
+        -> Result<Option<Employee>, sqlx::Error>;
+}
+
+pub struct PgEmployeeRepository {
+    pool: PgPool,
+}
+
+impl PgEmployeeRepository {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl EmployeeRepository for PgEmployeeRepository {
+    async fn create(
+        &self,
+        tenant_id: Uuid,
+        input: &CreateEmployee,
+    ) -> Result<Employee, sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        sqlx::query_as::<_, Employee>(
+            r#"
+            INSERT INTO employees (tenant_id, code, nfc_id, name, role)
+            VALUES ($1, $2, $3, $4, $5)
+            RETURNING *
+            "#,
+        )
+        .bind(tenant_id)
+        .bind(&input.code)
+        .bind(&input.nfc_id)
+        .bind(&input.name)
+        .bind(&input.role)
+        .fetch_one(&mut *tc.conn)
+        .await
+    }
+
+    async fn list(&self, tenant_id: Uuid) -> Result<Vec<Employee>, sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        sqlx::query_as::<_, Employee>(
+            "SELECT * FROM employees WHERE tenant_id = $1 AND deleted_at IS NULL ORDER BY name",
+        )
+        .bind(tenant_id)
+        .fetch_all(&mut *tc.conn)
+        .await
+    }
+
+    async fn get(&self, tenant_id: Uuid, id: Uuid) -> Result<Option<Employee>, sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        sqlx::query_as::<_, Employee>(
+            "SELECT * FROM employees WHERE tenant_id = $1 AND id = $2 AND deleted_at IS NULL",
+        )
+        .bind(tenant_id)
+        .bind(id)
+        .fetch_optional(&mut *tc.conn)
+        .await
+    }
+
+    async fn get_by_nfc(
+        &self,
+        tenant_id: Uuid,
+        nfc_id: &str,
+    ) -> Result<Option<Employee>, sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        sqlx::query_as::<_, Employee>(
+            "SELECT * FROM employees WHERE tenant_id = $1 AND nfc_id = $2 AND deleted_at IS NULL",
+        )
+        .bind(tenant_id)
+        .bind(nfc_id)
+        .fetch_optional(&mut *tc.conn)
+        .await
+    }
+
+    async fn get_by_code(
+        &self,
+        tenant_id: Uuid,
+        code: &str,
+    ) -> Result<Option<Employee>, sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        sqlx::query_as::<_, Employee>(
+            "SELECT * FROM employees WHERE tenant_id = $1 AND code = $2 AND deleted_at IS NULL",
+        )
+        .bind(tenant_id)
+        .bind(code)
+        .fetch_optional(&mut *tc.conn)
+        .await
+    }
+
+    async fn update(
+        &self,
+        tenant_id: Uuid,
+        id: Uuid,
+        input: &UpdateEmployee,
+    ) -> Result<Option<Employee>, sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        sqlx::query_as::<_, Employee>(
+            r#"
+            UPDATE employees SET name = $1, code = $2, role = COALESCE($5, role), updated_at = NOW()
+            WHERE id = $3 AND tenant_id = $4 AND deleted_at IS NULL
+            RETURNING *
+            "#,
+        )
+        .bind(&input.name)
+        .bind(&input.code)
+        .bind(id)
+        .bind(tenant_id)
+        .bind(&input.role)
+        .fetch_optional(&mut *tc.conn)
+        .await
+    }
+
+    async fn delete(&self, tenant_id: Uuid, id: Uuid) -> Result<bool, sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        let result = sqlx::query(
+            r#"
+            UPDATE employees SET deleted_at = NOW(), updated_at = NOW()
+            WHERE id = $1 AND tenant_id = $2 AND deleted_at IS NULL
+            "#,
+        )
+        .bind(id)
+        .bind(tenant_id)
+        .execute(&mut *tc.conn)
+        .await?;
+        Ok(result.rows_affected() > 0)
+    }
+
+    async fn update_face(
+        &self,
+        tenant_id: Uuid,
+        id: Uuid,
+        input: &UpdateFace,
+    ) -> Result<Option<Employee>, sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        sqlx::query_as::<_, Employee>(
+            r#"
+            UPDATE employees SET
+                face_photo_url = COALESCE($1, face_photo_url),
+                face_embedding = COALESCE($2, face_embedding),
+                face_embedding_at = CASE WHEN $2 IS NOT NULL THEN NOW() ELSE face_embedding_at END,
+                face_model_version = CASE WHEN $2 IS NOT NULL THEN $5 ELSE face_model_version END,
+                face_approval_status = CASE WHEN $2 IS NOT NULL THEN 'pending' ELSE face_approval_status END,
+                updated_at = NOW()
+            WHERE id = $3 AND tenant_id = $4 AND deleted_at IS NULL
+            RETURNING *
+            "#,
+        )
+        .bind(&input.face_photo_url)
+        .bind(&input.face_embedding)
+        .bind(id)
+        .bind(tenant_id)
+        .bind(&input.face_model_version)
+        .fetch_optional(&mut *tc.conn)
+        .await
+    }
+
+    async fn list_face_data(&self, tenant_id: Uuid) -> Result<Vec<FaceDataEntry>, sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        sqlx::query_as::<_, FaceDataEntry>(
+            r#"
+            SELECT id, face_embedding, face_embedding_at, face_model_version, face_approval_status
+            FROM employees
+            WHERE tenant_id = $1 AND deleted_at IS NULL AND face_embedding IS NOT NULL
+              AND face_approval_status = 'approved'
+            "#,
+        )
+        .bind(tenant_id)
+        .fetch_all(&mut *tc.conn)
+        .await
+    }
+
+    async fn update_license(
+        &self,
+        tenant_id: Uuid,
+        id: Uuid,
+        issue_date: Option<chrono::NaiveDate>,
+        expiry_date: Option<chrono::NaiveDate>,
+    ) -> Result<Option<Employee>, sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        sqlx::query_as::<_, Employee>(
+            r#"
+            UPDATE employees SET
+                license_issue_date = COALESCE($1, license_issue_date),
+                license_expiry_date = COALESCE($2, license_expiry_date),
+                updated_at = NOW()
+            WHERE id = $3 AND tenant_id = $4 AND deleted_at IS NULL
+            RETURNING *
+            "#,
+        )
+        .bind(issue_date)
+        .bind(expiry_date)
+        .bind(id)
+        .bind(tenant_id)
+        .fetch_optional(&mut *tc.conn)
+        .await
+    }
+
+    async fn update_nfc_id(
+        &self,
+        tenant_id: Uuid,
+        id: Uuid,
+        nfc_id: &str,
+    ) -> Result<Option<Employee>, sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        sqlx::query_as::<_, Employee>(
+            r#"
+            UPDATE employees SET nfc_id = $1, updated_at = NOW()
+            WHERE id = $2 AND tenant_id = $3
+            RETURNING *
+            "#,
+        )
+        .bind(nfc_id)
+        .bind(id)
+        .bind(tenant_id)
+        .fetch_optional(&mut *tc.conn)
+        .await
+    }
+
+    async fn approve_face(
+        &self,
+        tenant_id: Uuid,
+        id: Uuid,
+    ) -> Result<Option<Employee>, sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        sqlx::query_as::<_, Employee>(
+            r#"
+            UPDATE employees SET
+                face_approval_status = 'approved',
+                face_approved_at = NOW(),
+                updated_at = NOW()
+            WHERE id = $1 AND tenant_id = $2 AND face_approval_status = 'pending' AND deleted_at IS NULL
+            RETURNING *
+            "#,
+        )
+        .bind(id)
+        .bind(tenant_id)
+        .fetch_optional(&mut *tc.conn)
+        .await
+    }
+
+    async fn reject_face(
+        &self,
+        tenant_id: Uuid,
+        id: Uuid,
+    ) -> Result<Option<Employee>, sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        sqlx::query_as::<_, Employee>(
+            r#"
+            UPDATE employees SET
+                face_approval_status = 'rejected',
+                updated_at = NOW()
+            WHERE id = $1 AND tenant_id = $2 AND face_approval_status = 'pending' AND deleted_at IS NULL
+            RETURNING *
+            "#,
+        )
+        .bind(id)
+        .bind(tenant_id)
+        .fetch_optional(&mut *tc.conn)
+        .await
+    }
+}

--- a/src/db/repository/mod.rs
+++ b/src/db/repository/mod.rs
@@ -1,0 +1,19 @@
+pub mod employees;
+
+pub use employees::{EmployeeRepository, PgEmployeeRepository};
+
+use sqlx::PgPool;
+
+/// テナントスコープの DB コネクション
+/// acquire 時に set_current_tenant を自動呼び出しする
+pub struct TenantConn {
+    pub conn: sqlx::pool::PoolConnection<sqlx::Postgres>,
+}
+
+impl TenantConn {
+    pub async fn acquire(pool: &PgPool, tenant_id: &str) -> Result<Self, sqlx::Error> {
+        let mut conn = pool.acquire().await?;
+        super::tenant::set_current_tenant(&mut conn, tenant_id).await?;
+        Ok(Self { conn })
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,11 +14,13 @@ pub mod webhook;
 
 use std::sync::Arc;
 
+use db::repository::EmployeeRepository;
 use storage::StorageBackend;
 
 #[derive(Clone)]
 pub struct AppState {
     pub pool: sqlx::PgPool,
+    pub employees: Arc<dyn EmployeeRepository>,
     pub storage: Arc<dyn StorageBackend>,
     pub carins_storage: Option<Arc<dyn StorageBackend>>,
     pub dtako_storage: Option<Arc<dyn StorageBackend>>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ use tracing_subscriber::EnvFilter;
 
 use rust_alc_api::auth::google::GoogleTokenVerifier;
 use rust_alc_api::auth::jwt::JwtSecret;
+use rust_alc_api::db::repository::PgEmployeeRepository;
 use rust_alc_api::storage::StorageBackend;
 use rust_alc_api::AppState;
 
@@ -112,8 +113,11 @@ async fn main() -> anyhow::Result<()> {
             as Arc<dyn rust_alc_api::fcm::FcmSenderTrait>
     });
 
+    let employees = Arc::new(PgEmployeeRepository::new(pool.clone()));
+
     let state = AppState {
         pool: pool.clone(),
+        employees,
         storage,
         carins_storage,
         dtako_storage,

--- a/src/routes/employees.rs
+++ b/src/routes/employees.rs
@@ -9,7 +9,6 @@ use uuid::Uuid;
 use crate::db::models::{
     CreateEmployee, Employee, FaceDataEntry, UpdateEmployee, UpdateFace, UpdateLicense, UpdateNfcId,
 };
-use crate::db::tenant::set_current_tenant;
 use crate::middleware::auth::TenantId;
 use crate::AppState;
 
@@ -38,35 +37,14 @@ async fn create_employee(
     tenant: axum::Extension<TenantId>,
     Json(body): Json<CreateEmployee>,
 ) -> Result<(StatusCode, Json<Employee>), StatusCode> {
-    let tenant_id = tenant.0 .0;
-
-    let mut conn = state
-        .pool
-        .acquire()
+    let employee = state
+        .employees
+        .create(tenant.0 .0, &body)
         .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    set_current_tenant(&mut conn, &tenant_id.to_string())
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-
-    let employee = sqlx::query_as::<_, Employee>(
-        r#"
-        INSERT INTO employees (tenant_id, code, nfc_id, name, role)
-        VALUES ($1, $2, $3, $4, $5)
-        RETURNING *
-        "#,
-    )
-    .bind(tenant_id)
-    .bind(&body.code)
-    .bind(&body.nfc_id)
-    .bind(&body.name)
-    .bind(&body.role)
-    .fetch_one(&mut *conn)
-    .await
-    .map_err(|e| {
-        tracing::error!("create_employee error: {e}");
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?;
+        .map_err(|e| {
+            tracing::error!("create_employee error: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
 
     Ok((StatusCode::CREATED, Json(employee)))
 }
@@ -75,24 +53,11 @@ async fn list_employees(
     State(state): State<AppState>,
     tenant: axum::Extension<TenantId>,
 ) -> Result<Json<Vec<Employee>>, StatusCode> {
-    let tenant_id = tenant.0 .0;
-
-    let mut conn = state
-        .pool
-        .acquire()
+    let employees = state
+        .employees
+        .list(tenant.0 .0)
         .await
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    set_current_tenant(&mut conn, &tenant_id.to_string())
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-
-    let employees = sqlx::query_as::<_, Employee>(
-        "SELECT * FROM employees WHERE tenant_id = $1 AND deleted_at IS NULL ORDER BY name",
-    )
-    .bind(tenant_id)
-    .fetch_all(&mut *conn)
-    .await
-    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
     Ok(Json(employees))
 }
@@ -102,26 +67,12 @@ async fn get_employee(
     tenant: axum::Extension<TenantId>,
     Path(id): Path<Uuid>,
 ) -> Result<Json<Employee>, StatusCode> {
-    let tenant_id = tenant.0 .0;
-
-    let mut conn = state
-        .pool
-        .acquire()
+    let employee = state
+        .employees
+        .get(tenant.0 .0, id)
         .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    set_current_tenant(&mut conn, &tenant_id.to_string())
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-
-    let employee = sqlx::query_as::<_, Employee>(
-        "SELECT * FROM employees WHERE tenant_id = $1 AND id = $2 AND deleted_at IS NULL",
-    )
-    .bind(tenant_id)
-    .bind(id)
-    .fetch_optional(&mut *conn)
-    .await
-    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
-    .ok_or(StatusCode::NOT_FOUND)?;
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+        .ok_or(StatusCode::NOT_FOUND)?;
 
     Ok(Json(employee))
 }
@@ -131,26 +82,12 @@ async fn get_employee_by_nfc(
     tenant: axum::Extension<TenantId>,
     Path(nfc_id): Path<String>,
 ) -> Result<Json<Employee>, StatusCode> {
-    let tenant_id = tenant.0 .0;
-
-    let mut conn = state
-        .pool
-        .acquire()
+    let employee = state
+        .employees
+        .get_by_nfc(tenant.0 .0, &nfc_id)
         .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    set_current_tenant(&mut conn, &tenant_id.to_string())
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-
-    let employee = sqlx::query_as::<_, Employee>(
-        "SELECT * FROM employees WHERE tenant_id = $1 AND nfc_id = $2 AND deleted_at IS NULL",
-    )
-    .bind(tenant_id)
-    .bind(&nfc_id)
-    .fetch_optional(&mut *conn)
-    .await
-    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
-    .ok_or(StatusCode::NOT_FOUND)?;
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+        .ok_or(StatusCode::NOT_FOUND)?;
 
     Ok(Json(employee))
 }
@@ -160,26 +97,12 @@ async fn get_employee_by_code(
     tenant: axum::Extension<TenantId>,
     Path(code): Path<String>,
 ) -> Result<Json<Employee>, StatusCode> {
-    let tenant_id = tenant.0 .0;
-
-    let mut conn = state
-        .pool
-        .acquire()
+    let employee = state
+        .employees
+        .get_by_code(tenant.0 .0, &code)
         .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    set_current_tenant(&mut conn, &tenant_id.to_string())
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-
-    let employee = sqlx::query_as::<_, Employee>(
-        "SELECT * FROM employees WHERE tenant_id = $1 AND code = $2 AND deleted_at IS NULL",
-    )
-    .bind(tenant_id)
-    .bind(&code)
-    .fetch_optional(&mut *conn)
-    .await
-    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
-    .ok_or(StatusCode::NOT_FOUND)?;
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+        .ok_or(StatusCode::NOT_FOUND)?;
 
     Ok(Json(employee))
 }
@@ -190,39 +113,18 @@ async fn update_employee(
     Path(id): Path<Uuid>,
     Json(body): Json<UpdateEmployee>,
 ) -> Result<Json<Employee>, StatusCode> {
-    let tenant_id = tenant.0 .0;
-
-    let mut conn = state
-        .pool
-        .acquire()
+    let employee = state
+        .employees
+        .update(tenant.0 .0, id, &body)
         .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    set_current_tenant(&mut conn, &tenant_id.to_string())
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-
-    let employee = sqlx::query_as::<_, Employee>(
-        r#"
-        UPDATE employees SET name = $1, code = $2, role = COALESCE($5, role), updated_at = NOW()
-        WHERE id = $3 AND tenant_id = $4 AND deleted_at IS NULL
-        RETURNING *
-        "#,
-    )
-    .bind(&body.name)
-    .bind(&body.code)
-    .bind(id)
-    .bind(tenant_id)
-    .bind(&body.role)
-    .fetch_optional(&mut *conn)
-    .await
-    .map_err(|e| {
-        tracing::error!("update_employee error: {e}");
-        if e.to_string().contains("idx_employees_code") {
-            return StatusCode::CONFLICT;
-        }
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?
-    .ok_or(StatusCode::NOT_FOUND)?;
+        .map_err(|e| {
+            tracing::error!("update_employee error: {e}");
+            if e.to_string().contains("idx_employees_code") {
+                return StatusCode::CONFLICT;
+            }
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?
+        .ok_or(StatusCode::NOT_FOUND)?;
 
     Ok(Json(employee))
 }
@@ -232,33 +134,12 @@ async fn delete_employee(
     tenant: axum::Extension<TenantId>,
     Path(id): Path<Uuid>,
 ) -> Result<StatusCode, StatusCode> {
-    let tenant_id = tenant.0 .0;
-
-    let mut conn = state
-        .pool
-        .acquire()
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    set_current_tenant(&mut conn, &tenant_id.to_string())
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-
-    let result = sqlx::query(
-        r#"
-        UPDATE employees SET deleted_at = NOW(), updated_at = NOW()
-        WHERE id = $1 AND tenant_id = $2 AND deleted_at IS NULL
-        "#,
-    )
-    .bind(id)
-    .bind(tenant_id)
-    .execute(&mut *conn)
-    .await
-    .map_err(|e| {
+    let deleted = state.employees.delete(tenant.0 .0, id).await.map_err(|e| {
         tracing::error!("delete_employee error: {e}");
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
 
-    if result.rows_affected() == 0 {
+    if !deleted {
         return Err(StatusCode::NOT_FOUND);
     }
 
@@ -271,8 +152,6 @@ async fn update_face(
     Path(id): Path<Uuid>,
     Json(body): Json<UpdateFace>,
 ) -> Result<Json<Employee>, StatusCode> {
-    let tenant_id = tenant.0 .0;
-
     // embedding 長の検証 (Human.js faceres モデルは 1024 次元)
     if let Some(ref emb) = body.face_embedding {
         if emb.len() != 1024 {
@@ -280,40 +159,15 @@ async fn update_face(
         }
     }
 
-    let mut conn = state
-        .pool
-        .acquire()
+    let employee = state
+        .employees
+        .update_face(tenant.0 .0, id, &body)
         .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    set_current_tenant(&mut conn, &tenant_id.to_string())
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-
-    let employee = sqlx::query_as::<_, Employee>(
-        r#"
-        UPDATE employees SET
-            face_photo_url = COALESCE($1, face_photo_url),
-            face_embedding = COALESCE($2, face_embedding),
-            face_embedding_at = CASE WHEN $2 IS NOT NULL THEN NOW() ELSE face_embedding_at END,
-            face_model_version = CASE WHEN $2 IS NOT NULL THEN $5 ELSE face_model_version END,
-            face_approval_status = CASE WHEN $2 IS NOT NULL THEN 'pending' ELSE face_approval_status END,
-            updated_at = NOW()
-        WHERE id = $3 AND tenant_id = $4 AND deleted_at IS NULL
-        RETURNING *
-        "#,
-    )
-    .bind(&body.face_photo_url)
-    .bind(&body.face_embedding)
-    .bind(id)
-    .bind(tenant_id)
-    .bind(&body.face_model_version)
-    .fetch_optional(&mut *conn)
-    .await
-    .map_err(|e| {
-        tracing::error!("update_face error: {e}");
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?
-    .ok_or(StatusCode::NOT_FOUND)?;
+        .map_err(|e| {
+            tracing::error!("update_face error: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?
+        .ok_or(StatusCode::NOT_FOUND)?;
 
     Ok(Json(employee))
 }
@@ -322,29 +176,11 @@ async fn list_face_data(
     State(state): State<AppState>,
     tenant: axum::Extension<TenantId>,
 ) -> Result<Json<Vec<FaceDataEntry>>, StatusCode> {
-    let tenant_id = tenant.0 .0;
-
-    let mut conn = state
-        .pool
-        .acquire()
+    let rows = state
+        .employees
+        .list_face_data(tenant.0 .0)
         .await
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    set_current_tenant(&mut conn, &tenant_id.to_string())
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-
-    let rows = sqlx::query_as::<_, FaceDataEntry>(
-        r#"
-        SELECT id, face_embedding, face_embedding_at, face_model_version, face_approval_status
-        FROM employees
-        WHERE tenant_id = $1 AND deleted_at IS NULL AND face_embedding IS NOT NULL
-          AND face_approval_status = 'approved'
-        "#,
-    )
-    .bind(tenant_id)
-    .fetch_all(&mut *conn)
-    .await
-    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
     Ok(Json(rows))
 }
@@ -355,38 +191,20 @@ async fn update_license(
     Path(id): Path<Uuid>,
     Json(body): Json<UpdateLicense>,
 ) -> Result<Json<Employee>, StatusCode> {
-    let tenant_id = tenant.0 .0;
-
-    let mut conn = state
-        .pool
-        .acquire()
+    let employee = state
+        .employees
+        .update_license(
+            tenant.0 .0,
+            id,
+            body.license_issue_date,
+            body.license_expiry_date,
+        )
         .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    set_current_tenant(&mut conn, &tenant_id.to_string())
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-
-    let employee = sqlx::query_as::<_, Employee>(
-        r#"
-        UPDATE employees SET
-            license_issue_date = COALESCE($1, license_issue_date),
-            license_expiry_date = COALESCE($2, license_expiry_date),
-            updated_at = NOW()
-        WHERE id = $3 AND tenant_id = $4 AND deleted_at IS NULL
-        RETURNING *
-        "#,
-    )
-    .bind(body.license_issue_date)
-    .bind(body.license_expiry_date)
-    .bind(id)
-    .bind(tenant_id)
-    .fetch_optional(&mut *conn)
-    .await
-    .map_err(|e| {
-        tracing::error!("update_license error: {e}");
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?
-    .ok_or(StatusCode::NOT_FOUND)?;
+        .map_err(|e| {
+            tracing::error!("update_license error: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?
+        .ok_or(StatusCode::NOT_FOUND)?;
 
     Ok(Json(employee))
 }
@@ -397,34 +215,15 @@ async fn update_nfc_id(
     Path(id): Path<Uuid>,
     Json(body): Json<UpdateNfcId>,
 ) -> Result<Json<Employee>, StatusCode> {
-    let tenant_id = tenant.0 .0;
-
-    let mut conn = state
-        .pool
-        .acquire()
+    let employee = state
+        .employees
+        .update_nfc_id(tenant.0 .0, id, &body.nfc_id)
         .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    set_current_tenant(&mut conn, &tenant_id.to_string())
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-
-    let employee = sqlx::query_as::<_, Employee>(
-        r#"
-        UPDATE employees SET nfc_id = $1, updated_at = NOW()
-        WHERE id = $2 AND tenant_id = $3
-        RETURNING *
-        "#,
-    )
-    .bind(&body.nfc_id)
-    .bind(id)
-    .bind(tenant_id)
-    .fetch_optional(&mut *conn)
-    .await
-    .map_err(|e| {
-        tracing::error!("update_nfc_id error: {e}");
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?
-    .ok_or(StatusCode::NOT_FOUND)?;
+        .map_err(|e| {
+            tracing::error!("update_nfc_id error: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?
+        .ok_or(StatusCode::NOT_FOUND)?;
 
     Ok(Json(employee))
 }
@@ -434,36 +233,15 @@ async fn approve_face(
     tenant: axum::Extension<TenantId>,
     Path(id): Path<Uuid>,
 ) -> Result<Json<Employee>, StatusCode> {
-    let tenant_id = tenant.0 .0;
-
-    let mut conn = state
-        .pool
-        .acquire()
+    let employee = state
+        .employees
+        .approve_face(tenant.0 .0, id)
         .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    set_current_tenant(&mut conn, &tenant_id.to_string())
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-
-    let employee = sqlx::query_as::<_, Employee>(
-        r#"
-        UPDATE employees SET
-            face_approval_status = 'approved',
-            face_approved_at = NOW(),
-            updated_at = NOW()
-        WHERE id = $1 AND tenant_id = $2 AND face_approval_status = 'pending' AND deleted_at IS NULL
-        RETURNING *
-        "#,
-    )
-    .bind(id)
-    .bind(tenant_id)
-    .fetch_optional(&mut *conn)
-    .await
-    .map_err(|e| {
-        tracing::error!("approve_face error: {e}");
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?
-    .ok_or(StatusCode::NOT_FOUND)?;
+        .map_err(|e| {
+            tracing::error!("approve_face error: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?
+        .ok_or(StatusCode::NOT_FOUND)?;
 
     Ok(Json(employee))
 }
@@ -473,35 +251,15 @@ async fn reject_face(
     tenant: axum::Extension<TenantId>,
     Path(id): Path<Uuid>,
 ) -> Result<Json<Employee>, StatusCode> {
-    let tenant_id = tenant.0 .0;
-
-    let mut conn = state
-        .pool
-        .acquire()
+    let employee = state
+        .employees
+        .reject_face(tenant.0 .0, id)
         .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    set_current_tenant(&mut conn, &tenant_id.to_string())
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-
-    let employee = sqlx::query_as::<_, Employee>(
-        r#"
-        UPDATE employees SET
-            face_approval_status = 'rejected',
-            updated_at = NOW()
-        WHERE id = $1 AND tenant_id = $2 AND face_approval_status = 'pending' AND deleted_at IS NULL
-        RETURNING *
-        "#,
-    )
-    .bind(id)
-    .bind(tenant_id)
-    .fetch_optional(&mut *conn)
-    .await
-    .map_err(|e| {
-        tracing::error!("reject_face error: {e}");
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?
-    .ok_or(StatusCode::NOT_FOUND)?;
+        .map_err(|e| {
+            tracing::error!("reject_face error: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?
+        .ok_or(StatusCode::NOT_FOUND)?;
 
     Ok(Json(employee))
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -9,6 +9,7 @@ use uuid::Uuid;
 
 use rust_alc_api::auth::jwt::{create_access_token, JwtSecret};
 use rust_alc_api::db::models::User;
+use rust_alc_api::db::repository::PgEmployeeRepository;
 use rust_alc_api::AppState;
 
 use mock_storage::MockStorage;
@@ -212,8 +213,11 @@ pub async fn setup_app_state() -> AppState {
 
     let mock_fcm: Arc<dyn rust_alc_api::fcm::FcmSenderTrait> = Arc::new(MockFcmSender::new());
 
+    let employees = Arc::new(PgEmployeeRepository::new(pool.clone()));
+
     AppState {
         pool,
+        employees,
         storage,
         carins_storage: None,
         dtako_storage: Some(dtako_storage),
@@ -259,8 +263,11 @@ pub async fn setup_app_state_no_fcm() -> AppState {
     let dtako_storage: Arc<dyn rust_alc_api::storage::StorageBackend> =
         Arc::new(MockStorage::new("dtako-bucket"));
 
+    let employees = Arc::new(PgEmployeeRepository::new(pool.clone()));
+
     AppState {
         pool,
+        employees,
         storage,
         carins_storage: None,
         dtako_storage: Some(dtako_storage),
@@ -294,8 +301,11 @@ pub async fn setup_app_state_failing_fcm() -> AppState {
 
     let failing_fcm: Arc<dyn rust_alc_api::fcm::FcmSenderTrait> = Arc::new(FailingFcmSender);
 
+    let employees = Arc::new(PgEmployeeRepository::new(pool.clone()));
+
     AppState {
         pool,
+        employees,
         storage,
         carins_storage: None,
         dtako_storage: Some(dtako_storage),


### PR DESCRIPTION
## Summary
- Repository パターンの基盤導入 (Phase 0)
- `TenantConn` で `set_current_tenant` を自動化
- `EmployeeRepository` trait (13メソッド) + `PgEmployeeRepository` 実装
- `employees.rs` の全ハンドラを `state.employees.*()` 経由に書き換え
- AppState に `employees: Arc<dyn EmployeeRepository>` 追加

## Test plan
- [ ] CI (ci.yml) で全テスト pass 確認
- [ ] カバレッジリグレッションなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)