### PR TITLE
refactor: introduce CarInspectionRepository (Phase 1d)

### DIFF
--- a/src/db/repository/car_inspections.rs
+++ b/src/db/repository/car_inspections.rs
@@ -1,0 +1,200 @@
+use async_trait::async_trait;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use super::TenantConn;
+
+/// 車検証ファイル (car_inspection_files_a から取得)
+#[derive(Debug, Clone, sqlx::FromRow, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CarInspectionFile {
+    pub uuid: Uuid,
+    #[sqlx(rename = "type")]
+    pub file_type: String,
+    #[sqlx(rename = "ElectCertMgNo")]
+    pub elect_cert_mg_no: String,
+    #[sqlx(rename = "GrantdateE")]
+    pub grantdate_e: String,
+    #[sqlx(rename = "GrantdateY")]
+    pub grantdate_y: String,
+    #[sqlx(rename = "GrantdateM")]
+    pub grantdate_m: String,
+    #[sqlx(rename = "GrantdateD")]
+    pub grantdate_d: String,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub modified_at: Option<chrono::DateTime<chrono::Utc>>,
+    pub deleted_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+/// 車両カテゴリ集計
+#[derive(Debug, serde::Serialize, sqlx::FromRow)]
+pub struct VehicleCategories {
+    pub car_kinds: Vec<String>,
+    pub uses: Vec<String>,
+    pub car_shapes: Vec<String>,
+    pub private_businesses: Vec<String>,
+}
+
+#[async_trait]
+pub trait CarInspectionRepository: Send + Sync {
+    /// 現在有効な車検証一覧 (DISTINCT ON CarId, to_jsonb)
+    async fn list_current(&self, tenant_id: Uuid) -> Result<Vec<serde_json::Value>, sqlx::Error>;
+
+    /// 期限切れ間近の車検証一覧
+    async fn list_expired(&self, tenant_id: Uuid) -> Result<Vec<serde_json::Value>, sqlx::Error>;
+
+    /// 更新対象の車検証一覧
+    async fn list_renew(&self, tenant_id: Uuid) -> Result<Vec<serde_json::Value>, sqlx::Error>;
+
+    /// ID で車検証取得 (to_jsonb)
+    async fn get_by_id(
+        &self,
+        tenant_id: Uuid,
+        id: i32,
+    ) -> Result<Option<serde_json::Value>, sqlx::Error>;
+
+    /// 車両カテゴリ一覧
+    async fn vehicle_categories(&self, tenant_id: Uuid) -> Result<VehicleCategories, sqlx::Error>;
+
+    /// 現在有効な車検証に紐づくファイル一覧
+    async fn list_current_files(
+        &self,
+        tenant_id: Uuid,
+    ) -> Result<Vec<CarInspectionFile>, sqlx::Error>;
+}
+
+pub struct PgCarInspectionRepository {
+    pool: PgPool,
+}
+
+impl PgCarInspectionRepository {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl CarInspectionRepository for PgCarInspectionRepository {
+    async fn list_current(&self, tenant_id: Uuid) -> Result<Vec<serde_json::Value>, sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        let rows = sqlx::query_as::<_, (serde_json::Value,)>(
+            r#"
+            SELECT to_jsonb(sub) FROM (
+                SELECT DISTINCT ON (ci."CarId")
+                    ci.*,
+                    (SELECT uuid::text FROM car_inspection_files_b
+                     WHERE tenant_id = ci.tenant_id
+                       AND "ElectCertMgNo" = ci."ElectCertMgNo"
+                       AND "GrantdateE" = ci."GrantdateE"
+                       AND "GrantdateY" = ci."GrantdateY"
+                       AND "GrantdateM" = ci."GrantdateM"
+                       AND "GrantdateD" = ci."GrantdateD"
+                       AND type = 'application/pdf'
+                       AND deleted_at IS NULL
+                     ORDER BY created_at DESC LIMIT 1) as "pdfUuid",
+                    (SELECT uuid::text FROM car_inspection_files_a
+                     WHERE tenant_id = ci.tenant_id
+                       AND "ElectCertMgNo" = ci."ElectCertMgNo"
+                       AND "GrantdateE" = ci."GrantdateE"
+                       AND "GrantdateY" = ci."GrantdateY"
+                       AND "GrantdateM" = ci."GrantdateM"
+                       AND "GrantdateD" = ci."GrantdateD"
+                       AND type = 'application/json'
+                       AND deleted_at IS NULL
+                     ORDER BY created_at DESC LIMIT 1) as "jsonUuid"
+                FROM car_inspection ci
+                ORDER BY ci."CarId",
+                         ci."TwodimensionCodeInfoValidPeriodExpirdate" DESC,
+                         ci.created_at DESC
+            ) sub
+            "#,
+        )
+        .fetch_all(&mut *tc.conn)
+        .await?;
+        Ok(rows.into_iter().map(|r| r.0).collect())
+    }
+
+    async fn list_expired(&self, tenant_id: Uuid) -> Result<Vec<serde_json::Value>, sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        let rows = sqlx::query_as::<_, (serde_json::Value,)>(
+            r#"
+            SELECT to_jsonb(ci)
+            FROM car_inspection ci
+            WHERE "TwodimensionCodeInfoValidPeriodExpirdate" <= to_char(CURRENT_DATE + INTERVAL '30 days', 'YYMMDD')
+            ORDER BY "TwodimensionCodeInfoValidPeriodExpirdate" ASC
+            "#,
+        )
+        .fetch_all(&mut *tc.conn)
+        .await?;
+        Ok(rows.into_iter().map(|r| r.0).collect())
+    }
+
+    async fn list_renew(&self, tenant_id: Uuid) -> Result<Vec<serde_json::Value>, sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        let rows = sqlx::query_as::<_, (serde_json::Value,)>(
+            r#"
+            SELECT to_jsonb(ci)
+            FROM car_inspection ci
+            WHERE "TwodimensionCodeInfoValidPeriodExpirdate" >= to_char(CURRENT_DATE, 'YYMMDD')
+              AND "TwodimensionCodeInfoValidPeriodExpirdate" <= to_char(CURRENT_DATE + INTERVAL '60 days', 'YYMMDD')
+            ORDER BY "TwodimensionCodeInfoValidPeriodExpirdate" ASC
+            "#,
+        )
+        .fetch_all(&mut *tc.conn)
+        .await?;
+        Ok(rows.into_iter().map(|r| r.0).collect())
+    }
+
+    async fn get_by_id(
+        &self,
+        tenant_id: Uuid,
+        id: i32,
+    ) -> Result<Option<serde_json::Value>, sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        let row = sqlx::query_as::<_, (serde_json::Value,)>(
+            "SELECT to_jsonb(ci) FROM car_inspection ci WHERE id = $1",
+        )
+        .bind(id)
+        .fetch_optional(&mut *tc.conn)
+        .await?;
+        Ok(row.map(|r| r.0))
+    }
+
+    async fn vehicle_categories(&self, tenant_id: Uuid) -> Result<VehicleCategories, sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        sqlx::query_as::<_, VehicleCategories>(
+            r#"SELECT
+                COALESCE(ARRAY(SELECT DISTINCT "CarKind" FROM alc_api.car_inspection WHERE "CarKind" != '' ORDER BY "CarKind"), '{}') AS car_kinds,
+                COALESCE(ARRAY(SELECT DISTINCT "Use" FROM alc_api.car_inspection WHERE "Use" != '' ORDER BY "Use"), '{}') AS uses,
+                COALESCE(ARRAY(SELECT DISTINCT "CarShape" FROM alc_api.car_inspection WHERE "CarShape" != '' ORDER BY "CarShape"), '{}') AS car_shapes,
+                COALESCE(ARRAY(SELECT DISTINCT "PrivateBusiness" FROM alc_api.car_inspection WHERE "PrivateBusiness" != '' ORDER BY "PrivateBusiness"), '{}') AS private_businesses
+            "#,
+        )
+        .fetch_one(&mut *tc.conn)
+        .await
+    }
+
+    async fn list_current_files(
+        &self,
+        tenant_id: Uuid,
+    ) -> Result<Vec<CarInspectionFile>, sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        sqlx::query_as::<_, CarInspectionFile>(
+            r#"
+            SELECT cif.*
+            FROM car_inspection_files_a cif
+            INNER JOIN car_inspection ci ON
+                cif."ElectCertMgNo" = ci."ElectCertMgNo"
+                AND cif."GrantdateE" = ci."GrantdateE"
+                AND cif."GrantdateY" = ci."GrantdateY"
+                AND cif."GrantdateM" = ci."GrantdateM"
+                AND cif."GrantdateD" = ci."GrantdateD"
+            WHERE cif.deleted_at IS NULL
+              AND ci."TwodimensionCodeInfoValidPeriodExpirdate" >= to_char(CURRENT_DATE, 'YYMMDD')
+            ORDER BY cif.created_at DESC
+            "#,
+        )
+        .fetch_all(&mut *tc.conn)
+        .await
+    }
+}

--- a/src/db/repository/mod.rs
+++ b/src/db/repository/mod.rs
@@ -1,8 +1,10 @@
+pub mod car_inspections;
 pub mod employees;
 pub mod nfc_tags;
 pub mod tenko_call;
 pub mod timecard;
 
+pub use car_inspections::{CarInspectionRepository, PgCarInspectionRepository};
 pub use employees::{EmployeeRepository, PgEmployeeRepository};
 pub use nfc_tags::{NfcTagRepository, PgNfcTagRepository};
 pub use tenko_call::{PgTenkoCallRepository, TenkoCallRepository};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,13 +15,15 @@ pub mod webhook;
 use std::sync::Arc;
 
 use db::repository::{
-    EmployeeRepository, NfcTagRepository, TenkoCallRepository, TimecardRepository,
+    CarInspectionRepository, EmployeeRepository, NfcTagRepository, TenkoCallRepository,
+    TimecardRepository,
 };
 use storage::StorageBackend;
 
 #[derive(Clone)]
 pub struct AppState {
     pub pool: sqlx::PgPool,
+    pub car_inspections: Arc<dyn CarInspectionRepository>,
     pub employees: Arc<dyn EmployeeRepository>,
     pub timecard: Arc<dyn TimecardRepository>,
     pub tenko_call: Arc<dyn TenkoCallRepository>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,8 @@ use tracing_subscriber::EnvFilter;
 use rust_alc_api::auth::google::GoogleTokenVerifier;
 use rust_alc_api::auth::jwt::JwtSecret;
 use rust_alc_api::db::repository::{
-    PgEmployeeRepository, PgNfcTagRepository, PgTenkoCallRepository, PgTimecardRepository,
+    PgCarInspectionRepository, PgEmployeeRepository, PgNfcTagRepository, PgTenkoCallRepository,
+    PgTimecardRepository,
 };
 use rust_alc_api::storage::StorageBackend;
 use rust_alc_api::AppState;
@@ -115,6 +116,7 @@ async fn main() -> anyhow::Result<()> {
             as Arc<dyn rust_alc_api::fcm::FcmSenderTrait>
     });
 
+    let car_inspections = Arc::new(PgCarInspectionRepository::new(pool.clone()));
     let employees = Arc::new(PgEmployeeRepository::new(pool.clone()));
     let timecard = Arc::new(PgTimecardRepository::new(pool.clone()));
     let tenko_call = Arc::new(PgTenkoCallRepository::new(pool.clone()));
@@ -122,6 +124,7 @@ async fn main() -> anyhow::Result<()> {
 
     let state = AppState {
         pool: pool.clone(),
+        car_inspections,
         employees,
         timecard,
         tenko_call,

--- a/src/routes/car_inspection_files.rs
+++ b/src/routes/car_inspection_files.rs
@@ -1,35 +1,12 @@
 use axum::{extract::State, http::StatusCode, routing::get, Extension, Json, Router};
 use serde::Serialize;
-use sqlx::FromRow;
-use uuid::Uuid;
 
-use crate::db::tenant::set_current_tenant;
+use crate::db::repository::car_inspections::CarInspectionFile;
 use crate::middleware::auth::TenantId;
 use crate::AppState;
 
 pub fn tenant_router() -> Router<AppState> {
     Router::new().route("/car-inspection-files/current", get(list_current))
-}
-
-#[derive(Debug, Clone, FromRow, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct CarInspectionFile {
-    pub uuid: Uuid,
-    #[sqlx(rename = "type")]
-    pub file_type: String,
-    #[sqlx(rename = "ElectCertMgNo")]
-    pub elect_cert_mg_no: String,
-    #[sqlx(rename = "GrantdateE")]
-    pub grantdate_e: String,
-    #[sqlx(rename = "GrantdateY")]
-    pub grantdate_y: String,
-    #[sqlx(rename = "GrantdateM")]
-    pub grantdate_m: String,
-    #[sqlx(rename = "GrantdateD")]
-    pub grantdate_d: String,
-    pub created_at: chrono::DateTime<chrono::Utc>,
-    pub modified_at: Option<chrono::DateTime<chrono::Utc>>,
-    pub deleted_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 #[derive(Debug, Serialize)]
@@ -41,36 +18,14 @@ async fn list_current(
     State(state): State<AppState>,
     Extension(tenant_id): Extension<TenantId>,
 ) -> Result<Json<ListResponse>, StatusCode> {
-    let mut conn = state
-        .pool
-        .acquire()
+    let rows = state
+        .car_inspections
+        .list_current_files(tenant_id.0)
         .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    set_current_tenant(&mut conn, &tenant_id.0.to_string())
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-
-    let rows = sqlx::query_as::<_, CarInspectionFile>(
-        r#"
-        SELECT cif.*
-        FROM car_inspection_files_a cif
-        INNER JOIN car_inspection ci ON
-            cif."ElectCertMgNo" = ci."ElectCertMgNo"
-            AND cif."GrantdateE" = ci."GrantdateE"
-            AND cif."GrantdateY" = ci."GrantdateY"
-            AND cif."GrantdateM" = ci."GrantdateM"
-            AND cif."GrantdateD" = ci."GrantdateD"
-        WHERE cif.deleted_at IS NULL
-          AND ci."TwodimensionCodeInfoValidPeriodExpirdate" >= to_char(CURRENT_DATE, 'YYMMDD')
-        ORDER BY cif.created_at DESC
-        "#,
-    )
-    .fetch_all(&mut *conn)
-    .await
-    .map_err(|e| {
-        tracing::error!("list_current_car_inspection_files failed: {e}");
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?;
+        .map_err(|e| {
+            tracing::error!("list_current_car_inspection_files failed: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
 
     Ok(Json(ListResponse { files: rows }))
 }

--- a/src/routes/car_inspections.rs
+++ b/src/routes/car_inspections.rs
@@ -6,7 +6,6 @@ use axum::{
 };
 use serde::Serialize;
 
-use crate::db::tenant::set_current_tenant;
 use crate::middleware::auth::TenantId;
 use crate::AppState;
 
@@ -32,56 +31,17 @@ async fn list_current(
     State(state): State<AppState>,
     Extension(tenant_id): Extension<TenantId>,
 ) -> Result<Json<ListResponse>, StatusCode> {
-    let mut conn = state
-        .pool
-        .acquire()
+    let rows = state
+        .car_inspections
+        .list_current(tenant_id.0)
         .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    set_current_tenant(&mut conn, &tenant_id.0.to_string())
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-
-    let rows = sqlx::query_as::<_, (serde_json::Value,)>(
-        r#"
-        SELECT to_jsonb(sub) FROM (
-            SELECT DISTINCT ON (ci."CarId")
-                ci.*,
-                (SELECT uuid::text FROM car_inspection_files_b
-                 WHERE tenant_id = ci.tenant_id
-                   AND "ElectCertMgNo" = ci."ElectCertMgNo"
-                   AND "GrantdateE" = ci."GrantdateE"
-                   AND "GrantdateY" = ci."GrantdateY"
-                   AND "GrantdateM" = ci."GrantdateM"
-                   AND "GrantdateD" = ci."GrantdateD"
-                   AND type = 'application/pdf'
-                   AND deleted_at IS NULL
-                 ORDER BY created_at DESC LIMIT 1) as "pdfUuid",
-                (SELECT uuid::text FROM car_inspection_files_a
-                 WHERE tenant_id = ci.tenant_id
-                   AND "ElectCertMgNo" = ci."ElectCertMgNo"
-                   AND "GrantdateE" = ci."GrantdateE"
-                   AND "GrantdateY" = ci."GrantdateY"
-                   AND "GrantdateM" = ci."GrantdateM"
-                   AND "GrantdateD" = ci."GrantdateD"
-                   AND type = 'application/json'
-                   AND deleted_at IS NULL
-                 ORDER BY created_at DESC LIMIT 1) as "jsonUuid"
-            FROM car_inspection ci
-            ORDER BY ci."CarId",
-                     ci."TwodimensionCodeInfoValidPeriodExpirdate" DESC,
-                     ci.created_at DESC
-        ) sub
-        "#,
-    )
-    .fetch_all(&mut *conn)
-    .await
-    .map_err(|e| {
-        tracing::error!("list_current failed: {e}");
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?;
+        .map_err(|e| {
+            tracing::error!("list_current failed: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
 
     Ok(Json(ListResponse {
-        car_inspections: rows.into_iter().map(|r| r.0).collect(),
+        car_inspections: rows,
     }))
 }
 
@@ -90,65 +50,31 @@ async fn get_by_id(
     Extension(tenant_id): Extension<TenantId>,
     Path(id): Path<i32>,
 ) -> Result<Json<serde_json::Value>, StatusCode> {
-    let mut conn = state
-        .pool
-        .acquire()
+    let row = state
+        .car_inspections
+        .get_by_id(tenant_id.0, id)
         .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    set_current_tenant(&mut conn, &tenant_id.0.to_string())
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+        .map_err(|e| {
+            tracing::error!("get_by_id failed: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?
+        .ok_or(StatusCode::NOT_FOUND)?;
 
-    let row = sqlx::query_as::<_, (serde_json::Value,)>(
-        "SELECT to_jsonb(ci) FROM car_inspection ci WHERE id = $1",
-    )
-    .bind(id)
-    .fetch_optional(&mut *conn)
-    .await
-    .map_err(|e| {
-        tracing::error!("get_by_id failed: {e}");
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?
-    .ok_or(StatusCode::NOT_FOUND)?;
-
-    Ok(Json(row.0))
-}
-
-#[derive(Debug, Serialize, sqlx::FromRow)]
-struct VehicleCategories {
-    car_kinds: Vec<String>,
-    uses: Vec<String>,
-    car_shapes: Vec<String>,
-    private_businesses: Vec<String>,
+    Ok(Json(row))
 }
 
 async fn vehicle_categories(
     State(state): State<AppState>,
     Extension(tenant_id): Extension<TenantId>,
-) -> Result<Json<VehicleCategories>, StatusCode> {
-    let mut conn = state
-        .pool
-        .acquire()
+) -> Result<Json<crate::db::repository::car_inspections::VehicleCategories>, StatusCode> {
+    let row = state
+        .car_inspections
+        .vehicle_categories(tenant_id.0)
         .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    set_current_tenant(&mut conn, &tenant_id.0.to_string())
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-
-    let row = sqlx::query_as::<_, VehicleCategories>(
-        r#"SELECT
-            COALESCE(ARRAY(SELECT DISTINCT "CarKind" FROM alc_api.car_inspection WHERE "CarKind" != '' ORDER BY "CarKind"), '{}') AS car_kinds,
-            COALESCE(ARRAY(SELECT DISTINCT "Use" FROM alc_api.car_inspection WHERE "Use" != '' ORDER BY "Use"), '{}') AS uses,
-            COALESCE(ARRAY(SELECT DISTINCT "CarShape" FROM alc_api.car_inspection WHERE "CarShape" != '' ORDER BY "CarShape"), '{}') AS car_shapes,
-            COALESCE(ARRAY(SELECT DISTINCT "PrivateBusiness" FROM alc_api.car_inspection WHERE "PrivateBusiness" != '' ORDER BY "PrivateBusiness"), '{}') AS private_businesses
-        "#,
-    )
-    .fetch_one(&mut *conn)
-    .await
-    .map_err(|e| {
-        tracing::error!("vehicle_categories failed: {e}");
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?;
+        .map_err(|e| {
+            tracing::error!("vehicle_categories failed: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
 
     Ok(Json(row))
 }
@@ -157,32 +83,17 @@ async fn list_expired(
     State(state): State<AppState>,
     Extension(tenant_id): Extension<TenantId>,
 ) -> Result<Json<ListResponse>, StatusCode> {
-    let mut conn = state
-        .pool
-        .acquire()
+    let rows = state
+        .car_inspections
+        .list_expired(tenant_id.0)
         .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    set_current_tenant(&mut conn, &tenant_id.0.to_string())
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-
-    let rows = sqlx::query_as::<_, (serde_json::Value,)>(
-        r#"
-        SELECT to_jsonb(ci)
-        FROM car_inspection ci
-        WHERE "TwodimensionCodeInfoValidPeriodExpirdate" <= to_char(CURRENT_DATE + INTERVAL '30 days', 'YYMMDD')
-        ORDER BY "TwodimensionCodeInfoValidPeriodExpirdate" ASC
-        "#,
-    )
-    .fetch_all(&mut *conn)
-    .await
-    .map_err(|e| {
-        tracing::error!("list_expired failed: {e}");
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?;
+        .map_err(|e| {
+            tracing::error!("list_expired failed: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
 
     Ok(Json(ListResponse {
-        car_inspections: rows.into_iter().map(|r| r.0).collect(),
+        car_inspections: rows,
     }))
 }
 
@@ -190,32 +101,16 @@ async fn list_renew(
     State(state): State<AppState>,
     Extension(tenant_id): Extension<TenantId>,
 ) -> Result<Json<ListResponse>, StatusCode> {
-    let mut conn = state
-        .pool
-        .acquire()
+    let rows = state
+        .car_inspections
+        .list_renew(tenant_id.0)
         .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    set_current_tenant(&mut conn, &tenant_id.0.to_string())
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-
-    let rows = sqlx::query_as::<_, (serde_json::Value,)>(
-        r#"
-        SELECT to_jsonb(ci)
-        FROM car_inspection ci
-        WHERE "TwodimensionCodeInfoValidPeriodExpirdate" >= to_char(CURRENT_DATE, 'YYMMDD')
-          AND "TwodimensionCodeInfoValidPeriodExpirdate" <= to_char(CURRENT_DATE + INTERVAL '60 days', 'YYMMDD')
-        ORDER BY "TwodimensionCodeInfoValidPeriodExpirdate" ASC
-        "#,
-    )
-    .fetch_all(&mut *conn)
-    .await
-    .map_err(|e| {
-        tracing::error!("list_renew failed: {e}");
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?;
+        .map_err(|e| {
+            tracing::error!("list_renew failed: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
 
     Ok(Json(ListResponse {
-        car_inspections: rows.into_iter().map(|r| r.0).collect(),
+        car_inspections: rows,
     }))
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -10,7 +10,8 @@ use uuid::Uuid;
 use rust_alc_api::auth::jwt::{create_access_token, JwtSecret};
 use rust_alc_api::db::models::User;
 use rust_alc_api::db::repository::{
-    PgEmployeeRepository, PgNfcTagRepository, PgTenkoCallRepository, PgTimecardRepository,
+    PgCarInspectionRepository, PgEmployeeRepository, PgNfcTagRepository, PgTenkoCallRepository,
+    PgTimecardRepository,
 };
 use rust_alc_api::AppState;
 
@@ -215,6 +216,7 @@ pub async fn setup_app_state() -> AppState {
 
     let mock_fcm: Arc<dyn rust_alc_api::fcm::FcmSenderTrait> = Arc::new(MockFcmSender::new());
 
+    let car_inspections = Arc::new(PgCarInspectionRepository::new(pool.clone()));
     let employees = Arc::new(PgEmployeeRepository::new(pool.clone()));
     let timecard = Arc::new(PgTimecardRepository::new(pool.clone()));
     let tenko_call = Arc::new(PgTenkoCallRepository::new(pool.clone()));
@@ -222,6 +224,7 @@ pub async fn setup_app_state() -> AppState {
 
     AppState {
         pool,
+        car_inspections,
         employees,
         timecard,
         tenko_call,
@@ -271,6 +274,7 @@ pub async fn setup_app_state_no_fcm() -> AppState {
     let dtako_storage: Arc<dyn rust_alc_api::storage::StorageBackend> =
         Arc::new(MockStorage::new("dtako-bucket"));
 
+    let car_inspections = Arc::new(PgCarInspectionRepository::new(pool.clone()));
     let employees = Arc::new(PgEmployeeRepository::new(pool.clone()));
     let timecard = Arc::new(PgTimecardRepository::new(pool.clone()));
     let tenko_call = Arc::new(PgTenkoCallRepository::new(pool.clone()));
@@ -278,6 +282,7 @@ pub async fn setup_app_state_no_fcm() -> AppState {
 
     AppState {
         pool,
+        car_inspections,
         employees,
         timecard,
         tenko_call,
@@ -315,6 +320,7 @@ pub async fn setup_app_state_failing_fcm() -> AppState {
 
     let failing_fcm: Arc<dyn rust_alc_api::fcm::FcmSenderTrait> = Arc::new(FailingFcmSender);
 
+    let car_inspections = Arc::new(PgCarInspectionRepository::new(pool.clone()));
     let employees = Arc::new(PgEmployeeRepository::new(pool.clone()));
     let timecard = Arc::new(PgTimecardRepository::new(pool.clone()));
     let tenko_call = Arc::new(PgTenkoCallRepository::new(pool.clone()));
@@ -322,6 +328,7 @@ pub async fn setup_app_state_failing_fcm() -> AppState {
 
     AppState {
         pool,
+        car_inspections,
         employees,
         timecard,
         tenko_call,


### PR DESCRIPTION
## Summary
- `CarInspectionRepository` trait (6メソッド) + `PgCarInspectionRepository` 実装
- car_inspections.rs + car_inspection_files.rs を統合リポジトリに移行

## Test plan
- [ ] CI pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)