### PR TITLE
refactor: introduce TenkoCallRepository (Phase 1b)

### DIFF
--- a/src/db/repository/mod.rs
+++ b/src/db/repository/mod.rs
@@ -1,6 +1,8 @@
 pub mod employees;
+pub mod tenko_call;
 
 pub use employees::{EmployeeRepository, PgEmployeeRepository};
+pub use tenko_call::{PgTenkoCallRepository, TenkoCallRepository};
 
 use sqlx::PgPool;
 

--- a/src/db/repository/tenko_call.rs
+++ b/src/db/repository/tenko_call.rs
@@ -1,0 +1,260 @@
+use async_trait::async_trait;
+use sqlx::PgPool;
+
+/// ドライバー登録の結果 (driver_id, call_number)
+pub struct RegisterDriverResult {
+    pub driver_id: i32,
+    pub call_number: Option<String>,
+}
+
+/// 点呼送信時のドライバー情報
+pub struct DriverInfo {
+    pub id: i32,
+    pub call_number: Option<String>,
+    pub tenant_id: String,
+}
+
+/// 電話番号マスタ行
+pub struct TenkoCallNumberRow {
+    pub id: i32,
+    pub call_number: String,
+    pub tenant_id: String,
+    pub label: Option<String>,
+    pub created_at: String,
+}
+
+/// 登録ドライバー行
+pub struct TenkoCallDriverRow {
+    pub id: i32,
+    pub phone_number: String,
+    pub driver_name: String,
+    pub call_number: Option<String>,
+    pub tenant_id: String,
+    pub employee_code: Option<String>,
+    pub created_at: String,
+}
+
+#[async_trait]
+pub trait TenkoCallRepository: Send + Sync {
+    /// ドライバー登録 (トランザクション内で call_number 検証 + upsert)
+    /// call_number が未登録の場合は Ok(None) を返す
+    async fn register_driver(
+        &self,
+        call_number: &str,
+        phone_number: &str,
+        driver_name: &str,
+        employee_code: Option<&str>,
+    ) -> Result<Option<RegisterDriverResult>, sqlx::Error>;
+
+    /// 点呼送信 (トランザクション内でドライバー検索 + ログ挿入)
+    /// ドライバー未登録の場合は Ok(None) を返す
+    async fn record_tenko(
+        &self,
+        phone_number: &str,
+        driver_name: &str,
+        latitude: f64,
+        longitude: f64,
+    ) -> Result<Option<DriverInfo>, sqlx::Error>;
+
+    /// 電話番号マスタ一覧 (テナント認証なし、直接 pool 参照)
+    async fn list_numbers(&self) -> Result<Vec<TenkoCallNumberRow>, sqlx::Error>;
+
+    /// 電話番号マスタ追加
+    async fn create_number(
+        &self,
+        call_number: &str,
+        tenant_id: &str,
+        label: Option<&str>,
+    ) -> Result<i32, sqlx::Error>;
+
+    /// 電話番号マスタ削除
+    async fn delete_number(&self, id: i32) -> Result<(), sqlx::Error>;
+
+    /// 登録ドライバー一覧
+    async fn list_drivers(&self) -> Result<Vec<TenkoCallDriverRow>, sqlx::Error>;
+}
+
+pub struct PgTenkoCallRepository {
+    pool: PgPool,
+}
+
+impl PgTenkoCallRepository {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl TenkoCallRepository for PgTenkoCallRepository {
+    async fn register_driver(
+        &self,
+        call_number: &str,
+        phone_number: &str,
+        driver_name: &str,
+        employee_code: Option<&str>,
+    ) -> Result<Option<RegisterDriverResult>, sqlx::Error> {
+        let mut tx = self.pool.begin().await?;
+
+        // call_number がマスタに存在するか検証
+        let master = sqlx::query_as::<_, (String,)>(
+            "SELECT tenant_id FROM tenko_call_numbers WHERE call_number = $1",
+        )
+        .bind(call_number)
+        .fetch_optional(&mut *tx)
+        .await?;
+
+        let tenant_id = match master {
+            Some(row) => row.0,
+            None => return Ok(None),
+        };
+
+        // RLS 用にテナントをセット
+        sqlx::query("SELECT set_current_tenant($1)")
+            .bind(&tenant_id)
+            .execute(&mut *tx)
+            .await?;
+
+        let row = sqlx::query_as::<_, (i32, Option<String>)>(
+            r#"
+            INSERT INTO tenko_call_drivers (phone_number, driver_name, call_number, tenant_id, employee_code, updated_at)
+            VALUES ($1, $2, $3, $4, $5, now())
+            ON CONFLICT (phone_number) DO UPDATE SET
+                driver_name = $2, call_number = $3, tenant_id = $4, employee_code = $5, updated_at = now()
+            RETURNING id, call_number
+            "#,
+        )
+        .bind(phone_number)
+        .bind(driver_name)
+        .bind(call_number)
+        .bind(&tenant_id)
+        .bind(employee_code)
+        .fetch_one(&mut *tx)
+        .await?;
+
+        tx.commit().await?;
+
+        Ok(Some(RegisterDriverResult {
+            driver_id: row.0,
+            call_number: row.1,
+        }))
+    }
+
+    async fn record_tenko(
+        &self,
+        phone_number: &str,
+        driver_name: &str,
+        latitude: f64,
+        longitude: f64,
+    ) -> Result<Option<DriverInfo>, sqlx::Error> {
+        let mut tx = self.pool.begin().await?;
+
+        // 登録済みドライバーを検索
+        let driver = sqlx::query_as::<_, (i32, Option<String>, String)>(
+            "SELECT id, call_number, tenant_id FROM tenko_call_drivers WHERE phone_number = $1",
+        )
+        .bind(phone_number)
+        .fetch_optional(&mut *tx)
+        .await?;
+
+        let driver = match driver {
+            Some(d) => d,
+            None => return Ok(None),
+        };
+
+        // RLS 用にテナントをセット
+        sqlx::query("SELECT set_current_tenant($1)")
+            .bind(&driver.2)
+            .execute(&mut *tx)
+            .await?;
+
+        // 位置情報ログを保存
+        sqlx::query(
+            r#"
+            INSERT INTO tenko_call_logs (driver_id, phone_number, driver_name, latitude, longitude)
+            VALUES ($1, $2, $3, $4, $5)
+            "#,
+        )
+        .bind(driver.0)
+        .bind(phone_number)
+        .bind(driver_name)
+        .bind(latitude)
+        .bind(longitude)
+        .execute(&mut *tx)
+        .await?;
+
+        tx.commit().await?;
+
+        Ok(Some(DriverInfo {
+            id: driver.0,
+            call_number: driver.1,
+            tenant_id: driver.2,
+        }))
+    }
+
+    async fn list_numbers(&self) -> Result<Vec<TenkoCallNumberRow>, sqlx::Error> {
+        let rows = sqlx::query_as::<_, (i32, String, String, Option<String>, String)>(
+            "SELECT id, call_number, tenant_id, label, created_at::text FROM tenko_call_numbers ORDER BY id",
+        )
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows
+            .into_iter()
+            .map(|r| TenkoCallNumberRow {
+                id: r.0,
+                call_number: r.1,
+                tenant_id: r.2,
+                label: r.3,
+                created_at: r.4,
+            })
+            .collect())
+    }
+
+    async fn create_number(
+        &self,
+        call_number: &str,
+        tenant_id: &str,
+        label: Option<&str>,
+    ) -> Result<i32, sqlx::Error> {
+        let row = sqlx::query_as::<_, (i32,)>(
+            "INSERT INTO tenko_call_numbers (call_number, tenant_id, label) VALUES ($1, $2, $3) RETURNING id",
+        )
+        .bind(call_number)
+        .bind(tenant_id)
+        .bind(label)
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(row.0)
+    }
+
+    async fn delete_number(&self, id: i32) -> Result<(), sqlx::Error> {
+        sqlx::query("DELETE FROM tenko_call_numbers WHERE id = $1")
+            .bind(id)
+            .execute(&self.pool)
+            .await?;
+
+        Ok(())
+    }
+
+    async fn list_drivers(&self) -> Result<Vec<TenkoCallDriverRow>, sqlx::Error> {
+        let rows = sqlx::query_as::<_, (i32, String, String, Option<String>, String, Option<String>, String)>(
+            "SELECT id, phone_number, driver_name, call_number, tenant_id, employee_code, created_at::text FROM tenko_call_drivers ORDER BY id",
+        )
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows
+            .into_iter()
+            .map(|r| TenkoCallDriverRow {
+                id: r.0,
+                phone_number: r.1,
+                driver_name: r.2,
+                call_number: r.3,
+                tenant_id: r.4,
+                employee_code: r.5,
+                created_at: r.6,
+            })
+            .collect())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,12 +15,14 @@ pub mod webhook;
 use std::sync::Arc;
 
 use db::repository::EmployeeRepository;
+use db::repository::TenkoCallRepository;
 use storage::StorageBackend;
 
 #[derive(Clone)]
 pub struct AppState {
     pub pool: sqlx::PgPool,
     pub employees: Arc<dyn EmployeeRepository>,
+    pub tenko_call: Arc<dyn TenkoCallRepository>,
     pub storage: Arc<dyn StorageBackend>,
     pub carins_storage: Option<Arc<dyn StorageBackend>>,
     pub dtako_storage: Option<Arc<dyn StorageBackend>>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use tracing_subscriber::EnvFilter;
 
 use rust_alc_api::auth::google::GoogleTokenVerifier;
 use rust_alc_api::auth::jwt::JwtSecret;
-use rust_alc_api::db::repository::PgEmployeeRepository;
+use rust_alc_api::db::repository::{PgEmployeeRepository, PgTenkoCallRepository};
 use rust_alc_api::storage::StorageBackend;
 use rust_alc_api::AppState;
 
@@ -114,10 +114,12 @@ async fn main() -> anyhow::Result<()> {
     });
 
     let employees = Arc::new(PgEmployeeRepository::new(pool.clone()));
+    let tenko_call = Arc::new(PgTenkoCallRepository::new(pool.clone()));
 
     let state = AppState {
         pool: pool.clone(),
         employees,
+        tenko_call,
         storage,
         carins_storage,
         dtako_storage,

--- a/src/routes/tenko_call.rs
+++ b/src/routes/tenko_call.rs
@@ -46,80 +46,37 @@ async fn register(
     State(state): State<AppState>,
     Json(body): Json<RegisterRequest>,
 ) -> Result<Json<RegisterResponse>, (StatusCode, Json<RegisterResponse>)> {
-    let mut tx = state.pool.begin().await.map_err(|e| {
-        tracing::error!("tenko_call register tx begin error: {e}");
-        register_err("internal error")
-    })?;
-
-    // call_number がマスタに存在するか検証 (RLS 前にマスタ参照)
-    let master = sqlx::query_as::<_, (String,)>(
-        "SELECT tenant_id FROM tenko_call_numbers WHERE call_number = $1",
-    )
-    .bind(&body.call_number)
-    .fetch_optional(&mut *tx)
-    .await
-    .map_err(|e| {
-        tracing::error!("tenko_call register master lookup error: {e}");
-        register_err("internal error")
-    })?;
-
-    let tenant_id = match master {
-        Some(row) => row.0,
-        None => {
-            return Err((
-                StatusCode::BAD_REQUEST,
-                Json(RegisterResponse {
-                    success: false,
-                    driver_id: 0,
-                    call_number: None,
-                    error: Some("未登録の点呼用番号です".into()),
-                }),
-            ));
-        }
-    };
-
-    // RLS 用にテナントをセット
-    sqlx::query("SELECT set_current_tenant($1)")
-        .bind(&tenant_id)
-        .execute(&mut *tx)
+    let result = state
+        .tenko_call
+        .register_driver(
+            &body.call_number,
+            &body.phone_number,
+            &body.driver_name,
+            body.employee_code.as_deref(),
+        )
         .await
         .map_err(|e| {
-            tracing::error!("tenko_call register set_tenant error: {e}");
+            tracing::error!("tenko_call register error: {e}");
             register_err("internal error")
         })?;
 
-    let row = sqlx::query_as::<_, (i32, Option<String>)>(
-        r#"
-        INSERT INTO tenko_call_drivers (phone_number, driver_name, call_number, tenant_id, employee_code, updated_at)
-        VALUES ($1, $2, $3, $4, $5, now())
-        ON CONFLICT (phone_number) DO UPDATE SET
-            driver_name = $2, call_number = $3, tenant_id = $4, employee_code = $5, updated_at = now()
-        RETURNING id, call_number
-        "#,
-    )
-    .bind(&body.phone_number)
-    .bind(&body.driver_name)
-    .bind(&body.call_number)
-    .bind(&tenant_id)
-    .bind(&body.employee_code)
-    .fetch_one(&mut *tx)
-    .await
-    .map_err(|e| {
-        tracing::error!("tenko_call register error: {e}");
-        register_err("internal error")
-    })?;
-
-    tx.commit().await.map_err(|e| {
-        tracing::error!("tenko_call register tx commit error: {e}");
-        register_err("internal error")
-    })?;
-
-    Ok(Json(RegisterResponse {
-        success: true,
-        driver_id: row.0,
-        call_number: row.1,
-        error: None,
-    }))
+    match result {
+        Some(r) => Ok(Json(RegisterResponse {
+            success: true,
+            driver_id: r.driver_id,
+            call_number: r.call_number,
+            error: None,
+        })),
+        None => Err((
+            StatusCode::BAD_REQUEST,
+            Json(RegisterResponse {
+                success: false,
+                driver_id: 0,
+                call_number: None,
+                error: Some("未登録の点呼用番号です".into()),
+            }),
+        )),
+    }
 }
 
 fn register_err(msg: &str) -> (StatusCode, Json<RegisterResponse>) {
@@ -154,62 +111,27 @@ async fn tenko(
     State(state): State<AppState>,
     Json(body): Json<TenkoRequest>,
 ) -> Result<Json<TenkoResponse>, StatusCode> {
-    let mut tx = state.pool.begin().await.map_err(|e| {
-        tracing::error!("tenko_call tenko tx begin error: {e}");
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?;
-
-    // 登録済みドライバーを検索 (tenant_id も取得)
-    let driver = sqlx::query_as::<_, (i32, Option<String>, String)>(
-        "SELECT id, call_number, tenant_id FROM tenko_call_drivers WHERE phone_number = $1",
-    )
-    .bind(&body.phone_number)
-    .fetch_optional(&mut *tx)
-    .await
-    .map_err(|e| {
-        tracing::error!("tenko_call tenko driver lookup error: {e}");
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?
-    .ok_or(StatusCode::NOT_FOUND)?;
-
-    // RLS 用にテナントをセット
-    sqlx::query("SELECT set_current_tenant($1)")
-        .bind(&driver.2)
-        .execute(&mut *tx)
+    let result = state
+        .tenko_call
+        .record_tenko(
+            &body.phone_number,
+            &body.driver_name,
+            body.latitude,
+            body.longitude,
+        )
         .await
         .map_err(|e| {
-            tracing::error!("tenko_call tenko set_tenant error: {e}");
+            tracing::error!("tenko_call tenko error: {e}");
             StatusCode::INTERNAL_SERVER_ERROR
         })?;
 
-    // 位置情報ログを保存
-    sqlx::query(
-        r#"
-        INSERT INTO tenko_call_logs (driver_id, phone_number, driver_name, latitude, longitude)
-        VALUES ($1, $2, $3, $4, $5)
-        "#,
-    )
-    .bind(driver.0)
-    .bind(&body.phone_number)
-    .bind(&body.driver_name)
-    .bind(body.latitude)
-    .bind(body.longitude)
-    .execute(&mut *tx)
-    .await
-    .map_err(|e| {
-        tracing::error!("tenko_call tenko log insert error: {e}");
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?;
-
-    tx.commit().await.map_err(|e| {
-        tracing::error!("tenko_call tenko tx commit error: {e}");
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?;
-
-    Ok(Json(TenkoResponse {
-        success: true,
-        call_number: driver.1,
-    }))
+    match result {
+        Some(info) => Ok(Json(TenkoResponse {
+            success: true,
+            call_number: info.call_number,
+        })),
+        None => Err(StatusCode::NOT_FOUND),
+    }
 }
 
 // --- マスタ管理 (テナント認証付き) ---
@@ -226,12 +148,7 @@ struct TenkoCallNumber {
 async fn list_numbers(
     State(state): State<AppState>,
 ) -> Result<Json<Vec<TenkoCallNumber>>, StatusCode> {
-    let rows = sqlx::query_as::<_, (i32, String, String, Option<String>, String)>(
-        "SELECT id, call_number, tenant_id, label, created_at::text FROM tenko_call_numbers ORDER BY id",
-    )
-    .fetch_all(&state.pool)
-    .await
-    .map_err(|e| {
+    let rows = state.tenko_call.list_numbers().await.map_err(|e| {
         tracing::error!("tenko_call list_numbers error: {e}");
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
@@ -239,11 +156,11 @@ async fn list_numbers(
     Ok(Json(
         rows.into_iter()
             .map(|r| TenkoCallNumber {
-                id: r.0,
-                call_number: r.1,
-                tenant_id: r.2,
-                label: r.3,
-                created_at: r.4,
+                id: r.id,
+                call_number: r.call_number,
+                tenant_id: r.tenant_id,
+                label: r.label,
+                created_at: r.created_at,
             })
             .collect(),
     ))
@@ -267,37 +184,26 @@ async fn create_number(
     Json(body): Json<CreateNumberRequest>,
 ) -> Result<Json<CreateNumberResponse>, StatusCode> {
     let tenant = body.tenant_id.unwrap_or_else(|| "default".into());
-    let row = sqlx::query_as::<_, (i32,)>(
-        "INSERT INTO tenko_call_numbers (call_number, tenant_id, label) VALUES ($1, $2, $3) RETURNING id",
-    )
-    .bind(&body.call_number)
-    .bind(&tenant)
-    .bind(&body.label)
-    .fetch_one(&state.pool)
-    .await
-    .map_err(|e| {
-        tracing::error!("tenko_call create_number error: {e}");
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?;
+    let id = state
+        .tenko_call
+        .create_number(&body.call_number, &tenant, body.label.as_deref())
+        .await
+        .map_err(|e| {
+            tracing::error!("tenko_call create_number error: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
 
-    Ok(Json(CreateNumberResponse {
-        success: true,
-        id: row.0,
-    }))
+    Ok(Json(CreateNumberResponse { success: true, id }))
 }
 
 async fn delete_number(
     State(state): State<AppState>,
     Path(id): Path<i32>,
 ) -> Result<StatusCode, StatusCode> {
-    sqlx::query("DELETE FROM tenko_call_numbers WHERE id = $1")
-        .bind(id)
-        .execute(&state.pool)
-        .await
-        .map_err(|e| {
-            tracing::error!("tenko_call delete_number error: {e}");
-            StatusCode::INTERNAL_SERVER_ERROR
-        })?;
+    state.tenko_call.delete_number(id).await.map_err(|e| {
+        tracing::error!("tenko_call delete_number error: {e}");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
 
     Ok(StatusCode::NO_CONTENT)
 }
@@ -316,12 +222,7 @@ struct TenkoCallDriver {
 async fn list_drivers(
     State(state): State<AppState>,
 ) -> Result<Json<Vec<TenkoCallDriver>>, StatusCode> {
-    let rows = sqlx::query_as::<_, (i32, String, String, Option<String>, String, Option<String>, String)>(
-        "SELECT id, phone_number, driver_name, call_number, tenant_id, employee_code, created_at::text FROM tenko_call_drivers ORDER BY id",
-    )
-    .fetch_all(&state.pool)
-    .await
-    .map_err(|e| {
+    let rows = state.tenko_call.list_drivers().await.map_err(|e| {
         tracing::error!("tenko_call list_drivers error: {e}");
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
@@ -329,13 +230,13 @@ async fn list_drivers(
     Ok(Json(
         rows.into_iter()
             .map(|r| TenkoCallDriver {
-                id: r.0,
-                phone_number: r.1,
-                driver_name: r.2,
-                call_number: r.3,
-                tenant_id: r.4,
-                employee_code: r.5,
-                created_at: r.6,
+                id: r.id,
+                phone_number: r.phone_number,
+                driver_name: r.driver_name,
+                call_number: r.call_number,
+                tenant_id: r.tenant_id,
+                employee_code: r.employee_code,
+                created_at: r.created_at,
             })
             .collect(),
     ))

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -9,7 +9,7 @@ use uuid::Uuid;
 
 use rust_alc_api::auth::jwt::{create_access_token, JwtSecret};
 use rust_alc_api::db::models::User;
-use rust_alc_api::db::repository::PgEmployeeRepository;
+use rust_alc_api::db::repository::{PgEmployeeRepository, PgTenkoCallRepository};
 use rust_alc_api::AppState;
 
 use mock_storage::MockStorage;
@@ -214,10 +214,12 @@ pub async fn setup_app_state() -> AppState {
     let mock_fcm: Arc<dyn rust_alc_api::fcm::FcmSenderTrait> = Arc::new(MockFcmSender::new());
 
     let employees = Arc::new(PgEmployeeRepository::new(pool.clone()));
+    let tenko_call = Arc::new(PgTenkoCallRepository::new(pool.clone()));
 
     AppState {
         pool,
         employees,
+        tenko_call,
         storage,
         carins_storage: None,
         dtako_storage: Some(dtako_storage),
@@ -264,10 +266,12 @@ pub async fn setup_app_state_no_fcm() -> AppState {
         Arc::new(MockStorage::new("dtako-bucket"));
 
     let employees = Arc::new(PgEmployeeRepository::new(pool.clone()));
+    let tenko_call = Arc::new(PgTenkoCallRepository::new(pool.clone()));
 
     AppState {
         pool,
         employees,
+        tenko_call,
         storage,
         carins_storage: None,
         dtako_storage: Some(dtako_storage),
@@ -302,10 +306,12 @@ pub async fn setup_app_state_failing_fcm() -> AppState {
     let failing_fcm: Arc<dyn rust_alc_api::fcm::FcmSenderTrait> = Arc::new(FailingFcmSender);
 
     let employees = Arc::new(PgEmployeeRepository::new(pool.clone()));
+    let tenko_call = Arc::new(PgTenkoCallRepository::new(pool.clone()));
 
     AppState {
         pool,
         employees,
+        tenko_call,
         storage,
         carins_storage: None,
         dtako_storage: Some(dtako_storage),


### PR DESCRIPTION
## Summary
- `TenkoCallRepository` trait (6メソッド) + `PgTenkoCallRepository` 実装
- register_driver / record_tenko をトランザクション付きでリポジトリに移動
- tenko_call.rs の全ハンドラを `state.tenko_call.*()` 経由に書き換え

## Test plan
- [ ] CI pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)