### PR TITLE
refactor: introduce TimecardRepository (Phase 1a)

### DIFF
--- a/src/db/repository/mod.rs
+++ b/src/db/repository/mod.rs
@@ -1,6 +1,8 @@
 pub mod employees;
+pub mod timecard;
 
 pub use employees::{EmployeeRepository, PgEmployeeRepository};
+pub use timecard::{PgTimecardRepository, TimecardRepository};
 
 use sqlx::PgPool;
 

--- a/src/db/repository/timecard.rs
+++ b/src/db/repository/timecard.rs
@@ -1,0 +1,418 @@
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use crate::db::models::{TimePunch, TimePunchWithDevice, TimecardCard};
+
+use super::TenantConn;
+
+/// CSV エクスポート用の行データ
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct TimePunchCsvRow {
+    pub id: Uuid,
+    pub punched_at: DateTime<Utc>,
+    pub employee_name: String,
+    pub employee_code: Option<String>,
+    pub device_name: Option<String>,
+}
+
+#[async_trait]
+pub trait TimecardRepository: Send + Sync {
+    async fn create_card(
+        &self,
+        tenant_id: Uuid,
+        employee_id: Uuid,
+        card_id: &str,
+        label: Option<&str>,
+    ) -> Result<TimecardCard, sqlx::Error>;
+
+    async fn list_cards(
+        &self,
+        tenant_id: Uuid,
+        employee_id: Option<Uuid>,
+    ) -> Result<Vec<TimecardCard>, sqlx::Error>;
+
+    async fn get_card(
+        &self,
+        tenant_id: Uuid,
+        id: Uuid,
+    ) -> Result<Option<TimecardCard>, sqlx::Error>;
+
+    async fn get_card_by_card_id(
+        &self,
+        tenant_id: Uuid,
+        card_id: &str,
+    ) -> Result<Option<TimecardCard>, sqlx::Error>;
+
+    /// Delete a card. Returns true if a row was affected.
+    async fn delete_card(&self, tenant_id: Uuid, id: Uuid) -> Result<bool, sqlx::Error>;
+
+    /// Find a card by card_id (for punch lookup).
+    async fn find_card_by_card_id(
+        &self,
+        tenant_id: Uuid,
+        card_id: &str,
+    ) -> Result<Option<TimecardCard>, sqlx::Error>;
+
+    /// Find employee by nfc_id (fallback for punch).
+    async fn find_employee_id_by_nfc(
+        &self,
+        tenant_id: Uuid,
+        nfc_id: &str,
+    ) -> Result<Option<Uuid>, sqlx::Error>;
+
+    /// Create a time punch record.
+    async fn create_punch(
+        &self,
+        tenant_id: Uuid,
+        employee_id: Uuid,
+        device_id: Option<Uuid>,
+    ) -> Result<TimePunch, sqlx::Error>;
+
+    /// Get employee name by id.
+    async fn get_employee_name(
+        &self,
+        tenant_id: Uuid,
+        employee_id: Uuid,
+    ) -> Result<String, sqlx::Error>;
+
+    /// List today's punches for an employee.
+    async fn list_today_punches(
+        &self,
+        tenant_id: Uuid,
+        employee_id: Uuid,
+    ) -> Result<Vec<TimePunch>, sqlx::Error>;
+
+    /// Count punches with filters.
+    async fn count_punches(
+        &self,
+        tenant_id: Uuid,
+        employee_id: Option<Uuid>,
+        date_from: Option<DateTime<Utc>>,
+        date_to: Option<DateTime<Utc>>,
+    ) -> Result<i64, sqlx::Error>;
+
+    /// List punches with filters, pagination, and JOINed device/employee names.
+    async fn list_punches(
+        &self,
+        tenant_id: Uuid,
+        employee_id: Option<Uuid>,
+        date_from: Option<DateTime<Utc>>,
+        date_to: Option<DateTime<Utc>>,
+        limit: i64,
+        offset: i64,
+    ) -> Result<Vec<TimePunchWithDevice>, sqlx::Error>;
+
+    /// List punches for CSV export (with employee code, no pagination).
+    async fn list_punches_for_csv(
+        &self,
+        tenant_id: Uuid,
+        employee_id: Option<Uuid>,
+        date_from: Option<DateTime<Utc>>,
+        date_to: Option<DateTime<Utc>>,
+    ) -> Result<Vec<TimePunchCsvRow>, sqlx::Error>;
+}
+
+pub struct PgTimecardRepository {
+    pool: PgPool,
+}
+
+impl PgTimecardRepository {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+/// Build dynamic WHERE clause and bind parameters.
+/// Returns (where_clause, param_count_after).
+fn build_punch_where(
+    employee_id: Option<Uuid>,
+    date_from: Option<DateTime<Utc>>,
+    date_to: Option<DateTime<Utc>>,
+    table_prefix: &str,
+) -> (String, u32) {
+    let mut conditions = vec![format!("{table_prefix}.tenant_id = $1")];
+    let mut param_idx = 2u32;
+
+    if employee_id.is_some() {
+        conditions.push(format!("{table_prefix}.employee_id = ${param_idx}"));
+        param_idx += 1;
+    }
+    if date_from.is_some() {
+        conditions.push(format!("{table_prefix}.punched_at >= ${param_idx}"));
+        param_idx += 1;
+    }
+    if date_to.is_some() {
+        conditions.push(format!("{table_prefix}.punched_at <= ${param_idx}"));
+        param_idx += 1;
+    }
+
+    (conditions.join(" AND "), param_idx)
+}
+
+#[async_trait]
+impl TimecardRepository for PgTimecardRepository {
+    async fn create_card(
+        &self,
+        tenant_id: Uuid,
+        employee_id: Uuid,
+        card_id: &str,
+        label: Option<&str>,
+    ) -> Result<TimecardCard, sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        sqlx::query_as::<_, TimecardCard>(
+            r#"
+            INSERT INTO timecard_cards (tenant_id, employee_id, card_id, label)
+            VALUES ($1, $2, $3, $4)
+            RETURNING *
+            "#,
+        )
+        .bind(tenant_id)
+        .bind(employee_id)
+        .bind(card_id)
+        .bind(label)
+        .fetch_one(&mut *tc.conn)
+        .await
+    }
+
+    async fn list_cards(
+        &self,
+        tenant_id: Uuid,
+        employee_id: Option<Uuid>,
+    ) -> Result<Vec<TimecardCard>, sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        if let Some(eid) = employee_id {
+            sqlx::query_as::<_, TimecardCard>(
+                "SELECT * FROM timecard_cards WHERE tenant_id = $1 AND employee_id = $2 ORDER BY created_at",
+            )
+            .bind(tenant_id)
+            .bind(eid)
+            .fetch_all(&mut *tc.conn)
+            .await
+        } else {
+            sqlx::query_as::<_, TimecardCard>(
+                "SELECT * FROM timecard_cards WHERE tenant_id = $1 ORDER BY created_at",
+            )
+            .bind(tenant_id)
+            .fetch_all(&mut *tc.conn)
+            .await
+        }
+    }
+
+    async fn get_card(
+        &self,
+        tenant_id: Uuid,
+        id: Uuid,
+    ) -> Result<Option<TimecardCard>, sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        sqlx::query_as::<_, TimecardCard>(
+            "SELECT * FROM timecard_cards WHERE id = $1 AND tenant_id = $2",
+        )
+        .bind(id)
+        .bind(tenant_id)
+        .fetch_optional(&mut *tc.conn)
+        .await
+    }
+
+    async fn get_card_by_card_id(
+        &self,
+        tenant_id: Uuid,
+        card_id: &str,
+    ) -> Result<Option<TimecardCard>, sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        sqlx::query_as::<_, TimecardCard>(
+            "SELECT * FROM timecard_cards WHERE tenant_id = $1 AND card_id = $2",
+        )
+        .bind(tenant_id)
+        .bind(card_id)
+        .fetch_optional(&mut *tc.conn)
+        .await
+    }
+
+    async fn delete_card(&self, tenant_id: Uuid, id: Uuid) -> Result<bool, sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        let result = sqlx::query("DELETE FROM timecard_cards WHERE id = $1 AND tenant_id = $2")
+            .bind(id)
+            .bind(tenant_id)
+            .execute(&mut *tc.conn)
+            .await?;
+        Ok(result.rows_affected() > 0)
+    }
+
+    async fn find_card_by_card_id(
+        &self,
+        tenant_id: Uuid,
+        card_id: &str,
+    ) -> Result<Option<TimecardCard>, sqlx::Error> {
+        // Same as get_card_by_card_id — kept as alias for clarity in punch flow
+        self.get_card_by_card_id(tenant_id, card_id).await
+    }
+
+    async fn find_employee_id_by_nfc(
+        &self,
+        tenant_id: Uuid,
+        nfc_id: &str,
+    ) -> Result<Option<Uuid>, sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        sqlx::query_scalar::<_, Uuid>(
+            "SELECT id FROM employees WHERE tenant_id = $1 AND nfc_id = $2",
+        )
+        .bind(tenant_id)
+        .bind(nfc_id)
+        .fetch_optional(&mut *tc.conn)
+        .await
+    }
+
+    async fn create_punch(
+        &self,
+        tenant_id: Uuid,
+        employee_id: Uuid,
+        device_id: Option<Uuid>,
+    ) -> Result<TimePunch, sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        sqlx::query_as::<_, TimePunch>(
+            r#"
+            INSERT INTO time_punches (tenant_id, employee_id, device_id)
+            VALUES ($1, $2, $3)
+            RETURNING *
+            "#,
+        )
+        .bind(tenant_id)
+        .bind(employee_id)
+        .bind(device_id)
+        .fetch_one(&mut *tc.conn)
+        .await
+    }
+
+    async fn get_employee_name(
+        &self,
+        tenant_id: Uuid,
+        employee_id: Uuid,
+    ) -> Result<String, sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        sqlx::query_scalar("SELECT name FROM employees WHERE id = $1 AND tenant_id = $2")
+            .bind(employee_id)
+            .bind(tenant_id)
+            .fetch_one(&mut *tc.conn)
+            .await
+    }
+
+    async fn list_today_punches(
+        &self,
+        tenant_id: Uuid,
+        employee_id: Uuid,
+    ) -> Result<Vec<TimePunch>, sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        sqlx::query_as::<_, TimePunch>(
+            r#"
+            SELECT * FROM time_punches
+            WHERE tenant_id = $1 AND employee_id = $2
+              AND punched_at >= CURRENT_DATE
+            ORDER BY punched_at
+            "#,
+        )
+        .bind(tenant_id)
+        .bind(employee_id)
+        .fetch_all(&mut *tc.conn)
+        .await
+    }
+
+    async fn count_punches(
+        &self,
+        tenant_id: Uuid,
+        employee_id: Option<Uuid>,
+        date_from: Option<DateTime<Utc>>,
+        date_to: Option<DateTime<Utc>>,
+    ) -> Result<i64, sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        let (where_clause, _) = build_punch_where(employee_id, date_from, date_to, "tp");
+        let count_sql = format!("SELECT COUNT(*) FROM time_punches tp WHERE {where_clause}");
+
+        let mut query = sqlx::query_scalar::<_, i64>(&count_sql).bind(tenant_id);
+        if let Some(eid) = employee_id {
+            query = query.bind(eid);
+        }
+        if let Some(df) = date_from {
+            query = query.bind(df);
+        }
+        if let Some(dt) = date_to {
+            query = query.bind(dt);
+        }
+        query.fetch_one(&mut *tc.conn).await
+    }
+
+    async fn list_punches(
+        &self,
+        tenant_id: Uuid,
+        employee_id: Option<Uuid>,
+        date_from: Option<DateTime<Utc>>,
+        date_to: Option<DateTime<Utc>>,
+        limit: i64,
+        offset: i64,
+    ) -> Result<Vec<TimePunchWithDevice>, sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        let (where_clause, param_idx) = build_punch_where(employee_id, date_from, date_to, "tp");
+
+        let sql = format!(
+            r#"SELECT tp.id, tp.tenant_id, tp.employee_id, tp.device_id, d.device_name,
+                      e.name as employee_name, tp.punched_at, tp.created_at
+               FROM time_punches tp
+               LEFT JOIN devices d ON d.id = tp.device_id
+               LEFT JOIN employees e ON e.id = tp.employee_id
+               WHERE {where_clause}
+               ORDER BY tp.punched_at DESC LIMIT ${param_idx} OFFSET ${}"#,
+            param_idx + 1
+        );
+
+        let mut query = sqlx::query_as::<_, TimePunchWithDevice>(&sql).bind(tenant_id);
+        if let Some(eid) = employee_id {
+            query = query.bind(eid);
+        }
+        if let Some(df) = date_from {
+            query = query.bind(df);
+        }
+        if let Some(dt) = date_to {
+            query = query.bind(dt);
+        }
+        query = query.bind(limit).bind(offset);
+
+        query.fetch_all(&mut *tc.conn).await
+    }
+
+    async fn list_punches_for_csv(
+        &self,
+        tenant_id: Uuid,
+        employee_id: Option<Uuid>,
+        date_from: Option<DateTime<Utc>>,
+        date_to: Option<DateTime<Utc>>,
+    ) -> Result<Vec<TimePunchCsvRow>, sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        let (where_clause, _) = build_punch_where(employee_id, date_from, date_to, "tp");
+
+        let sql = format!(
+            r#"
+            SELECT tp.id, tp.punched_at, e.name as employee_name, e.code as employee_code,
+                   d.device_name
+            FROM time_punches tp
+            JOIN employees e ON e.id = tp.employee_id
+            LEFT JOIN devices d ON d.id = tp.device_id
+            WHERE {where_clause}
+            ORDER BY tp.punched_at DESC
+            "#
+        );
+
+        let mut query = sqlx::query_as::<_, TimePunchCsvRow>(&sql).bind(tenant_id);
+        if let Some(eid) = employee_id {
+            query = query.bind(eid);
+        }
+        if let Some(df) = date_from {
+            query = query.bind(df);
+        }
+        if let Some(dt) = date_to {
+            query = query.bind(dt);
+        }
+
+        query.fetch_all(&mut *tc.conn).await
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,13 +14,14 @@ pub mod webhook;
 
 use std::sync::Arc;
 
-use db::repository::EmployeeRepository;
+use db::repository::{EmployeeRepository, TimecardRepository};
 use storage::StorageBackend;
 
 #[derive(Clone)]
 pub struct AppState {
     pub pool: sqlx::PgPool,
     pub employees: Arc<dyn EmployeeRepository>,
+    pub timecard: Arc<dyn TimecardRepository>,
     pub storage: Arc<dyn StorageBackend>,
     pub carins_storage: Option<Arc<dyn StorageBackend>>,
     pub dtako_storage: Option<Arc<dyn StorageBackend>>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use tracing_subscriber::EnvFilter;
 
 use rust_alc_api::auth::google::GoogleTokenVerifier;
 use rust_alc_api::auth::jwt::JwtSecret;
-use rust_alc_api::db::repository::PgEmployeeRepository;
+use rust_alc_api::db::repository::{PgEmployeeRepository, PgTimecardRepository};
 use rust_alc_api::storage::StorageBackend;
 use rust_alc_api::AppState;
 
@@ -114,10 +114,12 @@ async fn main() -> anyhow::Result<()> {
     });
 
     let employees = Arc::new(PgEmployeeRepository::new(pool.clone()));
+    let timecard = Arc::new(PgTimecardRepository::new(pool.clone()));
 
     let state = AppState {
         pool: pool.clone(),
         employees,
+        timecard,
         storage,
         carins_storage,
         dtako_storage,

--- a/src/routes/timecard.rs
+++ b/src/routes/timecard.rs
@@ -8,10 +8,9 @@ use axum::{
 use uuid::Uuid;
 
 use crate::db::models::{
-    CreateTimePunchByCard, CreateTimecardCard, TimePunch, TimePunchFilter, TimePunchWithDevice,
-    TimePunchWithEmployee, TimePunchesResponse, TimecardCard,
+    CreateTimePunchByCard, CreateTimecardCard, TimePunchFilter, TimePunchWithEmployee,
+    TimePunchesResponse, TimecardCard,
 };
-use crate::db::tenant::set_current_tenant;
 use crate::middleware::auth::TenantId;
 use crate::AppState;
 
@@ -37,35 +36,22 @@ async fn create_card(
 ) -> Result<(StatusCode, Json<TimecardCard>), StatusCode> {
     let tenant_id = tenant.0 .0;
 
-    let mut conn = state
-        .pool
-        .acquire()
+    let card = state
+        .timecard
+        .create_card(
+            tenant_id,
+            body.employee_id,
+            &body.card_id,
+            body.label.as_deref(),
+        )
         .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    set_current_tenant(&mut conn, &tenant_id.to_string())
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-
-    let card = sqlx::query_as::<_, TimecardCard>(
-        r#"
-        INSERT INTO timecard_cards (tenant_id, employee_id, card_id, label)
-        VALUES ($1, $2, $3, $4)
-        RETURNING *
-        "#,
-    )
-    .bind(tenant_id)
-    .bind(body.employee_id)
-    .bind(&body.card_id)
-    .bind(&body.label)
-    .fetch_one(&mut *conn)
-    .await
-    .map_err(|e| {
-        tracing::error!("create_card error: {e}");
-        if e.to_string().contains("idx_timecard_cards_unique") {
-            return StatusCode::CONFLICT;
-        }
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?;
+        .map_err(|e| {
+            tracing::error!("create_card error: {e}");
+            if e.to_string().contains("idx_timecard_cards_unique") {
+                return StatusCode::CONFLICT;
+            }
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
 
     Ok((StatusCode::CREATED, Json(card)))
 }
@@ -82,32 +68,11 @@ async fn list_cards(
 ) -> Result<Json<Vec<TimecardCard>>, StatusCode> {
     let tenant_id = tenant.0 .0;
 
-    let mut conn = state
-        .pool
-        .acquire()
+    let cards = state
+        .timecard
+        .list_cards(tenant_id, filter.employee_id)
         .await
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    set_current_tenant(&mut conn, &tenant_id.to_string())
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-
-    let cards = if let Some(eid) = filter.employee_id {
-        sqlx::query_as::<_, TimecardCard>(
-            "SELECT * FROM timecard_cards WHERE tenant_id = $1 AND employee_id = $2 ORDER BY created_at",
-        )
-        .bind(tenant_id)
-        .bind(eid)
-        .fetch_all(&mut *conn)
-        .await
-    } else {
-        sqlx::query_as::<_, TimecardCard>(
-            "SELECT * FROM timecard_cards WHERE tenant_id = $1 ORDER BY created_at",
-        )
-        .bind(tenant_id)
-        .fetch_all(&mut *conn)
-        .await
-    }
-    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
     Ok(Json(cards))
 }
@@ -119,24 +84,12 @@ async fn get_card(
 ) -> Result<Json<TimecardCard>, StatusCode> {
     let tenant_id = tenant.0 .0;
 
-    let mut conn = state
-        .pool
-        .acquire()
+    let card = state
+        .timecard
+        .get_card(tenant_id, id)
         .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    set_current_tenant(&mut conn, &tenant_id.to_string())
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-
-    let card = sqlx::query_as::<_, TimecardCard>(
-        "SELECT * FROM timecard_cards WHERE id = $1 AND tenant_id = $2",
-    )
-    .bind(id)
-    .bind(tenant_id)
-    .fetch_optional(&mut *conn)
-    .await
-    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
-    .ok_or(StatusCode::NOT_FOUND)?;
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+        .ok_or(StatusCode::NOT_FOUND)?;
 
     Ok(Json(card))
 }
@@ -148,24 +101,12 @@ async fn get_card_by_card_id(
 ) -> Result<Json<TimecardCard>, StatusCode> {
     let tenant_id = tenant.0 .0;
 
-    let mut conn = state
-        .pool
-        .acquire()
+    let card = state
+        .timecard
+        .get_card_by_card_id(tenant_id, &card_id)
         .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    set_current_tenant(&mut conn, &tenant_id.to_string())
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-
-    let card = sqlx::query_as::<_, TimecardCard>(
-        "SELECT * FROM timecard_cards WHERE tenant_id = $1 AND card_id = $2",
-    )
-    .bind(tenant_id)
-    .bind(&card_id)
-    .fetch_optional(&mut *conn)
-    .await
-    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
-    .ok_or(StatusCode::NOT_FOUND)?;
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+        .ok_or(StatusCode::NOT_FOUND)?;
 
     Ok(Json(card))
 }
@@ -177,23 +118,13 @@ async fn delete_card(
 ) -> Result<StatusCode, StatusCode> {
     let tenant_id = tenant.0 .0;
 
-    let mut conn = state
-        .pool
-        .acquire()
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    set_current_tenant(&mut conn, &tenant_id.to_string())
+    let deleted = state
+        .timecard
+        .delete_card(tenant_id, id)
         .await
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
-    let result = sqlx::query("DELETE FROM timecard_cards WHERE id = $1 AND tenant_id = $2")
-        .bind(id)
-        .bind(tenant_id)
-        .execute(&mut *conn)
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-
-    if result.rows_affected() == 0 {
+    if !deleted {
         return Err(StatusCode::NOT_FOUND);
     }
 
@@ -209,80 +140,47 @@ async fn punch(
 ) -> Result<(StatusCode, Json<TimePunchWithEmployee>), StatusCode> {
     let tenant_id = tenant.0 .0;
 
-    let mut conn = state
-        .pool
-        .acquire()
+    // カードIDから社員を特定 (timecard_cards -> employees.nfc_id フォールバック)
+    let employee_id = if let Some(card) = state
+        .timecard
+        .find_card_by_card_id(tenant_id, &body.card_id)
         .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    set_current_tenant(&mut conn, &tenant_id.to_string())
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-
-    // カードIDから社員を特定 (timecard_cards → employees.nfc_id フォールバック)
-    let employee_id = if let Some(card) = sqlx::query_as::<_, TimecardCard>(
-        "SELECT * FROM timecard_cards WHERE tenant_id = $1 AND card_id = $2",
-    )
-    .bind(tenant_id)
-    .bind(&body.card_id)
-    .fetch_optional(&mut *conn)
-    .await
-    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
     {
         card.employee_id
     } else {
         // フォールバック: employees.nfc_id で検索
-        sqlx::query_scalar::<_, Uuid>(
-            "SELECT id FROM employees WHERE tenant_id = $1 AND nfc_id = $2",
-        )
-        .bind(tenant_id)
-        .bind(&body.card_id)
-        .fetch_optional(&mut *conn)
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
-        .ok_or(StatusCode::NOT_FOUND)?
+        state
+            .timecard
+            .find_employee_id_by_nfc(tenant_id, &body.card_id)
+            .await
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+            .ok_or(StatusCode::NOT_FOUND)?
     };
 
     // 打刻記録
-    let punch = sqlx::query_as::<_, TimePunch>(
-        r#"
-        INSERT INTO time_punches (tenant_id, employee_id, device_id)
-        VALUES ($1, $2, $3)
-        RETURNING *
-        "#,
-    )
-    .bind(tenant_id)
-    .bind(employee_id)
-    .bind(body.device_id)
-    .fetch_one(&mut *conn)
-    .await
-    .map_err(|e| {
-        tracing::error!("punch error: {e}");
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?;
+    let punch = state
+        .timecard
+        .create_punch(tenant_id, employee_id, body.device_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("punch error: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
 
     // 社員名を取得
-    let employee_name: String =
-        sqlx::query_scalar("SELECT name FROM employees WHERE id = $1 AND tenant_id = $2")
-            .bind(employee_id)
-            .bind(tenant_id)
-            .fetch_one(&mut *conn)
-            .await
-            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let employee_name = state
+        .timecard
+        .get_employee_name(tenant_id, employee_id)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
     // 当日の打刻一覧
-    let today_punches = sqlx::query_as::<_, TimePunch>(
-        r#"
-        SELECT * FROM time_punches
-        WHERE tenant_id = $1 AND employee_id = $2
-          AND punched_at >= CURRENT_DATE
-        ORDER BY punched_at
-        "#,
-    )
-    .bind(tenant_id)
-    .bind(employee_id)
-    .fetch_all(&mut *conn)
-    .await
-    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let today_punches = state
+        .timecard
+        .list_today_punches(tenant_id, employee_id)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
     Ok((
         StatusCode::CREATED,
@@ -306,75 +204,27 @@ async fn list_punches(
     let page = filter.page.unwrap_or(1).max(1);
     let offset = (page - 1) * per_page;
 
-    let mut conn = state
-        .pool
-        .acquire()
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    set_current_tenant(&mut conn, &tenant_id.to_string())
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-
-    let mut conditions = vec!["tp.tenant_id = $1".to_string()];
-    let mut param_idx = 2u32;
-
-    if filter.employee_id.is_some() {
-        conditions.push(format!("tp.employee_id = ${param_idx}"));
-        param_idx += 1;
-    }
-    if filter.date_from.is_some() {
-        conditions.push(format!("tp.punched_at >= ${param_idx}"));
-        param_idx += 1;
-    }
-    if filter.date_to.is_some() {
-        conditions.push(format!("tp.punched_at <= ${param_idx}"));
-        param_idx += 1;
-    }
-
-    let where_clause = conditions.join(" AND ");
-
-    // Count
-    let count_sql = format!("SELECT COUNT(*) FROM time_punches tp WHERE {where_clause}");
-    let mut count_query = sqlx::query_scalar::<_, i64>(&count_sql).bind(tenant_id);
-    if let Some(eid) = filter.employee_id {
-        count_query = count_query.bind(eid);
-    }
-    if let Some(df) = filter.date_from {
-        count_query = count_query.bind(df);
-    }
-    if let Some(dt) = filter.date_to {
-        count_query = count_query.bind(dt);
-    }
-    let total = count_query
-        .fetch_one(&mut *conn)
+    let total = state
+        .timecard
+        .count_punches(
+            tenant_id,
+            filter.employee_id,
+            filter.date_from,
+            filter.date_to,
+        )
         .await
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
-    // List
-    let sql = format!(
-        r#"SELECT tp.id, tp.tenant_id, tp.employee_id, tp.device_id, d.device_name,
-                  e.name as employee_name, tp.punched_at, tp.created_at
-           FROM time_punches tp
-           LEFT JOIN devices d ON d.id = tp.device_id
-           LEFT JOIN employees e ON e.id = tp.employee_id
-           WHERE {where_clause}
-           ORDER BY tp.punched_at DESC LIMIT ${param_idx} OFFSET ${}"#,
-        param_idx + 1
-    );
-    let mut query = sqlx::query_as::<_, TimePunchWithDevice>(&sql).bind(tenant_id);
-    if let Some(eid) = filter.employee_id {
-        query = query.bind(eid);
-    }
-    if let Some(df) = filter.date_from {
-        query = query.bind(df);
-    }
-    if let Some(dt) = filter.date_to {
-        query = query.bind(dt);
-    }
-    query = query.bind(per_page).bind(offset);
-
-    let punches = query
-        .fetch_all(&mut *conn)
+    let punches = state
+        .timecard
+        .list_punches(
+            tenant_id,
+            filter.employee_id,
+            filter.date_from,
+            filter.date_to,
+            per_page,
+            offset,
+        )
         .await
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
@@ -395,67 +245,14 @@ async fn export_csv(
 ) -> Result<impl IntoResponse, StatusCode> {
     let tenant_id = tenant.0 .0;
 
-    let mut conn = state
-        .pool
-        .acquire()
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    set_current_tenant(&mut conn, &tenant_id.to_string())
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-
-    let mut conditions = vec!["tp.tenant_id = $1".to_string()];
-    let mut param_idx = 2u32;
-
-    if filter.employee_id.is_some() {
-        conditions.push(format!("tp.employee_id = ${param_idx}"));
-        param_idx += 1;
-    }
-    if filter.date_from.is_some() {
-        conditions.push(format!("tp.punched_at >= ${param_idx}"));
-        param_idx += 1;
-    }
-    if filter.date_to.is_some() {
-        conditions.push(format!("tp.punched_at <= ${param_idx}"));
-        param_idx += 1;
-    }
-    let _ = param_idx;
-
-    let where_clause = conditions.join(" AND ");
-    let sql = format!(
-        r#"
-        SELECT tp.id, tp.punched_at, e.name as employee_name, e.code as employee_code,
-               d.device_name
-        FROM time_punches tp
-        JOIN employees e ON e.id = tp.employee_id
-        LEFT JOIN devices d ON d.id = tp.device_id
-        WHERE {where_clause}
-        ORDER BY tp.punched_at DESC
-        "#
-    );
-
-    #[derive(sqlx::FromRow)]
-    struct CsvRow {
-        id: Uuid,
-        punched_at: chrono::DateTime<chrono::Utc>,
-        employee_name: String,
-        employee_code: Option<String>,
-        device_name: Option<String>,
-    }
-
-    let mut query = sqlx::query_as::<_, CsvRow>(&sql).bind(tenant_id);
-    if let Some(eid) = filter.employee_id {
-        query = query.bind(eid);
-    }
-    if let Some(df) = filter.date_from {
-        query = query.bind(df);
-    }
-    if let Some(dt) = filter.date_to {
-        query = query.bind(dt);
-    }
-
-    let rows = query
-        .fetch_all(&mut *conn)
+    let rows = state
+        .timecard
+        .list_punches_for_csv(
+            tenant_id,
+            filter.employee_id,
+            filter.date_from,
+            filter.date_to,
+        )
         .await
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -9,7 +9,7 @@ use uuid::Uuid;
 
 use rust_alc_api::auth::jwt::{create_access_token, JwtSecret};
 use rust_alc_api::db::models::User;
-use rust_alc_api::db::repository::PgEmployeeRepository;
+use rust_alc_api::db::repository::{PgEmployeeRepository, PgTimecardRepository};
 use rust_alc_api::AppState;
 
 use mock_storage::MockStorage;
@@ -214,10 +214,12 @@ pub async fn setup_app_state() -> AppState {
     let mock_fcm: Arc<dyn rust_alc_api::fcm::FcmSenderTrait> = Arc::new(MockFcmSender::new());
 
     let employees = Arc::new(PgEmployeeRepository::new(pool.clone()));
+    let timecard = Arc::new(PgTimecardRepository::new(pool.clone()));
 
     AppState {
         pool,
         employees,
+        timecard,
         storage,
         carins_storage: None,
         dtako_storage: Some(dtako_storage),
@@ -264,10 +266,12 @@ pub async fn setup_app_state_no_fcm() -> AppState {
         Arc::new(MockStorage::new("dtako-bucket"));
 
     let employees = Arc::new(PgEmployeeRepository::new(pool.clone()));
+    let timecard = Arc::new(PgTimecardRepository::new(pool.clone()));
 
     AppState {
         pool,
         employees,
+        timecard,
         storage,
         carins_storage: None,
         dtako_storage: Some(dtako_storage),
@@ -302,10 +306,12 @@ pub async fn setup_app_state_failing_fcm() -> AppState {
     let failing_fcm: Arc<dyn rust_alc_api::fcm::FcmSenderTrait> = Arc::new(FailingFcmSender);
 
     let employees = Arc::new(PgEmployeeRepository::new(pool.clone()));
+    let timecard = Arc::new(PgTimecardRepository::new(pool.clone()));
 
     AppState {
         pool,
         employees,
+        timecard,
         storage,
         carins_storage: None,
         dtako_storage: Some(dtako_storage),


### PR DESCRIPTION
## Summary
- `TimecardRepository` trait (12メソッド) + `PgTimecardRepository` 実装
- timecard.rs の全ハンドラを `state.timecard.*()` 経由に書き換え
- Dynamic WHERE clause building をリポジトリに移動

## Test plan
- [ ] CI pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)