### PR TITLE
refactor: introduce CommunicationItemsRepository (Phase 1e)

### DIFF
--- a/src/db/repository/communication_items.rs
+++ b/src/db/repository/communication_items.rs
@@ -1,0 +1,234 @@
+use async_trait::async_trait;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use crate::db::models::{CommunicationItem, CreateCommunicationItem, UpdateCommunicationItem};
+
+use super::TenantConn;
+
+/// 伝達事項の一覧取得結果 (WITH name join)
+#[derive(Debug, serde::Serialize, sqlx::FromRow)]
+pub struct CommunicationItemWithName {
+    pub id: Uuid,
+    pub tenant_id: Uuid,
+    pub title: String,
+    pub content: String,
+    pub priority: String,
+    pub target_employee_id: Option<Uuid>,
+    pub target_employee_name: Option<String>,
+    pub is_active: bool,
+    pub effective_from: Option<chrono::DateTime<chrono::Utc>>,
+    pub effective_until: Option<chrono::DateTime<chrono::Utc>>,
+    pub created_by: Option<String>,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub updated_at: chrono::DateTime<chrono::Utc>,
+}
+
+#[async_trait]
+pub trait CommunicationItemsRepository: Send + Sync {
+    /// フィルタ付き一覧 (件数 + ページネーション)
+    async fn list(
+        &self,
+        tenant_id: Uuid,
+        is_active: Option<bool>,
+        target_employee_id: Option<Uuid>,
+        per_page: i64,
+        offset: i64,
+    ) -> Result<(Vec<CommunicationItemWithName>, i64), sqlx::Error>;
+
+    /// 有効期間内のアクティブ一覧
+    async fn list_active(
+        &self,
+        tenant_id: Uuid,
+        target_employee_id: Option<Uuid>,
+    ) -> Result<Vec<CommunicationItemWithName>, sqlx::Error>;
+
+    /// ID で取得
+    async fn get(
+        &self,
+        tenant_id: Uuid,
+        id: Uuid,
+    ) -> Result<Option<CommunicationItem>, sqlx::Error>;
+
+    /// 作成
+    async fn create(
+        &self,
+        tenant_id: Uuid,
+        input: &CreateCommunicationItem,
+    ) -> Result<CommunicationItem, sqlx::Error>;
+
+    /// 更新
+    async fn update(
+        &self,
+        tenant_id: Uuid,
+        id: Uuid,
+        input: &UpdateCommunicationItem,
+    ) -> Result<Option<CommunicationItem>, sqlx::Error>;
+
+    /// 削除。Returns true if a row was affected.
+    async fn delete(&self, tenant_id: Uuid, id: Uuid) -> Result<bool, sqlx::Error>;
+}
+
+pub struct PgCommunicationItemsRepository {
+    pool: PgPool,
+}
+
+impl PgCommunicationItemsRepository {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl CommunicationItemsRepository for PgCommunicationItemsRepository {
+    async fn list(
+        &self,
+        tenant_id: Uuid,
+        is_active: Option<bool>,
+        target_employee_id: Option<Uuid>,
+        per_page: i64,
+        offset: i64,
+    ) -> Result<(Vec<CommunicationItemWithName>, i64), sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+
+        let total: i64 = sqlx::query_scalar(
+            r#"SELECT COUNT(*) FROM alc_api.communication_items c
+               WHERE ($1::BOOLEAN IS NULL OR c.is_active = $1)
+                 AND ($2::UUID IS NULL OR c.target_employee_id = $2 OR c.target_employee_id IS NULL)"#,
+        )
+        .bind(is_active)
+        .bind(target_employee_id)
+        .fetch_one(&mut *tc.conn)
+        .await?;
+
+        let items = sqlx::query_as::<_, CommunicationItemWithName>(
+            r#"SELECT c.*, e.name AS target_employee_name
+               FROM alc_api.communication_items c
+               LEFT JOIN alc_api.employees e ON e.id = c.target_employee_id
+               WHERE ($1::BOOLEAN IS NULL OR c.is_active = $1)
+                 AND ($2::UUID IS NULL OR c.target_employee_id = $2 OR c.target_employee_id IS NULL)
+               ORDER BY
+                 CASE c.priority WHEN 'urgent' THEN 0 WHEN 'normal' THEN 1 ELSE 2 END,
+                 c.created_at DESC
+               LIMIT $3 OFFSET $4"#,
+        )
+        .bind(is_active)
+        .bind(target_employee_id)
+        .bind(per_page)
+        .bind(offset)
+        .fetch_all(&mut *tc.conn)
+        .await?;
+
+        Ok((items, total))
+    }
+
+    async fn list_active(
+        &self,
+        tenant_id: Uuid,
+        target_employee_id: Option<Uuid>,
+    ) -> Result<Vec<CommunicationItemWithName>, sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+
+        sqlx::query_as::<_, CommunicationItemWithName>(
+            r#"SELECT c.*, e.name AS target_employee_name
+               FROM alc_api.communication_items c
+               LEFT JOIN alc_api.employees e ON e.id = c.target_employee_id
+               WHERE c.is_active = true
+                 AND (c.effective_from IS NULL OR c.effective_from <= now())
+                 AND (c.effective_until IS NULL OR c.effective_until >= now())
+                 AND ($1::UUID IS NULL OR c.target_employee_id = $1 OR c.target_employee_id IS NULL)
+               ORDER BY
+                 CASE c.priority WHEN 'urgent' THEN 0 WHEN 'normal' THEN 1 ELSE 2 END,
+                 c.created_at DESC"#,
+        )
+        .bind(target_employee_id)
+        .fetch_all(&mut *tc.conn)
+        .await
+    }
+
+    async fn get(
+        &self,
+        tenant_id: Uuid,
+        id: Uuid,
+    ) -> Result<Option<CommunicationItem>, sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+
+        sqlx::query_as::<_, CommunicationItem>(
+            "SELECT * FROM alc_api.communication_items WHERE id = $1",
+        )
+        .bind(id)
+        .fetch_optional(&mut *tc.conn)
+        .await
+    }
+
+    async fn create(
+        &self,
+        tenant_id: Uuid,
+        input: &CreateCommunicationItem,
+    ) -> Result<CommunicationItem, sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+
+        sqlx::query_as::<_, CommunicationItem>(
+            r#"INSERT INTO alc_api.communication_items
+                   (tenant_id, title, content, priority, target_employee_id, effective_from, effective_until, created_by)
+               VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+               RETURNING *"#,
+        )
+        .bind(tenant_id)
+        .bind(&input.title)
+        .bind(input.content.as_deref().unwrap_or(""))
+        .bind(input.priority.as_deref().unwrap_or("normal"))
+        .bind(input.target_employee_id)
+        .bind(input.effective_from)
+        .bind(input.effective_until)
+        .bind(&input.created_by)
+        .fetch_one(&mut *tc.conn)
+        .await
+    }
+
+    async fn update(
+        &self,
+        tenant_id: Uuid,
+        id: Uuid,
+        input: &UpdateCommunicationItem,
+    ) -> Result<Option<CommunicationItem>, sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+
+        sqlx::query_as::<_, CommunicationItem>(
+            r#"UPDATE alc_api.communication_items SET
+                   title = COALESCE($1, title),
+                   content = COALESCE($2, content),
+                   priority = COALESCE($3, priority),
+                   target_employee_id = CASE WHEN $5 THEN $4 ELSE target_employee_id END,
+                   is_active = COALESCE($6, is_active),
+                   effective_from = CASE WHEN $8 THEN $7 ELSE effective_from END,
+                   effective_until = CASE WHEN $10 THEN $9 ELSE effective_until END,
+                   updated_at = now()
+               WHERE id = $11
+               RETURNING *"#,
+        )
+        .bind(&input.title)
+        .bind(&input.content)
+        .bind(&input.priority)
+        .bind(input.target_employee_id)
+        .bind(input.target_employee_id.is_some())
+        .bind(input.is_active)
+        .bind(input.effective_from)
+        .bind(input.effective_from.is_some())
+        .bind(input.effective_until)
+        .bind(input.effective_until.is_some())
+        .bind(id)
+        .fetch_optional(&mut *tc.conn)
+        .await
+    }
+
+    async fn delete(&self, tenant_id: Uuid, id: Uuid) -> Result<bool, sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+
+        let result = sqlx::query("DELETE FROM alc_api.communication_items WHERE id = $1")
+            .bind(id)
+            .execute(&mut *tc.conn)
+            .await?;
+        Ok(result.rows_affected() > 0)
+    }
+}

--- a/src/db/repository/mod.rs
+++ b/src/db/repository/mod.rs
@@ -1,8 +1,10 @@
+pub mod communication_items;
 pub mod employees;
 pub mod nfc_tags;
 pub mod tenko_call;
 pub mod timecard;
 
+pub use communication_items::{CommunicationItemsRepository, PgCommunicationItemsRepository};
 pub use employees::{EmployeeRepository, PgEmployeeRepository};
 pub use nfc_tags::{NfcTagRepository, PgNfcTagRepository};
 pub use tenko_call::{PgTenkoCallRepository, TenkoCallRepository};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,8 @@ pub mod webhook;
 use std::sync::Arc;
 
 use db::repository::{
-    EmployeeRepository, NfcTagRepository, TenkoCallRepository, TimecardRepository,
+    CommunicationItemsRepository, EmployeeRepository, NfcTagRepository, TenkoCallRepository,
+    TimecardRepository,
 };
 use storage::StorageBackend;
 
@@ -23,6 +24,7 @@ use storage::StorageBackend;
 pub struct AppState {
     pub pool: sqlx::PgPool,
     pub employees: Arc<dyn EmployeeRepository>,
+    pub communication_items: Arc<dyn CommunicationItemsRepository>,
     pub timecard: Arc<dyn TimecardRepository>,
     pub tenko_call: Arc<dyn TenkoCallRepository>,
     pub nfc_tags: Arc<dyn NfcTagRepository>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,8 @@ use tracing_subscriber::EnvFilter;
 use rust_alc_api::auth::google::GoogleTokenVerifier;
 use rust_alc_api::auth::jwt::JwtSecret;
 use rust_alc_api::db::repository::{
-    PgEmployeeRepository, PgNfcTagRepository, PgTenkoCallRepository, PgTimecardRepository,
+    PgCommunicationItemsRepository, PgEmployeeRepository, PgNfcTagRepository,
+    PgTenkoCallRepository, PgTimecardRepository,
 };
 use rust_alc_api::storage::StorageBackend;
 use rust_alc_api::AppState;
@@ -116,6 +117,7 @@ async fn main() -> anyhow::Result<()> {
     });
 
     let employees = Arc::new(PgEmployeeRepository::new(pool.clone()));
+    let communication_items = Arc::new(PgCommunicationItemsRepository::new(pool.clone()));
     let timecard = Arc::new(PgTimecardRepository::new(pool.clone()));
     let tenko_call = Arc::new(PgTenkoCallRepository::new(pool.clone()));
     let nfc_tags = Arc::new(PgNfcTagRepository::new(pool.clone()));
@@ -123,6 +125,7 @@ async fn main() -> anyhow::Result<()> {
     let state = AppState {
         pool: pool.clone(),
         employees,
+        communication_items,
         timecard,
         tenko_call,
         nfc_tags,

--- a/src/routes/communication_items.rs
+++ b/src/routes/communication_items.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::db::models::{CommunicationItem, CreateCommunicationItem, UpdateCommunicationItem};
-use crate::db::tenant::set_current_tenant;
+use crate::db::repository::communication_items::CommunicationItemWithName;
 use crate::middleware::auth::TenantId;
 use crate::AppState;
 
@@ -38,23 +38,6 @@ struct CommunicationItemsResponse {
     per_page: i64,
 }
 
-#[derive(Debug, Serialize, sqlx::FromRow)]
-struct CommunicationItemWithName {
-    id: Uuid,
-    tenant_id: Uuid,
-    title: String,
-    content: String,
-    priority: String,
-    target_employee_id: Option<Uuid>,
-    target_employee_name: Option<String>,
-    is_active: bool,
-    effective_from: Option<chrono::DateTime<chrono::Utc>>,
-    effective_until: Option<chrono::DateTime<chrono::Utc>>,
-    created_by: Option<String>,
-    created_at: chrono::DateTime<chrono::Utc>,
-    updated_at: chrono::DateTime<chrono::Utc>,
-}
-
 async fn list_items(
     State(state): State<AppState>,
     tenant: axum::Extension<TenantId>,
@@ -65,47 +48,20 @@ async fn list_items(
     let per_page = filter.per_page.unwrap_or(20).min(100);
     let offset = (page - 1) * per_page;
 
-    let mut conn = state
-        .pool
-        .acquire()
+    let (items, total) = state
+        .communication_items
+        .list(
+            tenant_id,
+            filter.is_active,
+            filter.target_employee_id,
+            per_page,
+            offset,
+        )
         .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    set_current_tenant(&mut conn, &tenant_id.to_string())
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-
-    let total: i64 = sqlx::query_scalar(
-        r#"SELECT COUNT(*) FROM alc_api.communication_items c
-           WHERE ($1::BOOLEAN IS NULL OR c.is_active = $1)
-             AND ($2::UUID IS NULL OR c.target_employee_id = $2 OR c.target_employee_id IS NULL)"#,
-    )
-    .bind(filter.is_active)
-    .bind(filter.target_employee_id)
-    .fetch_one(&mut *conn)
-    .await
-    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-
-    let items = sqlx::query_as::<_, CommunicationItemWithName>(
-        r#"SELECT c.*, e.name AS target_employee_name
-           FROM alc_api.communication_items c
-           LEFT JOIN alc_api.employees e ON e.id = c.target_employee_id
-           WHERE ($1::BOOLEAN IS NULL OR c.is_active = $1)
-             AND ($2::UUID IS NULL OR c.target_employee_id = $2 OR c.target_employee_id IS NULL)
-           ORDER BY
-             CASE c.priority WHEN 'urgent' THEN 0 WHEN 'normal' THEN 1 ELSE 2 END,
-             c.created_at DESC
-           LIMIT $3 OFFSET $4"#,
-    )
-    .bind(filter.is_active)
-    .bind(filter.target_employee_id)
-    .bind(per_page)
-    .bind(offset)
-    .fetch_all(&mut *conn)
-    .await
-    .map_err(|e| {
-        tracing::error!("communication_items list error: {:?}", e);
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?;
+        .map_err(|e| {
+            tracing::error!("communication_items list error: {:?}", e);
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
 
     Ok(Json(CommunicationItemsResponse {
         items,
@@ -122,34 +78,15 @@ async fn list_active_items(
     Query(filter): Query<CommunicationFilter>,
 ) -> Result<Json<Vec<CommunicationItemWithName>>, StatusCode> {
     let tenant_id = tenant.0 .0;
-    let mut conn = state
-        .pool
-        .acquire()
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    set_current_tenant(&mut conn, &tenant_id.to_string())
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
-    let items = sqlx::query_as::<_, CommunicationItemWithName>(
-        r#"SELECT c.*, e.name AS target_employee_name
-           FROM alc_api.communication_items c
-           LEFT JOIN alc_api.employees e ON e.id = c.target_employee_id
-           WHERE c.is_active = true
-             AND (c.effective_from IS NULL OR c.effective_from <= now())
-             AND (c.effective_until IS NULL OR c.effective_until >= now())
-             AND ($1::UUID IS NULL OR c.target_employee_id = $1 OR c.target_employee_id IS NULL)
-           ORDER BY
-             CASE c.priority WHEN 'urgent' THEN 0 WHEN 'normal' THEN 1 ELSE 2 END,
-             c.created_at DESC"#,
-    )
-    .bind(filter.target_employee_id)
-    .fetch_all(&mut *conn)
-    .await
-    .map_err(|e| {
-        tracing::error!("communication_items active error: {:?}", e);
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?;
+    let items = state
+        .communication_items
+        .list_active(tenant_id, filter.target_employee_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("communication_items active error: {:?}", e);
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
 
     Ok(Json(items))
 }
@@ -160,24 +97,14 @@ async fn get_item(
     Path(id): Path<Uuid>,
 ) -> Result<Json<CommunicationItem>, StatusCode> {
     let tenant_id = tenant.0 .0;
-    let mut conn = state
-        .pool
-        .acquire()
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    set_current_tenant(&mut conn, &tenant_id.to_string())
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
-    sqlx::query_as::<_, CommunicationItem>(
-        "SELECT * FROM alc_api.communication_items WHERE id = $1",
-    )
-    .bind(id)
-    .fetch_optional(&mut *conn)
-    .await
-    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
-    .map(Json)
-    .ok_or(StatusCode::NOT_FOUND)
+    state
+        .communication_items
+        .get(tenant_id, id)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+        .map(Json)
+        .ok_or(StatusCode::NOT_FOUND)
 }
 
 async fn create_item(
@@ -186,35 +113,15 @@ async fn create_item(
     Json(body): Json<CreateCommunicationItem>,
 ) -> Result<(StatusCode, Json<CommunicationItem>), StatusCode> {
     let tenant_id = tenant.0 .0;
-    let mut conn = state
-        .pool
-        .acquire()
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    set_current_tenant(&mut conn, &tenant_id.to_string())
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
-    let item = sqlx::query_as::<_, CommunicationItem>(
-        r#"INSERT INTO alc_api.communication_items
-               (tenant_id, title, content, priority, target_employee_id, effective_from, effective_until, created_by)
-           VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-           RETURNING *"#,
-    )
-    .bind(tenant_id)
-    .bind(&body.title)
-    .bind(body.content.as_deref().unwrap_or(""))
-    .bind(body.priority.as_deref().unwrap_or("normal"))
-    .bind(body.target_employee_id)
-    .bind(body.effective_from)
-    .bind(body.effective_until)
-    .bind(&body.created_by)
-    .fetch_one(&mut *conn)
-    .await
-    .map_err(|e| {
-        tracing::error!("communication_items create error: {:?}", e);
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?;
+    let item = state
+        .communication_items
+        .create(tenant_id, &body)
+        .await
+        .map_err(|e| {
+            tracing::error!("communication_items create error: {:?}", e);
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
 
     Ok((StatusCode::CREATED, Json(item)))
 }
@@ -226,44 +133,13 @@ async fn update_item(
     Json(body): Json<UpdateCommunicationItem>,
 ) -> Result<Json<CommunicationItem>, StatusCode> {
     let tenant_id = tenant.0 .0;
-    let mut conn = state
-        .pool
-        .acquire()
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    set_current_tenant(&mut conn, &tenant_id.to_string())
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
-    let item = sqlx::query_as::<_, CommunicationItem>(
-        r#"UPDATE alc_api.communication_items SET
-               title = COALESCE($1, title),
-               content = COALESCE($2, content),
-               priority = COALESCE($3, priority),
-               target_employee_id = CASE WHEN $5 THEN $4 ELSE target_employee_id END,
-               is_active = COALESCE($6, is_active),
-               effective_from = CASE WHEN $8 THEN $7 ELSE effective_from END,
-               effective_until = CASE WHEN $10 THEN $9 ELSE effective_until END,
-               updated_at = now()
-           WHERE id = $11
-           RETURNING *"#,
-    )
-    .bind(&body.title)
-    .bind(&body.content)
-    .bind(&body.priority)
-    .bind(body.target_employee_id)
-    .bind(body.target_employee_id.is_some())
-    .bind(body.is_active)
-    .bind(body.effective_from)
-    .bind(body.effective_from.is_some())
-    .bind(body.effective_until)
-    .bind(body.effective_until.is_some())
-    .bind(id)
-    .fetch_optional(&mut *conn)
-    .await
-    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-
-    match item {
+    match state
+        .communication_items
+        .update(tenant_id, id, &body)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+    {
         Some(i) => Ok(Json(i)),
         None => Err(StatusCode::NOT_FOUND),
     }
@@ -275,22 +151,14 @@ async fn delete_item(
     Path(id): Path<Uuid>,
 ) -> Result<StatusCode, StatusCode> {
     let tenant_id = tenant.0 .0;
-    let mut conn = state
-        .pool
-        .acquire()
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    set_current_tenant(&mut conn, &tenant_id.to_string())
+
+    let deleted = state
+        .communication_items
+        .delete(tenant_id, id)
         .await
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
-    let result = sqlx::query("DELETE FROM alc_api.communication_items WHERE id = $1")
-        .bind(id)
-        .execute(&mut *conn)
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-
-    if result.rows_affected() == 0 {
+    if !deleted {
         return Err(StatusCode::NOT_FOUND);
     }
     Ok(StatusCode::NO_CONTENT)

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -10,7 +10,8 @@ use uuid::Uuid;
 use rust_alc_api::auth::jwt::{create_access_token, JwtSecret};
 use rust_alc_api::db::models::User;
 use rust_alc_api::db::repository::{
-    PgEmployeeRepository, PgNfcTagRepository, PgTenkoCallRepository, PgTimecardRepository,
+    PgCommunicationItemsRepository, PgEmployeeRepository, PgNfcTagRepository,
+    PgTenkoCallRepository, PgTimecardRepository,
 };
 use rust_alc_api::AppState;
 
@@ -216,6 +217,7 @@ pub async fn setup_app_state() -> AppState {
     let mock_fcm: Arc<dyn rust_alc_api::fcm::FcmSenderTrait> = Arc::new(MockFcmSender::new());
 
     let employees = Arc::new(PgEmployeeRepository::new(pool.clone()));
+    let communication_items = Arc::new(PgCommunicationItemsRepository::new(pool.clone()));
     let timecard = Arc::new(PgTimecardRepository::new(pool.clone()));
     let tenko_call = Arc::new(PgTenkoCallRepository::new(pool.clone()));
     let nfc_tags = Arc::new(PgNfcTagRepository::new(pool.clone()));
@@ -223,6 +225,7 @@ pub async fn setup_app_state() -> AppState {
     AppState {
         pool,
         employees,
+        communication_items,
         timecard,
         tenko_call,
         nfc_tags,
@@ -272,6 +275,7 @@ pub async fn setup_app_state_no_fcm() -> AppState {
         Arc::new(MockStorage::new("dtako-bucket"));
 
     let employees = Arc::new(PgEmployeeRepository::new(pool.clone()));
+    let communication_items = Arc::new(PgCommunicationItemsRepository::new(pool.clone()));
     let timecard = Arc::new(PgTimecardRepository::new(pool.clone()));
     let tenko_call = Arc::new(PgTenkoCallRepository::new(pool.clone()));
     let nfc_tags = Arc::new(PgNfcTagRepository::new(pool.clone()));
@@ -279,6 +283,7 @@ pub async fn setup_app_state_no_fcm() -> AppState {
     AppState {
         pool,
         employees,
+        communication_items,
         timecard,
         tenko_call,
         nfc_tags,
@@ -316,6 +321,7 @@ pub async fn setup_app_state_failing_fcm() -> AppState {
     let failing_fcm: Arc<dyn rust_alc_api::fcm::FcmSenderTrait> = Arc::new(FailingFcmSender);
 
     let employees = Arc::new(PgEmployeeRepository::new(pool.clone()));
+    let communication_items = Arc::new(PgCommunicationItemsRepository::new(pool.clone()));
     let timecard = Arc::new(PgTimecardRepository::new(pool.clone()));
     let tenko_call = Arc::new(PgTenkoCallRepository::new(pool.clone()));
     let nfc_tags = Arc::new(PgNfcTagRepository::new(pool.clone()));
@@ -323,6 +329,7 @@ pub async fn setup_app_state_failing_fcm() -> AppState {
     AppState {
         pool,
         employees,
+        communication_items,
         timecard,
         tenko_call,
         nfc_tags,


### PR DESCRIPTION
## Summary
- `CommunicationItemsRepository` trait (6メソッド) + `PgCommunicationItemsRepository` 実装
- communication_items.rs の全ハンドラを `state.communication_items.*()` 経由に書き換え

## Test plan
- [ ] CI pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)