### PR TITLE
refactor: introduce NfcTagRepository (Phase 1c)

### DIFF
--- a/src/db/models.rs
+++ b/src/db/models.rs
@@ -903,6 +903,17 @@ pub struct DtakoSegmentsResponse {
     pub segments: Vec<DtakoDailyWorkSegment>,
 }
 
+// --- NFC Tag ---
+
+#[derive(Debug, Clone, sqlx::FromRow, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NfcTag {
+    pub id: i32,
+    pub nfc_uuid: String,
+    pub car_inspection_id: i32,
+    pub created_at: DateTime<Utc>,
+}
+
 // --- Carrying Items ---
 
 #[derive(Debug, Clone, Serialize, Deserialize, FromRow)]

--- a/src/db/repository/mod.rs
+++ b/src/db/repository/mod.rs
@@ -1,6 +1,8 @@
 pub mod employees;
+pub mod nfc_tags;
 
 pub use employees::{EmployeeRepository, PgEmployeeRepository};
+pub use nfc_tags::{NfcTagRepository, PgNfcTagRepository};
 
 use sqlx::PgPool;
 

--- a/src/db/repository/nfc_tags.rs
+++ b/src/db/repository/nfc_tags.rs
@@ -1,0 +1,133 @@
+use async_trait::async_trait;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use crate::db::models::NfcTag;
+
+use super::TenantConn;
+
+#[async_trait]
+pub trait NfcTagRepository: Send + Sync {
+    async fn search_by_uuid(
+        &self,
+        tenant_id: Uuid,
+        nfc_uuid: &str,
+    ) -> Result<Option<NfcTag>, sqlx::Error>;
+
+    async fn get_car_inspection_json(
+        &self,
+        tenant_id: Uuid,
+        car_inspection_id: i32,
+    ) -> Result<Option<serde_json::Value>, sqlx::Error>;
+
+    async fn list(
+        &self,
+        tenant_id: Uuid,
+        car_inspection_id: Option<i32>,
+    ) -> Result<Vec<NfcTag>, sqlx::Error>;
+
+    async fn register(
+        &self,
+        tenant_id: Uuid,
+        nfc_uuid: &str,
+        car_inspection_id: i32,
+    ) -> Result<NfcTag, sqlx::Error>;
+
+    async fn delete(&self, tenant_id: Uuid, nfc_uuid: &str) -> Result<bool, sqlx::Error>;
+}
+
+pub struct PgNfcTagRepository {
+    pool: PgPool,
+}
+
+impl PgNfcTagRepository {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl NfcTagRepository for PgNfcTagRepository {
+    async fn search_by_uuid(
+        &self,
+        tenant_id: Uuid,
+        nfc_uuid: &str,
+    ) -> Result<Option<NfcTag>, sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        sqlx::query_as::<_, NfcTag>(
+            "SELECT id, nfc_uuid, car_inspection_id, created_at FROM car_inspection_nfc_tags WHERE nfc_uuid = $1",
+        )
+        .bind(nfc_uuid)
+        .fetch_optional(&mut *tc.conn)
+        .await
+    }
+
+    async fn get_car_inspection_json(
+        &self,
+        tenant_id: Uuid,
+        car_inspection_id: i32,
+    ) -> Result<Option<serde_json::Value>, sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        let row = sqlx::query_as::<_, (serde_json::Value,)>(
+            "SELECT to_jsonb(ci) FROM car_inspection ci WHERE id = $1",
+        )
+        .bind(car_inspection_id)
+        .fetch_optional(&mut *tc.conn)
+        .await?;
+        Ok(row.map(|r| r.0))
+    }
+
+    async fn list(
+        &self,
+        tenant_id: Uuid,
+        car_inspection_id: Option<i32>,
+    ) -> Result<Vec<NfcTag>, sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        if let Some(ci_id) = car_inspection_id {
+            sqlx::query_as::<_, NfcTag>(
+                "SELECT id, nfc_uuid, car_inspection_id, created_at FROM car_inspection_nfc_tags WHERE car_inspection_id = $1 ORDER BY created_at DESC",
+            )
+            .bind(ci_id)
+            .fetch_all(&mut *tc.conn)
+            .await
+        } else {
+            sqlx::query_as::<_, NfcTag>(
+                "SELECT id, nfc_uuid, car_inspection_id, created_at FROM car_inspection_nfc_tags ORDER BY created_at DESC",
+            )
+            .fetch_all(&mut *tc.conn)
+            .await
+        }
+    }
+
+    async fn register(
+        &self,
+        tenant_id: Uuid,
+        nfc_uuid: &str,
+        car_inspection_id: i32,
+    ) -> Result<NfcTag, sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        sqlx::query_as::<_, NfcTag>(
+            r#"
+            INSERT INTO car_inspection_nfc_tags (tenant_id, nfc_uuid, car_inspection_id)
+            VALUES (current_setting('app.current_tenant_id')::uuid, $1, $2)
+            ON CONFLICT (tenant_id, nfc_uuid) DO UPDATE
+                SET car_inspection_id = EXCLUDED.car_inspection_id,
+                    created_at = NOW()
+            RETURNING id, nfc_uuid, car_inspection_id, created_at
+            "#,
+        )
+        .bind(nfc_uuid)
+        .bind(car_inspection_id)
+        .fetch_one(&mut *tc.conn)
+        .await
+    }
+
+    async fn delete(&self, tenant_id: Uuid, nfc_uuid: &str) -> Result<bool, sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        let result = sqlx::query("DELETE FROM car_inspection_nfc_tags WHERE nfc_uuid = $1")
+            .bind(nfc_uuid)
+            .execute(&mut *tc.conn)
+            .await?;
+        Ok(result.rows_affected() > 0)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,13 +14,14 @@ pub mod webhook;
 
 use std::sync::Arc;
 
-use db::repository::EmployeeRepository;
+use db::repository::{EmployeeRepository, NfcTagRepository};
 use storage::StorageBackend;
 
 #[derive(Clone)]
 pub struct AppState {
     pub pool: sqlx::PgPool,
     pub employees: Arc<dyn EmployeeRepository>,
+    pub nfc_tags: Arc<dyn NfcTagRepository>,
     pub storage: Arc<dyn StorageBackend>,
     pub carins_storage: Option<Arc<dyn StorageBackend>>,
     pub dtako_storage: Option<Arc<dyn StorageBackend>>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use tracing_subscriber::EnvFilter;
 
 use rust_alc_api::auth::google::GoogleTokenVerifier;
 use rust_alc_api::auth::jwt::JwtSecret;
-use rust_alc_api::db::repository::PgEmployeeRepository;
+use rust_alc_api::db::repository::{PgEmployeeRepository, PgNfcTagRepository};
 use rust_alc_api::storage::StorageBackend;
 use rust_alc_api::AppState;
 
@@ -114,10 +114,12 @@ async fn main() -> anyhow::Result<()> {
     });
 
     let employees = Arc::new(PgEmployeeRepository::new(pool.clone()));
+    let nfc_tags = Arc::new(PgNfcTagRepository::new(pool.clone()));
 
     let state = AppState {
         pool: pool.clone(),
         employees,
+        nfc_tags,
         storage,
         carins_storage,
         dtako_storage,

--- a/src/routes/nfc_tags.rs
+++ b/src/routes/nfc_tags.rs
@@ -5,9 +5,8 @@ use axum::{
     Extension, Json, Router,
 };
 use serde::{Deserialize, Serialize};
-use sqlx::FromRow;
 
-use crate::db::tenant::set_current_tenant;
+use crate::db::models::NfcTag;
 use crate::middleware::auth::TenantId;
 use crate::AppState;
 
@@ -16,15 +15,6 @@ pub fn tenant_router() -> Router<AppState> {
         .route("/nfc-tags", get(list_tags).post(register_tag))
         .route("/nfc-tags/search", get(search_by_uuid))
         .route("/nfc-tags/{nfc_uuid}", delete(delete_tag))
-}
-
-#[derive(Debug, Clone, FromRow, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct NfcTag {
-    pub id: i32,
-    pub nfc_uuid: String,
-    pub car_inspection_id: i32,
-    pub created_at: chrono::DateTime<chrono::Utc>,
 }
 
 fn normalize_nfc_uuid(uuid: &str) -> String {
@@ -47,35 +37,20 @@ async fn search_by_uuid(
     Extension(tenant_id): Extension<TenantId>,
     Query(q): Query<SearchQuery>,
 ) -> Result<Json<SearchResponse>, StatusCode> {
-    let mut conn = state
-        .pool
-        .acquire()
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    set_current_tenant(&mut conn, &tenant_id.0.to_string())
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-
     let nfc_uuid = normalize_nfc_uuid(&q.uuid);
 
-    let tag = sqlx::query_as::<_, NfcTag>(
-        "SELECT id, nfc_uuid, car_inspection_id, created_at FROM car_inspection_nfc_tags WHERE nfc_uuid = $1",
-    )
-    .bind(&nfc_uuid)
-    .fetch_optional(&mut *conn)
-    .await
-    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
-    .ok_or(StatusCode::NOT_FOUND)?;
+    let tag = state
+        .nfc_tags
+        .search_by_uuid(tenant_id.0, &nfc_uuid)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+        .ok_or(StatusCode::NOT_FOUND)?;
 
-    // Get linked car inspection
-    let ci = sqlx::query_as::<_, (serde_json::Value,)>(
-        "SELECT to_jsonb(ci) FROM car_inspection ci WHERE id = $1",
-    )
-    .bind(tag.car_inspection_id)
-    .fetch_optional(&mut *conn)
-    .await
-    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
-    .map(|r| r.0);
+    let ci = state
+        .nfc_tags
+        .get_car_inspection_json(tenant_id.0, tag.car_inspection_id)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
     Ok(Json(SearchResponse {
         nfc_tag: tag,
@@ -93,30 +68,11 @@ async fn list_tags(
     Extension(tenant_id): Extension<TenantId>,
     Query(q): Query<ListQuery>,
 ) -> Result<Json<Vec<NfcTag>>, StatusCode> {
-    let mut conn = state
-        .pool
-        .acquire()
+    let rows = state
+        .nfc_tags
+        .list(tenant_id.0, q.car_inspection_id)
         .await
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    set_current_tenant(&mut conn, &tenant_id.0.to_string())
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-
-    let rows = if let Some(ci_id) = q.car_inspection_id {
-        sqlx::query_as::<_, NfcTag>(
-            "SELECT id, nfc_uuid, car_inspection_id, created_at FROM car_inspection_nfc_tags WHERE car_inspection_id = $1 ORDER BY created_at DESC",
-        )
-        .bind(ci_id)
-        .fetch_all(&mut *conn)
-        .await
-    } else {
-        sqlx::query_as::<_, NfcTag>(
-            "SELECT id, nfc_uuid, car_inspection_id, created_at FROM car_inspection_nfc_tags ORDER BY created_at DESC",
-        )
-        .fetch_all(&mut *conn)
-        .await
-    }
-    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
     Ok(Json(rows))
 }
@@ -132,35 +88,16 @@ async fn register_tag(
     Extension(tenant_id): Extension<TenantId>,
     Json(body): Json<RegisterRequest>,
 ) -> Result<(StatusCode, Json<NfcTag>), StatusCode> {
-    let mut conn = state
-        .pool
-        .acquire()
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    set_current_tenant(&mut conn, &tenant_id.0.to_string())
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-
     let nfc_uuid = normalize_nfc_uuid(&body.nfc_uuid);
 
-    let tag = sqlx::query_as::<_, NfcTag>(
-        r#"
-        INSERT INTO car_inspection_nfc_tags (tenant_id, nfc_uuid, car_inspection_id)
-        VALUES (current_setting('app.current_tenant_id')::uuid, $1, $2)
-        ON CONFLICT (tenant_id, nfc_uuid) DO UPDATE
-            SET car_inspection_id = EXCLUDED.car_inspection_id,
-                created_at = NOW()
-        RETURNING id, nfc_uuid, car_inspection_id, created_at
-        "#,
-    )
-    .bind(&nfc_uuid)
-    .bind(body.car_inspection_id)
-    .fetch_one(&mut *conn)
-    .await
-    .map_err(|e| {
-        tracing::error!("register_tag failed: {e}");
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?;
+    let tag = state
+        .nfc_tags
+        .register(tenant_id.0, &nfc_uuid, body.car_inspection_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("register_tag failed: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
 
     Ok((StatusCode::CREATED, Json(tag)))
 }
@@ -170,24 +107,15 @@ async fn delete_tag(
     Extension(tenant_id): Extension<TenantId>,
     Path(nfc_uuid): Path<String>,
 ) -> Result<StatusCode, StatusCode> {
-    let mut conn = state
-        .pool
-        .acquire()
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    set_current_tenant(&mut conn, &tenant_id.0.to_string())
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-
     let normalized = normalize_nfc_uuid(&nfc_uuid);
 
-    let result = sqlx::query("DELETE FROM car_inspection_nfc_tags WHERE nfc_uuid = $1")
-        .bind(&normalized)
-        .execute(&mut *conn)
+    let deleted = state
+        .nfc_tags
+        .delete(tenant_id.0, &normalized)
         .await
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
-    if result.rows_affected() == 0 {
+    if !deleted {
         return Err(StatusCode::NOT_FOUND);
     }
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -9,7 +9,7 @@ use uuid::Uuid;
 
 use rust_alc_api::auth::jwt::{create_access_token, JwtSecret};
 use rust_alc_api::db::models::User;
-use rust_alc_api::db::repository::PgEmployeeRepository;
+use rust_alc_api::db::repository::{PgEmployeeRepository, PgNfcTagRepository};
 use rust_alc_api::AppState;
 
 use mock_storage::MockStorage;
@@ -214,10 +214,12 @@ pub async fn setup_app_state() -> AppState {
     let mock_fcm: Arc<dyn rust_alc_api::fcm::FcmSenderTrait> = Arc::new(MockFcmSender::new());
 
     let employees = Arc::new(PgEmployeeRepository::new(pool.clone()));
+    let nfc_tags = Arc::new(PgNfcTagRepository::new(pool.clone()));
 
     AppState {
         pool,
         employees,
+        nfc_tags,
         storage,
         carins_storage: None,
         dtako_storage: Some(dtako_storage),
@@ -264,10 +266,12 @@ pub async fn setup_app_state_no_fcm() -> AppState {
         Arc::new(MockStorage::new("dtako-bucket"));
 
     let employees = Arc::new(PgEmployeeRepository::new(pool.clone()));
+    let nfc_tags = Arc::new(PgNfcTagRepository::new(pool.clone()));
 
     AppState {
         pool,
         employees,
+        nfc_tags,
         storage,
         carins_storage: None,
         dtako_storage: Some(dtako_storage),
@@ -302,10 +306,12 @@ pub async fn setup_app_state_failing_fcm() -> AppState {
     let failing_fcm: Arc<dyn rust_alc_api::fcm::FcmSenderTrait> = Arc::new(FailingFcmSender);
 
     let employees = Arc::new(PgEmployeeRepository::new(pool.clone()));
+    let nfc_tags = Arc::new(PgNfcTagRepository::new(pool.clone()));
 
     AppState {
         pool,
         employees,
+        nfc_tags,
         storage,
         carins_storage: None,
         dtako_storage: Some(dtako_storage),


### PR DESCRIPTION
## Summary
- `NfcTagRepository` trait (5メソッド) + `PgNfcTagRepository` 実装
- NfcTag struct を db/models.rs に移動
- nfc_tags.rs の全ハンドラを `state.nfc_tags.*()` 経由に書き換え

## Test plan
- [ ] CI pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)