### PR TITLE
feat: add mock repository infrastructure + 12 route tests (#49)

### DIFF
--- a/src/db/repository/tenant_users.rs
+++ b/src/db/repository/tenant_users.rs
@@ -6,7 +6,7 @@ use crate::db::models::TenantAllowedEmail;
 
 use super::TenantConn;
 
-#[derive(Debug, sqlx::FromRow)]
+#[derive(Debug, Clone, sqlx::FromRow)]
 pub struct UserRow {
     pub id: Uuid,
     pub email: String,

--- a/tests/mock_car_inspection_files_test.rs
+++ b/tests/mock_car_inspection_files_test.rs
@@ -1,0 +1,126 @@
+mod common;
+mod mock_helpers;
+
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+use mock_helpers::app_state::setup_mock_app_state;
+use mock_helpers::MockCarInspectionRepository;
+
+// ---------------------------------------------------------------------------
+// GET /api/car-inspection-files/current — success (empty list)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_list_current_files_success_empty() {
+    let state = setup_mock_app_state().await;
+    let base_url = common::spawn_test_server(state.clone()).await;
+    let tenant_id = common::create_test_tenant(&state.pool, "MockCIFEmpty").await;
+    let jwt = common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!("{base_url}/api/car-inspection-files/current"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert!(body["files"].is_array());
+    assert_eq!(body["files"].as_array().unwrap().len(), 0);
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/car-inspection-files/current — no auth → 401
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_list_current_files_no_auth() {
+    let state = setup_mock_app_state().await;
+    let base_url = common::spawn_test_server(state).await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!("{base_url}/api/car-inspection-files/current"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 401);
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/car-inspection-files/current — X-Tenant-ID header (kiosk) → 200
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_list_current_files_tenant_header() {
+    let state = setup_mock_app_state().await;
+    let base_url = common::spawn_test_server(state.clone()).await;
+    let tenant_id = common::create_test_tenant(&state.pool, "MockCIFTenant").await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!("{base_url}/api/car-inspection-files/current"))
+        .header("X-Tenant-ID", tenant_id.to_string())
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert!(body["files"].is_array());
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/car-inspection-files/current — DB error (fail_next) → 500
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_list_current_files_db_error() {
+    let mut state = setup_mock_app_state().await;
+
+    let mock = Arc::new(MockCarInspectionRepository::default());
+    mock.fail_next.store(true, Ordering::SeqCst);
+    state.car_inspections = mock;
+
+    let base_url = common::spawn_test_server(state.clone()).await;
+    let tenant_id = common::create_test_tenant(&state.pool, "MockCIFErr").await;
+    let jwt = common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!("{base_url}/api/car-inspection-files/current"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 500);
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/car-inspection-files/current — viewer role → 200 (no admin restriction)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_list_current_files_viewer_allowed() {
+    let state = setup_mock_app_state().await;
+    let base_url = common::spawn_test_server(state.clone()).await;
+    let tenant_id = common::create_test_tenant(&state.pool, "MockCIFViewer").await;
+    let jwt = common::create_test_jwt(tenant_id, "viewer");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!("{base_url}/api/car-inspection-files/current"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert!(body["files"].is_array());
+}

--- a/tests/mock_car_inspections_test.rs
+++ b/tests/mock_car_inspections_test.rs
@@ -1,0 +1,338 @@
+#[macro_use]
+mod common;
+mod mock_helpers;
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use serde_json::Value;
+use uuid::Uuid;
+
+use rust_alc_api::db::repository::car_inspections::{
+    CarInspectionFile, CarInspectionRepository, VehicleCategories,
+};
+
+// ============================================================
+// SuccessMock: returns realistic data for success-path tests
+// ============================================================
+
+struct SuccessMockCarInspectionRepository {
+    fail_next: AtomicBool,
+}
+
+impl SuccessMockCarInspectionRepository {
+    fn new() -> Self {
+        Self {
+            fail_next: AtomicBool::new(false),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl CarInspectionRepository for SuccessMockCarInspectionRepository {
+    async fn list_current(&self, _tenant_id: Uuid) -> Result<Vec<serde_json::Value>, sqlx::Error> {
+        if self.fail_next.swap(false, Ordering::SeqCst) {
+            return Err(sqlx::Error::RowNotFound);
+        }
+        Ok(vec![serde_json::json!({"id": 1, "CarId": "ABC-123"})])
+    }
+
+    async fn list_expired(&self, _tenant_id: Uuid) -> Result<Vec<serde_json::Value>, sqlx::Error> {
+        if self.fail_next.swap(false, Ordering::SeqCst) {
+            return Err(sqlx::Error::RowNotFound);
+        }
+        Ok(vec![
+            serde_json::json!({"id": 2, "CarId": "DEF-456", "expired": true}),
+        ])
+    }
+
+    async fn list_renew(&self, _tenant_id: Uuid) -> Result<Vec<serde_json::Value>, sqlx::Error> {
+        if self.fail_next.swap(false, Ordering::SeqCst) {
+            return Err(sqlx::Error::RowNotFound);
+        }
+        Ok(vec![
+            serde_json::json!({"id": 3, "CarId": "GHI-789", "renew": true}),
+        ])
+    }
+
+    async fn get_by_id(
+        &self,
+        _tenant_id: Uuid,
+        id: i32,
+    ) -> Result<Option<serde_json::Value>, sqlx::Error> {
+        if self.fail_next.swap(false, Ordering::SeqCst) {
+            return Err(sqlx::Error::RowNotFound);
+        }
+        if id == 999 {
+            return Ok(None);
+        }
+        Ok(Some(serde_json::json!({"id": id, "CarId": "ABC-123"})))
+    }
+
+    async fn vehicle_categories(&self, _tenant_id: Uuid) -> Result<VehicleCategories, sqlx::Error> {
+        if self.fail_next.swap(false, Ordering::SeqCst) {
+            return Err(sqlx::Error::RowNotFound);
+        }
+        Ok(VehicleCategories {
+            car_kinds: vec!["普通".to_string(), "小型".to_string()],
+            uses: vec!["自家用".to_string()],
+            car_shapes: vec!["箱型".to_string()],
+            private_businesses: vec!["運送".to_string()],
+        })
+    }
+
+    async fn list_current_files(
+        &self,
+        _tenant_id: Uuid,
+    ) -> Result<Vec<CarInspectionFile>, sqlx::Error> {
+        if self.fail_next.swap(false, Ordering::SeqCst) {
+            return Err(sqlx::Error::RowNotFound);
+        }
+        Ok(vec![])
+    }
+}
+
+// ============================================================
+// Helper: spawn server with a given mock
+// ============================================================
+
+async fn spawn_with_mock(mock: Arc<dyn CarInspectionRepository>) -> (String, String) {
+    let tenant_id = Uuid::new_v4();
+    let jwt = common::create_test_jwt(tenant_id, "admin");
+
+    let mut state = mock_helpers::app_state::setup_mock_app_state().await;
+    state.car_inspections = mock;
+    let base_url = common::spawn_test_server(state).await;
+
+    (base_url, jwt)
+}
+
+fn auth(jwt: &str) -> String {
+    format!("Bearer {jwt}")
+}
+
+// ============================================================
+// list_current: GET /api/car-inspections/current
+// ============================================================
+
+#[tokio::test]
+async fn test_list_current_success() {
+    let mock = Arc::new(SuccessMockCarInspectionRepository::new());
+    let (base_url, jwt) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!("{base_url}/api/car-inspections/current"))
+        .header("Authorization", auth(&jwt))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+
+    let body: Value = res.json().await.unwrap();
+    let inspections = body["carInspections"].as_array().unwrap();
+    assert_eq!(inspections.len(), 1);
+    assert_eq!(inspections[0]["CarId"], "ABC-123");
+}
+
+#[tokio::test]
+async fn test_list_current_db_error() {
+    let mock = Arc::new(mock_helpers::MockCarInspectionRepository::default());
+    mock.fail_next.store(true, Ordering::SeqCst);
+    let (base_url, jwt) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!("{base_url}/api/car-inspections/current"))
+        .header("Authorization", auth(&jwt))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}
+
+// ============================================================
+// list_expired: GET /api/car-inspections/expired
+// ============================================================
+
+#[tokio::test]
+async fn test_list_expired_success() {
+    let mock = Arc::new(SuccessMockCarInspectionRepository::new());
+    let (base_url, jwt) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!("{base_url}/api/car-inspections/expired"))
+        .header("Authorization", auth(&jwt))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+
+    let body: Value = res.json().await.unwrap();
+    let inspections = body["carInspections"].as_array().unwrap();
+    assert_eq!(inspections.len(), 1);
+    assert_eq!(inspections[0]["CarId"], "DEF-456");
+}
+
+#[tokio::test]
+async fn test_list_expired_db_error() {
+    let mock = Arc::new(mock_helpers::MockCarInspectionRepository::default());
+    mock.fail_next.store(true, Ordering::SeqCst);
+    let (base_url, jwt) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!("{base_url}/api/car-inspections/expired"))
+        .header("Authorization", auth(&jwt))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}
+
+// ============================================================
+// list_renew: GET /api/car-inspections/renew
+// ============================================================
+
+#[tokio::test]
+async fn test_list_renew_success() {
+    let mock = Arc::new(SuccessMockCarInspectionRepository::new());
+    let (base_url, jwt) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!("{base_url}/api/car-inspections/renew"))
+        .header("Authorization", auth(&jwt))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+
+    let body: Value = res.json().await.unwrap();
+    let inspections = body["carInspections"].as_array().unwrap();
+    assert_eq!(inspections.len(), 1);
+    assert_eq!(inspections[0]["CarId"], "GHI-789");
+}
+
+#[tokio::test]
+async fn test_list_renew_db_error() {
+    let mock = Arc::new(mock_helpers::MockCarInspectionRepository::default());
+    mock.fail_next.store(true, Ordering::SeqCst);
+    let (base_url, jwt) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!("{base_url}/api/car-inspections/renew"))
+        .header("Authorization", auth(&jwt))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}
+
+// ============================================================
+// vehicle_categories: GET /api/car-inspections/vehicle-categories
+// ============================================================
+
+#[tokio::test]
+async fn test_vehicle_categories_success() {
+    let mock = Arc::new(SuccessMockCarInspectionRepository::new());
+    let (base_url, jwt) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!("{base_url}/api/car-inspections/vehicle-categories"))
+        .header("Authorization", auth(&jwt))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+
+    let body: Value = res.json().await.unwrap();
+    let car_kinds = body["car_kinds"].as_array().unwrap();
+    assert_eq!(car_kinds.len(), 2);
+    assert_eq!(car_kinds[0], "普通");
+    assert_eq!(car_kinds[1], "小型");
+
+    let uses = body["uses"].as_array().unwrap();
+    assert_eq!(uses.len(), 1);
+    assert_eq!(uses[0], "自家用");
+
+    let car_shapes = body["car_shapes"].as_array().unwrap();
+    assert_eq!(car_shapes.len(), 1);
+
+    let private_businesses = body["private_businesses"].as_array().unwrap();
+    assert_eq!(private_businesses.len(), 1);
+}
+
+#[tokio::test]
+async fn test_vehicle_categories_db_error() {
+    let mock = Arc::new(mock_helpers::MockCarInspectionRepository::default());
+    mock.fail_next.store(true, Ordering::SeqCst);
+    let (base_url, jwt) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!("{base_url}/api/car-inspections/vehicle-categories"))
+        .header("Authorization", auth(&jwt))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}
+
+// ============================================================
+// get_by_id: GET /api/car-inspections/{id}
+// ============================================================
+
+#[tokio::test]
+async fn test_get_by_id_success() {
+    let mock = Arc::new(SuccessMockCarInspectionRepository::new());
+    let (base_url, jwt) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!("{base_url}/api/car-inspections/42"))
+        .header("Authorization", auth(&jwt))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+
+    let body: Value = res.json().await.unwrap();
+    assert_eq!(body["id"], 42);
+    assert_eq!(body["CarId"], "ABC-123");
+}
+
+#[tokio::test]
+async fn test_get_by_id_not_found() {
+    let mock = Arc::new(SuccessMockCarInspectionRepository::new());
+    let (base_url, jwt) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    // id=999 returns None in our mock
+    let res = client
+        .get(format!("{base_url}/api/car-inspections/999"))
+        .header("Authorization", auth(&jwt))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 404);
+}
+
+#[tokio::test]
+async fn test_get_by_id_db_error() {
+    let mock = Arc::new(mock_helpers::MockCarInspectionRepository::default());
+    mock.fail_next.store(true, Ordering::SeqCst);
+    let (base_url, jwt) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!("{base_url}/api/car-inspections/1"))
+        .header("Authorization", auth(&jwt))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}

--- a/tests/mock_communication_items_test.rs
+++ b/tests/mock_communication_items_test.rs
@@ -1,0 +1,637 @@
+#[macro_use]
+mod common;
+mod mock_helpers;
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use chrono::Utc;
+use serde_json::Value;
+use uuid::Uuid;
+
+use rust_alc_api::db::models::{
+    CommunicationItem, CreateCommunicationItem, UpdateCommunicationItem,
+};
+use rust_alc_api::db::repository::communication_items::{
+    CommunicationItemWithName, CommunicationItemsRepository,
+};
+
+// ============================================================
+// SuccessMock: returns realistic data for success-path tests
+// ============================================================
+
+struct SuccessMockCommunicationItemsRepository {
+    fail_next: AtomicBool,
+    item_id: Uuid,
+    tenant_id: Uuid,
+}
+
+impl SuccessMockCommunicationItemsRepository {
+    fn new(tenant_id: Uuid) -> Self {
+        Self {
+            fail_next: AtomicBool::new(false),
+            item_id: Uuid::new_v4(),
+            tenant_id,
+        }
+    }
+
+    fn make_item(&self, title: &str) -> CommunicationItem {
+        CommunicationItem {
+            id: self.item_id,
+            tenant_id: self.tenant_id,
+            title: title.to_string(),
+            content: "テスト内容".to_string(),
+            priority: "normal".to_string(),
+            target_employee_id: None,
+            is_active: true,
+            effective_from: None,
+            effective_until: None,
+            created_by: Some("テストユーザー".to_string()),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
+
+    fn make_item_with_name(&self, title: &str) -> CommunicationItemWithName {
+        CommunicationItemWithName {
+            id: self.item_id,
+            tenant_id: self.tenant_id,
+            title: title.to_string(),
+            content: "テスト内容".to_string(),
+            priority: "normal".to_string(),
+            target_employee_id: None,
+            target_employee_name: None,
+            is_active: true,
+            effective_from: None,
+            effective_until: None,
+            created_by: Some("テストユーザー".to_string()),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl CommunicationItemsRepository for SuccessMockCommunicationItemsRepository {
+    async fn list(
+        &self,
+        _tenant_id: Uuid,
+        _is_active: Option<bool>,
+        _target_employee_id: Option<Uuid>,
+        _per_page: i64,
+        _offset: i64,
+    ) -> Result<(Vec<CommunicationItemWithName>, i64), sqlx::Error> {
+        if self.fail_next.swap(false, Ordering::SeqCst) {
+            return Err(sqlx::Error::RowNotFound);
+        }
+        Ok((vec![self.make_item_with_name("定期連絡")], 1))
+    }
+
+    async fn list_active(
+        &self,
+        _tenant_id: Uuid,
+        _target_employee_id: Option<Uuid>,
+    ) -> Result<Vec<CommunicationItemWithName>, sqlx::Error> {
+        if self.fail_next.swap(false, Ordering::SeqCst) {
+            return Err(sqlx::Error::RowNotFound);
+        }
+        Ok(vec![self.make_item_with_name("有効な連絡")])
+    }
+
+    async fn get(
+        &self,
+        _tenant_id: Uuid,
+        _id: Uuid,
+    ) -> Result<Option<CommunicationItem>, sqlx::Error> {
+        if self.fail_next.swap(false, Ordering::SeqCst) {
+            return Err(sqlx::Error::RowNotFound);
+        }
+        Ok(Some(self.make_item("詳細連絡")))
+    }
+
+    async fn create(
+        &self,
+        _tenant_id: Uuid,
+        input: &CreateCommunicationItem,
+    ) -> Result<CommunicationItem, sqlx::Error> {
+        if self.fail_next.swap(false, Ordering::SeqCst) {
+            return Err(sqlx::Error::RowNotFound);
+        }
+        Ok(self.make_item(&input.title))
+    }
+
+    async fn update(
+        &self,
+        _tenant_id: Uuid,
+        _id: Uuid,
+        input: &UpdateCommunicationItem,
+    ) -> Result<Option<CommunicationItem>, sqlx::Error> {
+        if self.fail_next.swap(false, Ordering::SeqCst) {
+            return Err(sqlx::Error::RowNotFound);
+        }
+        let title = input.title.as_deref().unwrap_or("更新済み");
+        Ok(Some(self.make_item(title)))
+    }
+
+    async fn delete(&self, _tenant_id: Uuid, _id: Uuid) -> Result<bool, sqlx::Error> {
+        if self.fail_next.swap(false, Ordering::SeqCst) {
+            return Err(sqlx::Error::RowNotFound);
+        }
+        Ok(true)
+    }
+}
+
+// ============================================================
+// Helper: spawn server with a given mock
+// ============================================================
+
+async fn spawn_with_mock(mock: Arc<dyn CommunicationItemsRepository>) -> (String, String, Uuid) {
+    let tenant_id = Uuid::new_v4();
+    let jwt = common::create_test_jwt(tenant_id, "admin");
+
+    let mut state = mock_helpers::app_state::setup_mock_app_state().await;
+    state.communication_items = mock;
+    let base_url = common::spawn_test_server(state).await;
+
+    (base_url, jwt, tenant_id)
+}
+
+fn auth(jwt: &str) -> String {
+    format!("Bearer {jwt}")
+}
+
+// ============================================================
+// list_items: GET /api/communication-items
+// ============================================================
+
+#[tokio::test]
+async fn test_list_items_success() {
+    let tenant_id = Uuid::new_v4();
+    let mock = Arc::new(SuccessMockCommunicationItemsRepository::new(tenant_id));
+    let (base_url, jwt, _) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!("{base_url}/api/communication-items"))
+        .header("Authorization", auth(&jwt))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+
+    let body: Value = res.json().await.unwrap();
+    assert_eq!(body["items"].as_array().unwrap().len(), 1);
+    assert_eq!(body["items"][0]["title"], "定期連絡");
+    assert_eq!(body["total"], 1);
+    assert_eq!(body["page"], 1);
+    assert_eq!(body["per_page"], 20);
+}
+
+#[tokio::test]
+async fn test_list_items_with_filter_params() {
+    let tenant_id = Uuid::new_v4();
+    let mock = Arc::new(SuccessMockCommunicationItemsRepository::new(tenant_id));
+    let (base_url, jwt, _) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+    let emp_id = Uuid::new_v4();
+
+    let res = client
+        .get(format!(
+            "{base_url}/api/communication-items?is_active=true&target_employee_id={emp_id}&page=2&per_page=5"
+        ))
+        .header("Authorization", auth(&jwt))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+
+    let body: Value = res.json().await.unwrap();
+    assert_eq!(body["page"], 2);
+    assert_eq!(body["per_page"], 5);
+}
+
+#[tokio::test]
+async fn test_list_items_page_zero_clamped_to_one() {
+    let tenant_id = Uuid::new_v4();
+    let mock = Arc::new(SuccessMockCommunicationItemsRepository::new(tenant_id));
+    let (base_url, jwt, _) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    // page=0 should be clamped to 1
+    let res = client
+        .get(format!("{base_url}/api/communication-items?page=0"))
+        .header("Authorization", auth(&jwt))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+
+    let body: Value = res.json().await.unwrap();
+    assert_eq!(body["page"], 1);
+}
+
+#[tokio::test]
+async fn test_list_items_per_page_capped_at_100() {
+    let tenant_id = Uuid::new_v4();
+    let mock = Arc::new(SuccessMockCommunicationItemsRepository::new(tenant_id));
+    let (base_url, jwt, _) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    // per_page=200 should be capped to 100
+    let res = client
+        .get(format!("{base_url}/api/communication-items?per_page=200"))
+        .header("Authorization", auth(&jwt))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+
+    let body: Value = res.json().await.unwrap();
+    assert_eq!(body["per_page"], 100);
+}
+
+#[tokio::test]
+async fn test_list_items_db_error() {
+    let mock = Arc::new(mock_helpers::MockCommunicationItemsRepository::default());
+    mock.fail_next.store(true, Ordering::SeqCst);
+    let (base_url, jwt, _) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!("{base_url}/api/communication-items"))
+        .header("Authorization", auth(&jwt))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}
+
+// ============================================================
+// list_active_items: GET /api/communication-items/active
+// ============================================================
+
+#[tokio::test]
+async fn test_list_active_items_success() {
+    let tenant_id = Uuid::new_v4();
+    let mock = Arc::new(SuccessMockCommunicationItemsRepository::new(tenant_id));
+    let (base_url, jwt, _) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!("{base_url}/api/communication-items/active"))
+        .header("Authorization", auth(&jwt))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+
+    let body: Vec<Value> = res.json().await.unwrap();
+    assert_eq!(body.len(), 1);
+    assert_eq!(body[0]["title"], "有効な連絡");
+}
+
+#[tokio::test]
+async fn test_list_active_items_with_target_employee() {
+    let tenant_id = Uuid::new_v4();
+    let mock = Arc::new(SuccessMockCommunicationItemsRepository::new(tenant_id));
+    let (base_url, jwt, _) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+    let emp_id = Uuid::new_v4();
+
+    let res = client
+        .get(format!(
+            "{base_url}/api/communication-items/active?target_employee_id={emp_id}"
+        ))
+        .header("Authorization", auth(&jwt))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+
+    let body: Vec<Value> = res.json().await.unwrap();
+    assert_eq!(body.len(), 1);
+}
+
+#[tokio::test]
+async fn test_list_active_items_db_error() {
+    let mock = Arc::new(mock_helpers::MockCommunicationItemsRepository::default());
+    mock.fail_next.store(true, Ordering::SeqCst);
+    let (base_url, jwt, _) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!("{base_url}/api/communication-items/active"))
+        .header("Authorization", auth(&jwt))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}
+
+// ============================================================
+// get_item: GET /api/communication-items/{id}
+// ============================================================
+
+#[tokio::test]
+async fn test_get_item_success() {
+    let tenant_id = Uuid::new_v4();
+    let mock = Arc::new(SuccessMockCommunicationItemsRepository::new(tenant_id));
+    let item_id = mock.item_id;
+    let (base_url, jwt, _) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!("{base_url}/api/communication-items/{item_id}"))
+        .header("Authorization", auth(&jwt))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+
+    let body: Value = res.json().await.unwrap();
+    assert_eq!(body["title"], "詳細連絡");
+}
+
+#[tokio::test]
+async fn test_get_item_not_found() {
+    // Default mock returns Ok(None) from get
+    let mock = Arc::new(mock_helpers::MockCommunicationItemsRepository::default());
+    let (base_url, jwt, _) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+    let fake_id = Uuid::new_v4();
+
+    let res = client
+        .get(format!("{base_url}/api/communication-items/{fake_id}"))
+        .header("Authorization", auth(&jwt))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 404);
+}
+
+#[tokio::test]
+async fn test_get_item_db_error() {
+    let mock = Arc::new(mock_helpers::MockCommunicationItemsRepository::default());
+    mock.fail_next.store(true, Ordering::SeqCst);
+    let (base_url, jwt, _) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+    let fake_id = Uuid::new_v4();
+
+    let res = client
+        .get(format!("{base_url}/api/communication-items/{fake_id}"))
+        .header("Authorization", auth(&jwt))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}
+
+// ============================================================
+// create_item: POST /api/communication-items
+// ============================================================
+
+#[tokio::test]
+async fn test_create_item_success() {
+    let tenant_id = Uuid::new_v4();
+    let mock = Arc::new(SuccessMockCommunicationItemsRepository::new(tenant_id));
+    let (base_url, jwt, _) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/communication-items"))
+        .header("Authorization", auth(&jwt))
+        .json(&serde_json::json!({
+            "title": "新規連絡事項",
+            "content": "内容です",
+            "priority": "high"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 201);
+
+    let body: Value = res.json().await.unwrap();
+    assert_eq!(body["title"], "新規連絡事項");
+}
+
+#[tokio::test]
+async fn test_create_item_minimal_body() {
+    let tenant_id = Uuid::new_v4();
+    let mock = Arc::new(SuccessMockCommunicationItemsRepository::new(tenant_id));
+    let (base_url, jwt, _) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    // Only title is required
+    let res = client
+        .post(format!("{base_url}/api/communication-items"))
+        .header("Authorization", auth(&jwt))
+        .json(&serde_json::json!({
+            "title": "最小限"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 201);
+}
+
+#[tokio::test]
+async fn test_create_item_db_error() {
+    let mock = Arc::new(mock_helpers::MockCommunicationItemsRepository::default());
+    mock.fail_next.store(true, Ordering::SeqCst);
+    let (base_url, jwt, _) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/communication-items"))
+        .header("Authorization", auth(&jwt))
+        .json(&serde_json::json!({
+            "title": "エラーテスト"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}
+
+// ============================================================
+// update_item: PUT /api/communication-items/{id}
+// ============================================================
+
+#[tokio::test]
+async fn test_update_item_success() {
+    let tenant_id = Uuid::new_v4();
+    let mock = Arc::new(SuccessMockCommunicationItemsRepository::new(tenant_id));
+    let item_id = mock.item_id;
+    let (base_url, jwt, _) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .put(format!("{base_url}/api/communication-items/{item_id}"))
+        .header("Authorization", auth(&jwt))
+        .json(&serde_json::json!({
+            "title": "更新後タイトル",
+            "is_active": false
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+
+    let body: Value = res.json().await.unwrap();
+    assert_eq!(body["title"], "更新後タイトル");
+}
+
+#[tokio::test]
+async fn test_update_item_not_found() {
+    // Default mock returns Ok(None) from update
+    let mock = Arc::new(mock_helpers::MockCommunicationItemsRepository::default());
+    let (base_url, jwt, _) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+    let fake_id = Uuid::new_v4();
+
+    let res = client
+        .put(format!("{base_url}/api/communication-items/{fake_id}"))
+        .header("Authorization", auth(&jwt))
+        .json(&serde_json::json!({ "title": "xxx" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 404);
+}
+
+#[tokio::test]
+async fn test_update_item_db_error() {
+    let mock = Arc::new(mock_helpers::MockCommunicationItemsRepository::default());
+    mock.fail_next.store(true, Ordering::SeqCst);
+    let (base_url, jwt, _) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+    let fake_id = Uuid::new_v4();
+
+    let res = client
+        .put(format!("{base_url}/api/communication-items/{fake_id}"))
+        .header("Authorization", auth(&jwt))
+        .json(&serde_json::json!({ "title": "xxx" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}
+
+// ============================================================
+// delete_item: DELETE /api/communication-items/{id}
+// ============================================================
+
+#[tokio::test]
+async fn test_delete_item_success() {
+    let tenant_id = Uuid::new_v4();
+    let mock = Arc::new(SuccessMockCommunicationItemsRepository::new(tenant_id));
+    let item_id = mock.item_id;
+    let (base_url, jwt, _) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .delete(format!("{base_url}/api/communication-items/{item_id}"))
+        .header("Authorization", auth(&jwt))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 204);
+}
+
+#[tokio::test]
+async fn test_delete_item_not_found() {
+    // Default mock returns Ok(false) from delete
+    let mock = Arc::new(mock_helpers::MockCommunicationItemsRepository::default());
+    let (base_url, jwt, _) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+    let fake_id = Uuid::new_v4();
+
+    let res = client
+        .delete(format!("{base_url}/api/communication-items/{fake_id}"))
+        .header("Authorization", auth(&jwt))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 404);
+}
+
+#[tokio::test]
+async fn test_delete_item_db_error() {
+    let mock = Arc::new(mock_helpers::MockCommunicationItemsRepository::default());
+    mock.fail_next.store(true, Ordering::SeqCst);
+    let (base_url, jwt, _) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+    let fake_id = Uuid::new_v4();
+
+    let res = client
+        .delete(format!("{base_url}/api/communication-items/{fake_id}"))
+        .header("Authorization", auth(&jwt))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}
+
+// ============================================================
+// Auth: no JWT -> 401
+// ============================================================
+
+#[tokio::test]
+async fn test_no_auth_returns_401() {
+    let mock = Arc::new(mock_helpers::MockCommunicationItemsRepository::default());
+    let mut state = mock_helpers::app_state::setup_mock_app_state().await;
+    state.communication_items = mock;
+    let base_url = common::spawn_test_server(state).await;
+    let client = reqwest::Client::new();
+    let fake_id = Uuid::new_v4();
+
+    // GET list
+    let res = client
+        .get(format!("{base_url}/api/communication-items"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 401);
+
+    // GET active
+    let res = client
+        .get(format!("{base_url}/api/communication-items/active"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 401);
+
+    // GET by id
+    let res = client
+        .get(format!("{base_url}/api/communication-items/{fake_id}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 401);
+
+    // POST
+    let res = client
+        .post(format!("{base_url}/api/communication-items"))
+        .json(&serde_json::json!({ "title": "x" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 401);
+
+    // PUT
+    let res = client
+        .put(format!("{base_url}/api/communication-items/{fake_id}"))
+        .json(&serde_json::json!({ "title": "x" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 401);
+
+    // DELETE
+    let res = client
+        .delete(format!("{base_url}/api/communication-items/{fake_id}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 401);
+}

--- a/tests/mock_dtako_operations_test.rs
+++ b/tests/mock_dtako_operations_test.rs
@@ -1,0 +1,514 @@
+mod common;
+mod mock_helpers;
+
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+use chrono::{NaiveDate, Utc};
+use uuid::Uuid;
+
+use mock_helpers::app_state::setup_mock_app_state;
+use mock_helpers::MockDtakoOperationsRepository;
+use rust_alc_api::db::models::DtakoOperation;
+
+fn make_operation(unko_no: &str) -> DtakoOperation {
+    DtakoOperation {
+        id: Uuid::new_v4(),
+        tenant_id: Uuid::new_v4(),
+        unko_no: unko_no.to_string(),
+        crew_role: 1,
+        reading_date: NaiveDate::from_ymd_opt(2026, 3, 1).unwrap(),
+        operation_date: Some(NaiveDate::from_ymd_opt(2026, 3, 1).unwrap()),
+        office_id: None,
+        vehicle_id: None,
+        driver_id: None,
+        departure_at: None,
+        return_at: None,
+        garage_out_at: None,
+        garage_in_at: None,
+        meter_start: None,
+        meter_end: None,
+        total_distance: Some(100.0),
+        drive_time_general: Some(120),
+        drive_time_highway: Some(30),
+        drive_time_bypass: Some(10),
+        safety_score: Some(85.0),
+        economy_score: Some(90.0),
+        total_score: Some(87.5),
+        raw_data: serde_json::json!({}),
+        r2_key_prefix: None,
+        uploaded_at: Utc::now(),
+        has_kudgivt: true,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/operations — success (empty list)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_list_operations_success() {
+    let state = setup_mock_app_state().await;
+    let base_url = common::spawn_test_server(state.clone()).await;
+    let tenant_id = common::create_test_tenant(&state.pool, "MockOps1").await;
+    let jwt = common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!("{base_url}/api/operations"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(body["operations"].as_array().unwrap().len(), 0);
+    assert_eq!(body["total"], 0);
+    assert_eq!(body["page"], 1);
+    assert_eq!(body["per_page"], 50);
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/operations — no auth → 401
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_list_operations_no_auth() {
+    let state = setup_mock_app_state().await;
+    let base_url = common::spawn_test_server(state).await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!("{base_url}/api/operations"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 401);
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/operations — X-Tenant-ID header (kiosk mode) → 200
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_list_operations_tenant_header() {
+    let state = setup_mock_app_state().await;
+    let base_url = common::spawn_test_server(state.clone()).await;
+    let tenant_id = common::create_test_tenant(&state.pool, "MockOps2").await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!("{base_url}/api/operations"))
+        .header("X-Tenant-ID", tenant_id.to_string())
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/operations — DB error → 500
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_list_operations_db_error() {
+    let mut state = setup_mock_app_state().await;
+    let mock = Arc::new(MockDtakoOperationsRepository::default());
+    mock.fail_next.store(true, Ordering::SeqCst);
+    state.dtako_operations = mock;
+
+    let base_url = common::spawn_test_server(state.clone()).await;
+    let tenant_id = common::create_test_tenant(&state.pool, "MockOpsErr1").await;
+    let jwt = common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!("{base_url}/api/operations"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 500);
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/operations/calendar — success (empty)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_calendar_dates_success_empty() {
+    let state = setup_mock_app_state().await;
+    let base_url = common::spawn_test_server(state.clone()).await;
+    let tenant_id = common::create_test_tenant(&state.pool, "MockCal1").await;
+    let jwt = common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!(
+            "{base_url}/api/operations/calendar?year=2026&month=3"
+        ))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(body["year"], 2026);
+    assert_eq!(body["month"], 3);
+    assert_eq!(body["dates"].as_array().unwrap().len(), 0);
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/operations/calendar — success with data
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_calendar_dates_success_with_data() {
+    let mut state = setup_mock_app_state().await;
+    let mock = Arc::new(MockDtakoOperationsRepository::default());
+    *mock.calendar_dates_result.lock().unwrap() = vec![
+        (NaiveDate::from_ymd_opt(2026, 3, 1).unwrap(), 5),
+        (NaiveDate::from_ymd_opt(2026, 3, 15).unwrap(), 3),
+    ];
+    state.dtako_operations = mock;
+
+    let base_url = common::spawn_test_server(state.clone()).await;
+    let tenant_id = common::create_test_tenant(&state.pool, "MockCal2").await;
+    let jwt = common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!(
+            "{base_url}/api/operations/calendar?year=2026&month=3"
+        ))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+    let body: serde_json::Value = res.json().await.unwrap();
+    let dates = body["dates"].as_array().unwrap();
+    assert_eq!(dates.len(), 2);
+    assert_eq!(dates[0]["date"], "2026-03-01");
+    assert_eq!(dates[0]["count"], 5);
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/operations/calendar — month=12 (December, special branch)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_calendar_dates_december() {
+    let state = setup_mock_app_state().await;
+    let base_url = common::spawn_test_server(state.clone()).await;
+    let tenant_id = common::create_test_tenant(&state.pool, "MockCalDec").await;
+    let jwt = common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!(
+            "{base_url}/api/operations/calendar?year=2026&month=12"
+        ))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(body["year"], 2026);
+    assert_eq!(body["month"], 12);
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/operations/calendar — invalid month=0 → 400
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_calendar_dates_invalid_month_zero() {
+    let state = setup_mock_app_state().await;
+    let base_url = common::spawn_test_server(state.clone()).await;
+    let tenant_id = common::create_test_tenant(&state.pool, "MockCalBad1").await;
+    let jwt = common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!(
+            "{base_url}/api/operations/calendar?year=2026&month=0"
+        ))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 400);
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/operations/calendar — invalid month=13 → 400
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_calendar_dates_invalid_month_13() {
+    let state = setup_mock_app_state().await;
+    let base_url = common::spawn_test_server(state.clone()).await;
+    let tenant_id = common::create_test_tenant(&state.pool, "MockCalBad2").await;
+    let jwt = common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!(
+            "{base_url}/api/operations/calendar?year=2026&month=13"
+        ))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 400);
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/operations/calendar — no auth → 401
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_calendar_dates_no_auth() {
+    let state = setup_mock_app_state().await;
+    let base_url = common::spawn_test_server(state).await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!(
+            "{base_url}/api/operations/calendar?year=2026&month=3"
+        ))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 401);
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/operations/calendar — DB error → 500
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_calendar_dates_db_error() {
+    let mut state = setup_mock_app_state().await;
+    let mock = Arc::new(MockDtakoOperationsRepository::default());
+    mock.fail_next.store(true, Ordering::SeqCst);
+    state.dtako_operations = mock;
+
+    let base_url = common::spawn_test_server(state.clone()).await;
+    let tenant_id = common::create_test_tenant(&state.pool, "MockCalErr").await;
+    let jwt = common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!(
+            "{base_url}/api/operations/calendar?year=2026&month=3"
+        ))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 500);
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/operations/{unko_no} — success (found)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_get_operation_success() {
+    let mut state = setup_mock_app_state().await;
+    let mock = Arc::new(MockDtakoOperationsRepository::default());
+    *mock.get_result.lock().unwrap() = vec![make_operation("1001")];
+    state.dtako_operations = mock;
+
+    let base_url = common::spawn_test_server(state.clone()).await;
+    let tenant_id = common::create_test_tenant(&state.pool, "MockGet1").await;
+    let jwt = common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!("{base_url}/api/operations/1001"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert!(body.is_array());
+    assert_eq!(body.as_array().unwrap().len(), 1);
+    assert_eq!(body[0]["unko_no"], "1001");
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/operations/{unko_no} — not found (empty) → 404
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_get_operation_not_found() {
+    let state = setup_mock_app_state().await;
+    let base_url = common::spawn_test_server(state.clone()).await;
+    let tenant_id = common::create_test_tenant(&state.pool, "MockGet2").await;
+    let jwt = common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!("{base_url}/api/operations/9999"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 404);
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/operations/{unko_no} — no auth → 401
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_get_operation_no_auth() {
+    let state = setup_mock_app_state().await;
+    let base_url = common::spawn_test_server(state).await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!("{base_url}/api/operations/1001"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 401);
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/operations/{unko_no} — DB error → 500
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_get_operation_db_error() {
+    let mut state = setup_mock_app_state().await;
+    let mock = Arc::new(MockDtakoOperationsRepository::default());
+    mock.fail_next.store(true, Ordering::SeqCst);
+    state.dtako_operations = mock;
+
+    let base_url = common::spawn_test_server(state.clone()).await;
+    let tenant_id = common::create_test_tenant(&state.pool, "MockGetErr").await;
+    let jwt = common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!("{base_url}/api/operations/1001"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 500);
+}
+
+// ---------------------------------------------------------------------------
+// DELETE /api/operations/{unko_no} — success (rows deleted) → 204
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_delete_operation_success() {
+    let mut state = setup_mock_app_state().await;
+    let mock = Arc::new(MockDtakoOperationsRepository::default());
+    *mock.delete_rows_affected.lock().unwrap() = 1;
+    state.dtako_operations = mock;
+
+    let base_url = common::spawn_test_server(state.clone()).await;
+    let tenant_id = common::create_test_tenant(&state.pool, "MockDel1").await;
+    let jwt = common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .delete(format!("{base_url}/api/operations/1001"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 204);
+}
+
+// ---------------------------------------------------------------------------
+// DELETE /api/operations/{unko_no} — not found (0 rows) → 404
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_delete_operation_not_found() {
+    let state = setup_mock_app_state().await;
+    let base_url = common::spawn_test_server(state.clone()).await;
+    let tenant_id = common::create_test_tenant(&state.pool, "MockDel2").await;
+    let jwt = common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .delete(format!("{base_url}/api/operations/9999"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 404);
+}
+
+// ---------------------------------------------------------------------------
+// DELETE /api/operations/{unko_no} — no auth → 401
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_delete_operation_no_auth() {
+    let state = setup_mock_app_state().await;
+    let base_url = common::spawn_test_server(state).await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .delete(format!("{base_url}/api/operations/1001"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 401);
+}
+
+// ---------------------------------------------------------------------------
+// DELETE /api/operations/{unko_no} — DB error → 500
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_delete_operation_db_error() {
+    let mut state = setup_mock_app_state().await;
+    let mock = Arc::new(MockDtakoOperationsRepository::default());
+    mock.fail_next.store(true, Ordering::SeqCst);
+    state.dtako_operations = mock;
+
+    let base_url = common::spawn_test_server(state.clone()).await;
+    let tenant_id = common::create_test_tenant(&state.pool, "MockDelErr").await;
+    let jwt = common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .delete(format!("{base_url}/api/operations/1001"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 500);
+}

--- a/tests/mock_health_baselines_test.rs
+++ b/tests/mock_health_baselines_test.rs
@@ -1,0 +1,465 @@
+mod common;
+mod mock_helpers;
+
+use std::sync::Arc;
+
+use chrono::Utc;
+use mock_helpers::MockHealthBaselinesRepository;
+use rust_alc_api::db::models::EmployeeHealthBaseline;
+
+// ---------------------------------------------------------------------------
+// Helper: spawn server with default mock state
+// ---------------------------------------------------------------------------
+
+async fn setup() -> (String, String) {
+    let state = mock_helpers::app_state::setup_mock_app_state().await;
+    let tenant_id = common::create_test_tenant(&state.pool, "hb-test").await;
+    let jwt = common::create_test_jwt(tenant_id, "admin");
+    let base = common::spawn_test_server(state).await;
+    let auth = format!("Bearer {jwt}");
+    (base, auth)
+}
+
+/// spawn server with a custom health_baselines mock
+async fn setup_with_mock(mock: Arc<MockHealthBaselinesRepository>) -> (String, String) {
+    let mut state = mock_helpers::app_state::setup_mock_app_state().await;
+    let tenant_id = common::create_test_tenant(&state.pool, "hb-custom").await;
+    let jwt = common::create_test_jwt(tenant_id, "admin");
+    state.health_baselines = mock;
+    let base = common::spawn_test_server(state).await;
+    let auth = format!("Bearer {jwt}");
+    (base, auth)
+}
+
+/// spawn server with fail_next=true on health_baselines mock
+async fn setup_failing() -> (String, String) {
+    let mock = Arc::new(MockHealthBaselinesRepository::default());
+    mock.fail_next
+        .store(true, std::sync::atomic::Ordering::SeqCst);
+    let mut state = mock_helpers::app_state::setup_mock_app_state().await;
+    let tenant_id = common::create_test_tenant(&state.pool, "hb-fail").await;
+    let jwt = common::create_test_jwt(tenant_id, "admin");
+    state.health_baselines = mock;
+    let base = common::spawn_test_server(state).await;
+    let auth = format!("Bearer {jwt}");
+    (base, auth)
+}
+
+fn make_sample_baseline(tenant_id: uuid::Uuid, employee_id: uuid::Uuid) -> EmployeeHealthBaseline {
+    EmployeeHealthBaseline {
+        id: uuid::Uuid::new_v4(),
+        tenant_id,
+        employee_id,
+        baseline_systolic: 120,
+        baseline_diastolic: 80,
+        baseline_temperature: 36.5,
+        systolic_tolerance: 10,
+        diastolic_tolerance: 10,
+        temperature_tolerance: 0.5,
+        measurement_validity_minutes: 30,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    }
+}
+
+fn client() -> reqwest::Client {
+    reqwest::Client::new()
+}
+
+// ===========================================================================
+// POST /api/tenko/health-baselines — upsert_baseline
+// ===========================================================================
+
+#[tokio::test]
+async fn upsert_baseline_success() {
+    let (base, auth) = setup().await;
+    let employee_id = uuid::Uuid::new_v4();
+    let res = client()
+        .post(format!("{base}/api/tenko/health-baselines"))
+        .header("Authorization", &auth)
+        .json(&serde_json::json!({
+            "employee_id": employee_id.to_string(),
+            "baseline_systolic": 130,
+            "baseline_diastolic": 85
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 201);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(body["employee_id"], employee_id.to_string());
+    assert_eq!(body["baseline_systolic"], 130);
+    assert_eq!(body["baseline_diastolic"], 85);
+}
+
+#[tokio::test]
+async fn upsert_baseline_with_defaults() {
+    let (base, auth) = setup().await;
+    let employee_id = uuid::Uuid::new_v4();
+    let res = client()
+        .post(format!("{base}/api/tenko/health-baselines"))
+        .header("Authorization", &auth)
+        .json(&serde_json::json!({
+            "employee_id": employee_id.to_string()
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 201);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(body["employee_id"], employee_id.to_string());
+    // defaults
+    assert_eq!(body["baseline_systolic"], 120);
+    assert_eq!(body["baseline_diastolic"], 80);
+    assert_eq!(body["baseline_temperature"], 36.5);
+    assert_eq!(body["systolic_tolerance"], 10);
+    assert_eq!(body["diastolic_tolerance"], 10);
+    assert_eq!(body["temperature_tolerance"], 0.5);
+    assert_eq!(body["measurement_validity_minutes"], 30);
+}
+
+#[tokio::test]
+async fn upsert_baseline_with_all_fields() {
+    let (base, auth) = setup().await;
+    let employee_id = uuid::Uuid::new_v4();
+    let res = client()
+        .post(format!("{base}/api/tenko/health-baselines"))
+        .header("Authorization", &auth)
+        .json(&serde_json::json!({
+            "employee_id": employee_id.to_string(),
+            "baseline_systolic": 140,
+            "baseline_diastolic": 90,
+            "baseline_temperature": 37.0,
+            "systolic_tolerance": 15,
+            "diastolic_tolerance": 12,
+            "temperature_tolerance": 0.8,
+            "measurement_validity_minutes": 60
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 201);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(body["baseline_systolic"], 140);
+    assert_eq!(body["baseline_diastolic"], 90);
+    assert_eq!(body["baseline_temperature"], 37.0);
+    assert_eq!(body["systolic_tolerance"], 15);
+    assert_eq!(body["diastolic_tolerance"], 12);
+    assert_eq!(body["temperature_tolerance"], 0.8);
+    assert_eq!(body["measurement_validity_minutes"], 60);
+}
+
+#[tokio::test]
+async fn upsert_baseline_db_error_returns_500() {
+    let (base, auth) = setup_failing().await;
+    let res = client()
+        .post(format!("{base}/api/tenko/health-baselines"))
+        .header("Authorization", &auth)
+        .json(&serde_json::json!({
+            "employee_id": uuid::Uuid::new_v4().to_string()
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}
+
+#[tokio::test]
+async fn upsert_baseline_no_auth_returns_401() {
+    let (base, _auth) = setup().await;
+    let res = client()
+        .post(format!("{base}/api/tenko/health-baselines"))
+        .json(&serde_json::json!({
+            "employee_id": uuid::Uuid::new_v4().to_string()
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 401);
+}
+
+// ===========================================================================
+// GET /api/tenko/health-baselines — list_baselines
+// ===========================================================================
+
+#[tokio::test]
+async fn list_baselines_success_empty() {
+    let (base, auth) = setup().await;
+    let res = client()
+        .get(format!("{base}/api/tenko/health-baselines"))
+        .header("Authorization", &auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    let body: Vec<serde_json::Value> = res.json().await.unwrap();
+    assert!(body.is_empty());
+}
+
+#[tokio::test]
+async fn list_baselines_success_with_data() {
+    let tenant_id = uuid::Uuid::new_v4();
+    let employee_id = uuid::Uuid::new_v4();
+    let baseline = make_sample_baseline(tenant_id, employee_id);
+    let baseline_id = baseline.id;
+
+    let mock = Arc::new(MockHealthBaselinesRepository::default());
+    *mock.list_result.lock().unwrap() = vec![baseline];
+    let (base, auth) = setup_with_mock(mock).await;
+
+    let res = client()
+        .get(format!("{base}/api/tenko/health-baselines"))
+        .header("Authorization", &auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    let body: Vec<serde_json::Value> = res.json().await.unwrap();
+    assert_eq!(body.len(), 1);
+    assert_eq!(body[0]["id"], baseline_id.to_string());
+    assert_eq!(body[0]["employee_id"], employee_id.to_string());
+}
+
+#[tokio::test]
+async fn list_baselines_db_error_returns_500() {
+    let (base, auth) = setup_failing().await;
+    let res = client()
+        .get(format!("{base}/api/tenko/health-baselines"))
+        .header("Authorization", &auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}
+
+#[tokio::test]
+async fn list_baselines_no_auth_returns_401() {
+    let (base, _auth) = setup().await;
+    let res = client()
+        .get(format!("{base}/api/tenko/health-baselines"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 401);
+}
+
+// ===========================================================================
+// GET /api/tenko/health-baselines/{employee_id} — get_baseline
+// ===========================================================================
+
+#[tokio::test]
+async fn get_baseline_not_found() {
+    let (base, auth) = setup().await;
+    let employee_id = uuid::Uuid::new_v4();
+    let res = client()
+        .get(format!("{base}/api/tenko/health-baselines/{employee_id}"))
+        .header("Authorization", &auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 404);
+}
+
+#[tokio::test]
+async fn get_baseline_found() {
+    let tenant_id = uuid::Uuid::new_v4();
+    let employee_id = uuid::Uuid::new_v4();
+    let baseline = make_sample_baseline(tenant_id, employee_id);
+
+    let mock = Arc::new(MockHealthBaselinesRepository::default());
+    *mock.get_result.lock().unwrap() = Some(baseline);
+    let (base, auth) = setup_with_mock(mock).await;
+
+    let res = client()
+        .get(format!("{base}/api/tenko/health-baselines/{employee_id}"))
+        .header("Authorization", &auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(body["employee_id"], employee_id.to_string());
+    assert_eq!(body["baseline_systolic"], 120);
+}
+
+#[tokio::test]
+async fn get_baseline_db_error_returns_500() {
+    let (base, auth) = setup_failing().await;
+    let employee_id = uuid::Uuid::new_v4();
+    let res = client()
+        .get(format!("{base}/api/tenko/health-baselines/{employee_id}"))
+        .header("Authorization", &auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}
+
+#[tokio::test]
+async fn get_baseline_no_auth_returns_401() {
+    let (base, _auth) = setup().await;
+    let employee_id = uuid::Uuid::new_v4();
+    let res = client()
+        .get(format!("{base}/api/tenko/health-baselines/{employee_id}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 401);
+}
+
+// ===========================================================================
+// PUT /api/tenko/health-baselines/{employee_id} — update_baseline
+// ===========================================================================
+
+#[tokio::test]
+async fn update_baseline_not_found() {
+    let (base, auth) = setup().await;
+    let employee_id = uuid::Uuid::new_v4();
+    let res = client()
+        .put(format!("{base}/api/tenko/health-baselines/{employee_id}"))
+        .header("Authorization", &auth)
+        .json(&serde_json::json!({
+            "baseline_systolic": 130
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 404);
+}
+
+#[tokio::test]
+async fn update_baseline_found() {
+    let tenant_id = uuid::Uuid::new_v4();
+    let employee_id = uuid::Uuid::new_v4();
+    let mut baseline = make_sample_baseline(tenant_id, employee_id);
+    baseline.baseline_systolic = 135;
+
+    let mock = Arc::new(MockHealthBaselinesRepository::default());
+    *mock.update_result.lock().unwrap() = Some(baseline);
+    let (base, auth) = setup_with_mock(mock).await;
+
+    let res = client()
+        .put(format!("{base}/api/tenko/health-baselines/{employee_id}"))
+        .header("Authorization", &auth)
+        .json(&serde_json::json!({
+            "baseline_systolic": 135
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(body["employee_id"], employee_id.to_string());
+    assert_eq!(body["baseline_systolic"], 135);
+}
+
+#[tokio::test]
+async fn update_baseline_db_error_returns_500() {
+    let (base, auth) = setup_failing().await;
+    let employee_id = uuid::Uuid::new_v4();
+    let res = client()
+        .put(format!("{base}/api/tenko/health-baselines/{employee_id}"))
+        .header("Authorization", &auth)
+        .json(&serde_json::json!({
+            "baseline_systolic": 130
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}
+
+#[tokio::test]
+async fn update_baseline_no_auth_returns_401() {
+    let (base, _auth) = setup().await;
+    let employee_id = uuid::Uuid::new_v4();
+    let res = client()
+        .put(format!("{base}/api/tenko/health-baselines/{employee_id}"))
+        .json(&serde_json::json!({
+            "baseline_systolic": 130
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 401);
+}
+
+// ===========================================================================
+// DELETE /api/tenko/health-baselines/{employee_id} — delete_baseline
+// ===========================================================================
+
+#[tokio::test]
+async fn delete_baseline_not_found() {
+    let (base, auth) = setup().await;
+    let employee_id = uuid::Uuid::new_v4();
+    let res = client()
+        .delete(format!("{base}/api/tenko/health-baselines/{employee_id}"))
+        .header("Authorization", &auth)
+        .send()
+        .await
+        .unwrap();
+    // Mock returns false => 404
+    assert_eq!(res.status(), 404);
+}
+
+#[tokio::test]
+async fn delete_baseline_success() {
+    let mock = Arc::new(MockHealthBaselinesRepository::default());
+    *mock.delete_result.lock().unwrap() = true;
+    let (base, auth) = setup_with_mock(mock).await;
+
+    let employee_id = uuid::Uuid::new_v4();
+    let res = client()
+        .delete(format!("{base}/api/tenko/health-baselines/{employee_id}"))
+        .header("Authorization", &auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 204);
+}
+
+#[tokio::test]
+async fn delete_baseline_db_error_returns_500() {
+    let (base, auth) = setup_failing().await;
+    let employee_id = uuid::Uuid::new_v4();
+    let res = client()
+        .delete(format!("{base}/api/tenko/health-baselines/{employee_id}"))
+        .header("Authorization", &auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}
+
+#[tokio::test]
+async fn delete_baseline_no_auth_returns_401() {
+    let (base, _auth) = setup().await;
+    let employee_id = uuid::Uuid::new_v4();
+    let res = client()
+        .delete(format!("{base}/api/tenko/health-baselines/{employee_id}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 401);
+}
+
+// ===========================================================================
+// X-Tenant-ID header fallback (no JWT)
+// ===========================================================================
+
+#[tokio::test]
+async fn list_baselines_with_tenant_header() {
+    let state = mock_helpers::app_state::setup_mock_app_state().await;
+    let tenant_id = common::create_test_tenant(&state.pool, "hb-header").await;
+    let base = common::spawn_test_server(state).await;
+
+    let res = client()
+        .get(format!("{base}/api/tenko/health-baselines"))
+        .header("X-Tenant-ID", tenant_id.to_string())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    let body: Vec<serde_json::Value> = res.json().await.unwrap();
+    assert!(body.is_empty());
+}

--- a/tests/mock_health_test.rs
+++ b/tests/mock_health_test.rs
@@ -1,0 +1,25 @@
+mod common;
+mod mock_helpers;
+
+use mock_helpers::app_state::setup_mock_app_state;
+
+// ---------------------------------------------------------------------------
+// GET /api/health — returns {"status": "ok"}
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_health_check_returns_ok() {
+    let state = setup_mock_app_state().await;
+    let base_url = common::spawn_test_server(state).await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!("{base_url}/api/health"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(body["status"], "ok");
+}

--- a/tests/mock_helpers/repos_a.rs
+++ b/tests/mock_helpers/repos_a.rs
@@ -322,7 +322,12 @@ impl CarInspectionRepository for MockCarInspectionRepository {
 
     async fn vehicle_categories(&self, _tenant_id: Uuid) -> Result<VehicleCategories, sqlx::Error> {
         check_fail!(self);
-        todo!("MockCarInspectionRepository::vehicle_categories")
+        Ok(VehicleCategories {
+            car_kinds: vec![],
+            uses: vec![],
+            car_shapes: vec![],
+            private_businesses: vec![],
+        })
     }
 
     async fn list_current_files(
@@ -553,7 +558,23 @@ impl CommunicationItemsRepository for MockCommunicationItemsRepository {
         _input: &CreateCommunicationItem,
     ) -> Result<CommunicationItem, sqlx::Error> {
         check_fail!(self);
-        todo!("MockCommunicationItemsRepository::create")
+        Ok(CommunicationItem {
+            id: Uuid::new_v4(),
+            tenant_id: _tenant_id,
+            title: _input.title.clone(),
+            content: _input.content.clone().unwrap_or_default(),
+            priority: _input
+                .priority
+                .clone()
+                .unwrap_or_else(|| "normal".to_string()),
+            target_employee_id: _input.target_employee_id,
+            is_active: true,
+            effective_from: _input.effective_from,
+            effective_until: _input.effective_until,
+            created_by: _input.created_by.clone(),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        })
     }
 
     async fn update(

--- a/tests/mock_helpers/repos_b.rs
+++ b/tests/mock_helpers/repos_b.rs
@@ -78,12 +78,18 @@ impl DtakoEventClassificationsRepository for MockDtakoEventClassificationsReposi
 
 pub struct MockDtakoOperationsRepository {
     pub fail_next: AtomicBool,
+    pub calendar_dates_result: std::sync::Mutex<Vec<(NaiveDate, i64)>>,
+    pub get_result: std::sync::Mutex<Vec<DtakoOperation>>,
+    pub delete_rows_affected: std::sync::Mutex<u64>,
 }
 
 impl Default for MockDtakoOperationsRepository {
     fn default() -> Self {
         Self {
             fail_next: AtomicBool::new(false),
+            calendar_dates_result: std::sync::Mutex::new(vec![]),
+            get_result: std::sync::Mutex::new(vec![]),
+            delete_rows_affected: std::sync::Mutex::new(0),
         }
     }
 }
@@ -97,7 +103,7 @@ impl DtakoOperationsRepository for MockDtakoOperationsRepository {
         _date_to: NaiveDate,
     ) -> Result<Vec<(NaiveDate, i64)>, sqlx::Error> {
         check_fail!(self);
-        Ok(vec![])
+        Ok(self.calendar_dates_result.lock().unwrap().clone())
     }
 
     async fn list(
@@ -120,7 +126,7 @@ impl DtakoOperationsRepository for MockDtakoOperationsRepository {
         _unko_no: &str,
     ) -> Result<Vec<DtakoOperation>, sqlx::Error> {
         check_fail!(self);
-        Ok(vec![])
+        Ok(self.get_result.lock().unwrap().clone())
     }
 
     async fn delete_by_unko_no(
@@ -129,7 +135,7 @@ impl DtakoOperationsRepository for MockDtakoOperationsRepository {
         _unko_no: &str,
     ) -> Result<u64, sqlx::Error> {
         check_fail!(self);
-        Ok(0)
+        Ok(*self.delete_rows_affected.lock().unwrap())
     }
 }
 
@@ -1002,12 +1008,22 @@ impl GuidanceRecordsRepository for MockGuidanceRecordsRepository {
 
 pub struct MockHealthBaselinesRepository {
     pub fail_next: AtomicBool,
+    pub upsert_result: std::sync::Mutex<Option<EmployeeHealthBaseline>>,
+    pub list_result: std::sync::Mutex<Vec<EmployeeHealthBaseline>>,
+    pub get_result: std::sync::Mutex<Option<EmployeeHealthBaseline>>,
+    pub update_result: std::sync::Mutex<Option<EmployeeHealthBaseline>>,
+    pub delete_result: std::sync::Mutex<bool>,
 }
 
 impl Default for MockHealthBaselinesRepository {
     fn default() -> Self {
         Self {
             fail_next: AtomicBool::new(false),
+            upsert_result: std::sync::Mutex::new(None),
+            list_result: std::sync::Mutex::new(vec![]),
+            get_result: std::sync::Mutex::new(None),
+            update_result: std::sync::Mutex::new(None),
+            delete_result: std::sync::Mutex::new(false),
         }
     }
 }
@@ -1020,12 +1036,29 @@ impl HealthBaselinesRepository for MockHealthBaselinesRepository {
         _body: &CreateHealthBaseline,
     ) -> Result<EmployeeHealthBaseline, sqlx::Error> {
         check_fail!(self);
-        todo!("MockHealthBaselinesRepository::upsert")
+        let result = self.upsert_result.lock().unwrap().clone();
+        match result {
+            Some(b) => Ok(b),
+            None => Ok(EmployeeHealthBaseline {
+                id: Uuid::new_v4(),
+                tenant_id: _tenant_id,
+                employee_id: _body.employee_id,
+                baseline_systolic: _body.baseline_systolic.unwrap_or(120),
+                baseline_diastolic: _body.baseline_diastolic.unwrap_or(80),
+                baseline_temperature: _body.baseline_temperature.unwrap_or(36.5),
+                systolic_tolerance: _body.systolic_tolerance.unwrap_or(10),
+                diastolic_tolerance: _body.diastolic_tolerance.unwrap_or(10),
+                temperature_tolerance: _body.temperature_tolerance.unwrap_or(0.5),
+                measurement_validity_minutes: _body.measurement_validity_minutes.unwrap_or(30),
+                created_at: Utc::now(),
+                updated_at: Utc::now(),
+            }),
+        }
     }
 
     async fn list(&self, _tenant_id: Uuid) -> Result<Vec<EmployeeHealthBaseline>, sqlx::Error> {
         check_fail!(self);
-        Ok(vec![])
+        Ok(self.list_result.lock().unwrap().clone())
     }
 
     async fn get(
@@ -1034,7 +1067,7 @@ impl HealthBaselinesRepository for MockHealthBaselinesRepository {
         _employee_id: Uuid,
     ) -> Result<Option<EmployeeHealthBaseline>, sqlx::Error> {
         check_fail!(self);
-        Ok(None)
+        Ok(self.get_result.lock().unwrap().clone())
     }
 
     async fn update(
@@ -1044,12 +1077,12 @@ impl HealthBaselinesRepository for MockHealthBaselinesRepository {
         _body: &UpdateHealthBaseline,
     ) -> Result<Option<EmployeeHealthBaseline>, sqlx::Error> {
         check_fail!(self);
-        Ok(None)
+        Ok(self.update_result.lock().unwrap().clone())
     }
 
     async fn delete(&self, _tenant_id: Uuid, _employee_id: Uuid) -> Result<bool, sqlx::Error> {
         check_fail!(self);
-        Ok(false)
+        Ok(*self.delete_result.lock().unwrap())
     }
 }
 

--- a/tests/mock_helpers/repos_c.rs
+++ b/tests/mock_helpers/repos_c.rs
@@ -30,12 +30,18 @@ macro_rules! check_fail {
 
 pub struct MockNfcTagRepository {
     pub fail_next: AtomicBool,
+    pub tag_data: std::sync::Mutex<Option<NfcTag>>,
+    pub car_inspection_json: std::sync::Mutex<Option<serde_json::Value>>,
+    pub delete_returns_true: AtomicBool,
 }
 
 impl Default for MockNfcTagRepository {
     fn default() -> Self {
         Self {
             fail_next: AtomicBool::new(false),
+            tag_data: std::sync::Mutex::new(None),
+            car_inspection_json: std::sync::Mutex::new(None),
+            delete_returns_true: AtomicBool::new(false),
         }
     }
 }
@@ -48,7 +54,7 @@ impl NfcTagRepository for MockNfcTagRepository {
         _nfc_uuid: &str,
     ) -> Result<Option<NfcTag>, sqlx::Error> {
         check_fail!(self);
-        Ok(None)
+        Ok(self.tag_data.lock().unwrap().clone())
     }
 
     async fn get_car_inspection_json(
@@ -57,7 +63,7 @@ impl NfcTagRepository for MockNfcTagRepository {
         _car_inspection_id: i32,
     ) -> Result<Option<serde_json::Value>, sqlx::Error> {
         check_fail!(self);
-        Ok(None)
+        Ok(self.car_inspection_json.lock().unwrap().clone())
     }
 
     async fn list(
@@ -66,22 +72,28 @@ impl NfcTagRepository for MockNfcTagRepository {
         _car_inspection_id: Option<i32>,
     ) -> Result<Vec<NfcTag>, sqlx::Error> {
         check_fail!(self);
-        Ok(vec![])
+        let data = self.tag_data.lock().unwrap();
+        Ok(data.iter().cloned().collect())
     }
 
     async fn register(
         &self,
         _tenant_id: Uuid,
-        _nfc_uuid: &str,
-        _car_inspection_id: i32,
+        nfc_uuid: &str,
+        car_inspection_id: i32,
     ) -> Result<NfcTag, sqlx::Error> {
         check_fail!(self);
-        todo!("MockNfcTagRepository::register")
+        Ok(NfcTag {
+            id: 1,
+            nfc_uuid: nfc_uuid.to_string(),
+            car_inspection_id,
+            created_at: Utc::now(),
+        })
     }
 
     async fn delete(&self, _tenant_id: Uuid, _nfc_uuid: &str) -> Result<bool, sqlx::Error> {
         check_fail!(self);
-        Ok(false)
+        Ok(self.delete_returns_true.load(Ordering::SeqCst))
     }
 }
 
@@ -163,12 +175,14 @@ impl SsoAdminRepository for MockSsoAdminRepository {
 
 pub struct MockTenantUsersRepository {
     pub fail_next: AtomicBool,
+    pub users: std::sync::Mutex<Vec<UserRow>>,
 }
 
 impl Default for MockTenantUsersRepository {
     fn default() -> Self {
         Self {
             fail_next: AtomicBool::new(false),
+            users: std::sync::Mutex::new(vec![]),
         }
     }
 }
@@ -177,7 +191,7 @@ impl Default for MockTenantUsersRepository {
 impl TenantUsersRepository for MockTenantUsersRepository {
     async fn list_users(&self, _tenant_id: Uuid) -> Result<Vec<UserRow>, sqlx::Error> {
         check_fail!(self);
-        Ok(vec![])
+        Ok(self.users.lock().unwrap().clone())
     }
 
     async fn list_invitations(
@@ -195,7 +209,13 @@ impl TenantUsersRepository for MockTenantUsersRepository {
         _role: &str,
     ) -> Result<TenantAllowedEmail, sqlx::Error> {
         check_fail!(self);
-        todo!("MockTenantUsersRepository::invite_user")
+        Ok(TenantAllowedEmail {
+            id: Uuid::new_v4(),
+            tenant_id: _tenant_id,
+            email: _email.to_string(),
+            role: _role.to_string(),
+            created_at: chrono::Utc::now(),
+        })
     }
 
     async fn delete_invitation(&self, _tenant_id: Uuid, _id: Uuid) -> Result<(), sqlx::Error> {
@@ -215,12 +235,18 @@ impl TenantUsersRepository for MockTenantUsersRepository {
 
 pub struct MockTenkoCallRepository {
     pub fail_next: AtomicBool,
+    /// true にすると register_driver / record_tenko が Some を返す (成功パス)
+    pub return_some: AtomicBool,
+    /// true にすると list_numbers / list_drivers がサンプルデータを返す
+    pub return_data: AtomicBool,
 }
 
 impl Default for MockTenkoCallRepository {
     fn default() -> Self {
         Self {
             fail_next: AtomicBool::new(false),
+            return_some: AtomicBool::new(false),
+            return_data: AtomicBool::new(false),
         }
     }
 }
@@ -229,13 +255,20 @@ impl Default for MockTenkoCallRepository {
 impl TenkoCallRepository for MockTenkoCallRepository {
     async fn register_driver(
         &self,
-        _call_number: &str,
+        call_number: &str,
         _phone_number: &str,
         _driver_name: &str,
         _employee_code: Option<&str>,
     ) -> Result<Option<RegisterDriverResult>, sqlx::Error> {
         check_fail!(self);
-        Ok(None)
+        if self.return_some.load(Ordering::SeqCst) {
+            Ok(Some(RegisterDriverResult {
+                driver_id: 42,
+                call_number: Some(call_number.to_string()),
+            }))
+        } else {
+            Ok(None)
+        }
     }
 
     async fn record_tenko(
@@ -246,12 +279,30 @@ impl TenkoCallRepository for MockTenkoCallRepository {
         _longitude: f64,
     ) -> Result<Option<DriverInfo>, sqlx::Error> {
         check_fail!(self);
-        Ok(None)
+        if self.return_some.load(Ordering::SeqCst) {
+            Ok(Some(DriverInfo {
+                id: 42,
+                call_number: Some("090-1234-5678".to_string()),
+                tenant_id: "test-tenant".to_string(),
+            }))
+        } else {
+            Ok(None)
+        }
     }
 
     async fn list_numbers(&self) -> Result<Vec<TenkoCallNumberRow>, sqlx::Error> {
         check_fail!(self);
-        Ok(vec![])
+        if self.return_data.load(Ordering::SeqCst) {
+            Ok(vec![TenkoCallNumberRow {
+                id: 1,
+                call_number: "090-0000-0001".to_string(),
+                tenant_id: "test-tenant".to_string(),
+                label: Some("Office A".to_string()),
+                created_at: "2026-01-01 00:00:00".to_string(),
+            }])
+        } else {
+            Ok(vec![])
+        }
     }
 
     async fn create_number(
@@ -261,7 +312,7 @@ impl TenkoCallRepository for MockTenkoCallRepository {
         _label: Option<&str>,
     ) -> Result<i32, sqlx::Error> {
         check_fail!(self);
-        Ok(0)
+        Ok(99)
     }
 
     async fn delete_number(&self, _id: i32) -> Result<(), sqlx::Error> {
@@ -271,7 +322,19 @@ impl TenkoCallRepository for MockTenkoCallRepository {
 
     async fn list_drivers(&self) -> Result<Vec<TenkoCallDriverRow>, sqlx::Error> {
         check_fail!(self);
-        Ok(vec![])
+        if self.return_data.load(Ordering::SeqCst) {
+            Ok(vec![TenkoCallDriverRow {
+                id: 1,
+                phone_number: "080-1111-2222".to_string(),
+                driver_name: "Test Driver".to_string(),
+                call_number: Some("090-0000-0001".to_string()),
+                tenant_id: "test-tenant".to_string(),
+                employee_code: Some("EMP001".to_string()),
+                created_at: "2026-01-01 00:00:00".to_string(),
+            }])
+        } else {
+            Ok(vec![])
+        }
     }
 }
 
@@ -334,13 +397,54 @@ impl TenkoRecordsRepository for MockTenkoRecordsRepository {
 
 pub struct MockTenkoSchedulesRepository {
     pub fail_next: AtomicBool,
+    pub return_none: AtomicBool,
 }
 
 impl Default for MockTenkoSchedulesRepository {
     fn default() -> Self {
         Self {
             fail_next: AtomicBool::new(false),
+            return_none: AtomicBool::new(false),
         }
+    }
+}
+
+fn make_mock_schedule(
+    tenant_id: Uuid,
+    employee_id: Uuid,
+    tenko_type: &str,
+    instruction: Option<String>,
+) -> TenkoSchedule {
+    TenkoSchedule {
+        id: Uuid::new_v4(),
+        tenant_id,
+        employee_id,
+        tenko_type: tenko_type.to_string(),
+        responsible_manager_name: "Manager".to_string(),
+        scheduled_at: Utc::now(),
+        instruction,
+        consumed: false,
+        consumed_by_session_id: None,
+        overdue_notified_at: None,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    }
+}
+
+fn make_mock_schedule_with_id(id: Uuid, tenant_id: Uuid) -> TenkoSchedule {
+    TenkoSchedule {
+        id,
+        tenant_id,
+        employee_id: Uuid::new_v4(),
+        tenko_type: "pre_operation".to_string(),
+        responsible_manager_name: "Manager".to_string(),
+        scheduled_at: Utc::now(),
+        instruction: Some("Test instruction".to_string()),
+        consumed: false,
+        consumed_by_session_id: None,
+        overdue_notified_at: None,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
     }
 }
 
@@ -348,20 +452,35 @@ impl Default for MockTenkoSchedulesRepository {
 impl TenkoSchedulesRepository for MockTenkoSchedulesRepository {
     async fn create(
         &self,
-        _tenant_id: Uuid,
-        _input: &CreateTenkoSchedule,
+        tenant_id: Uuid,
+        input: &CreateTenkoSchedule,
     ) -> Result<TenkoSchedule, sqlx::Error> {
         check_fail!(self);
-        todo!("MockTenkoSchedulesRepository::create")
+        Ok(make_mock_schedule(
+            tenant_id,
+            input.employee_id,
+            &input.tenko_type,
+            input.instruction.clone(),
+        ))
     }
 
     async fn batch_create(
         &self,
-        _tenant_id: Uuid,
-        _inputs: &[CreateTenkoSchedule],
+        tenant_id: Uuid,
+        inputs: &[CreateTenkoSchedule],
     ) -> Result<Vec<TenkoSchedule>, sqlx::Error> {
         check_fail!(self);
-        Ok(vec![])
+        Ok(inputs
+            .iter()
+            .map(|s| {
+                make_mock_schedule(
+                    tenant_id,
+                    s.employee_id,
+                    &s.tenko_type,
+                    s.instruction.clone(),
+                )
+            })
+            .collect())
     }
 
     async fn list(
@@ -378,24 +497,33 @@ impl TenkoSchedulesRepository for MockTenkoSchedulesRepository {
         })
     }
 
-    async fn get(&self, _tenant_id: Uuid, _id: Uuid) -> Result<Option<TenkoSchedule>, sqlx::Error> {
+    async fn get(&self, tenant_id: Uuid, id: Uuid) -> Result<Option<TenkoSchedule>, sqlx::Error> {
         check_fail!(self);
-        Ok(None)
+        if self.return_none.load(Ordering::SeqCst) {
+            return Ok(None);
+        }
+        Ok(Some(make_mock_schedule_with_id(id, tenant_id)))
     }
 
     async fn update(
         &self,
-        _tenant_id: Uuid,
-        _id: Uuid,
+        tenant_id: Uuid,
+        id: Uuid,
         _input: &UpdateTenkoSchedule,
     ) -> Result<Option<TenkoSchedule>, sqlx::Error> {
         check_fail!(self);
-        Ok(None)
+        if self.return_none.load(Ordering::SeqCst) {
+            return Ok(None);
+        }
+        Ok(Some(make_mock_schedule_with_id(id, tenant_id)))
     }
 
     async fn delete(&self, _tenant_id: Uuid, _id: Uuid) -> Result<bool, sqlx::Error> {
         check_fail!(self);
-        Ok(false)
+        if self.return_none.load(Ordering::SeqCst) {
+            return Ok(false);
+        }
+        Ok(true)
     }
 
     async fn get_pending(
@@ -710,12 +838,15 @@ impl TenkoSessionRepository for MockTenkoSessionRepository {
 
 pub struct MockTenkoWebhooksRepository {
     pub fail_next: AtomicBool,
+    /// When true, `get` returns Some and `delete` returns true.
+    pub return_found: AtomicBool,
 }
 
 impl Default for MockTenkoWebhooksRepository {
     fn default() -> Self {
         Self {
             fail_next: AtomicBool::new(false),
+            return_found: AtomicBool::new(false),
         }
     }
 }
@@ -724,11 +855,21 @@ impl Default for MockTenkoWebhooksRepository {
 impl TenkoWebhooksRepository for MockTenkoWebhooksRepository {
     async fn upsert(
         &self,
-        _tenant_id: Uuid,
-        _input: &CreateWebhookConfig,
+        tenant_id: Uuid,
+        input: &CreateWebhookConfig,
     ) -> Result<WebhookConfig, sqlx::Error> {
         check_fail!(self);
-        todo!("MockTenkoWebhooksRepository::upsert")
+        let now = Utc::now();
+        Ok(WebhookConfig {
+            id: Uuid::new_v4(),
+            tenant_id,
+            event_type: input.event_type.clone(),
+            url: input.url.clone(),
+            secret: input.secret.clone(),
+            enabled: input.enabled,
+            created_at: now,
+            updated_at: now,
+        })
     }
 
     async fn list(&self, _tenant_id: Uuid) -> Result<Vec<WebhookConfig>, sqlx::Error> {
@@ -736,14 +877,32 @@ impl TenkoWebhooksRepository for MockTenkoWebhooksRepository {
         Ok(vec![])
     }
 
-    async fn get(&self, _tenant_id: Uuid, _id: Uuid) -> Result<Option<WebhookConfig>, sqlx::Error> {
+    async fn get(&self, tenant_id: Uuid, id: Uuid) -> Result<Option<WebhookConfig>, sqlx::Error> {
         check_fail!(self);
-        Ok(None)
+        if self.return_found.load(Ordering::SeqCst) {
+            let now = Utc::now();
+            Ok(Some(WebhookConfig {
+                id,
+                tenant_id,
+                event_type: "tenko_completed".to_string(),
+                url: "https://example.com/hook".to_string(),
+                secret: None,
+                enabled: true,
+                created_at: now,
+                updated_at: now,
+            }))
+        } else {
+            Ok(None)
+        }
     }
 
     async fn delete(&self, _tenant_id: Uuid, _id: Uuid) -> Result<bool, sqlx::Error> {
         check_fail!(self);
-        Ok(false)
+        if self.return_found.load(Ordering::SeqCst) {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
     }
 
     async fn list_deliveries(

--- a/tests/mock_nfc_tags_test.rs
+++ b/tests/mock_nfc_tags_test.rs
@@ -1,0 +1,462 @@
+#[macro_use]
+mod common;
+mod mock_helpers;
+
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+use chrono::Utc;
+use serde_json::Value;
+use uuid::Uuid;
+
+use rust_alc_api::db::models::NfcTag;
+use rust_alc_api::db::repository::nfc_tags::NfcTagRepository;
+
+// ============================================================
+// Helper: spawn server with a given NfcTag mock
+// ============================================================
+
+async fn spawn_with_mock(mock: Arc<dyn NfcTagRepository>) -> (String, String) {
+    let tenant_id = Uuid::new_v4();
+    let jwt = common::create_test_jwt(tenant_id, "admin");
+
+    let mut state = mock_helpers::app_state::setup_mock_app_state().await;
+    state.nfc_tags = mock;
+    let base_url = common::spawn_test_server(state).await;
+
+    (base_url, jwt)
+}
+
+fn auth(jwt: &str) -> String {
+    format!("Bearer {jwt}")
+}
+
+fn make_tag(nfc_uuid: &str, car_inspection_id: i32) -> NfcTag {
+    NfcTag {
+        id: 1,
+        nfc_uuid: nfc_uuid.to_string(),
+        car_inspection_id,
+        created_at: Utc::now(),
+    }
+}
+
+// ============================================================
+// SearchByUuidFailOnInspection: succeeds on search_by_uuid, fails on get_car_inspection_json
+// ============================================================
+
+struct SearchByUuidFailOnInspection;
+
+#[async_trait::async_trait]
+impl NfcTagRepository for SearchByUuidFailOnInspection {
+    async fn search_by_uuid(
+        &self,
+        _tenant_id: Uuid,
+        nfc_uuid: &str,
+    ) -> Result<Option<NfcTag>, sqlx::Error> {
+        Ok(Some(make_tag(nfc_uuid, 42)))
+    }
+
+    async fn get_car_inspection_json(
+        &self,
+        _tenant_id: Uuid,
+        _car_inspection_id: i32,
+    ) -> Result<Option<serde_json::Value>, sqlx::Error> {
+        Err(sqlx::Error::RowNotFound)
+    }
+
+    async fn list(&self, _: Uuid, _: Option<i32>) -> Result<Vec<NfcTag>, sqlx::Error> {
+        unreachable!()
+    }
+
+    async fn register(&self, _: Uuid, _: &str, _: i32) -> Result<NfcTag, sqlx::Error> {
+        unreachable!()
+    }
+
+    async fn delete(&self, _: Uuid, _: &str) -> Result<bool, sqlx::Error> {
+        unreachable!()
+    }
+}
+
+// ============================================================
+// search_by_uuid: GET /api/nfc-tags/search?uuid=xxx
+// ============================================================
+
+#[tokio::test]
+async fn test_search_by_uuid_success() {
+    let mock = Arc::new(mock_helpers::MockNfcTagRepository::default());
+    *mock.tag_data.lock().unwrap() = Some(make_tag("aabb0011", 42));
+    *mock.car_inspection_json.lock().unwrap() =
+        Some(serde_json::json!({"id": 42, "EntryNoCarNo": "ABC-123"}));
+
+    let (base_url, jwt) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!("{base_url}/api/nfc-tags/search?uuid=aabb0011"))
+        .header("Authorization", auth(&jwt))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+
+    let body: Value = res.json().await.unwrap();
+    assert_eq!(body["nfc_tag"]["nfcUuid"], "aabb0011");
+    assert_eq!(body["nfc_tag"]["carInspectionId"], 42);
+    assert_eq!(body["car_inspection"]["EntryNoCarNo"], "ABC-123");
+}
+
+#[tokio::test]
+async fn test_search_by_uuid_normalizes_colons() {
+    // UUID with colons like "AA:BB:00:11" should be normalized to "aabb0011"
+    let mock = Arc::new(mock_helpers::MockNfcTagRepository::default());
+    *mock.tag_data.lock().unwrap() = Some(make_tag("aabb0011", 10));
+
+    let (base_url, jwt) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!("{base_url}/api/nfc-tags/search?uuid=AA:BB:00:11"))
+        .header("Authorization", auth(&jwt))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+
+    let body: Value = res.json().await.unwrap();
+    assert_eq!(body["nfc_tag"]["nfcUuid"], "aabb0011");
+}
+
+#[tokio::test]
+async fn test_search_by_uuid_car_inspection_null() {
+    // Tag found but no car_inspection JSON (returns null)
+    let mock = Arc::new(mock_helpers::MockNfcTagRepository::default());
+    *mock.tag_data.lock().unwrap() = Some(make_tag("aabb0011", 99));
+    // car_inspection_json stays None
+
+    let (base_url, jwt) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!("{base_url}/api/nfc-tags/search?uuid=aabb0011"))
+        .header("Authorization", auth(&jwt))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+
+    let body: Value = res.json().await.unwrap();
+    assert!(body["car_inspection"].is_null());
+}
+
+#[tokio::test]
+async fn test_search_by_uuid_not_found() {
+    // Default mock returns None for search_by_uuid
+    let mock = Arc::new(mock_helpers::MockNfcTagRepository::default());
+    let (base_url, jwt) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!("{base_url}/api/nfc-tags/search?uuid=nonexistent"))
+        .header("Authorization", auth(&jwt))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 404);
+}
+
+#[tokio::test]
+async fn test_search_by_uuid_db_error() {
+    let mock = Arc::new(mock_helpers::MockNfcTagRepository::default());
+    mock.fail_next.store(true, Ordering::SeqCst);
+    let (base_url, jwt) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!("{base_url}/api/nfc-tags/search?uuid=abc"))
+        .header("Authorization", auth(&jwt))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}
+
+#[tokio::test]
+async fn test_search_by_uuid_car_inspection_db_error() {
+    // search_by_uuid succeeds but get_car_inspection_json fails
+    let mock = Arc::new(SearchByUuidFailOnInspection);
+    let (base_url, jwt) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!("{base_url}/api/nfc-tags/search?uuid=aabb0011"))
+        .header("Authorization", auth(&jwt))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}
+
+// ============================================================
+// list_tags: GET /api/nfc-tags
+// ============================================================
+
+#[tokio::test]
+async fn test_list_tags_success_empty() {
+    let mock = Arc::new(mock_helpers::MockNfcTagRepository::default());
+    let (base_url, jwt) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!("{base_url}/api/nfc-tags"))
+        .header("Authorization", auth(&jwt))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+
+    let body: Vec<Value> = res.json().await.unwrap();
+    assert!(body.is_empty());
+}
+
+#[tokio::test]
+async fn test_list_tags_success_with_data() {
+    let mock = Arc::new(mock_helpers::MockNfcTagRepository::default());
+    *mock.tag_data.lock().unwrap() = Some(make_tag("aabb0011", 5));
+    let (base_url, jwt) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!("{base_url}/api/nfc-tags"))
+        .header("Authorization", auth(&jwt))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+
+    let body: Vec<Value> = res.json().await.unwrap();
+    assert_eq!(body.len(), 1);
+    assert_eq!(body[0]["nfcUuid"], "aabb0011");
+}
+
+#[tokio::test]
+async fn test_list_tags_with_car_inspection_id_filter() {
+    let mock = Arc::new(mock_helpers::MockNfcTagRepository::default());
+    *mock.tag_data.lock().unwrap() = Some(make_tag("cc0022", 7));
+    let (base_url, jwt) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!("{base_url}/api/nfc-tags?car_inspection_id=7"))
+        .header("Authorization", auth(&jwt))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+
+    let body: Vec<Value> = res.json().await.unwrap();
+    assert_eq!(body.len(), 1);
+}
+
+#[tokio::test]
+async fn test_list_tags_db_error() {
+    let mock = Arc::new(mock_helpers::MockNfcTagRepository::default());
+    mock.fail_next.store(true, Ordering::SeqCst);
+    let (base_url, jwt) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!("{base_url}/api/nfc-tags"))
+        .header("Authorization", auth(&jwt))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}
+
+// ============================================================
+// register_tag: POST /api/nfc-tags
+// ============================================================
+
+#[tokio::test]
+async fn test_register_tag_success() {
+    let mock = Arc::new(mock_helpers::MockNfcTagRepository::default());
+    let (base_url, jwt) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/nfc-tags"))
+        .header("Authorization", auth(&jwt))
+        .json(&serde_json::json!({
+            "nfc_uuid": "DD:EE:FF:00",
+            "car_inspection_id": 123
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 201);
+
+    let body: Value = res.json().await.unwrap();
+    // UUID should be normalized: lowercase, colons removed
+    assert_eq!(body["nfcUuid"], "ddeeff00");
+    assert_eq!(body["carInspectionId"], 123);
+}
+
+#[tokio::test]
+async fn test_register_tag_normalizes_uuid() {
+    let mock = Arc::new(mock_helpers::MockNfcTagRepository::default());
+    let (base_url, jwt) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/nfc-tags"))
+        .header("Authorization", auth(&jwt))
+        .json(&serde_json::json!({
+            "nfc_uuid": "AA:BB:CC:DD",
+            "car_inspection_id": 1
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 201);
+
+    let body: Value = res.json().await.unwrap();
+    assert_eq!(body["nfcUuid"], "aabbccdd");
+}
+
+#[tokio::test]
+async fn test_register_tag_db_error() {
+    let mock = Arc::new(mock_helpers::MockNfcTagRepository::default());
+    mock.fail_next.store(true, Ordering::SeqCst);
+    let (base_url, jwt) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/nfc-tags"))
+        .header("Authorization", auth(&jwt))
+        .json(&serde_json::json!({
+            "nfc_uuid": "aabb0011",
+            "car_inspection_id": 1
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}
+
+// ============================================================
+// delete_tag: DELETE /api/nfc-tags/{nfc_uuid}
+// ============================================================
+
+#[tokio::test]
+async fn test_delete_tag_success() {
+    let mock = Arc::new(mock_helpers::MockNfcTagRepository::default());
+    mock.delete_returns_true.store(true, Ordering::SeqCst);
+    let (base_url, jwt) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .delete(format!("{base_url}/api/nfc-tags/aabb0011"))
+        .header("Authorization", auth(&jwt))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 204);
+}
+
+#[tokio::test]
+async fn test_delete_tag_normalizes_uuid() {
+    let mock = Arc::new(mock_helpers::MockNfcTagRepository::default());
+    mock.delete_returns_true.store(true, Ordering::SeqCst);
+    let (base_url, jwt) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    // Colons and uppercase in path should be normalized
+    let res = client
+        .delete(format!("{base_url}/api/nfc-tags/AA:BB:00:11"))
+        .header("Authorization", auth(&jwt))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 204);
+}
+
+#[tokio::test]
+async fn test_delete_tag_not_found() {
+    // Default mock returns Ok(false) from delete
+    let mock = Arc::new(mock_helpers::MockNfcTagRepository::default());
+    let (base_url, jwt) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .delete(format!("{base_url}/api/nfc-tags/nonexistent"))
+        .header("Authorization", auth(&jwt))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 404);
+}
+
+#[tokio::test]
+async fn test_delete_tag_db_error() {
+    let mock = Arc::new(mock_helpers::MockNfcTagRepository::default());
+    mock.fail_next.store(true, Ordering::SeqCst);
+    let (base_url, jwt) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .delete(format!("{base_url}/api/nfc-tags/aabb0011"))
+        .header("Authorization", auth(&jwt))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}
+
+// ============================================================
+// Auth: no JWT -> 401
+// ============================================================
+
+#[tokio::test]
+async fn test_no_auth_returns_401() {
+    let mock = Arc::new(mock_helpers::MockNfcTagRepository::default());
+    let mut state = mock_helpers::app_state::setup_mock_app_state().await;
+    state.nfc_tags = mock;
+    let base_url = common::spawn_test_server(state).await;
+    let client = reqwest::Client::new();
+
+    // GET /nfc-tags
+    let res = client
+        .get(format!("{base_url}/api/nfc-tags"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 401);
+
+    // POST /nfc-tags
+    let res = client
+        .post(format!("{base_url}/api/nfc-tags"))
+        .json(&serde_json::json!({
+            "nfc_uuid": "aabb",
+            "car_inspection_id": 1
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 401);
+
+    // GET /nfc-tags/search
+    let res = client
+        .get(format!("{base_url}/api/nfc-tags/search?uuid=abc"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 401);
+
+    // DELETE /nfc-tags/{uuid}
+    let res = client
+        .delete(format!("{base_url}/api/nfc-tags/aabb0011"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 401);
+}

--- a/tests/mock_tenant_users_test.rs
+++ b/tests/mock_tenant_users_test.rs
@@ -1,0 +1,523 @@
+mod common;
+mod mock_helpers;
+
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+use mock_helpers::MockTenantUsersRepository;
+
+/// Helper: set up mock AppState and spawn test server with admin JWT.
+/// Returns (base_url, auth_header, user_id, tenant_id).
+async fn setup() -> (String, String, uuid::Uuid, uuid::Uuid) {
+    let state = mock_helpers::app_state::setup_mock_app_state().await;
+    let tenant_id = uuid::Uuid::new_v4();
+    let user_id = uuid::Uuid::new_v4();
+    let base_url = common::spawn_test_server(state).await;
+    let jwt = common::create_test_jwt_for_user(user_id, tenant_id, "admin@example.com", "admin");
+    let auth_header = format!("Bearer {jwt}");
+    (base_url, auth_header, user_id, tenant_id)
+}
+
+/// Helper: set up with a failing mock for tenant_users.
+async fn setup_failing() -> (String, String, uuid::Uuid, uuid::Uuid) {
+    let mock = Arc::new(MockTenantUsersRepository::default());
+    mock.fail_next.store(true, Ordering::SeqCst);
+    let mut state = mock_helpers::app_state::setup_mock_app_state().await;
+    state.tenant_users = mock;
+    let tenant_id = uuid::Uuid::new_v4();
+    let user_id = uuid::Uuid::new_v4();
+    let base_url = common::spawn_test_server(state).await;
+    let jwt = common::create_test_jwt_for_user(user_id, tenant_id, "admin@example.com", "admin");
+    let auth_header = format!("Bearer {jwt}");
+    (base_url, auth_header, user_id, tenant_id)
+}
+
+// =========================================================================
+// GET /api/admin/users — list_users
+// =========================================================================
+
+#[tokio::test]
+async fn test_list_users_success() {
+    let (base_url, auth_header, _, _) = setup().await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!("{base_url}/api/admin/users"))
+        .header("Authorization", &auth_header)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert!(body["users"].is_array());
+    assert_eq!(body["users"].as_array().unwrap().len(), 0);
+}
+
+#[tokio::test]
+async fn test_list_users_forbidden_for_viewer() {
+    let state = mock_helpers::app_state::setup_mock_app_state().await;
+    let tenant_id = uuid::Uuid::new_v4();
+    let base_url = common::spawn_test_server(state).await;
+    let jwt = common::create_test_jwt(tenant_id, "viewer");
+    let auth_header = format!("Bearer {jwt}");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!("{base_url}/api/admin/users"))
+        .header("Authorization", &auth_header)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 403);
+}
+
+#[tokio::test]
+async fn test_list_users_no_auth() {
+    let state = mock_helpers::app_state::setup_mock_app_state().await;
+    let base_url = common::spawn_test_server(state).await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!("{base_url}/api/admin/users"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 401);
+}
+
+#[tokio::test]
+async fn test_list_users_db_error() {
+    let (base_url, auth_header, _, _) = setup_failing().await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!("{base_url}/api/admin/users"))
+        .header("Authorization", &auth_header)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}
+
+// =========================================================================
+// GET /api/admin/users/invitations — list_invitations
+// =========================================================================
+
+#[tokio::test]
+async fn test_list_invitations_success() {
+    let (base_url, auth_header, _, _) = setup().await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!("{base_url}/api/admin/users/invitations"))
+        .header("Authorization", &auth_header)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert!(body["invitations"].is_array());
+    assert_eq!(body["invitations"].as_array().unwrap().len(), 0);
+}
+
+#[tokio::test]
+async fn test_list_invitations_forbidden_for_viewer() {
+    let state = mock_helpers::app_state::setup_mock_app_state().await;
+    let tenant_id = uuid::Uuid::new_v4();
+    let base_url = common::spawn_test_server(state).await;
+    let jwt = common::create_test_jwt(tenant_id, "viewer");
+    let auth_header = format!("Bearer {jwt}");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!("{base_url}/api/admin/users/invitations"))
+        .header("Authorization", &auth_header)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 403);
+}
+
+#[tokio::test]
+async fn test_list_invitations_no_auth() {
+    let state = mock_helpers::app_state::setup_mock_app_state().await;
+    let base_url = common::spawn_test_server(state).await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!("{base_url}/api/admin/users/invitations"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 401);
+}
+
+#[tokio::test]
+async fn test_list_invitations_db_error() {
+    let mock = Arc::new(MockTenantUsersRepository::default());
+    mock.fail_next.store(true, Ordering::SeqCst);
+    let mut state = mock_helpers::app_state::setup_mock_app_state().await;
+    state.tenant_users = mock;
+    let tenant_id = uuid::Uuid::new_v4();
+    let base_url = common::spawn_test_server(state).await;
+    let jwt = common::create_test_jwt(tenant_id, "admin");
+    let auth_header = format!("Bearer {jwt}");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!("{base_url}/api/admin/users/invitations"))
+        .header("Authorization", &auth_header)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}
+
+// =========================================================================
+// POST /api/admin/users/invite — invite_user
+// =========================================================================
+
+#[tokio::test]
+async fn test_invite_user_success_default_role() {
+    let (base_url, auth_header, _, _) = setup().await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/admin/users/invite"))
+        .header("Authorization", &auth_header)
+        .json(&serde_json::json!({
+            "email": "newuser@example.com"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(body["email"], "newuser@example.com");
+    assert_eq!(body["role"], "admin"); // default role
+}
+
+#[tokio::test]
+async fn test_invite_user_success_viewer_role() {
+    let (base_url, auth_header, _, _) = setup().await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/admin/users/invite"))
+        .header("Authorization", &auth_header)
+        .json(&serde_json::json!({
+            "email": "viewer@example.com",
+            "role": "viewer"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(body["email"], "viewer@example.com");
+    assert_eq!(body["role"], "viewer");
+}
+
+#[tokio::test]
+async fn test_invite_user_success_admin_role() {
+    let (base_url, auth_header, _, _) = setup().await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/admin/users/invite"))
+        .header("Authorization", &auth_header)
+        .json(&serde_json::json!({
+            "email": "admin2@example.com",
+            "role": "admin"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(body["email"], "admin2@example.com");
+    assert_eq!(body["role"], "admin");
+}
+
+#[tokio::test]
+async fn test_invite_user_invalid_role() {
+    let (base_url, auth_header, _, _) = setup().await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/admin/users/invite"))
+        .header("Authorization", &auth_header)
+        .json(&serde_json::json!({
+            "email": "user@example.com",
+            "role": "superuser"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 400);
+}
+
+#[tokio::test]
+async fn test_invite_user_forbidden_for_viewer() {
+    let state = mock_helpers::app_state::setup_mock_app_state().await;
+    let tenant_id = uuid::Uuid::new_v4();
+    let base_url = common::spawn_test_server(state).await;
+    let jwt = common::create_test_jwt(tenant_id, "viewer");
+    let auth_header = format!("Bearer {jwt}");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/admin/users/invite"))
+        .header("Authorization", &auth_header)
+        .json(&serde_json::json!({
+            "email": "user@example.com"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 403);
+}
+
+#[tokio::test]
+async fn test_invite_user_no_auth() {
+    let state = mock_helpers::app_state::setup_mock_app_state().await;
+    let base_url = common::spawn_test_server(state).await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/admin/users/invite"))
+        .json(&serde_json::json!({
+            "email": "user@example.com"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 401);
+}
+
+#[tokio::test]
+async fn test_invite_user_db_error() {
+    let mock = Arc::new(MockTenantUsersRepository::default());
+    mock.fail_next.store(true, Ordering::SeqCst);
+    let mut state = mock_helpers::app_state::setup_mock_app_state().await;
+    state.tenant_users = mock;
+    let tenant_id = uuid::Uuid::new_v4();
+    let base_url = common::spawn_test_server(state).await;
+    let jwt = common::create_test_jwt(tenant_id, "admin");
+    let auth_header = format!("Bearer {jwt}");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/admin/users/invite"))
+        .header("Authorization", &auth_header)
+        .json(&serde_json::json!({
+            "email": "user@example.com"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}
+
+// =========================================================================
+// DELETE /api/admin/users/invite/{id} — delete_invitation
+// =========================================================================
+
+#[tokio::test]
+async fn test_delete_invitation_success() {
+    let (base_url, auth_header, _, _) = setup().await;
+    let client = reqwest::Client::new();
+    let invitation_id = uuid::Uuid::new_v4();
+
+    let res = client
+        .delete(format!("{base_url}/api/admin/users/invite/{invitation_id}"))
+        .header("Authorization", &auth_header)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 204);
+}
+
+#[tokio::test]
+async fn test_delete_invitation_forbidden_for_viewer() {
+    let state = mock_helpers::app_state::setup_mock_app_state().await;
+    let tenant_id = uuid::Uuid::new_v4();
+    let base_url = common::spawn_test_server(state).await;
+    let jwt = common::create_test_jwt(tenant_id, "viewer");
+    let auth_header = format!("Bearer {jwt}");
+    let client = reqwest::Client::new();
+    let id = uuid::Uuid::new_v4();
+
+    let res = client
+        .delete(format!("{base_url}/api/admin/users/invite/{id}"))
+        .header("Authorization", &auth_header)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 403);
+}
+
+#[tokio::test]
+async fn test_delete_invitation_no_auth() {
+    let state = mock_helpers::app_state::setup_mock_app_state().await;
+    let base_url = common::spawn_test_server(state).await;
+    let client = reqwest::Client::new();
+    let id = uuid::Uuid::new_v4();
+
+    let res = client
+        .delete(format!("{base_url}/api/admin/users/invite/{id}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 401);
+}
+
+#[tokio::test]
+async fn test_delete_invitation_db_error() {
+    let mock = Arc::new(MockTenantUsersRepository::default());
+    mock.fail_next.store(true, Ordering::SeqCst);
+    let mut state = mock_helpers::app_state::setup_mock_app_state().await;
+    state.tenant_users = mock;
+    let tenant_id = uuid::Uuid::new_v4();
+    let base_url = common::spawn_test_server(state).await;
+    let jwt = common::create_test_jwt(tenant_id, "admin");
+    let auth_header = format!("Bearer {jwt}");
+    let client = reqwest::Client::new();
+    let id = uuid::Uuid::new_v4();
+
+    let res = client
+        .delete(format!("{base_url}/api/admin/users/invite/{id}"))
+        .header("Authorization", &auth_header)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}
+
+// =========================================================================
+// DELETE /api/admin/users/{id} — delete_user
+// =========================================================================
+
+#[tokio::test]
+async fn test_delete_user_success() {
+    let (base_url, auth_header, _, _) = setup().await;
+    let client = reqwest::Client::new();
+    let other_user_id = uuid::Uuid::new_v4();
+
+    let res = client
+        .delete(format!("{base_url}/api/admin/users/{other_user_id}"))
+        .header("Authorization", &auth_header)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 204);
+}
+
+#[tokio::test]
+async fn test_delete_user_cannot_delete_self() {
+    let (base_url, auth_header, user_id, _) = setup().await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .delete(format!("{base_url}/api/admin/users/{user_id}"))
+        .header("Authorization", &auth_header)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 400);
+}
+
+#[tokio::test]
+async fn test_delete_user_forbidden_for_viewer() {
+    let state = mock_helpers::app_state::setup_mock_app_state().await;
+    let tenant_id = uuid::Uuid::new_v4();
+    let base_url = common::spawn_test_server(state).await;
+    let jwt = common::create_test_jwt(tenant_id, "viewer");
+    let auth_header = format!("Bearer {jwt}");
+    let client = reqwest::Client::new();
+    let id = uuid::Uuid::new_v4();
+
+    let res = client
+        .delete(format!("{base_url}/api/admin/users/{id}"))
+        .header("Authorization", &auth_header)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 403);
+}
+
+#[tokio::test]
+async fn test_delete_user_no_auth() {
+    let state = mock_helpers::app_state::setup_mock_app_state().await;
+    let base_url = common::spawn_test_server(state).await;
+    let client = reqwest::Client::new();
+    let id = uuid::Uuid::new_v4();
+
+    let res = client
+        .delete(format!("{base_url}/api/admin/users/{id}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 401);
+}
+
+#[tokio::test]
+async fn test_delete_user_db_error() {
+    let mock = Arc::new(MockTenantUsersRepository::default());
+    mock.fail_next.store(true, Ordering::SeqCst);
+    let mut state = mock_helpers::app_state::setup_mock_app_state().await;
+    state.tenant_users = mock;
+    let tenant_id = uuid::Uuid::new_v4();
+    let user_id = uuid::Uuid::new_v4();
+    let base_url = common::spawn_test_server(state).await;
+    let jwt = common::create_test_jwt_for_user(user_id, tenant_id, "admin@example.com", "admin");
+    let auth_header = format!("Bearer {jwt}");
+    let client = reqwest::Client::new();
+    let other_user_id = uuid::Uuid::new_v4();
+
+    let res = client
+        .delete(format!("{base_url}/api/admin/users/{other_user_id}"))
+        .header("Authorization", &auth_header)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}
+
+// ---------------------------------------------------------------------------
+// list_users with data — covers UserRow → UserResponse From impl
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_list_users_with_data() {
+    use rust_alc_api::db::repository::tenant_users::UserRow;
+
+    let mut state = mock_helpers::app_state::setup_mock_app_state().await;
+    let tenant_id = common::create_test_tenant(&state.pool, "MockTUData").await;
+
+    let mock = std::sync::Arc::new(mock_helpers::MockTenantUsersRepository::default());
+    *mock.users.lock().unwrap() = vec![UserRow {
+        id: uuid::Uuid::new_v4(),
+        email: "test@example.com".to_string(),
+        name: "Test User".to_string(),
+        role: "admin".to_string(),
+        created_at: chrono::Utc::now(),
+    }];
+    state.tenant_users = mock;
+
+    let base_url = common::spawn_test_server(state).await;
+    let jwt = common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!("{base_url}/api/admin/users"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    let body: serde_json::Value = res.json().await.unwrap();
+    let users = body["users"].as_array().unwrap();
+    assert_eq!(users.len(), 1);
+    assert_eq!(users[0]["email"], "test@example.com");
+}

--- a/tests/mock_tenko_call_test.rs
+++ b/tests/mock_tenko_call_test.rs
@@ -1,0 +1,731 @@
+#[macro_use]
+mod common;
+mod mock_helpers;
+
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+use serde_json::Value;
+use uuid::Uuid;
+
+use mock_helpers::app_state::setup_mock_app_state;
+use mock_helpers::MockTenkoCallRepository;
+
+// ============================================================
+// POST /tenko-call/register — public (no auth)
+// ============================================================
+
+#[tokio::test]
+async fn test_register_success() {
+    test_group!("TenkoCall: register success");
+    test_case!("call_number がマスタに存在し登録成功", {
+        let _guard = common::ENV_LOCK.lock().unwrap();
+        std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
+
+        let mock = Arc::new(MockTenkoCallRepository::default());
+        mock.return_some.store(true, Ordering::SeqCst);
+        let mut state = setup_mock_app_state().await;
+        state.tenko_call = mock;
+        let base_url = common::spawn_test_server(state).await;
+
+        let client = reqwest::Client::new();
+        let res = client
+            .post(format!("{base_url}/api/tenko-call/register"))
+            .json(&serde_json::json!({
+                "phone_number": "080-1111-2222",
+                "driver_name": "Test Driver",
+                "call_number": "090-0000-0001",
+                "employee_code": "EMP001"
+            }))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(res.status(), 200);
+        let body: Value = res.json().await.unwrap();
+        assert_eq!(body["success"], true);
+        assert_eq!(body["driver_id"], 42);
+        assert_eq!(body["call_number"], "090-0000-0001");
+        assert!(body.get("error").is_none() || body["error"].is_null());
+    });
+}
+
+#[tokio::test]
+async fn test_register_without_employee_code() {
+    test_group!("TenkoCall: register without employee_code");
+    test_case!("employee_code なしでも登録成功", {
+        let _guard = common::ENV_LOCK.lock().unwrap();
+        std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
+
+        let mock = Arc::new(MockTenkoCallRepository::default());
+        mock.return_some.store(true, Ordering::SeqCst);
+        let mut state = setup_mock_app_state().await;
+        state.tenko_call = mock;
+        let base_url = common::spawn_test_server(state).await;
+
+        let client = reqwest::Client::new();
+        let res = client
+            .post(format!("{base_url}/api/tenko-call/register"))
+            .json(&serde_json::json!({
+                "phone_number": "080-3333-4444",
+                "driver_name": "Driver No Code",
+                "call_number": "090-0000-0001"
+            }))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(res.status(), 200);
+        let body: Value = res.json().await.unwrap();
+        assert_eq!(body["success"], true);
+        assert_eq!(body["driver_id"], 42);
+    });
+}
+
+#[tokio::test]
+async fn test_register_unknown_call_number() {
+    test_group!("TenkoCall: register unknown call_number");
+    test_case!("未登録の call_number は 400", {
+        let _guard = common::ENV_LOCK.lock().unwrap();
+        std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
+
+        let mock = Arc::new(MockTenkoCallRepository::default());
+        // return_some = false (default) → Ok(None) → BAD_REQUEST
+        let mut state = setup_mock_app_state().await;
+        state.tenko_call = mock;
+        let base_url = common::spawn_test_server(state).await;
+
+        let client = reqwest::Client::new();
+        let res = client
+            .post(format!("{base_url}/api/tenko-call/register"))
+            .json(&serde_json::json!({
+                "phone_number": "080-1111-2222",
+                "driver_name": "Test Driver",
+                "call_number": "999-9999-9999"
+            }))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(res.status(), 400);
+        let body: Value = res.json().await.unwrap();
+        assert_eq!(body["success"], false);
+        assert_eq!(body["driver_id"], 0);
+        assert!(body["error"].as_str().unwrap().contains("未登録"));
+    });
+}
+
+#[tokio::test]
+async fn test_register_db_error() {
+    test_group!("TenkoCall: register DB error");
+    test_case!("DB エラー時に 500 を返す", {
+        let _guard = common::ENV_LOCK.lock().unwrap();
+        std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
+
+        let mock = Arc::new(MockTenkoCallRepository::default());
+        mock.fail_next.store(true, Ordering::SeqCst);
+        let mut state = setup_mock_app_state().await;
+        state.tenko_call = mock;
+        let base_url = common::spawn_test_server(state).await;
+
+        let client = reqwest::Client::new();
+        let res = client
+            .post(format!("{base_url}/api/tenko-call/register"))
+            .json(&serde_json::json!({
+                "phone_number": "080-1111-2222",
+                "driver_name": "Test Driver",
+                "call_number": "090-0000-0001"
+            }))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(res.status(), 500);
+        let body: Value = res.json().await.unwrap();
+        assert_eq!(body["success"], false);
+        assert!(body["error"].as_str().unwrap().contains("internal error"));
+    });
+}
+
+// ============================================================
+// POST /tenko-call/tenko — public (no auth)
+// ============================================================
+
+#[tokio::test]
+async fn test_tenko_success() {
+    test_group!("TenkoCall: tenko success");
+    test_case!("登録済みドライバーの点呼が成功", {
+        let _guard = common::ENV_LOCK.lock().unwrap();
+        std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
+
+        let mock = Arc::new(MockTenkoCallRepository::default());
+        mock.return_some.store(true, Ordering::SeqCst);
+        let mut state = setup_mock_app_state().await;
+        state.tenko_call = mock;
+        let base_url = common::spawn_test_server(state).await;
+
+        let client = reqwest::Client::new();
+        let res = client
+            .post(format!("{base_url}/api/tenko-call/tenko"))
+            .json(&serde_json::json!({
+                "phone_number": "080-1111-2222",
+                "driver_name": "Test Driver",
+                "latitude": 35.6812,
+                "longitude": 139.7671
+            }))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(res.status(), 200);
+        let body: Value = res.json().await.unwrap();
+        assert_eq!(body["success"], true);
+        assert_eq!(body["call_number"], "090-1234-5678");
+    });
+}
+
+#[tokio::test]
+async fn test_tenko_driver_not_found() {
+    test_group!("TenkoCall: tenko driver not found");
+    test_case!("未登録ドライバーの点呼は 404", {
+        let _guard = common::ENV_LOCK.lock().unwrap();
+        std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
+
+        let mock = Arc::new(MockTenkoCallRepository::default());
+        // return_some = false (default) → Ok(None) → NOT_FOUND
+        let mut state = setup_mock_app_state().await;
+        state.tenko_call = mock;
+        let base_url = common::spawn_test_server(state).await;
+
+        let client = reqwest::Client::new();
+        let res = client
+            .post(format!("{base_url}/api/tenko-call/tenko"))
+            .json(&serde_json::json!({
+                "phone_number": "080-9999-9999",
+                "driver_name": "Unknown",
+                "latitude": 35.0,
+                "longitude": 139.0
+            }))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(res.status(), 404);
+    });
+}
+
+#[tokio::test]
+async fn test_tenko_db_error() {
+    test_group!("TenkoCall: tenko DB error");
+    test_case!("DB エラー時に 500 を返す", {
+        let _guard = common::ENV_LOCK.lock().unwrap();
+        std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
+
+        let mock = Arc::new(MockTenkoCallRepository::default());
+        mock.fail_next.store(true, Ordering::SeqCst);
+        let mut state = setup_mock_app_state().await;
+        state.tenko_call = mock;
+        let base_url = common::spawn_test_server(state).await;
+
+        let client = reqwest::Client::new();
+        let res = client
+            .post(format!("{base_url}/api/tenko-call/tenko"))
+            .json(&serde_json::json!({
+                "phone_number": "080-1111-2222",
+                "driver_name": "Test Driver",
+                "latitude": 35.0,
+                "longitude": 139.0
+            }))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(res.status(), 500);
+    });
+}
+
+// ============================================================
+// GET /tenko-call/numbers — tenant auth required
+// ============================================================
+
+#[tokio::test]
+async fn test_list_numbers_empty() {
+    test_group!("TenkoCall: list_numbers empty");
+    test_case!("空のリストを取得できる", {
+        let _guard = common::ENV_LOCK.lock().unwrap();
+        std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
+
+        let mock = Arc::new(MockTenkoCallRepository::default());
+        let mut state = setup_mock_app_state().await;
+        state.tenko_call = mock;
+        let base_url = common::spawn_test_server(state).await;
+
+        let tenant_id = Uuid::new_v4();
+        let jwt = common::create_test_jwt(tenant_id, "admin");
+        let client = reqwest::Client::new();
+
+        let res = client
+            .get(format!("{base_url}/api/tenko-call/numbers"))
+            .header("Authorization", format!("Bearer {jwt}"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(res.status(), 200);
+        let body: Value = res.json().await.unwrap();
+        assert_eq!(body.as_array().unwrap().len(), 0);
+    });
+}
+
+#[tokio::test]
+async fn test_list_numbers_with_data() {
+    test_group!("TenkoCall: list_numbers with data");
+    test_case!("データがある場合にリストを取得できる", {
+        let _guard = common::ENV_LOCK.lock().unwrap();
+        std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
+
+        let mock = Arc::new(MockTenkoCallRepository::default());
+        mock.return_data.store(true, Ordering::SeqCst);
+        let mut state = setup_mock_app_state().await;
+        state.tenko_call = mock;
+        let base_url = common::spawn_test_server(state).await;
+
+        let tenant_id = Uuid::new_v4();
+        let jwt = common::create_test_jwt(tenant_id, "admin");
+        let client = reqwest::Client::new();
+
+        let res = client
+            .get(format!("{base_url}/api/tenko-call/numbers"))
+            .header("Authorization", format!("Bearer {jwt}"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(res.status(), 200);
+        let body: Value = res.json().await.unwrap();
+        let arr = body.as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["id"], 1);
+        assert_eq!(arr[0]["call_number"], "090-0000-0001");
+        assert_eq!(arr[0]["tenant_id"], "test-tenant");
+        assert_eq!(arr[0]["label"], "Office A");
+        assert_eq!(arr[0]["created_at"], "2026-01-01 00:00:00");
+    });
+}
+
+#[tokio::test]
+async fn test_list_numbers_with_x_tenant_id() {
+    test_group!("TenkoCall: list_numbers with X-Tenant-ID");
+    test_case!("X-Tenant-ID ヘッダーでもアクセスできる", {
+        let _guard = common::ENV_LOCK.lock().unwrap();
+        std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
+
+        let mock = Arc::new(MockTenkoCallRepository::default());
+        let mut state = setup_mock_app_state().await;
+        state.tenko_call = mock;
+        let base_url = common::spawn_test_server(state).await;
+
+        let client = reqwest::Client::new();
+        let res = client
+            .get(format!("{base_url}/api/tenko-call/numbers"))
+            .header("X-Tenant-ID", Uuid::new_v4().to_string())
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(res.status(), 200);
+    });
+}
+
+#[tokio::test]
+async fn test_list_numbers_no_auth() {
+    test_group!("TenkoCall: list_numbers no auth");
+    test_case!("認証なしは 401", {
+        let _guard = common::ENV_LOCK.lock().unwrap();
+        std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
+
+        let mock = Arc::new(MockTenkoCallRepository::default());
+        let mut state = setup_mock_app_state().await;
+        state.tenko_call = mock;
+        let base_url = common::spawn_test_server(state).await;
+
+        let client = reqwest::Client::new();
+        let res = client
+            .get(format!("{base_url}/api/tenko-call/numbers"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(res.status(), 401);
+    });
+}
+
+#[tokio::test]
+async fn test_list_numbers_db_error() {
+    test_group!("TenkoCall: list_numbers DB error");
+    test_case!("DB エラー時に 500 を返す", {
+        let _guard = common::ENV_LOCK.lock().unwrap();
+        std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
+
+        let mock = Arc::new(MockTenkoCallRepository::default());
+        mock.fail_next.store(true, Ordering::SeqCst);
+        let mut state = setup_mock_app_state().await;
+        state.tenko_call = mock;
+        let base_url = common::spawn_test_server(state).await;
+
+        let tenant_id = Uuid::new_v4();
+        let jwt = common::create_test_jwt(tenant_id, "admin");
+        let client = reqwest::Client::new();
+
+        let res = client
+            .get(format!("{base_url}/api/tenko-call/numbers"))
+            .header("Authorization", format!("Bearer {jwt}"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(res.status(), 500);
+    });
+}
+
+// ============================================================
+// POST /tenko-call/numbers — tenant auth required
+// ============================================================
+
+#[tokio::test]
+async fn test_create_number_success() {
+    test_group!("TenkoCall: create_number success");
+    test_case!("電話番号マスタの追加が成功する", {
+        let _guard = common::ENV_LOCK.lock().unwrap();
+        std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
+
+        let mock = Arc::new(MockTenkoCallRepository::default());
+        let mut state = setup_mock_app_state().await;
+        state.tenko_call = mock;
+        let base_url = common::spawn_test_server(state).await;
+
+        let tenant_id = Uuid::new_v4();
+        let jwt = common::create_test_jwt(tenant_id, "admin");
+        let client = reqwest::Client::new();
+
+        let res = client
+            .post(format!("{base_url}/api/tenko-call/numbers"))
+            .header("Authorization", format!("Bearer {jwt}"))
+            .json(&serde_json::json!({
+                "call_number": "090-0000-0099",
+                "tenant_id": tenant_id.to_string(),
+                "label": "New Office"
+            }))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(res.status(), 200);
+        let body: Value = res.json().await.unwrap();
+        assert_eq!(body["success"], true);
+        assert_eq!(body["id"], 99);
+    });
+}
+
+#[tokio::test]
+async fn test_create_number_without_tenant_id() {
+    test_group!("TenkoCall: create_number without tenant_id");
+    test_case!("tenant_id 省略時はデフォルト値を使用", {
+        let _guard = common::ENV_LOCK.lock().unwrap();
+        std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
+
+        let mock = Arc::new(MockTenkoCallRepository::default());
+        let mut state = setup_mock_app_state().await;
+        state.tenko_call = mock;
+        let base_url = common::spawn_test_server(state).await;
+
+        let tenant_id = Uuid::new_v4();
+        let jwt = common::create_test_jwt(tenant_id, "admin");
+        let client = reqwest::Client::new();
+
+        let res = client
+            .post(format!("{base_url}/api/tenko-call/numbers"))
+            .header("Authorization", format!("Bearer {jwt}"))
+            .json(&serde_json::json!({
+                "call_number": "090-0000-0100"
+            }))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(res.status(), 200);
+        let body: Value = res.json().await.unwrap();
+        assert_eq!(body["success"], true);
+        assert_eq!(body["id"], 99);
+    });
+}
+
+#[tokio::test]
+async fn test_create_number_without_label() {
+    test_group!("TenkoCall: create_number without label");
+    test_case!("label 省略でも成功", {
+        let _guard = common::ENV_LOCK.lock().unwrap();
+        std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
+
+        let mock = Arc::new(MockTenkoCallRepository::default());
+        let mut state = setup_mock_app_state().await;
+        state.tenko_call = mock;
+        let base_url = common::spawn_test_server(state).await;
+
+        let tenant_id = Uuid::new_v4();
+        let jwt = common::create_test_jwt(tenant_id, "admin");
+        let client = reqwest::Client::new();
+
+        let res = client
+            .post(format!("{base_url}/api/tenko-call/numbers"))
+            .header("Authorization", format!("Bearer {jwt}"))
+            .json(&serde_json::json!({
+                "call_number": "090-0000-0200",
+                "tenant_id": "custom-tenant"
+            }))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(res.status(), 200);
+        let body: Value = res.json().await.unwrap();
+        assert_eq!(body["success"], true);
+    });
+}
+
+#[tokio::test]
+async fn test_create_number_no_auth() {
+    test_group!("TenkoCall: create_number no auth");
+    test_case!("認証なしは 401", {
+        let _guard = common::ENV_LOCK.lock().unwrap();
+        std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
+
+        let mock = Arc::new(MockTenkoCallRepository::default());
+        let mut state = setup_mock_app_state().await;
+        state.tenko_call = mock;
+        let base_url = common::spawn_test_server(state).await;
+
+        let client = reqwest::Client::new();
+        let res = client
+            .post(format!("{base_url}/api/tenko-call/numbers"))
+            .json(&serde_json::json!({
+                "call_number": "090-0000-0099"
+            }))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(res.status(), 401);
+    });
+}
+
+#[tokio::test]
+async fn test_create_number_db_error() {
+    test_group!("TenkoCall: create_number DB error");
+    test_case!("DB エラー時に 500 を返す", {
+        let _guard = common::ENV_LOCK.lock().unwrap();
+        std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
+
+        let mock = Arc::new(MockTenkoCallRepository::default());
+        mock.fail_next.store(true, Ordering::SeqCst);
+        let mut state = setup_mock_app_state().await;
+        state.tenko_call = mock;
+        let base_url = common::spawn_test_server(state).await;
+
+        let tenant_id = Uuid::new_v4();
+        let jwt = common::create_test_jwt(tenant_id, "admin");
+        let client = reqwest::Client::new();
+
+        let res = client
+            .post(format!("{base_url}/api/tenko-call/numbers"))
+            .header("Authorization", format!("Bearer {jwt}"))
+            .json(&serde_json::json!({
+                "call_number": "090-0000-0099"
+            }))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(res.status(), 500);
+    });
+}
+
+// ============================================================
+// DELETE /tenko-call/numbers/{id} — tenant auth required
+// ============================================================
+
+#[tokio::test]
+async fn test_delete_number_success() {
+    test_group!("TenkoCall: delete_number success");
+    test_case!("電話番号マスタの削除が成功する", {
+        let _guard = common::ENV_LOCK.lock().unwrap();
+        std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
+
+        let mock = Arc::new(MockTenkoCallRepository::default());
+        let mut state = setup_mock_app_state().await;
+        state.tenko_call = mock;
+        let base_url = common::spawn_test_server(state).await;
+
+        let tenant_id = Uuid::new_v4();
+        let jwt = common::create_test_jwt(tenant_id, "admin");
+        let client = reqwest::Client::new();
+
+        let res = client
+            .delete(format!("{base_url}/api/tenko-call/numbers/1"))
+            .header("Authorization", format!("Bearer {jwt}"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(res.status(), 204);
+    });
+}
+
+#[tokio::test]
+async fn test_delete_number_no_auth() {
+    test_group!("TenkoCall: delete_number no auth");
+    test_case!("認証なしは 401", {
+        let _guard = common::ENV_LOCK.lock().unwrap();
+        std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
+
+        let mock = Arc::new(MockTenkoCallRepository::default());
+        let mut state = setup_mock_app_state().await;
+        state.tenko_call = mock;
+        let base_url = common::spawn_test_server(state).await;
+
+        let client = reqwest::Client::new();
+        let res = client
+            .delete(format!("{base_url}/api/tenko-call/numbers/1"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(res.status(), 401);
+    });
+}
+
+#[tokio::test]
+async fn test_delete_number_db_error() {
+    test_group!("TenkoCall: delete_number DB error");
+    test_case!("DB エラー時に 500 を返す", {
+        let _guard = common::ENV_LOCK.lock().unwrap();
+        std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
+
+        let mock = Arc::new(MockTenkoCallRepository::default());
+        mock.fail_next.store(true, Ordering::SeqCst);
+        let mut state = setup_mock_app_state().await;
+        state.tenko_call = mock;
+        let base_url = common::spawn_test_server(state).await;
+
+        let tenant_id = Uuid::new_v4();
+        let jwt = common::create_test_jwt(tenant_id, "admin");
+        let client = reqwest::Client::new();
+
+        let res = client
+            .delete(format!("{base_url}/api/tenko-call/numbers/1"))
+            .header("Authorization", format!("Bearer {jwt}"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(res.status(), 500);
+    });
+}
+
+// ============================================================
+// GET /tenko-call/drivers — tenant auth required
+// ============================================================
+
+#[tokio::test]
+async fn test_list_drivers_empty() {
+    test_group!("TenkoCall: list_drivers empty");
+    test_case!("空のリストを取得できる", {
+        let _guard = common::ENV_LOCK.lock().unwrap();
+        std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
+
+        let mock = Arc::new(MockTenkoCallRepository::default());
+        let mut state = setup_mock_app_state().await;
+        state.tenko_call = mock;
+        let base_url = common::spawn_test_server(state).await;
+
+        let tenant_id = Uuid::new_v4();
+        let jwt = common::create_test_jwt(tenant_id, "admin");
+        let client = reqwest::Client::new();
+
+        let res = client
+            .get(format!("{base_url}/api/tenko-call/drivers"))
+            .header("Authorization", format!("Bearer {jwt}"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(res.status(), 200);
+        let body: Value = res.json().await.unwrap();
+        assert_eq!(body.as_array().unwrap().len(), 0);
+    });
+}
+
+#[tokio::test]
+async fn test_list_drivers_with_data() {
+    test_group!("TenkoCall: list_drivers with data");
+    test_case!("データがある場合にリストを取得できる", {
+        let _guard = common::ENV_LOCK.lock().unwrap();
+        std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
+
+        let mock = Arc::new(MockTenkoCallRepository::default());
+        mock.return_data.store(true, Ordering::SeqCst);
+        let mut state = setup_mock_app_state().await;
+        state.tenko_call = mock;
+        let base_url = common::spawn_test_server(state).await;
+
+        let tenant_id = Uuid::new_v4();
+        let jwt = common::create_test_jwt(tenant_id, "admin");
+        let client = reqwest::Client::new();
+
+        let res = client
+            .get(format!("{base_url}/api/tenko-call/drivers"))
+            .header("Authorization", format!("Bearer {jwt}"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(res.status(), 200);
+        let body: Value = res.json().await.unwrap();
+        let arr = body.as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["id"], 1);
+        assert_eq!(arr[0]["phone_number"], "080-1111-2222");
+        assert_eq!(arr[0]["driver_name"], "Test Driver");
+        assert_eq!(arr[0]["call_number"], "090-0000-0001");
+        assert_eq!(arr[0]["tenant_id"], "test-tenant");
+        assert_eq!(arr[0]["employee_code"], "EMP001");
+        assert_eq!(arr[0]["created_at"], "2026-01-01 00:00:00");
+    });
+}
+
+#[tokio::test]
+async fn test_list_drivers_no_auth() {
+    test_group!("TenkoCall: list_drivers no auth");
+    test_case!("認証なしは 401", {
+        let _guard = common::ENV_LOCK.lock().unwrap();
+        std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
+
+        let mock = Arc::new(MockTenkoCallRepository::default());
+        let mut state = setup_mock_app_state().await;
+        state.tenko_call = mock;
+        let base_url = common::spawn_test_server(state).await;
+
+        let client = reqwest::Client::new();
+        let res = client
+            .get(format!("{base_url}/api/tenko-call/drivers"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(res.status(), 401);
+    });
+}
+
+#[tokio::test]
+async fn test_list_drivers_db_error() {
+    test_group!("TenkoCall: list_drivers DB error");
+    test_case!("DB エラー時に 500 を返す", {
+        let _guard = common::ENV_LOCK.lock().unwrap();
+        std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
+
+        let mock = Arc::new(MockTenkoCallRepository::default());
+        mock.fail_next.store(true, Ordering::SeqCst);
+        let mut state = setup_mock_app_state().await;
+        state.tenko_call = mock;
+        let base_url = common::spawn_test_server(state).await;
+
+        let tenant_id = Uuid::new_v4();
+        let jwt = common::create_test_jwt(tenant_id, "admin");
+        let client = reqwest::Client::new();
+
+        let res = client
+            .get(format!("{base_url}/api/tenko-call/drivers"))
+            .header("Authorization", format!("Bearer {jwt}"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(res.status(), 500);
+    });
+}

--- a/tests/mock_tenko_schedules_test.rs
+++ b/tests/mock_tenko_schedules_test.rs
@@ -1,0 +1,767 @@
+mod common;
+mod mock_helpers;
+
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+use mock_helpers::MockTenkoSchedulesRepository;
+
+/// Helper: set up mock AppState and spawn test server with admin JWT.
+/// Returns (base_url, auth_header, tenant_id).
+async fn setup() -> (String, String, uuid::Uuid) {
+    let state = mock_helpers::app_state::setup_mock_app_state().await;
+    let tenant_id = uuid::Uuid::new_v4();
+    let base_url = common::spawn_test_server(state).await;
+    let jwt = common::create_test_jwt(tenant_id, "admin");
+    let auth_header = format!("Bearer {jwt}");
+    (base_url, auth_header, tenant_id)
+}
+
+/// Helper: set up with a failing mock for tenko_schedules.
+async fn setup_failing() -> (String, String) {
+    let mock = Arc::new(MockTenkoSchedulesRepository::default());
+    mock.fail_next.store(true, Ordering::SeqCst);
+    let mut state = mock_helpers::app_state::setup_mock_app_state().await;
+    state.tenko_schedules = mock;
+    let tenant_id = uuid::Uuid::new_v4();
+    let base_url = common::spawn_test_server(state).await;
+    let jwt = common::create_test_jwt(tenant_id, "admin");
+    let auth_header = format!("Bearer {jwt}");
+    (base_url, auth_header)
+}
+
+/// Helper: set up with return_none mock (get/update/delete return None/false).
+async fn setup_not_found() -> (String, String) {
+    let mock = Arc::new(MockTenkoSchedulesRepository::default());
+    mock.return_none.store(true, Ordering::SeqCst);
+    let mut state = mock_helpers::app_state::setup_mock_app_state().await;
+    state.tenko_schedules = mock;
+    let tenant_id = uuid::Uuid::new_v4();
+    let base_url = common::spawn_test_server(state).await;
+    let jwt = common::create_test_jwt(tenant_id, "admin");
+    let auth_header = format!("Bearer {jwt}");
+    (base_url, auth_header)
+}
+
+fn valid_pre_operation_body() -> serde_json::Value {
+    serde_json::json!({
+        "employee_id": uuid::Uuid::new_v4(),
+        "tenko_type": "pre_operation",
+        "responsible_manager_name": "Manager A",
+        "scheduled_at": "2026-04-01T08:00:00Z",
+        "instruction": "Drive safely"
+    })
+}
+
+fn valid_post_operation_body() -> serde_json::Value {
+    serde_json::json!({
+        "employee_id": uuid::Uuid::new_v4(),
+        "tenko_type": "post_operation",
+        "responsible_manager_name": "Manager B",
+        "scheduled_at": "2026-04-01T18:00:00Z"
+    })
+}
+
+// =========================================================================
+// POST /api/tenko/schedules — create_schedule
+// =========================================================================
+
+#[tokio::test]
+async fn test_create_schedule_pre_operation_success() {
+    let (base_url, auth_header, _) = setup().await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/tenko/schedules"))
+        .header("Authorization", &auth_header)
+        .json(&valid_pre_operation_body())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 201);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(body["tenko_type"], "pre_operation");
+    assert!(!body["id"].as_str().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn test_create_schedule_post_operation_success() {
+    let (base_url, auth_header, _) = setup().await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/tenko/schedules"))
+        .header("Authorization", &auth_header)
+        .json(&valid_post_operation_body())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 201);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(body["tenko_type"], "post_operation");
+}
+
+#[tokio::test]
+async fn test_create_schedule_invalid_type() {
+    let (base_url, auth_header, _) = setup().await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/tenko/schedules"))
+        .header("Authorization", &auth_header)
+        .json(&serde_json::json!({
+            "employee_id": uuid::Uuid::new_v4(),
+            "tenko_type": "invalid_type",
+            "responsible_manager_name": "Manager",
+            "scheduled_at": "2026-04-01T08:00:00Z",
+            "instruction": "Test"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 400);
+}
+
+#[tokio::test]
+async fn test_create_schedule_pre_operation_missing_instruction() {
+    let (base_url, auth_header, _) = setup().await;
+    let client = reqwest::Client::new();
+
+    // pre_operation without instruction -> BAD_REQUEST
+    let res = client
+        .post(format!("{base_url}/api/tenko/schedules"))
+        .header("Authorization", &auth_header)
+        .json(&serde_json::json!({
+            "employee_id": uuid::Uuid::new_v4(),
+            "tenko_type": "pre_operation",
+            "responsible_manager_name": "Manager",
+            "scheduled_at": "2026-04-01T08:00:00Z"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 400);
+}
+
+#[tokio::test]
+async fn test_create_schedule_pre_operation_empty_instruction() {
+    let (base_url, auth_header, _) = setup().await;
+    let client = reqwest::Client::new();
+
+    // pre_operation with empty instruction -> BAD_REQUEST
+    let res = client
+        .post(format!("{base_url}/api/tenko/schedules"))
+        .header("Authorization", &auth_header)
+        .json(&serde_json::json!({
+            "employee_id": uuid::Uuid::new_v4(),
+            "tenko_type": "pre_operation",
+            "responsible_manager_name": "Manager",
+            "scheduled_at": "2026-04-01T08:00:00Z",
+            "instruction": ""
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 400);
+}
+
+#[tokio::test]
+async fn test_create_schedule_no_auth() {
+    let (base_url, _, _) = setup().await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/tenko/schedules"))
+        .json(&valid_pre_operation_body())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 401);
+}
+
+#[tokio::test]
+async fn test_create_schedule_x_tenant_id_header() {
+    let (base_url, _, _) = setup().await;
+    let client = reqwest::Client::new();
+    let tenant_id = uuid::Uuid::new_v4();
+
+    let res = client
+        .post(format!("{base_url}/api/tenko/schedules"))
+        .header("X-Tenant-ID", tenant_id.to_string())
+        .json(&valid_pre_operation_body())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 201);
+}
+
+#[tokio::test]
+async fn test_create_schedule_db_error() {
+    let (base_url, auth_header) = setup_failing().await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/tenko/schedules"))
+        .header("Authorization", &auth_header)
+        .json(&valid_pre_operation_body())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}
+
+// =========================================================================
+// POST /api/tenko/schedules/batch — batch_create_schedules
+// =========================================================================
+
+#[tokio::test]
+async fn test_batch_create_schedules_success() {
+    let (base_url, auth_header, _) = setup().await;
+    let client = reqwest::Client::new();
+
+    let emp1 = uuid::Uuid::new_v4();
+    let emp2 = uuid::Uuid::new_v4();
+
+    let res = client
+        .post(format!("{base_url}/api/tenko/schedules/batch"))
+        .header("Authorization", &auth_header)
+        .json(&serde_json::json!({
+            "schedules": [
+                {
+                    "employee_id": emp1,
+                    "tenko_type": "pre_operation",
+                    "responsible_manager_name": "Manager A",
+                    "scheduled_at": "2026-04-01T08:00:00Z",
+                    "instruction": "Instruction 1"
+                },
+                {
+                    "employee_id": emp2,
+                    "tenko_type": "post_operation",
+                    "responsible_manager_name": "Manager B",
+                    "scheduled_at": "2026-04-01T18:00:00Z"
+                }
+            ]
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 201);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(body.as_array().unwrap().len(), 2);
+}
+
+#[tokio::test]
+async fn test_batch_create_schedules_empty() {
+    let (base_url, auth_header, _) = setup().await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/tenko/schedules/batch"))
+        .header("Authorization", &auth_header)
+        .json(&serde_json::json!({ "schedules": [] }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 400);
+}
+
+#[tokio::test]
+async fn test_batch_create_schedules_invalid_type_in_batch() {
+    let (base_url, auth_header, _) = setup().await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/tenko/schedules/batch"))
+        .header("Authorization", &auth_header)
+        .json(&serde_json::json!({
+            "schedules": [
+                {
+                    "employee_id": uuid::Uuid::new_v4(),
+                    "tenko_type": "invalid",
+                    "responsible_manager_name": "Manager",
+                    "scheduled_at": "2026-04-01T08:00:00Z",
+                    "instruction": "Test"
+                }
+            ]
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 400);
+}
+
+#[tokio::test]
+async fn test_batch_create_schedules_pre_op_missing_instruction() {
+    let (base_url, auth_header, _) = setup().await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/tenko/schedules/batch"))
+        .header("Authorization", &auth_header)
+        .json(&serde_json::json!({
+            "schedules": [
+                {
+                    "employee_id": uuid::Uuid::new_v4(),
+                    "tenko_type": "pre_operation",
+                    "responsible_manager_name": "Manager",
+                    "scheduled_at": "2026-04-01T08:00:00Z"
+                }
+            ]
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 400);
+}
+
+#[tokio::test]
+async fn test_batch_create_schedules_no_auth() {
+    let (base_url, _, _) = setup().await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/tenko/schedules/batch"))
+        .json(&serde_json::json!({
+            "schedules": [{
+                "employee_id": uuid::Uuid::new_v4(),
+                "tenko_type": "post_operation",
+                "responsible_manager_name": "Manager",
+                "scheduled_at": "2026-04-01T08:00:00Z"
+            }]
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 401);
+}
+
+#[tokio::test]
+async fn test_batch_create_schedules_db_error() {
+    let (base_url, auth_header) = setup_failing().await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/tenko/schedules/batch"))
+        .header("Authorization", &auth_header)
+        .json(&serde_json::json!({
+            "schedules": [{
+                "employee_id": uuid::Uuid::new_v4(),
+                "tenko_type": "post_operation",
+                "responsible_manager_name": "Manager",
+                "scheduled_at": "2026-04-01T08:00:00Z"
+            }]
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}
+
+// =========================================================================
+// GET /api/tenko/schedules — list_schedules
+// =========================================================================
+
+#[tokio::test]
+async fn test_list_schedules_success() {
+    let (base_url, auth_header, _) = setup().await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!("{base_url}/api/tenko/schedules"))
+        .header("Authorization", &auth_header)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert!(body["schedules"].is_array());
+    assert_eq!(body["total"], 0);
+    assert_eq!(body["page"], 1);
+    assert_eq!(body["per_page"], 50);
+}
+
+#[tokio::test]
+async fn test_list_schedules_with_pagination() {
+    let (base_url, auth_header, _) = setup().await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!("{base_url}/api/tenko/schedules?page=2&per_page=10"))
+        .header("Authorization", &auth_header)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(body["page"], 2);
+    assert_eq!(body["per_page"], 10);
+}
+
+#[tokio::test]
+async fn test_list_schedules_per_page_capped_at_100() {
+    let (base_url, auth_header, _) = setup().await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!("{base_url}/api/tenko/schedules?per_page=999"))
+        .header("Authorization", &auth_header)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(body["per_page"], 100);
+}
+
+#[tokio::test]
+async fn test_list_schedules_page_min_1() {
+    let (base_url, auth_header, _) = setup().await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!("{base_url}/api/tenko/schedules?page=0"))
+        .header("Authorization", &auth_header)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(body["page"], 1);
+}
+
+#[tokio::test]
+async fn test_list_schedules_with_filters() {
+    let (base_url, auth_header, _) = setup().await;
+    let client = reqwest::Client::new();
+    let emp_id = uuid::Uuid::new_v4();
+
+    let res = client
+        .get(format!(
+            "{base_url}/api/tenko/schedules?employee_id={emp_id}&tenko_type=pre_operation&consumed=false&date_from=2026-01-01T00:00:00Z&date_to=2026-12-31T23:59:59Z"
+        ))
+        .header("Authorization", &auth_header)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+}
+
+#[tokio::test]
+async fn test_list_schedules_no_auth() {
+    let (base_url, _, _) = setup().await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!("{base_url}/api/tenko/schedules"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 401);
+}
+
+#[tokio::test]
+async fn test_list_schedules_x_tenant_id() {
+    let (base_url, _, _) = setup().await;
+    let client = reqwest::Client::new();
+    let tenant_id = uuid::Uuid::new_v4();
+
+    let res = client
+        .get(format!("{base_url}/api/tenko/schedules"))
+        .header("X-Tenant-ID", tenant_id.to_string())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+}
+
+#[tokio::test]
+async fn test_list_schedules_db_error() {
+    let (base_url, auth_header) = setup_failing().await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!("{base_url}/api/tenko/schedules"))
+        .header("Authorization", &auth_header)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}
+
+// =========================================================================
+// GET /api/tenko/schedules/{id} — get_schedule
+// =========================================================================
+
+#[tokio::test]
+async fn test_get_schedule_success() {
+    let (base_url, auth_header, _) = setup().await;
+    let client = reqwest::Client::new();
+    let id = uuid::Uuid::new_v4();
+
+    let res = client
+        .get(format!("{base_url}/api/tenko/schedules/{id}"))
+        .header("Authorization", &auth_header)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(body["id"], id.to_string());
+}
+
+#[tokio::test]
+async fn test_get_schedule_not_found() {
+    let (base_url, auth_header) = setup_not_found().await;
+    let client = reqwest::Client::new();
+    let id = uuid::Uuid::new_v4();
+
+    let res = client
+        .get(format!("{base_url}/api/tenko/schedules/{id}"))
+        .header("Authorization", &auth_header)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 404);
+}
+
+#[tokio::test]
+async fn test_get_schedule_no_auth() {
+    let (base_url, _, _) = setup().await;
+    let client = reqwest::Client::new();
+    let id = uuid::Uuid::new_v4();
+
+    let res = client
+        .get(format!("{base_url}/api/tenko/schedules/{id}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 401);
+}
+
+#[tokio::test]
+async fn test_get_schedule_db_error() {
+    let (base_url, auth_header) = setup_failing().await;
+    let client = reqwest::Client::new();
+    let id = uuid::Uuid::new_v4();
+
+    let res = client
+        .get(format!("{base_url}/api/tenko/schedules/{id}"))
+        .header("Authorization", &auth_header)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}
+
+// =========================================================================
+// PUT /api/tenko/schedules/{id} — update_schedule
+// =========================================================================
+
+#[tokio::test]
+async fn test_update_schedule_success() {
+    let (base_url, auth_header, _) = setup().await;
+    let client = reqwest::Client::new();
+    let id = uuid::Uuid::new_v4();
+
+    let res = client
+        .put(format!("{base_url}/api/tenko/schedules/{id}"))
+        .header("Authorization", &auth_header)
+        .json(&serde_json::json!({
+            "responsible_manager_name": "New Manager",
+            "scheduled_at": "2026-05-01T09:00:00Z",
+            "instruction": "Updated instruction"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(body["id"], id.to_string());
+}
+
+#[tokio::test]
+async fn test_update_schedule_not_found() {
+    let (base_url, auth_header) = setup_not_found().await;
+    let client = reqwest::Client::new();
+    let id = uuid::Uuid::new_v4();
+
+    let res = client
+        .put(format!("{base_url}/api/tenko/schedules/{id}"))
+        .header("Authorization", &auth_header)
+        .json(&serde_json::json!({
+            "instruction": "Updated"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 404);
+}
+
+#[tokio::test]
+async fn test_update_schedule_no_auth() {
+    let (base_url, _, _) = setup().await;
+    let client = reqwest::Client::new();
+    let id = uuid::Uuid::new_v4();
+
+    let res = client
+        .put(format!("{base_url}/api/tenko/schedules/{id}"))
+        .json(&serde_json::json!({ "instruction": "X" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 401);
+}
+
+#[tokio::test]
+async fn test_update_schedule_db_error() {
+    let (base_url, auth_header) = setup_failing().await;
+    let client = reqwest::Client::new();
+    let id = uuid::Uuid::new_v4();
+
+    let res = client
+        .put(format!("{base_url}/api/tenko/schedules/{id}"))
+        .header("Authorization", &auth_header)
+        .json(&serde_json::json!({ "instruction": "X" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}
+
+// =========================================================================
+// DELETE /api/tenko/schedules/{id} — delete_schedule
+// =========================================================================
+
+#[tokio::test]
+async fn test_delete_schedule_success() {
+    let (base_url, auth_header, _) = setup().await;
+    let client = reqwest::Client::new();
+    let id = uuid::Uuid::new_v4();
+
+    let res = client
+        .delete(format!("{base_url}/api/tenko/schedules/{id}"))
+        .header("Authorization", &auth_header)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 204);
+}
+
+#[tokio::test]
+async fn test_delete_schedule_not_found() {
+    let (base_url, auth_header) = setup_not_found().await;
+    let client = reqwest::Client::new();
+    let id = uuid::Uuid::new_v4();
+
+    let res = client
+        .delete(format!("{base_url}/api/tenko/schedules/{id}"))
+        .header("Authorization", &auth_header)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 404);
+}
+
+#[tokio::test]
+async fn test_delete_schedule_no_auth() {
+    let (base_url, _, _) = setup().await;
+    let client = reqwest::Client::new();
+    let id = uuid::Uuid::new_v4();
+
+    let res = client
+        .delete(format!("{base_url}/api/tenko/schedules/{id}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 401);
+}
+
+#[tokio::test]
+async fn test_delete_schedule_db_error() {
+    let (base_url, auth_header) = setup_failing().await;
+    let client = reqwest::Client::new();
+    let id = uuid::Uuid::new_v4();
+
+    let res = client
+        .delete(format!("{base_url}/api/tenko/schedules/{id}"))
+        .header("Authorization", &auth_header)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}
+
+// =========================================================================
+// GET /api/tenko/schedules/pending/{employee_id} — get_pending_schedules
+// =========================================================================
+
+#[tokio::test]
+async fn test_get_pending_schedules_success() {
+    let (base_url, auth_header, _) = setup().await;
+    let client = reqwest::Client::new();
+    let employee_id = uuid::Uuid::new_v4();
+
+    let res = client
+        .get(format!(
+            "{base_url}/api/tenko/schedules/pending/{employee_id}"
+        ))
+        .header("Authorization", &auth_header)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert!(body.is_array());
+    assert_eq!(body.as_array().unwrap().len(), 0);
+}
+
+#[tokio::test]
+async fn test_get_pending_schedules_no_auth() {
+    let (base_url, _, _) = setup().await;
+    let client = reqwest::Client::new();
+    let employee_id = uuid::Uuid::new_v4();
+
+    let res = client
+        .get(format!(
+            "{base_url}/api/tenko/schedules/pending/{employee_id}"
+        ))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 401);
+}
+
+#[tokio::test]
+async fn test_get_pending_schedules_x_tenant_id() {
+    let (base_url, _, _) = setup().await;
+    let client = reqwest::Client::new();
+    let tenant_id = uuid::Uuid::new_v4();
+    let employee_id = uuid::Uuid::new_v4();
+
+    let res = client
+        .get(format!(
+            "{base_url}/api/tenko/schedules/pending/{employee_id}"
+        ))
+        .header("X-Tenant-ID", tenant_id.to_string())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+}
+
+#[tokio::test]
+async fn test_get_pending_schedules_db_error() {
+    let (base_url, auth_header) = setup_failing().await;
+    let client = reqwest::Client::new();
+    let employee_id = uuid::Uuid::new_v4();
+
+    let res = client
+        .get(format!(
+            "{base_url}/api/tenko/schedules/pending/{employee_id}"
+        ))
+        .header("Authorization", &auth_header)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}

--- a/tests/mock_tenko_webhooks_test.rs
+++ b/tests/mock_tenko_webhooks_test.rs
@@ -1,0 +1,480 @@
+mod common;
+mod mock_helpers;
+
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+use serde_json::Value;
+use uuid::Uuid;
+
+use mock_helpers::app_state::setup_mock_app_state;
+use mock_helpers::MockTenkoWebhooksRepository;
+
+// =========================================================================
+// Helper: set up mock AppState and spawn test server with admin JWT.
+// =========================================================================
+
+async fn setup() -> (String, String) {
+    let state = setup_mock_app_state().await;
+    let tenant_id = Uuid::new_v4();
+    let base_url = common::spawn_test_server(state).await;
+    let jwt = common::create_test_jwt(tenant_id, "admin");
+    (base_url, format!("Bearer {jwt}"))
+}
+
+async fn setup_with_mock(mock: Arc<MockTenkoWebhooksRepository>) -> (String, String) {
+    let mut state = setup_mock_app_state().await;
+    state.tenko_webhooks = mock;
+    let tenant_id = Uuid::new_v4();
+    let base_url = common::spawn_test_server(state).await;
+    let jwt = common::create_test_jwt(tenant_id, "admin");
+    (base_url, format!("Bearer {jwt}"))
+}
+
+fn valid_webhook_body() -> serde_json::Value {
+    serde_json::json!({
+        "event_type": "tenko_completed",
+        "url": "https://example.com/hook",
+        "secret": "my-secret",
+        "enabled": true
+    })
+}
+
+// =========================================================================
+// POST /api/tenko/webhooks — upsert
+// =========================================================================
+
+#[tokio::test]
+async fn test_upsert_webhook_success() {
+    let (base_url, auth) = setup().await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/tenko/webhooks"))
+        .header("Authorization", &auth)
+        .json(&valid_webhook_body())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 201);
+    let body: Value = res.json().await.unwrap();
+    assert_eq!(body["event_type"], "tenko_completed");
+    assert_eq!(body["url"], "https://example.com/hook");
+    assert_eq!(body["enabled"], true);
+    // secret is skip_serializing, should not appear
+    assert!(body.get("secret").is_none() || body["secret"].is_null());
+}
+
+#[tokio::test]
+async fn test_upsert_webhook_all_valid_event_types() {
+    let valid_events = [
+        "alcohol_detected",
+        "tenko_overdue",
+        "tenko_completed",
+        "tenko_cancelled",
+        "tenko_interrupted",
+        "inspection_ng",
+        "safety_judgment_fail",
+        "equipment_failure",
+        "report_submitted",
+    ];
+    for event_type in valid_events {
+        let (base_url, auth) = setup().await;
+        let client = reqwest::Client::new();
+
+        let res = client
+            .post(format!("{base_url}/api/tenko/webhooks"))
+            .header("Authorization", &auth)
+            .json(&serde_json::json!({
+                "event_type": event_type,
+                "url": "https://example.com/hook"
+            }))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(res.status(), 201, "Failed for event_type: {event_type}");
+    }
+}
+
+#[tokio::test]
+async fn test_upsert_webhook_without_secret() {
+    let (base_url, auth) = setup().await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/tenko/webhooks"))
+        .header("Authorization", &auth)
+        .json(&serde_json::json!({
+            "event_type": "tenko_completed",
+            "url": "https://example.com/hook"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 201);
+    let body: Value = res.json().await.unwrap();
+    assert_eq!(body["enabled"], true); // default_true
+}
+
+#[tokio::test]
+async fn test_upsert_webhook_enabled_false() {
+    let (base_url, auth) = setup().await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/tenko/webhooks"))
+        .header("Authorization", &auth)
+        .json(&serde_json::json!({
+            "event_type": "alcohol_detected",
+            "url": "https://example.com/hook",
+            "enabled": false
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 201);
+    let body: Value = res.json().await.unwrap();
+    assert_eq!(body["enabled"], false);
+}
+
+#[tokio::test]
+async fn test_upsert_webhook_invalid_event_type() {
+    let (base_url, auth) = setup().await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/tenko/webhooks"))
+        .header("Authorization", &auth)
+        .json(&serde_json::json!({
+            "event_type": "invalid_event",
+            "url": "https://example.com/hook"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 400);
+}
+
+#[tokio::test]
+async fn test_upsert_webhook_no_auth() {
+    let state = setup_mock_app_state().await;
+    let base_url = common::spawn_test_server(state).await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/tenko/webhooks"))
+        .json(&valid_webhook_body())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 401);
+}
+
+#[tokio::test]
+async fn test_upsert_webhook_with_x_tenant_id() {
+    let state = setup_mock_app_state().await;
+    let base_url = common::spawn_test_server(state).await;
+    let tenant_id = Uuid::new_v4();
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/tenko/webhooks"))
+        .header("X-Tenant-ID", tenant_id.to_string())
+        .json(&valid_webhook_body())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 201);
+}
+
+#[tokio::test]
+async fn test_upsert_webhook_db_error() {
+    let mock = Arc::new(MockTenkoWebhooksRepository::default());
+    mock.fail_next.store(true, Ordering::SeqCst);
+    let (base_url, auth) = setup_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/tenko/webhooks"))
+        .header("Authorization", &auth)
+        .json(&valid_webhook_body())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}
+
+// =========================================================================
+// GET /api/tenko/webhooks — list
+// =========================================================================
+
+#[tokio::test]
+async fn test_list_webhooks_success() {
+    let (base_url, auth) = setup().await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!("{base_url}/api/tenko/webhooks"))
+        .header("Authorization", &auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    let body: Vec<Value> = res.json().await.unwrap();
+    assert!(body.is_empty());
+}
+
+#[tokio::test]
+async fn test_list_webhooks_no_auth() {
+    let state = setup_mock_app_state().await;
+    let base_url = common::spawn_test_server(state).await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!("{base_url}/api/tenko/webhooks"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 401);
+}
+
+#[tokio::test]
+async fn test_list_webhooks_with_x_tenant_id() {
+    let state = setup_mock_app_state().await;
+    let base_url = common::spawn_test_server(state).await;
+    let tenant_id = Uuid::new_v4();
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!("{base_url}/api/tenko/webhooks"))
+        .header("X-Tenant-ID", tenant_id.to_string())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+}
+
+#[tokio::test]
+async fn test_list_webhooks_db_error() {
+    let mock = Arc::new(MockTenkoWebhooksRepository::default());
+    mock.fail_next.store(true, Ordering::SeqCst);
+    let (base_url, auth) = setup_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!("{base_url}/api/tenko/webhooks"))
+        .header("Authorization", &auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}
+
+// =========================================================================
+// GET /api/tenko/webhooks/{id} — get
+// =========================================================================
+
+#[tokio::test]
+async fn test_get_webhook_success() {
+    let mock = Arc::new(MockTenkoWebhooksRepository::default());
+    mock.return_found.store(true, Ordering::SeqCst);
+    let (base_url, auth) = setup_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    let id = Uuid::new_v4();
+    let res = client
+        .get(format!("{base_url}/api/tenko/webhooks/{id}"))
+        .header("Authorization", &auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    let body: Value = res.json().await.unwrap();
+    assert_eq!(body["event_type"], "tenko_completed");
+    assert_eq!(body["url"], "https://example.com/hook");
+}
+
+#[tokio::test]
+async fn test_get_webhook_not_found() {
+    let (base_url, auth) = setup().await;
+    let client = reqwest::Client::new();
+
+    let id = Uuid::new_v4();
+    let res = client
+        .get(format!("{base_url}/api/tenko/webhooks/{id}"))
+        .header("Authorization", &auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 404);
+}
+
+#[tokio::test]
+async fn test_get_webhook_no_auth() {
+    let state = setup_mock_app_state().await;
+    let base_url = common::spawn_test_server(state).await;
+    let client = reqwest::Client::new();
+
+    let id = Uuid::new_v4();
+    let res = client
+        .get(format!("{base_url}/api/tenko/webhooks/{id}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 401);
+}
+
+#[tokio::test]
+async fn test_get_webhook_db_error() {
+    let mock = Arc::new(MockTenkoWebhooksRepository::default());
+    mock.fail_next.store(true, Ordering::SeqCst);
+    let (base_url, auth) = setup_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    let id = Uuid::new_v4();
+    let res = client
+        .get(format!("{base_url}/api/tenko/webhooks/{id}"))
+        .header("Authorization", &auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}
+
+// =========================================================================
+// DELETE /api/tenko/webhooks/{id} — delete
+// =========================================================================
+
+#[tokio::test]
+async fn test_delete_webhook_success() {
+    let mock = Arc::new(MockTenkoWebhooksRepository::default());
+    mock.return_found.store(true, Ordering::SeqCst);
+    let (base_url, auth) = setup_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    let id = Uuid::new_v4();
+    let res = client
+        .delete(format!("{base_url}/api/tenko/webhooks/{id}"))
+        .header("Authorization", &auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 204);
+}
+
+#[tokio::test]
+async fn test_delete_webhook_not_found() {
+    let (base_url, auth) = setup().await;
+    let client = reqwest::Client::new();
+
+    let id = Uuid::new_v4();
+    let res = client
+        .delete(format!("{base_url}/api/tenko/webhooks/{id}"))
+        .header("Authorization", &auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 404);
+}
+
+#[tokio::test]
+async fn test_delete_webhook_no_auth() {
+    let state = setup_mock_app_state().await;
+    let base_url = common::spawn_test_server(state).await;
+    let client = reqwest::Client::new();
+
+    let id = Uuid::new_v4();
+    let res = client
+        .delete(format!("{base_url}/api/tenko/webhooks/{id}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 401);
+}
+
+#[tokio::test]
+async fn test_delete_webhook_db_error() {
+    let mock = Arc::new(MockTenkoWebhooksRepository::default());
+    mock.fail_next.store(true, Ordering::SeqCst);
+    let (base_url, auth) = setup_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    let id = Uuid::new_v4();
+    let res = client
+        .delete(format!("{base_url}/api/tenko/webhooks/{id}"))
+        .header("Authorization", &auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}
+
+// =========================================================================
+// GET /api/tenko/webhooks/{id}/deliveries — list_deliveries
+// =========================================================================
+
+#[tokio::test]
+async fn test_list_deliveries_success() {
+    let (base_url, auth) = setup().await;
+    let client = reqwest::Client::new();
+
+    let id = Uuid::new_v4();
+    let res = client
+        .get(format!("{base_url}/api/tenko/webhooks/{id}/deliveries"))
+        .header("Authorization", &auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    let body: Vec<Value> = res.json().await.unwrap();
+    assert!(body.is_empty());
+}
+
+#[tokio::test]
+async fn test_list_deliveries_no_auth() {
+    let state = setup_mock_app_state().await;
+    let base_url = common::spawn_test_server(state).await;
+    let client = reqwest::Client::new();
+
+    let id = Uuid::new_v4();
+    let res = client
+        .get(format!("{base_url}/api/tenko/webhooks/{id}/deliveries"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 401);
+}
+
+#[tokio::test]
+async fn test_list_deliveries_with_x_tenant_id() {
+    let state = setup_mock_app_state().await;
+    let base_url = common::spawn_test_server(state).await;
+    let tenant_id = Uuid::new_v4();
+    let client = reqwest::Client::new();
+
+    let id = Uuid::new_v4();
+    let res = client
+        .get(format!("{base_url}/api/tenko/webhooks/{id}/deliveries"))
+        .header("X-Tenant-ID", tenant_id.to_string())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+}
+
+#[tokio::test]
+async fn test_list_deliveries_db_error() {
+    let mock = Arc::new(MockTenkoWebhooksRepository::default());
+    mock.fail_next.store(true, Ordering::SeqCst);
+    let (base_url, auth) = setup_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    let id = Uuid::new_v4();
+    let res = client
+        .get(format!("{base_url}/api/tenko/webhooks/{id}/deliveries"))
+        .header("Authorization", &auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}

--- a/tests/mock_upload_test.rs
+++ b/tests/mock_upload_test.rs
@@ -1,0 +1,447 @@
+mod common;
+mod mock_helpers;
+
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+use common::mock_storage::MockStorage;
+use uuid::Uuid;
+
+/// Helper: set up mock AppState and spawn test server with JWT.
+/// Returns (base_url, auth_header, tenant_id).
+async fn setup() -> (String, String, Uuid) {
+    let state = mock_helpers::app_state::setup_mock_app_state().await;
+    let tenant_id = Uuid::new_v4();
+    let base_url = common::spawn_test_server(state).await;
+    let jwt = common::create_test_jwt(tenant_id, "admin");
+    let auth_header = format!("Bearer {jwt}");
+    (base_url, auth_header, tenant_id)
+}
+
+/// Helper: set up with fail_upload = true on storage.
+/// Returns (base_url, auth_header).
+async fn setup_failing_storage() -> (String, String) {
+    let mock_storage = Arc::new(MockStorage::new("test-bucket"));
+    mock_storage.fail_upload.store(true, Ordering::SeqCst);
+
+    let mut state = mock_helpers::app_state::setup_mock_app_state().await;
+    state.storage = mock_storage;
+
+    let tenant_id = Uuid::new_v4();
+    let base_url = common::spawn_test_server(state).await;
+    let jwt = common::create_test_jwt(tenant_id, "admin");
+    let auth_header = format!("Bearer {jwt}");
+    (base_url, auth_header)
+}
+
+// =========================================================================
+// POST /api/upload/face-photo — success
+// =========================================================================
+
+#[tokio::test]
+async fn test_upload_face_photo_success() {
+    let (base_url, auth_header, tenant_id) = setup().await;
+    let client = reqwest::Client::new();
+
+    let part = reqwest::multipart::Part::bytes(vec![0xFF, 0xD8, 0xFF, 0xE0])
+        .file_name("test.jpg")
+        .mime_str("image/jpeg")
+        .unwrap();
+    let form = reqwest::multipart::Form::new().part("file", part);
+
+    let res = client
+        .post(format!("{base_url}/api/upload/face-photo"))
+        .header("Authorization", &auth_header)
+        .multipart(form)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert!(body["url"]
+        .as_str()
+        .unwrap()
+        .contains(&tenant_id.to_string()));
+    assert!(body["filename"].as_str().unwrap().ends_with(".jpg"));
+}
+
+// =========================================================================
+// POST /api/upload/face-photo — storage error → 500
+// =========================================================================
+
+#[tokio::test]
+async fn test_upload_face_photo_storage_error() {
+    let (base_url, auth_header) = setup_failing_storage().await;
+    let client = reqwest::Client::new();
+
+    let part = reqwest::multipart::Part::bytes(vec![0xFF, 0xD8])
+        .file_name("test.jpg")
+        .mime_str("image/jpeg")
+        .unwrap();
+    let form = reqwest::multipart::Form::new().part("file", part);
+
+    let res = client
+        .post(format!("{base_url}/api/upload/face-photo"))
+        .header("Authorization", &auth_header)
+        .multipart(form)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 500);
+}
+
+// =========================================================================
+// POST /api/upload/face-photo — no multipart field → 400
+// =========================================================================
+
+#[tokio::test]
+async fn test_upload_face_photo_no_field() {
+    let (base_url, auth_header, _) = setup().await;
+    let client = reqwest::Client::new();
+
+    let form = reqwest::multipart::Form::new();
+
+    let res = client
+        .post(format!("{base_url}/api/upload/face-photo"))
+        .header("Authorization", &auth_header)
+        .multipart(form)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 400);
+}
+
+// =========================================================================
+// POST /api/upload/face-photo — no auth → 401
+// =========================================================================
+
+#[tokio::test]
+async fn test_upload_face_photo_no_auth() {
+    let (base_url, _, _) = setup().await;
+    let client = reqwest::Client::new();
+
+    let part = reqwest::multipart::Part::bytes(vec![0xFF])
+        .file_name("test.jpg")
+        .mime_str("image/jpeg")
+        .unwrap();
+    let form = reqwest::multipart::Form::new().part("file", part);
+
+    let res = client
+        .post(format!("{base_url}/api/upload/face-photo"))
+        .multipart(form)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 401);
+}
+
+// =========================================================================
+// POST /api/upload/report-audio — success
+// =========================================================================
+
+#[tokio::test]
+async fn test_upload_report_audio_success() {
+    let (base_url, auth_header, tenant_id) = setup().await;
+    let client = reqwest::Client::new();
+
+    let part = reqwest::multipart::Part::bytes(vec![0x1A, 0x45, 0xDF, 0xA3])
+        .file_name("report.webm")
+        .mime_str("audio/webm")
+        .unwrap();
+    let form = reqwest::multipart::Form::new().part("file", part);
+
+    let res = client
+        .post(format!("{base_url}/api/upload/report-audio"))
+        .header("Authorization", &auth_header)
+        .multipart(form)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+    let body: serde_json::Value = res.json().await.unwrap();
+    let url = body["url"].as_str().unwrap();
+    assert!(url.contains(&tenant_id.to_string()));
+    assert!(url.contains("report-audio"));
+    assert!(body["filename"].as_str().unwrap().ends_with(".webm"));
+}
+
+// =========================================================================
+// POST /api/upload/report-audio — storage error → 500
+// =========================================================================
+
+#[tokio::test]
+async fn test_upload_report_audio_storage_error() {
+    let (base_url, auth_header) = setup_failing_storage().await;
+    let client = reqwest::Client::new();
+
+    let part = reqwest::multipart::Part::bytes(vec![0x1A])
+        .file_name("report.webm")
+        .mime_str("audio/webm")
+        .unwrap();
+    let form = reqwest::multipart::Form::new().part("file", part);
+
+    let res = client
+        .post(format!("{base_url}/api/upload/report-audio"))
+        .header("Authorization", &auth_header)
+        .multipart(form)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 500);
+}
+
+// =========================================================================
+// POST /api/upload/report-audio — no multipart field → 400
+// =========================================================================
+
+#[tokio::test]
+async fn test_upload_report_audio_no_field() {
+    let (base_url, auth_header, _) = setup().await;
+    let client = reqwest::Client::new();
+
+    let form = reqwest::multipart::Form::new();
+
+    let res = client
+        .post(format!("{base_url}/api/upload/report-audio"))
+        .header("Authorization", &auth_header)
+        .multipart(form)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 400);
+}
+
+// =========================================================================
+// POST /api/upload/report-audio — no auth → 401
+// =========================================================================
+
+#[tokio::test]
+async fn test_upload_report_audio_no_auth() {
+    let (base_url, _, _) = setup().await;
+    let client = reqwest::Client::new();
+
+    let part = reqwest::multipart::Part::bytes(vec![0x1A])
+        .file_name("report.webm")
+        .mime_str("audio/webm")
+        .unwrap();
+    let form = reqwest::multipart::Form::new().part("file", part);
+
+    let res = client
+        .post(format!("{base_url}/api/upload/report-audio"))
+        .multipart(form)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 401);
+}
+
+// =========================================================================
+// POST /api/upload/blow-video — success
+// =========================================================================
+
+#[tokio::test]
+async fn test_upload_blow_video_success() {
+    let (base_url, auth_header, tenant_id) = setup().await;
+    let client = reqwest::Client::new();
+
+    let part = reqwest::multipart::Part::bytes(vec![0x1A, 0x45, 0xDF, 0xA3])
+        .file_name("blow.webm")
+        .mime_str("video/webm")
+        .unwrap();
+    let form = reqwest::multipart::Form::new().part("file", part);
+
+    let res = client
+        .post(format!("{base_url}/api/upload/blow-video"))
+        .header("Authorization", &auth_header)
+        .multipart(form)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+    let body: serde_json::Value = res.json().await.unwrap();
+    let url = body["url"].as_str().unwrap();
+    assert!(url.contains(&tenant_id.to_string()));
+    assert!(url.contains("blow-video"));
+    assert!(body["filename"].as_str().unwrap().ends_with(".webm"));
+}
+
+// =========================================================================
+// POST /api/upload/blow-video — storage error → 500
+// =========================================================================
+
+#[tokio::test]
+async fn test_upload_blow_video_storage_error() {
+    let (base_url, auth_header) = setup_failing_storage().await;
+    let client = reqwest::Client::new();
+
+    let part = reqwest::multipart::Part::bytes(vec![0x1A])
+        .file_name("blow.webm")
+        .mime_str("video/webm")
+        .unwrap();
+    let form = reqwest::multipart::Form::new().part("file", part);
+
+    let res = client
+        .post(format!("{base_url}/api/upload/blow-video"))
+        .header("Authorization", &auth_header)
+        .multipart(form)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 500);
+}
+
+// =========================================================================
+// POST /api/upload/blow-video — no multipart field → 400
+// =========================================================================
+
+#[tokio::test]
+async fn test_upload_blow_video_no_field() {
+    let (base_url, auth_header, _) = setup().await;
+    let client = reqwest::Client::new();
+
+    let form = reqwest::multipart::Form::new();
+
+    let res = client
+        .post(format!("{base_url}/api/upload/blow-video"))
+        .header("Authorization", &auth_header)
+        .multipart(form)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 400);
+}
+
+// =========================================================================
+// POST /api/upload/blow-video — no auth → 401
+// =========================================================================
+
+#[tokio::test]
+async fn test_upload_blow_video_no_auth() {
+    let (base_url, _, _) = setup().await;
+    let client = reqwest::Client::new();
+
+    let part = reqwest::multipart::Part::bytes(vec![0x1A])
+        .file_name("blow.webm")
+        .mime_str("video/webm")
+        .unwrap();
+    let form = reqwest::multipart::Form::new().part("file", part);
+
+    let res = client
+        .post(format!("{base_url}/api/upload/blow-video"))
+        .multipart(form)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 401);
+}
+
+// =========================================================================
+// POST /api/upload/face-photo — invalid multipart body → 400
+// (triggers next_field() map_err path)
+// =========================================================================
+
+#[tokio::test]
+async fn test_upload_face_photo_invalid_multipart() {
+    let (base_url, auth_header, _) = setup().await;
+    let client = reqwest::Client::new();
+
+    // Send raw body with multipart content-type but invalid body
+    let res = client
+        .post(format!("{base_url}/api/upload/face-photo"))
+        .header("Authorization", &auth_header)
+        .header("Content-Type", "multipart/form-data; boundary=INVALID")
+        .body("not a valid multipart body")
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 400);
+}
+
+// =========================================================================
+// POST /api/upload/report-audio — invalid multipart body → 400
+// =========================================================================
+
+#[tokio::test]
+async fn test_upload_report_audio_invalid_multipart() {
+    let (base_url, auth_header, _) = setup().await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/upload/report-audio"))
+        .header("Authorization", &auth_header)
+        .header("Content-Type", "multipart/form-data; boundary=INVALID")
+        .body("not a valid multipart body")
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 400);
+}
+
+// =========================================================================
+// POST /api/upload/blow-video — invalid multipart body → 400
+// =========================================================================
+
+#[tokio::test]
+async fn test_upload_blow_video_invalid_multipart() {
+    let (base_url, auth_header, _) = setup().await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/upload/blow-video"))
+        .header("Authorization", &auth_header)
+        .header("Content-Type", "multipart/form-data; boundary=INVALID")
+        .body("not a valid multipart body")
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 400);
+}
+
+// =========================================================================
+// X-Tenant-ID header fallback (no JWT) — success
+// =========================================================================
+
+#[tokio::test]
+async fn test_upload_face_photo_with_tenant_header() {
+    let state = mock_helpers::app_state::setup_mock_app_state().await;
+    let tenant_id = Uuid::new_v4();
+    let base_url = common::spawn_test_server(state).await;
+    let client = reqwest::Client::new();
+
+    let part = reqwest::multipart::Part::bytes(vec![0xFF, 0xD8, 0xFF, 0xE0])
+        .file_name("test.jpg")
+        .mime_str("image/jpeg")
+        .unwrap();
+    let form = reqwest::multipart::Form::new().part("file", part);
+
+    let res = client
+        .post(format!("{base_url}/api/upload/face-photo"))
+        .header("X-Tenant-ID", tenant_id.to_string())
+        .multipart(form)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert!(body["url"]
+        .as_str()
+        .unwrap()
+        .contains(&tenant_id.to_string()));
+    assert!(body["filename"].as_str().unwrap().ends_with(".jpg"));
+}


### PR DESCRIPTION
## Summary
- 12 new mock-based route test files (batch 2): health, car_inspection_files, health_baselines, car_inspections, upload, dtako_operations, nfc_tags, tenko_webhooks, communication_items, tenant_users, tenko_schedules, tenko_call
- Updated mock repos with data fields for full coverage
- Added `Clone` derive to `DailyHealthRow` and `UserRow`
- **All 24 route files at 100% line coverage** (mock tests only)

## Progress: 24/36 routes complete (67%)

## Test plan
- [x] All ~370 mock tests pass locally
- [x] All 24 route files at 100% coverage
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)