### PR TITLE
refactor: make mock tests DB-free (Phase 4)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ use storage::StorageBackend;
 
 #[derive(Clone)]
 pub struct AppState {
-    pub pool: sqlx::PgPool,
+    pub pool: Option<sqlx::PgPool>,
     pub auth: Arc<dyn AuthRepository>,
     pub bot_admin: Arc<dyn BotAdminRepository>,
     pub car_inspections: Arc<dyn CarInspectionRepository>,
@@ -69,4 +69,11 @@ pub struct AppState {
     pub carins_storage: Option<Arc<dyn StorageBackend>>,
     pub dtako_storage: Option<Arc<dyn StorageBackend>>,
     pub fcm: Option<Arc<dyn fcm::FcmSenderTrait>>,
+}
+
+impl AppState {
+    /// pool が必要な統合テスト・本番コード用。None なら panic。
+    pub fn pool(&self) -> &sqlx::PgPool {
+        self.pool.as_ref().expect("PgPool is required but not set")
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -163,7 +163,7 @@ async fn main() -> anyhow::Result<()> {
     let timecard = Arc::new(PgTimecardRepository::new(pool.clone()));
 
     let state = AppState {
-        pool: pool.clone(),
+        pool: Some(pool.clone()),
         auth,
         bot_admin,
         car_inspections,

--- a/src/routes/tenko_sessions.rs
+++ b/src/routes/tenko_sessions.rs
@@ -213,7 +213,10 @@ async fn submit_alcohol(
             }
         });
 
-        let pool = state.pool.clone();
+        let pool = match state.pool.clone() {
+            Some(p) => p,
+            None => return Ok(Json(session)),
+        };
         #[rustfmt::skip]
         tokio::spawn(async move { let _ = crate::webhook::fire_event(&pool, tenant_id, "alcohol_detected", payload).await; });
     }
@@ -376,7 +379,10 @@ async fn submit_report(
             }
         });
 
-        let pool = state.pool.clone();
+        let pool = match state.pool.clone() {
+            Some(p) => p,
+            None => return Ok(Json(session)),
+        };
         tokio::spawn(async move {
             let _ = crate::webhook::fire_event(&pool, tenant_id, "report_submitted", payload).await;
         });
@@ -565,8 +571,12 @@ async fn submit_self_declaration(
             StatusCode::INTERNAL_SERVER_ERROR
         })?;
 
-    // 安全判定を自動実行
-    let session = perform_safety_judgment(repo, &session, tenant_id, &state.pool).await?;
+    // 安全判定を自動実行 (pool がない場合はスキップ)
+    let session = if let Some(pool) = state.pool.as_ref() {
+        perform_safety_judgment(repo, &session, tenant_id, pool).await?
+    } else {
+        session
+    };
 
     Ok(Json(session))
 }
@@ -856,7 +866,10 @@ async fn submit_daily_inspection(
             }
         });
 
-        let pool = state.pool.clone();
+        let pool = match state.pool.clone() {
+            Some(p) => p,
+            None => return Ok(Json(session)),
+        };
         #[rustfmt::skip]
         tokio::spawn(async move { let _ = crate::webhook::fire_event(&pool, tenant_id, "inspection_ng", payload).await; });
     }
@@ -981,7 +994,10 @@ async fn interrupt_session(
         }
     });
 
-    let pool = state.pool.clone();
+    let pool = match state.pool.clone() {
+        Some(p) => p,
+        None => return Ok(Json(session)),
+    };
     tokio::spawn(async move {
         let _ = crate::webhook::fire_event(&pool, tenant_id, "tenko_interrupted", payload).await;
     });

--- a/tests/admin_test.rs
+++ b/tests/admin_test.rs
@@ -18,12 +18,12 @@ async fn setup_admin() -> (
     let state = common::setup_app_state().await;
     let base_url = common::spawn_test_server(state.clone()).await;
     let tenant_id = common::create_test_tenant(
-        &state.pool,
+        state.pool(),
         &format!("Admin{}", uuid::Uuid::new_v4().simple()),
     )
     .await;
     let (user_id, _) =
-        common::create_test_user_in_db(&state.pool, tenant_id, "admin@test.com", "admin").await;
+        common::create_test_user_in_db(state.pool(), tenant_id, "admin@test.com", "admin").await;
     let jwt = common::create_test_jwt_for_user(user_id, tenant_id, "admin@test.com", "admin");
     let client = reqwest::Client::new();
     (guard, state, base_url, tenant_id, jwt, client)
@@ -140,7 +140,7 @@ async fn test_delete_user() {
 
         // 削除用ユーザーを作成
         let (target_id, _) =
-            common::create_test_user_in_db(&state.pool, tenant_id, "target@test.com", "viewer")
+            common::create_test_user_in_db(state.pool(), tenant_id, "target@test.com", "viewer")
                 .await;
 
         let res = client
@@ -159,9 +159,9 @@ async fn test_users_forbidden_for_viewer() {
     test_case!("viewerロールでユーザー一覧が403", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "ViewerForbid").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "ViewerForbid").await;
         let (user_id, _) =
-            common::create_test_user_in_db(&state.pool, tenant_id, "viewer@test.com", "viewer")
+            common::create_test_user_in_db(state.pool(), tenant_id, "viewer@test.com", "viewer")
                 .await;
         let jwt = common::create_test_jwt_for_user(user_id, tenant_id, "viewer@test.com", "viewer");
         let client = reqwest::Client::new();
@@ -488,7 +488,7 @@ async fn test_bot_forbidden_for_viewer() {
         let (_guard, state, base_url, tenant_id, _jwt, client) = setup_admin().await;
 
         let (viewer_id, _) =
-            common::create_test_user_in_db(&state.pool, tenant_id, "botviewer@test.com", "viewer")
+            common::create_test_user_in_db(state.pool(), tenant_id, "botviewer@test.com", "viewer")
                 .await;
         let viewer_jwt =
             common::create_test_jwt_for_user(viewer_id, tenant_id, "botviewer@test.com", "viewer");
@@ -638,7 +638,7 @@ async fn test_sso_forbidden_for_viewer() {
         let (_guard, state, base_url, tenant_id, _jwt, client) = setup_admin().await;
 
         let (viewer_id, _) =
-            common::create_test_user_in_db(&state.pool, tenant_id, "ssoviewer@test.com", "viewer")
+            common::create_test_user_in_db(state.pool(), tenant_id, "ssoviewer@test.com", "viewer")
                 .await;
         let viewer_jwt =
             common::create_test_jwt_for_user(viewer_id, tenant_id, "ssoviewer@test.com", "viewer");
@@ -686,7 +686,7 @@ async fn test_tenant_users_viewer_forbidden_all() {
         let (_guard, state, base_url, tenant_id, _jwt, client) = setup_admin().await;
 
         let (viewer_id, _) =
-            common::create_test_user_in_db(&state.pool, tenant_id, "tu-viewer@test.com", "viewer")
+            common::create_test_user_in_db(state.pool(), tenant_id, "tu-viewer@test.com", "viewer")
                 .await;
         let viewer_jwt =
             common::create_test_jwt_for_user(viewer_id, tenant_id, "tu-viewer@test.com", "viewer");
@@ -760,7 +760,7 @@ async fn test_delete_user_self_delete() {
         let (_guard, state, base_url, tenant_id, _jwt, client) = setup_admin().await;
 
         let (self_id, _) =
-            common::create_test_user_in_db(&state.pool, tenant_id, "selfdelete@test.com", "admin")
+            common::create_test_user_in_db(state.pool(), tenant_id, "selfdelete@test.com", "admin")
                 .await;
         let self_jwt =
             common::create_test_jwt_for_user(self_id, tenant_id, "selfdelete@test.com", "admin");
@@ -790,9 +790,9 @@ async fn test_bot_upsert_encrypt_error_no_key() {
 
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "BotNoKey").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "BotNoKey").await;
         let (user_id, _) =
-            common::create_test_user_in_db(&state.pool, tenant_id, "botnokey@test.com", "admin")
+            common::create_test_user_in_db(state.pool(), tenant_id, "botnokey@test.com", "admin")
                 .await;
         let jwt =
             common::create_test_jwt_for_user(user_id, tenant_id, "botnokey@test.com", "admin");

--- a/tests/auth_test.rs
+++ b/tests/auth_test.rs
@@ -52,7 +52,7 @@ async fn test_valid_jwt_succeeds() {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
 
-        let tenant_id = common::create_test_tenant(&state.pool, "Auth Test Tenant").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "Auth Test Tenant").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
 
         let client = reqwest::Client::new();
@@ -100,10 +100,10 @@ async fn test_me_returns_user_info() {
     test_case!("認証済みユーザーの情報を返す", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "Me Test").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "Me Test").await;
 
         let (user_id, _) =
-            common::create_test_user_in_db(&state.pool, tenant_id, "me@test.com", "admin").await;
+            common::create_test_user_in_db(state.pool(), tenant_id, "me@test.com", "admin").await;
         let jwt = common::create_test_jwt_for_user(user_id, tenant_id, "me@test.com", "admin");
 
         let client = reqwest::Client::new();
@@ -151,11 +151,15 @@ async fn test_refresh_token_success() {
         {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "Refresh OK").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "Refresh OK").await;
 
-            let (_user_id, raw_token) =
-                common::create_test_user_in_db(&state.pool, tenant_id, "refresh@test.com", "admin")
-                    .await;
+            let (_user_id, raw_token) = common::create_test_user_in_db(
+                state.pool(),
+                tenant_id,
+                "refresh@test.com",
+                "admin",
+            )
+            .await;
 
             let client = reqwest::Client::new();
             let res = client
@@ -198,16 +202,20 @@ async fn test_refresh_token_expired() {
         {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "Refresh Exp").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "Refresh Exp").await;
 
-            let (_user_id, raw_token) =
-                common::create_test_user_in_db(&state.pool, tenant_id, "expired@test.com", "admin")
-                    .await;
+            let (_user_id, raw_token) = common::create_test_user_in_db(
+                state.pool(),
+                tenant_id,
+                "expired@test.com",
+                "admin",
+            )
+            .await;
 
             // 有効期限を過去に更新
             sqlx::query("UPDATE users SET refresh_token_expires_at = NOW() - INTERVAL '1 day' WHERE tenant_id = $1 AND email = 'expired@test.com'")
             .bind(tenant_id)
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
 
@@ -235,10 +243,10 @@ async fn test_logout_clears_refresh() {
         {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "Logout Test").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "Logout Test").await;
 
             let (user_id, raw_token) =
-                common::create_test_user_in_db(&state.pool, tenant_id, "logout@test.com", "admin")
+                common::create_test_user_in_db(state.pool(), tenant_id, "logout@test.com", "admin")
                     .await;
             let jwt =
                 common::create_test_jwt_for_user(user_id, tenant_id, "logout@test.com", "admin");
@@ -297,10 +305,10 @@ async fn test_my_orgs() {
     test_case!("所属テナント一覧を返す", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "MyOrgs Test").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "MyOrgs Test").await;
 
         let (user_id, _) =
-            common::create_test_user_in_db(&state.pool, tenant_id, "orgs@test.com", "admin").await;
+            common::create_test_user_in_db(state.pool(), tenant_id, "orgs@test.com", "admin").await;
         let jwt = common::create_test_jwt_for_user(user_id, tenant_id, "orgs@test.com", "admin");
 
         let client = reqwest::Client::new();
@@ -334,11 +342,11 @@ async fn test_google_login_success_new_user() {
             let client = reqwest::Client::new();
 
             // テナントを作成 (email domain でマッチさせる)
-            let tenant_id = common::create_test_tenant(&state.pool, "GoogleLogin").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "GoogleLogin").await;
             // email_domain を設定
             sqlx::query("UPDATE tenants SET email_domain = 'example.com' WHERE id = $1")
                 .bind(tenant_id)
-                .execute(&state.pool)
+                .execute(state.pool())
                 .await
                 .unwrap();
 
@@ -367,10 +375,10 @@ async fn test_google_login_existing_user() {
         let base_url = common::spawn_test_server(state.clone()).await;
         let client = reqwest::Client::new();
 
-        let tenant_id = common::create_test_tenant(&state.pool, "GoogleExist").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "GoogleExist").await;
         sqlx::query("UPDATE tenants SET email_domain = 'example.com' WHERE id = $1")
             .bind(tenant_id)
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
 
@@ -408,10 +416,10 @@ async fn test_google_code_login_success() {
         let base_url = common::spawn_test_server(state.clone()).await;
         let client = reqwest::Client::new();
 
-        let tenant_id = common::create_test_tenant(&state.pool, "GoogleCode").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "GoogleCode").await;
         sqlx::query("UPDATE tenants SET email_domain = 'example.com' WHERE id = $1")
             .bind(tenant_id)
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
 
@@ -444,10 +452,10 @@ async fn test_google_callback_success() {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
 
-            let tenant_id = common::create_test_tenant(&state.pool, "GoogleCB").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "GoogleCB").await;
             sqlx::query("UPDATE tenants SET email_domain = 'example.com' WHERE id = $1")
                 .bind(tenant_id)
-                .execute(&state.pool)
+                .execute(state.pool())
                 .await
                 .unwrap();
 
@@ -1149,11 +1157,11 @@ async fn test_google_login_with_invitation() {
             let base_url = common::spawn_test_server(state.clone()).await;
             let client = reqwest::Client::new();
 
-            let tenant_id = common::create_test_tenant(&state.pool, "InvitedTenant").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "InvitedTenant").await;
 
             // Clean up any existing user with this google_sub from previous test runs
             sqlx::query("DELETE FROM users WHERE google_sub = 'test-google-sub-12345'")
-                .execute(&state.pool)
+                .execute(state.pool())
                 .await
                 .unwrap();
 
@@ -1162,7 +1170,7 @@ async fn test_google_login_with_invitation() {
             "INSERT INTO tenant_allowed_emails (tenant_id, email, role) VALUES ($1, 'google-test@example.com', 'viewer') ON CONFLICT (email) DO UPDATE SET tenant_id = $1, role = 'viewer'",
         )
         .bind(tenant_id)
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -1189,7 +1197,7 @@ async fn test_google_login_with_invitation() {
             let count: (i64,) = sqlx::query_as(
             "SELECT COUNT(*) FROM tenant_allowed_emails WHERE email = 'google-test@example.com'",
         )
-        .fetch_one(&state.pool)
+        .fetch_one(state.pool())
         .await
         .unwrap();
             assert_eq!(count.0, 0, "Invitation should be consumed after login");
@@ -1199,7 +1207,7 @@ async fn test_google_login_with_invitation() {
                 "DELETE FROM users WHERE google_sub = 'test-google-sub-12345' AND tenant_id = $1",
             )
             .bind(tenant_id)
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
         }
@@ -1222,18 +1230,18 @@ async fn test_google_login_creates_new_tenant() {
             sqlx::query(
                 "DELETE FROM tenant_allowed_emails WHERE email = 'google-test@example.com'",
             )
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
             sqlx::query("DELETE FROM users WHERE google_sub = 'test-google-sub-12345'")
-                .execute(&state.pool)
+                .execute(state.pool())
                 .await
                 .unwrap();
             // Remove email_domain match to force new tenant creation
             sqlx::query(
                 "UPDATE tenants SET email_domain = NULL WHERE email_domain = 'example.com'",
             )
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
 
@@ -1254,12 +1262,12 @@ async fn test_google_login_creates_new_tenant() {
             // Cleanup
             let user_tenant_id = body["user"]["tenant_id"].as_str().unwrap();
             sqlx::query("DELETE FROM users WHERE google_sub = 'test-google-sub-12345'")
-                .execute(&state.pool)
+                .execute(state.pool())
                 .await
                 .unwrap();
             sqlx::query("DELETE FROM tenants WHERE id = $1::UUID AND name = 'example.com'")
                 .bind(user_tenant_id)
-                .execute(&state.pool)
+                .execute(state.pool())
                 .await
                 .unwrap();
         }

--- a/tests/carins_test.rs
+++ b/tests/carins_test.rs
@@ -13,7 +13,7 @@ async fn test_list_files() {
     test_case!("GET /api/files でファイル一覧を取得する", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "CarinsFiles").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "CarinsFiles").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -37,7 +37,7 @@ async fn test_list_files_with_type_filter() {
         {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "CarinsType").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "CarinsType").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
             let client = reqwest::Client::new();
 
@@ -58,7 +58,7 @@ async fn test_list_recent_files() {
     test_case!("最近のファイル一覧を取得する", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "CarinsRecent").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "CarinsRecent").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -78,7 +78,7 @@ async fn test_list_not_attached_files() {
     test_case!("未添付ファイル一覧を取得する", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "CarinsNotAtt").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "CarinsNotAtt").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -120,7 +120,7 @@ async fn test_get_file_not_found() {
     test_case!("存在しないファイル UUID で 404 を返す", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "CarinsGetNF").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "CarinsGetNF").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -145,7 +145,7 @@ async fn test_upload_face_photo() {
     test_case!("顔写真をアップロードする", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "UploadFace").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "UploadFace").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -174,7 +174,7 @@ async fn test_upload_report_audio() {
     test_case!("レポート音声をアップロードする", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "UploadAudio").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "UploadAudio").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -203,7 +203,7 @@ async fn test_upload_blow_video() {
     test_case!("吹込動画をアップロードする", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "UploadVideo").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "UploadVideo").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -240,7 +240,7 @@ async fn test_create_file_base64() {
 
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "CarinsCreate").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "CarinsCreate").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
             let auth = format!("Bearer {jwt}");
             let client = reqwest::Client::new();
@@ -298,7 +298,7 @@ async fn test_delete_file_not_found() {
     test_case!("存在しないファイルの削除で 404 を返す", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "CarinsDelNF").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "CarinsDelNF").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -323,7 +323,7 @@ async fn test_download_file() {
 
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "CarinsDL").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "CarinsDL").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
             let auth = format!("Bearer {jwt}");
             let client = reqwest::Client::new();
@@ -371,14 +371,14 @@ async fn test_car_inspections_db_error() {
             let _flock = common::db_rename_flock();
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "CarInsDbErr").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "CarInsDbErr").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
             let auth = format!("Bearer {jwt}");
             let client = reqwest::Client::new();
 
             // RENAME car_inspection to break all queries
             sqlx::query("ALTER TABLE alc_api.car_inspection RENAME TO car_inspection_bak")
-                .execute(&state.pool)
+                .execute(state.pool())
                 .await
                 .unwrap();
 
@@ -438,7 +438,7 @@ async fn test_car_inspections_db_error() {
 
             // Restore
             sqlx::query("ALTER TABLE alc_api.car_inspection_bak RENAME TO car_inspection")
-                .execute(&state.pool)
+                .execute(state.pool())
                 .await
                 .unwrap();
         }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -273,7 +273,7 @@ fn build_app_state(
     let timecard = Arc::new(PgTimecardRepository::new(pool.clone()));
 
     AppState {
-        pool,
+        pool: Some(pool),
         auth,
         bot_admin,
         car_inspections,

--- a/tests/coverage/admin_coverage.rs
+++ b/tests/coverage/admin_coverage.rs
@@ -16,12 +16,12 @@ async fn setup_admin_for_coverage() -> (
     let state = common::setup_app_state().await;
     let base_url = common::spawn_test_server(state.clone()).await;
     let tenant_id = common::create_test_tenant(
-        &state.pool,
+        state.pool(),
         &format!("AdmCov{}", uuid::Uuid::new_v4().simple()),
     )
     .await;
     let (user_id, _) =
-        common::create_test_user_in_db(&state.pool, tenant_id, "admcov@test.com", "admin").await;
+        common::create_test_user_in_db(state.pool(), tenant_id, "admcov@test.com", "admin").await;
     let jwt = common::create_test_jwt_for_user(user_id, tenant_id, "admcov@test.com", "admin");
     let client = reqwest::Client::new();
     (state, base_url, tenant_id, jwt, client)
@@ -41,7 +41,7 @@ async fn test_tenant_users_list_users_db_error() {
         let (state, base_url, _tenant_id, jwt, client) = setup_admin_for_coverage().await;
 
         sqlx::query("ALTER TABLE alc_api.users RENAME TO users_bak_tu")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
 
@@ -54,7 +54,7 @@ async fn test_tenant_users_list_users_db_error() {
         assert_eq!(res.status(), 500);
 
         sqlx::query("ALTER TABLE alc_api.users_bak_tu RENAME TO users")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
     });
@@ -76,7 +76,7 @@ async fn test_tenant_users_list_invitations_db_error() {
         sqlx::query(
             "ALTER TABLE alc_api.tenant_allowed_emails RENAME TO tenant_allowed_emails_bak_tu",
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -91,7 +91,7 @@ async fn test_tenant_users_list_invitations_db_error() {
         sqlx::query(
             "ALTER TABLE alc_api.tenant_allowed_emails_bak_tu RENAME TO tenant_allowed_emails",
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
     });
@@ -114,7 +114,7 @@ async fn test_tenant_users_invite_user_db_error() {
         sqlx::query(
             "ALTER TABLE alc_api.tenant_allowed_emails RENAME TO tenant_allowed_emails_bak_inv",
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -133,7 +133,7 @@ async fn test_tenant_users_invite_user_db_error() {
         sqlx::query(
             "ALTER TABLE alc_api.tenant_allowed_emails_bak_inv RENAME TO tenant_allowed_emails",
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
     });
@@ -155,7 +155,7 @@ async fn test_tenant_users_delete_invitation_db_error() {
         sqlx::query(
             "ALTER TABLE alc_api.tenant_allowed_emails RENAME TO tenant_allowed_emails_bak_di",
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -171,7 +171,7 @@ async fn test_tenant_users_delete_invitation_db_error() {
         sqlx::query(
             "ALTER TABLE alc_api.tenant_allowed_emails_bak_di RENAME TO tenant_allowed_emails",
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
     });
@@ -191,7 +191,7 @@ async fn test_tenant_users_delete_user_db_error() {
         let (state, base_url, _tenant_id, jwt, client) = setup_admin_for_coverage().await;
 
         sqlx::query("ALTER TABLE alc_api.users RENAME TO users_bak_du")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
 
@@ -205,7 +205,7 @@ async fn test_tenant_users_delete_user_db_error() {
         assert_eq!(res.status(), 500);
 
         sqlx::query("ALTER TABLE alc_api.users_bak_du RENAME TO users")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
     });
@@ -225,7 +225,7 @@ async fn test_bot_list_configs_db_error() {
         let (state, base_url, _tenant_id, jwt, client) = setup_admin_for_coverage().await;
 
         sqlx::query("ALTER TABLE alc_api.bot_configs RENAME TO bot_configs_bak_lc")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
 
@@ -238,7 +238,7 @@ async fn test_bot_list_configs_db_error() {
         assert_eq!(res.status(), 500);
 
         sqlx::query("ALTER TABLE alc_api.bot_configs_bak_lc RENAME TO bot_configs")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
     });
@@ -262,14 +262,14 @@ async fn test_bot_upsert_db_error() {
                BEGIN RAISE EXCEPTION 'test: bot_configs insert blocked'; END;
                $$ LANGUAGE plpgsql"#,
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
         sqlx::query(
             "CREATE TRIGGER reject_bot_config_insert BEFORE INSERT ON alc_api.bot_configs \
              FOR EACH ROW EXECUTE FUNCTION alc_api.reject_bot_config_insert()",
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -288,11 +288,11 @@ async fn test_bot_upsert_db_error() {
         assert_eq!(res.status(), 500);
 
         sqlx::query("DROP TRIGGER reject_bot_config_insert ON alc_api.bot_configs")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
         sqlx::query("DROP FUNCTION alc_api.reject_bot_config_insert()")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
     });
@@ -312,7 +312,7 @@ async fn test_bot_delete_db_error() {
         let (state, base_url, _tenant_id, jwt, client) = setup_admin_for_coverage().await;
 
         sqlx::query("ALTER TABLE alc_api.bot_configs RENAME TO bot_configs_bak_dc")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
 
@@ -327,7 +327,7 @@ async fn test_bot_delete_db_error() {
         assert_eq!(res.status(), 500);
 
         sqlx::query("ALTER TABLE alc_api.bot_configs_bak_dc RENAME TO bot_configs")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
     });

--- a/tests/coverage/auth_coverage.rs
+++ b/tests/coverage/auth_coverage.rs
@@ -151,9 +151,9 @@ async fn test_lineworks_redirect_happy_path() {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
 
-            let tenant_id = common::create_test_tenant(&state.pool, "LW Redirect").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "LW Redirect").await;
             let encrypted = encrypt_test_secret("dummy-secret", common::TEST_JWT_SECRET);
-            insert_sso_config(&state.pool, tenant_id, "test-lw-domain", &encrypted, None).await;
+            insert_sso_config(state.pool(), tenant_id, "test-lw-domain", &encrypted, None).await;
 
             let client = reqwest::ClientBuilder::new()
                 .redirect(reqwest::redirect::Policy::none())
@@ -237,14 +237,14 @@ async fn test_lineworks_callback_happy_path() {
 
             // 前回テストの残存ユーザーを削除 (INSERT パスをカバーするため)
             sqlx::query("DELETE FROM users WHERE lineworks_id = 'lw-user-001'")
-                .execute(&state.pool)
+                .execute(state.pool())
                 .await
                 .unwrap();
 
-            let tenant_id = common::create_test_tenant(&state.pool, "LW Callback").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "LW Callback").await;
             let encrypted = encrypt_test_secret("test-client-secret", common::TEST_JWT_SECRET);
             let ext_org_id = format!("test-lw-cb-{}", Uuid::new_v4().simple());
-            insert_sso_config(&state.pool, tenant_id, &ext_org_id, &encrypted, None).await;
+            insert_sso_config(state.pool(), tenant_id, &ext_org_id, &encrypted, None).await;
 
             // 有効な HMAC state 生成 (subdomain URL for extract_parent_domain coverage)
             let state_payload = rust_alc_api::auth::lineworks::state::StatePayload {
@@ -310,11 +310,11 @@ async fn test_woff_config_happy_path() {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
 
-        let tenant_id = common::create_test_tenant(&state.pool, "WOFF Config").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "WOFF Config").await;
         let encrypted = encrypt_test_secret("dummy", common::TEST_JWT_SECRET);
         let domain = format!("woff-cfg-{}", Uuid::new_v4().simple());
         insert_sso_config(
-            &state.pool,
+            state.pool(),
             tenant_id,
             &domain,
             &encrypted,
@@ -349,10 +349,10 @@ async fn test_woff_config_no_woff_id() {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
 
-        let tenant_id = common::create_test_tenant(&state.pool, "WOFF NoId").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "WOFF NoId").await;
         let encrypted = encrypt_test_secret("dummy", common::TEST_JWT_SECRET);
         let domain = format!("woff-noid-{}", Uuid::new_v4().simple());
-        insert_sso_config(&state.pool, tenant_id, &domain, &encrypted, None).await;
+        insert_sso_config(state.pool(), tenant_id, &domain, &encrypted, None).await;
 
         let client = reqwest::Client::new();
         let res = client
@@ -403,14 +403,21 @@ async fn test_woff_auth_happy_path() {
 
         // 前回テストの残存ユーザーを削除
         sqlx::query("DELETE FROM users WHERE lineworks_id = 'woff-user-unique-001'")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
 
-        let tenant_id = common::create_test_tenant(&state.pool, "WOFF Auth").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "WOFF Auth").await;
         let encrypted = encrypt_test_secret("dummy", common::TEST_JWT_SECRET);
         let domain = format!("woff-auth-{}", Uuid::new_v4().simple());
-        insert_sso_config(&state.pool, tenant_id, &domain, &encrypted, Some("woff-id")).await;
+        insert_sso_config(
+            state.pool(),
+            tenant_id,
+            &domain,
+            &encrypted,
+            Some("woff-id"),
+        )
+        .await;
 
         let client = reqwest::Client::new();
         let res = client
@@ -454,10 +461,10 @@ async fn test_lineworks_redirect_no_oauth_secret() {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
 
-        let tenant_id = common::create_test_tenant(&state.pool, "LW NoSecret").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "LW NoSecret").await;
         let encrypted = encrypt_test_secret("dummy", common::TEST_JWT_SECRET);
         let domain = format!("nosecret-{}", Uuid::new_v4().simple());
-        insert_sso_config(&state.pool, tenant_id, &domain, &encrypted, None).await;
+        insert_sso_config(state.pool(), tenant_id, &domain, &encrypted, None).await;
 
         let client = reqwest::ClientBuilder::new()
             .redirect(reqwest::redirect::Policy::none())
@@ -544,11 +551,11 @@ async fn test_lineworks_callback_decrypt_error() {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
 
-        let tenant_id = common::create_test_tenant(&state.pool, "LW Decrypt Err").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "LW Decrypt Err").await;
         let ext_org_id = format!("decrypt-err-{}", Uuid::new_v4().simple());
         // 不正な暗号文を挿入
         insert_sso_config(
-            &state.pool,
+            state.pool(),
             tenant_id,
             &ext_org_id,
             "invalid-base64-not-encrypted",
@@ -615,10 +622,10 @@ async fn test_lineworks_callback_token_exchange_error() {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
 
-        let tenant_id = common::create_test_tenant(&state.pool, "LW TokExch Err").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "LW TokExch Err").await;
         let encrypted = encrypt_test_secret("test-secret", common::TEST_JWT_SECRET);
         let ext_org_id = format!("texch-err-{}", Uuid::new_v4().simple());
-        insert_sso_config(&state.pool, tenant_id, &ext_org_id, &encrypted, None).await;
+        insert_sso_config(state.pool(), tenant_id, &ext_org_id, &encrypted, None).await;
 
         let state_payload = rust_alc_api::auth::lineworks::state::StatePayload {
             redirect_uri: "https://example.com/login".into(),
@@ -692,10 +699,10 @@ async fn test_lineworks_callback_profile_error() {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
 
-        let tenant_id = common::create_test_tenant(&state.pool, "LW Prof Err").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "LW Prof Err").await;
         let encrypted = encrypt_test_secret("test-secret", common::TEST_JWT_SECRET);
         let ext_org_id = format!("prof-err-{}", Uuid::new_v4().simple());
-        insert_sso_config(&state.pool, tenant_id, &ext_org_id, &encrypted, None).await;
+        insert_sso_config(state.pool(), tenant_id, &ext_org_id, &encrypted, None).await;
 
         let state_payload = rust_alc_api::auth::lineworks::state::StatePayload {
             redirect_uri: "https://example.com/login".into(),
@@ -757,10 +764,17 @@ async fn test_woff_auth_profile_error() {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
 
-        let tenant_id = common::create_test_tenant(&state.pool, "WOFF Prof Err").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "WOFF Prof Err").await;
         let encrypted = encrypt_test_secret("dummy", common::TEST_JWT_SECRET);
         let domain = format!("woff-proferr-{}", Uuid::new_v4().simple());
-        insert_sso_config(&state.pool, tenant_id, &domain, &encrypted, Some("woff-id")).await;
+        insert_sso_config(
+            state.pool(),
+            tenant_id,
+            &domain,
+            &encrypted,
+            Some("woff-id"),
+        )
+        .await;
 
         let client = reqwest::Client::new();
         let res = client
@@ -815,14 +829,21 @@ async fn test_woff_auth_existing_user() {
 
             // 前回の残存ユーザーを削除
             sqlx::query("DELETE FROM users WHERE lineworks_id = 'woff-existing-user-002'")
-                .execute(&state.pool)
+                .execute(state.pool())
                 .await
                 .unwrap();
 
-            let tenant_id = common::create_test_tenant(&state.pool, "WOFF Exist").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "WOFF Exist").await;
             let encrypted = encrypt_test_secret("dummy", common::TEST_JWT_SECRET);
             let domain = format!("woff-exist-{}", Uuid::new_v4().simple());
-            insert_sso_config(&state.pool, tenant_id, &domain, &encrypted, Some("woff-id")).await;
+            insert_sso_config(
+                state.pool(),
+                tenant_id,
+                &domain,
+                &encrypted,
+                Some("woff-id"),
+            )
+            .await;
 
             let client = reqwest::Client::new();
             let body = serde_json::json!({
@@ -891,7 +912,7 @@ async fn test_sso_query_error_lineworks_redirect() {
 
         // 関数を DROP (コミット済み)
         sqlx::query("DROP FUNCTION IF EXISTS alc_api.resolve_sso_config(TEXT, TEXT)")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
 
@@ -912,7 +933,7 @@ async fn test_sso_query_error_lineworks_redirect() {
 
         // 再作成
         sqlx::query(RECREATE_RESOLVE_SSO_CONFIG)
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
     });
@@ -930,7 +951,7 @@ async fn test_sso_query_error_woff_config() {
         let base_url = common::spawn_test_server(state.clone()).await;
 
         sqlx::query("DROP FUNCTION IF EXISTS alc_api.resolve_sso_config(TEXT, TEXT)")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
 
@@ -944,7 +965,7 @@ async fn test_sso_query_error_woff_config() {
         assert_eq!(res.status(), 500, "Dropped function → 500");
 
         sqlx::query(RECREATE_RESOLVE_SSO_CONFIG)
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
     });
@@ -962,7 +983,7 @@ async fn test_sso_query_error_woff_auth() {
         let base_url = common::spawn_test_server(state.clone()).await;
 
         sqlx::query("DROP FUNCTION IF EXISTS alc_api.resolve_sso_config(TEXT, TEXT)")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
 
@@ -980,7 +1001,7 @@ async fn test_sso_query_error_woff_auth() {
         assert_eq!(res.status(), 500, "Dropped function → 500");
 
         sqlx::query(RECREATE_RESOLVE_SSO_CONFIG)
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
     });
@@ -1033,7 +1054,7 @@ async fn test_upsert_lineworks_user_insert_error() {
 
         // 前回の残存ユーザーを削除
         sqlx::query("DELETE FROM users WHERE lineworks_id = 'insert-err-user-001'")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
 
@@ -1049,7 +1070,7 @@ async fn test_upsert_lineworks_user_insert_error() {
         .bind(format!("cli-{}", Uuid::new_v4().simple()))
         .bind(&encrypt_test_secret("test", common::TEST_JWT_SECRET))
         .bind(&ext_org_id)
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -1082,7 +1103,7 @@ async fn test_upsert_lineworks_user_insert_error() {
         // Cleanup
         sqlx::query("DELETE FROM sso_provider_configs WHERE external_org_id = $1")
             .bind(&state_payload.external_org_id)
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
         std::env::remove_var("LINEWORKS_TOKEN_URL");

--- a/tests/coverage/daily_health.rs
+++ b/tests/coverage/daily_health.rs
@@ -9,13 +9,13 @@ async fn test_daily_health_db_error() {
         let _flock = crate::common::db_rename_flock();
         let state = crate::common::setup_app_state().await;
         let base_url = crate::common::spawn_test_server(state.clone()).await;
-        let tenant_id = crate::common::create_test_tenant(&state.pool, "DHErr").await;
+        let tenant_id = crate::common::create_test_tenant(state.pool(), "DHErr").await;
         let jwt = crate::common::create_test_jwt(tenant_id, "admin");
 
         // employees テーブルを RENAME してクエリエラーを発生させる
         // (ENV_LOCK で他テストと直列化)
         sqlx::query("ALTER TABLE alc_api.employees RENAME TO employees_cov_bak")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
 
@@ -29,7 +29,7 @@ async fn test_daily_health_db_error() {
         assert_eq!(res.status(), 500);
 
         sqlx::query("ALTER TABLE alc_api.employees_cov_bak RENAME TO employees")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
     });
@@ -44,7 +44,7 @@ async fn test_daily_health_safety_judgment_counts() {
         let _flock = crate::common::db_rename_flock();
         let state = crate::common::setup_app_state().await;
         let base_url = crate::common::spawn_test_server(state.clone()).await;
-        let tenant_id = crate::common::create_test_tenant(&state.pool, "DHJudge").await;
+        let tenant_id = crate::common::create_test_tenant(state.pool(), "DHJudge").await;
         let jwt = crate::common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -61,7 +61,7 @@ async fn test_daily_health_safety_judgment_counts() {
             .await;
 
         {
-            let mut conn = state.pool.acquire().await.unwrap();
+            let mut conn = state.pool().acquire().await.unwrap();
             sqlx::query("SELECT set_config('app.current_tenant_id', $1, true)")
                 .bind(tenant_id.to_string())
                 .execute(&mut *conn)

--- a/tests/coverage/dtako_csv_proxy.rs
+++ b/tests/coverage/dtako_csv_proxy.rs
@@ -9,7 +9,7 @@ async fn csv_proxy_setup_and_get(
 ) -> reqwest::StatusCode {
     let state = crate::common::setup_app_state().await;
     let base_url = crate::common::spawn_test_server(state.clone()).await;
-    let tenant_id = crate::common::create_test_tenant(&state.pool, tenant_suffix).await;
+    let tenant_id = crate::common::create_test_tenant(state.pool(), tenant_suffix).await;
     let jwt = crate::common::create_test_jwt(tenant_id, "admin");
     let auth = format!("Bearer {jwt}");
     let client = reqwest::Client::new();
@@ -94,7 +94,7 @@ async fn test_invalid_type() {
         let _flock = crate::common::db_rename_flock();
         let state = crate::common::setup_app_state().await;
         let base_url = crate::common::spawn_test_server(state.clone()).await;
-        let tenant_id = crate::common::create_test_tenant(&state.pool, "CsvBad").await;
+        let tenant_id = crate::common::create_test_tenant(state.pool(), "CsvBad").await;
         let jwt = crate::common::create_test_jwt(tenant_id, "admin");
 
         let res = reqwest::Client::new()
@@ -116,7 +116,7 @@ async fn test_not_found() {
         let _flock = crate::common::db_rename_flock();
         let state = crate::common::setup_app_state().await;
         let base_url = crate::common::spawn_test_server(state.clone()).await;
-        let tenant_id = crate::common::create_test_tenant(&state.pool, "CsvNF").await;
+        let tenant_id = crate::common::create_test_tenant(state.pool(), "CsvNF").await;
         let jwt = crate::common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -157,7 +157,7 @@ async fn test_no_operation_record() {
             let _flock = crate::common::db_rename_flock();
             let state = crate::common::setup_app_state().await;
             let base_url = crate::common::spawn_test_server(state.clone()).await;
-            let tenant_id = crate::common::create_test_tenant(&state.pool, "CsvNoOp").await;
+            let tenant_id = crate::common::create_test_tenant(state.pool(), "CsvNoOp").await;
             let jwt = crate::common::create_test_jwt(tenant_id, "admin");
             let auth = format!("Bearer {jwt}");
 

--- a/tests/coverage/dtako_daily_hours.rs
+++ b/tests/coverage/dtako_daily_hours.rs
@@ -9,7 +9,7 @@ async fn test_daily_segments() {
         let _flock = crate::common::db_rename_flock();
         let state = crate::common::setup_app_state().await;
         let base_url = crate::common::spawn_test_server(state.clone()).await;
-        let tenant_id = crate::common::create_test_tenant(&state.pool, "DtakoSeg").await;
+        let tenant_id = crate::common::create_test_tenant(state.pool(), "DtakoSeg").await;
         let jwt = crate::common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -20,7 +20,7 @@ async fn test_daily_segments() {
         let emp_id: uuid::Uuid = emp["id"].as_str().unwrap().parse().unwrap();
 
         {
-            let mut conn = state.pool.acquire().await.unwrap();
+            let mut conn = state.pool().acquire().await.unwrap();
             sqlx::query("SELECT set_config('app.current_tenant_id', $1, true)")
                 .bind(tenant_id.to_string())
                 .execute(&mut *conn)
@@ -64,7 +64,7 @@ async fn test_daily_segments() {
     test_case!("データなしで空配列を返す", {
         let state = crate::common::setup_app_state().await;
         let base_url = crate::common::spawn_test_server(state.clone()).await;
-        let tenant_id = crate::common::create_test_tenant(&state.pool, "DtakoSegE").await;
+        let tenant_id = crate::common::create_test_tenant(state.pool(), "DtakoSegE").await;
         let jwt = crate::common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();

--- a/tests/coverage/dtako_scraper.rs
+++ b/tests/coverage/dtako_scraper.rs
@@ -18,7 +18,7 @@ async fn test_get_scrape_history_empty() {
         let _flock = crate::common::db_rename_flock();
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "Scraper Hist").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "Scraper Hist").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
 
         let client = reqwest::Client::new();
@@ -44,7 +44,7 @@ async fn test_get_scrape_history_with_data() {
         let _flock = crate::common::db_rename_flock();
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "Scraper Hist2").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "Scraper Hist2").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
 
         // テストデータ挿入
@@ -53,7 +53,7 @@ async fn test_get_scrape_history_with_data() {
                VALUES ($1, '2026-03-01', 'COMP001', 'success', 'test message')"#,
         )
         .bind(tenant_id)
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -87,7 +87,7 @@ async fn test_trigger_scrape_connection_error() {
         let state = common::setup_app_state().await;
         let base_url =
             common::spawn_test_server_with_scraper(state.clone(), "http://127.0.0.1:19999").await;
-        let tenant_id = common::create_test_tenant(&state.pool, "Scraper Err").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "Scraper Err").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
 
         let client = reqwest::Client::new();
@@ -127,7 +127,7 @@ async fn test_trigger_scrape_scraper_error_response() {
         let state = common::setup_app_state().await;
         let base_url =
             common::spawn_test_server_with_scraper(state.clone(), &mock_server.uri()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "Scraper 500").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "Scraper 500").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
 
         let client = reqwest::Client::new();
@@ -181,7 +181,7 @@ async fn test_trigger_scrape_sse_happy_path() {
         let state = common::setup_app_state().await;
         let base_url =
             common::spawn_test_server_with_scraper(state.clone(), &mock_server.uri()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "Scraper SSE").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "Scraper SSE").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
 
         let client = reqwest::Client::new();
@@ -211,7 +211,7 @@ async fn test_trigger_scrape_sse_happy_path() {
         let count: (i64,) =
             sqlx::query_as("SELECT COUNT(*) FROM dtako_scrape_history WHERE tenant_id = $1")
                 .bind(tenant_id)
-                .fetch_one(&state.pool)
+                .fetch_one(state.pool())
                 .await
                 .unwrap();
         assert!(
@@ -253,7 +253,7 @@ async fn test_trigger_scrape_default_date() {
             let state = common::setup_app_state().await;
             let base_url =
                 common::spawn_test_server_with_scraper(state.clone(), &mock_server.uri()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "Scraper Def").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "Scraper Def").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
 
             let client = reqwest::Client::new();
@@ -301,7 +301,7 @@ async fn test_trigger_scrape_invalid_date() {
             let state = common::setup_app_state().await;
             let base_url =
                 common::spawn_test_server_with_scraper(state.clone(), &mock_server.uri()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "Scraper BadDate").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "Scraper BadDate").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
 
             let client = reqwest::Client::new();
@@ -358,7 +358,7 @@ async fn test_trigger_scrape_with_id_token() {
             let state = common::setup_app_state().await;
             let base_url =
                 common::spawn_test_server_with_scraper(state.clone(), &scraper_server.uri()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "Scraper Token").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "Scraper Token").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
 
             let client = reqwest::Client::new();
@@ -415,7 +415,7 @@ async fn test_trigger_scrape_metadata_error() {
             let state = common::setup_app_state().await;
             let base_url =
                 common::spawn_test_server_with_scraper(state.clone(), &scraper_server.uri()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "Scraper MetaErr").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "Scraper MetaErr").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
 
             let client = reqwest::Client::new();
@@ -477,7 +477,7 @@ async fn test_trigger_scrape_sse_edge_cases() {
             let state = common::setup_app_state().await;
             let base_url =
                 common::spawn_test_server_with_scraper(state.clone(), &mock_server.uri()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "Scraper Edge").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "Scraper Edge").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
 
             let client = reqwest::Client::new();
@@ -509,12 +509,12 @@ async fn test_get_scrape_history_db_error() {
             let _db = crate::common::DB_RENAME_LOCK.lock().unwrap();
             let _flock = crate::common::db_rename_flock();
             let state = common::setup_app_state().await;
-            let tenant_id = common::create_test_tenant(&state.pool, "Scraper DB Err").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "Scraper DB Err").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
             let base_url = common::spawn_test_server(state.clone()).await;
 
             // pool を閉じて DB エラーを発生させる (他テストに影響しない)
-            state.pool.close().await;
+            state.pool().close().await;
 
             let client = reqwest::Client::new();
             let res = client
@@ -563,7 +563,7 @@ async fn test_trigger_scrape_client_disconnect() {
         let state = common::setup_app_state().await;
         let base_url =
             common::spawn_test_server_with_scraper(state.clone(), &mock_server.uri()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "Scraper Disc").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "Scraper Disc").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
 
         // リクエスト送信後、レスポンスを読まずに drop → tx.send() 失敗
@@ -632,7 +632,7 @@ async fn test_trigger_scrape_stream_error() {
         let state = common::setup_app_state().await;
         let base_url =
             common::spawn_test_server_with_scraper(state.clone(), &format!("http://{addr}")).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "Scraper StreamErr").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "Scraper StreamErr").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
 
         let client = reqwest::Client::new();

--- a/tests/coverage/employees_coverage.rs
+++ b/tests/coverage/employees_coverage.rs
@@ -17,7 +17,7 @@ async fn test_create_employee_db_error() {
         let _flock = crate::common::db_rename_flock();
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "EmpCreateErr").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "EmpCreateErr").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -27,14 +27,14 @@ async fn test_create_employee_db_error() {
                BEGIN RAISE EXCEPTION 'test: employees insert blocked'; END;
                $$ LANGUAGE plpgsql"#,
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
         sqlx::query(
             "CREATE TRIGGER reject_emp_insert BEFORE INSERT ON alc_api.employees \
              FOR EACH ROW EXECUTE FUNCTION alc_api.reject_emp_insert()",
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -51,11 +51,11 @@ async fn test_create_employee_db_error() {
         assert_eq!(res.status(), 500);
 
         sqlx::query("DROP TRIGGER reject_emp_insert ON alc_api.employees")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
         sqlx::query("DROP FUNCTION alc_api.reject_emp_insert()")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
     });
@@ -74,7 +74,7 @@ async fn test_delete_employee_db_error() {
         let _flock = crate::common::db_rename_flock();
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "EmpDelErr").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "EmpDelErr").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -90,14 +90,14 @@ async fn test_delete_employee_db_error() {
                BEGIN RAISE EXCEPTION 'test: employees update blocked'; END;
                $$ LANGUAGE plpgsql"#,
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
         sqlx::query(
             "CREATE TRIGGER reject_emp_update BEFORE UPDATE ON alc_api.employees \
              FOR EACH ROW EXECUTE FUNCTION alc_api.reject_emp_update()",
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -110,11 +110,11 @@ async fn test_delete_employee_db_error() {
         assert_eq!(res.status(), 500);
 
         sqlx::query("DROP TRIGGER reject_emp_update ON alc_api.employees")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
         sqlx::query("DROP FUNCTION alc_api.reject_emp_update()")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
     });
@@ -133,7 +133,7 @@ async fn test_update_face_db_error() {
         let _flock = crate::common::db_rename_flock();
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "FaceErr").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "FaceErr").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -147,14 +147,14 @@ async fn test_update_face_db_error() {
                BEGIN RAISE EXCEPTION 'test: employees update blocked'; END;
                $$ LANGUAGE plpgsql"#,
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
         sqlx::query(
             "CREATE TRIGGER reject_emp_update_face BEFORE UPDATE ON alc_api.employees \
              FOR EACH ROW EXECUTE FUNCTION alc_api.reject_emp_update_face()",
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -172,11 +172,11 @@ async fn test_update_face_db_error() {
         assert_eq!(res.status(), 500);
 
         sqlx::query("DROP TRIGGER reject_emp_update_face ON alc_api.employees")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
         sqlx::query("DROP FUNCTION alc_api.reject_emp_update_face()")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
     });
@@ -195,7 +195,7 @@ async fn test_update_license_db_error() {
         let _flock = crate::common::db_rename_flock();
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "LicErr").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "LicErr").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -209,14 +209,14 @@ async fn test_update_license_db_error() {
                BEGIN RAISE EXCEPTION 'test: employees update blocked'; END;
                $$ LANGUAGE plpgsql"#,
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
         sqlx::query(
             "CREATE TRIGGER reject_emp_update_lic BEFORE UPDATE ON alc_api.employees \
              FOR EACH ROW EXECUTE FUNCTION alc_api.reject_emp_update_lic()",
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -233,11 +233,11 @@ async fn test_update_license_db_error() {
         assert_eq!(res.status(), 500);
 
         sqlx::query("DROP TRIGGER reject_emp_update_lic ON alc_api.employees")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
         sqlx::query("DROP FUNCTION alc_api.reject_emp_update_lic()")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
     });
@@ -256,7 +256,7 @@ async fn test_update_nfc_id_db_error() {
         let _flock = crate::common::db_rename_flock();
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "NfcErr").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "NfcErr").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -270,14 +270,14 @@ async fn test_update_nfc_id_db_error() {
                BEGIN RAISE EXCEPTION 'test: employees update blocked'; END;
                $$ LANGUAGE plpgsql"#,
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
         sqlx::query(
             "CREATE TRIGGER reject_emp_update_nfc BEFORE UPDATE ON alc_api.employees \
              FOR EACH ROW EXECUTE FUNCTION alc_api.reject_emp_update_nfc()",
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -293,11 +293,11 @@ async fn test_update_nfc_id_db_error() {
         assert_eq!(res.status(), 500);
 
         sqlx::query("DROP TRIGGER reject_emp_update_nfc ON alc_api.employees")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
         sqlx::query("DROP FUNCTION alc_api.reject_emp_update_nfc()")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
     });
@@ -316,7 +316,7 @@ async fn test_approve_face_db_error() {
         let _flock = crate::common::db_rename_flock();
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "AppFaceErr").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "AppFaceErr").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -345,14 +345,14 @@ async fn test_approve_face_db_error() {
                BEGIN RAISE EXCEPTION 'test: employees update blocked'; END;
                $$ LANGUAGE plpgsql"#,
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
         sqlx::query(
             "CREATE TRIGGER reject_emp_update_appr BEFORE UPDATE ON alc_api.employees \
              FOR EACH ROW EXECUTE FUNCTION alc_api.reject_emp_update_appr()",
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -365,11 +365,11 @@ async fn test_approve_face_db_error() {
         assert_eq!(res.status(), 500);
 
         sqlx::query("DROP TRIGGER reject_emp_update_appr ON alc_api.employees")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
         sqlx::query("DROP FUNCTION alc_api.reject_emp_update_appr()")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
     });
@@ -388,7 +388,7 @@ async fn test_reject_face_db_error() {
         let _flock = crate::common::db_rename_flock();
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "RejFaceErr").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "RejFaceErr").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -417,14 +417,14 @@ async fn test_reject_face_db_error() {
                BEGIN RAISE EXCEPTION 'test: employees update blocked'; END;
                $$ LANGUAGE plpgsql"#,
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
         sqlx::query(
             "CREATE TRIGGER reject_emp_update_rej BEFORE UPDATE ON alc_api.employees \
              FOR EACH ROW EXECUTE FUNCTION alc_api.reject_emp_update_rej()",
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -437,11 +437,11 @@ async fn test_reject_face_db_error() {
         assert_eq!(res.status(), 500);
 
         sqlx::query("DROP TRIGGER reject_emp_update_rej ON alc_api.employees")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
         sqlx::query("DROP FUNCTION alc_api.reject_emp_update_rej()")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
     });

--- a/tests/coverage/misc.rs
+++ b/tests/coverage/misc.rs
@@ -10,7 +10,7 @@ async fn test_calendar_december() {
         let _flock = crate::common::db_rename_flock();
         let state = crate::common::setup_app_state().await;
         let base_url = crate::common::spawn_test_server(state.clone()).await;
-        let tenant_id = crate::common::create_test_tenant(&state.pool, "CalDec").await;
+        let tenant_id = crate::common::create_test_tenant(state.pool(), "CalDec").await;
         let jwt = crate::common::create_test_jwt(tenant_id, "admin");
 
         let client = reqwest::Client::new();
@@ -40,7 +40,7 @@ async fn test_auth_jwt_fail_fallback_to_tenant_id() {
             let _flock = crate::common::db_rename_flock();
             let state = crate::common::setup_app_state().await;
             let base_url = crate::common::spawn_test_server(state.clone()).await;
-            let tenant_id = crate::common::create_test_tenant(&state.pool, "AuthFB").await;
+            let tenant_id = crate::common::create_test_tenant(state.pool(), "AuthFB").await;
 
             let client = reqwest::Client::new();
             let res = client
@@ -64,7 +64,7 @@ async fn test_nfc_tag_register_db_error() {
         let _flock = crate::common::db_rename_flock();
         let state = crate::common::setup_app_state().await;
         let base_url = crate::common::spawn_test_server(state.clone()).await;
-        let tenant_id = crate::common::create_test_tenant(&state.pool, "NFCErr").await;
+        let tenant_id = crate::common::create_test_tenant(state.pool(), "NFCErr").await;
         let jwt = crate::common::create_test_jwt(tenant_id, "admin");
 
         sqlx::query(
@@ -72,14 +72,14 @@ async fn test_nfc_tag_register_db_error() {
                BEGIN RAISE EXCEPTION 'test: nfc insert blocked'; END;
                $$ LANGUAGE plpgsql"#,
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
         sqlx::query(
             "CREATE TRIGGER reject_nfc_insert BEFORE INSERT ON alc_api.car_inspection_nfc_tags \
              FOR EACH ROW EXECUTE FUNCTION alc_api.reject_nfc_insert()",
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -97,11 +97,11 @@ async fn test_nfc_tag_register_db_error() {
         assert_eq!(res.status(), 500);
 
         sqlx::query("DROP TRIGGER reject_nfc_insert ON alc_api.car_inspection_nfc_tags")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
         sqlx::query("DROP FUNCTION alc_api.reject_nfc_insert()")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
     });
@@ -118,7 +118,7 @@ async fn test_health_baseline_upsert_db_error() {
             let _flock = crate::common::db_rename_flock();
             let state = crate::common::setup_app_state().await;
             let base_url = crate::common::spawn_test_server(state.clone()).await;
-            let tenant_id = crate::common::create_test_tenant(&state.pool, "HBErr").await;
+            let tenant_id = crate::common::create_test_tenant(state.pool(), "HBErr").await;
             let jwt = crate::common::create_test_jwt(tenant_id, "admin");
 
             sqlx::query(
@@ -126,14 +126,14 @@ async fn test_health_baseline_upsert_db_error() {
                BEGIN RAISE EXCEPTION 'test: health baseline insert blocked'; END;
                $$ LANGUAGE plpgsql"#,
             )
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
             sqlx::query(
                 "CREATE TRIGGER reject_hb_insert BEFORE INSERT ON alc_api.employee_health_baselines \
                  FOR EACH ROW EXECUTE FUNCTION alc_api.reject_hb_insert()",
             )
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
 
@@ -153,11 +153,11 @@ async fn test_health_baseline_upsert_db_error() {
             assert_eq!(res.status(), 500);
 
             sqlx::query("DROP TRIGGER reject_hb_insert ON alc_api.employee_health_baselines")
-                .execute(&state.pool)
+                .execute(state.pool())
                 .await
                 .unwrap();
             sqlx::query("DROP FUNCTION alc_api.reject_hb_insert()")
-                .execute(&state.pool)
+                .execute(state.pool())
                 .await
                 .unwrap();
         }
@@ -175,7 +175,7 @@ async fn test_carrying_items_empty_tenant() {
             let _flock = crate::common::db_rename_flock();
             let state = crate::common::setup_app_state().await;
             let base_url = crate::common::spawn_test_server(state.clone()).await;
-            let tenant_id = crate::common::create_test_tenant(&state.pool, "CarryEmpty").await;
+            let tenant_id = crate::common::create_test_tenant(state.pool(), "CarryEmpty").await;
             let jwt = crate::common::create_test_jwt(tenant_id, "admin");
 
             let client = reqwest::Client::new();
@@ -205,7 +205,7 @@ async fn test_car_inspection_get_by_id_success() {
         let _flock = crate::common::db_rename_flock();
         let state = crate::common::setup_app_state().await;
         let base_url = crate::common::spawn_test_server(state.clone()).await;
-        let tenant_id = crate::common::create_test_tenant(&state.pool, "CarInsGet").await;
+        let tenant_id = crate::common::create_test_tenant(state.pool(), "CarInsGet").await;
         let jwt = crate::common::create_test_jwt(tenant_id, "admin");
 
         // INSERT a minimal car_inspection row with all 96 NOT NULL columns
@@ -292,7 +292,7 @@ async fn test_car_inspection_get_by_id_success() {
             ) RETURNING id"#,
         )
         .bind(tenant_id)
-        .fetch_one(&state.pool)
+        .fetch_one(state.pool())
         .await
         .unwrap();
 
@@ -310,7 +310,7 @@ async fn test_car_inspection_get_by_id_success() {
         // Cleanup
         sqlx::query("DELETE FROM alc_api.car_inspection WHERE id = $1")
             .bind(row)
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
     });
@@ -329,7 +329,7 @@ async fn test_update_employee_non_conflict_db_error() {
         let _flock = crate::common::db_rename_flock();
         let state = crate::common::setup_app_state().await;
         let base_url = crate::common::spawn_test_server(state.clone()).await;
-        let tenant_id = crate::common::create_test_tenant(&state.pool, "EmpUpdISE").await;
+        let tenant_id = crate::common::create_test_tenant(state.pool(), "EmpUpdISE").await;
         let jwt = crate::common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -346,14 +346,14 @@ async fn test_update_employee_non_conflict_db_error() {
                BEGIN RAISE EXCEPTION 'test: generic update error'; END;
                $$ LANGUAGE plpgsql"#,
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
         sqlx::query(
             "CREATE TRIGGER reject_emp_update_ise BEFORE UPDATE ON alc_api.employees \
              FOR EACH ROW EXECUTE FUNCTION alc_api.reject_emp_update_ise()",
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -371,11 +371,11 @@ async fn test_update_employee_non_conflict_db_error() {
 
         // Cleanup
         sqlx::query("DROP TRIGGER reject_emp_update_ise ON alc_api.employees")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
         sqlx::query("DROP FUNCTION alc_api.reject_emp_update_ise()")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
     });
@@ -394,13 +394,13 @@ async fn test_communication_items_list_db_error() {
         let _flock = crate::common::db_rename_flock();
         let state = crate::common::setup_app_state().await;
         let base_url = crate::common::spawn_test_server(state.clone()).await;
-        let tenant_id = crate::common::create_test_tenant(&state.pool, "CommListErr").await;
+        let tenant_id = crate::common::create_test_tenant(state.pool(), "CommListErr").await;
         let jwt = crate::common::create_test_jwt(tenant_id, "admin");
 
         // Rename employees table so the JOIN in the second query fails,
         // but the COUNT query (no join) succeeds.
         sqlx::query("ALTER TABLE alc_api.employees RENAME TO employees_bak")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
 
@@ -415,7 +415,7 @@ async fn test_communication_items_list_db_error() {
 
         // Restore
         sqlx::query("ALTER TABLE alc_api.employees_bak RENAME TO employees")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
     });
@@ -436,12 +436,12 @@ async fn test_sso_upsert_no_client_secret() {
         let state = crate::common::setup_app_state().await;
         let base_url = crate::common::spawn_test_server(state.clone()).await;
         let tenant_id = crate::common::create_test_tenant(
-            &state.pool,
+            state.pool(),
             &format!("SSONoSec{}", uuid::Uuid::new_v4().simple()),
         )
         .await;
         let (user_id, _) = crate::common::create_test_user_in_db(
-            &state.pool,
+            state.pool(),
             tenant_id,
             "ssonosec@test.com",
             "admin",
@@ -493,12 +493,12 @@ async fn test_bot_admin_update_with_secrets() {
             let state = crate::common::setup_app_state().await;
             let base_url = crate::common::spawn_test_server(state.clone()).await;
             let tenant_id = crate::common::create_test_tenant(
-                &state.pool,
+                state.pool(),
                 &format!("BotUpd{}", uuid::Uuid::new_v4().simple()),
             )
             .await;
             let (user_id, _) = crate::common::create_test_user_in_db(
-                &state.pool,
+                state.pool(),
                 tenant_id,
                 "botupd@test.com",
                 "admin",
@@ -554,7 +554,7 @@ async fn test_bot_admin_update_with_secrets() {
             // Cleanup
             sqlx::query("DELETE FROM alc_api.bot_configs WHERE id = $1::uuid")
                 .bind(&config_id)
-                .execute(&state.pool)
+                .execute(state.pool())
                 .await
                 .unwrap();
         }
@@ -579,12 +579,12 @@ async fn test_bot_admin_update_without_secrets() {
             let state = crate::common::setup_app_state().await;
             let base_url = crate::common::spawn_test_server(state.clone()).await;
             let tenant_id = crate::common::create_test_tenant(
-                &state.pool,
+                state.pool(),
                 &format!("BotNone{}", uuid::Uuid::new_v4().simple()),
             )
             .await;
             let (user_id, _) = crate::common::create_test_user_in_db(
-                &state.pool,
+                state.pool(),
                 tenant_id,
                 "botnone@test.com",
                 "admin",
@@ -636,7 +636,7 @@ async fn test_bot_admin_update_without_secrets() {
             // Cleanup
             sqlx::query("DELETE FROM alc_api.bot_configs WHERE id = $1::uuid")
                 .bind(&config_id)
-                .execute(&state.pool)
+                .execute(state.pool())
                 .await
                 .unwrap();
         }
@@ -656,7 +656,7 @@ async fn test_tenko_schedules_batch_empty() {
         let _flock = crate::common::db_rename_flock();
         let state = crate::common::setup_app_state().await;
         let base_url = crate::common::spawn_test_server(state.clone()).await;
-        let tenant_id = crate::common::create_test_tenant(&state.pool, "TSchEmpty").await;
+        let tenant_id = crate::common::create_test_tenant(state.pool(), "TSchEmpty").await;
         let jwt = crate::common::create_test_jwt(tenant_id, "admin");
 
         let client = reqwest::Client::new();
@@ -686,7 +686,7 @@ async fn test_tenko_schedules_pre_op_no_instruction() {
             let _flock = crate::common::db_rename_flock();
             let state = crate::common::setup_app_state().await;
             let base_url = crate::common::spawn_test_server(state.clone()).await;
-            let tenant_id = crate::common::create_test_tenant(&state.pool, "TSchNoIns").await;
+            let tenant_id = crate::common::create_test_tenant(state.pool(), "TSchNoIns").await;
             let jwt = crate::common::create_test_jwt(tenant_id, "admin");
 
             let client = reqwest::Client::new();
@@ -724,7 +724,7 @@ async fn test_tenko_schedules_list_with_filters() {
             let _flock = crate::common::db_rename_flock();
             let state = crate::common::setup_app_state().await;
             let base_url = crate::common::spawn_test_server(state.clone()).await;
-            let tenant_id = crate::common::create_test_tenant(&state.pool, "TSchFilt").await;
+            let tenant_id = crate::common::create_test_tenant(state.pool(), "TSchFilt").await;
             let jwt = crate::common::create_test_jwt(tenant_id, "admin");
 
             let emp_id = "00000000-0000-0000-0000-000000000099";
@@ -757,7 +757,7 @@ async fn test_tenko_schedules_batch_db_error() {
         let _flock = crate::common::db_rename_flock();
         let state = crate::common::setup_app_state().await;
         let base_url = crate::common::spawn_test_server(state.clone()).await;
-        let tenant_id = crate::common::create_test_tenant(&state.pool, "TSchBErr").await;
+        let tenant_id = crate::common::create_test_tenant(state.pool(), "TSchBErr").await;
         let jwt = crate::common::create_test_jwt(tenant_id, "admin");
 
         // Create trigger to block INSERT
@@ -766,14 +766,14 @@ async fn test_tenko_schedules_batch_db_error() {
                BEGIN RAISE EXCEPTION 'test: schedule insert blocked'; END;
                $$ LANGUAGE plpgsql"#,
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
         sqlx::query(
             "CREATE TRIGGER reject_sched_insert BEFORE INSERT ON alc_api.tenko_schedules \
              FOR EACH ROW EXECUTE FUNCTION alc_api.reject_sched_insert()",
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -796,11 +796,11 @@ async fn test_tenko_schedules_batch_db_error() {
 
         // Cleanup
         sqlx::query("DROP TRIGGER reject_sched_insert ON alc_api.tenko_schedules")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
         sqlx::query("DROP FUNCTION alc_api.reject_sched_insert()")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
     });
@@ -819,7 +819,7 @@ async fn test_equipment_failures_list_with_filters() {
         let _flock = crate::common::db_rename_flock();
         let state = crate::common::setup_app_state().await;
         let base_url = crate::common::spawn_test_server(state.clone()).await;
-        let tenant_id = crate::common::create_test_tenant(&state.pool, "EqFltFilt").await;
+        let tenant_id = crate::common::create_test_tenant(state.pool(), "EqFltFilt").await;
         let jwt = crate::common::create_test_jwt(tenant_id, "admin");
 
         let session_id = "00000000-0000-0000-0000-000000000099";
@@ -851,7 +851,7 @@ async fn test_equipment_failures_csv_with_date_filters() {
         let _flock = crate::common::db_rename_flock();
         let state = crate::common::setup_app_state().await;
         let base_url = crate::common::spawn_test_server(state.clone()).await;
-        let tenant_id = crate::common::create_test_tenant(&state.pool, "EqCsvFlt").await;
+        let tenant_id = crate::common::create_test_tenant(state.pool(), "EqCsvFlt").await;
         let jwt = crate::common::create_test_jwt(tenant_id, "admin");
 
         let client = reqwest::Client::new();
@@ -882,7 +882,7 @@ async fn test_tenko_webhooks_invalid_event_type() {
         let _flock = crate::common::db_rename_flock();
         let state = crate::common::setup_app_state().await;
         let base_url = crate::common::spawn_test_server(state.clone()).await;
-        let tenant_id = crate::common::create_test_tenant(&state.pool, "WHInvEvt").await;
+        let tenant_id = crate::common::create_test_tenant(state.pool(), "WHInvEvt").await;
         let jwt = crate::common::create_test_jwt(tenant_id, "admin");
 
         let client = reqwest::Client::new();
@@ -913,7 +913,7 @@ async fn test_tenko_webhooks_get_and_delete_not_found() {
         let _flock = crate::common::db_rename_flock();
         let state = crate::common::setup_app_state().await;
         let base_url = crate::common::spawn_test_server(state.clone()).await;
-        let tenant_id = crate::common::create_test_tenant(&state.pool, "WHGetDel").await;
+        let tenant_id = crate::common::create_test_tenant(state.pool(), "WHGetDel").await;
         let jwt = crate::common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -955,7 +955,7 @@ async fn test_tenko_webhooks_get_and_delete_not_found() {
         // Cleanup: delete the actual webhook
         sqlx::query("DELETE FROM alc_api.webhook_configs WHERE id = $1::uuid")
             .bind(webhook_id)
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
     });
@@ -974,7 +974,7 @@ async fn test_tenko_webhooks_upsert_db_error() {
         let _flock = crate::common::db_rename_flock();
         let state = crate::common::setup_app_state().await;
         let base_url = crate::common::spawn_test_server(state.clone()).await;
-        let tenant_id = crate::common::create_test_tenant(&state.pool, "WHUpsErr").await;
+        let tenant_id = crate::common::create_test_tenant(state.pool(), "WHUpsErr").await;
         let jwt = crate::common::create_test_jwt(tenant_id, "admin");
 
         // Create trigger to block INSERT on webhook_configs
@@ -983,14 +983,14 @@ async fn test_tenko_webhooks_upsert_db_error() {
                BEGIN RAISE EXCEPTION 'test: webhook insert blocked'; END;
                $$ LANGUAGE plpgsql"#,
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
         sqlx::query(
             "CREATE TRIGGER reject_wh_insert BEFORE INSERT ON alc_api.webhook_configs \
              FOR EACH ROW EXECUTE FUNCTION alc_api.reject_wh_insert()",
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -1009,11 +1009,11 @@ async fn test_tenko_webhooks_upsert_db_error() {
 
         // Cleanup
         sqlx::query("DROP TRIGGER reject_wh_insert ON alc_api.webhook_configs")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
         sqlx::query("DROP FUNCTION alc_api.reject_wh_insert()")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
     });
@@ -1032,12 +1032,12 @@ async fn test_tenko_webhooks_delete_db_error() {
         let _flock = crate::common::db_rename_flock();
         let state = crate::common::setup_app_state().await;
         let base_url = crate::common::spawn_test_server(state.clone()).await;
-        let tenant_id = crate::common::create_test_tenant(&state.pool, "WHDelErr").await;
+        let tenant_id = crate::common::create_test_tenant(state.pool(), "WHDelErr").await;
         let jwt = crate::common::create_test_jwt(tenant_id, "admin");
 
         // RENAME webhook_configs to cause DB error
         sqlx::query("ALTER TABLE alc_api.webhook_configs RENAME TO webhook_configs_bak")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
 
@@ -1053,7 +1053,7 @@ async fn test_tenko_webhooks_delete_db_error() {
 
         // Restore
         sqlx::query("ALTER TABLE alc_api.webhook_configs_bak RENAME TO webhook_configs")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
     });
@@ -1074,12 +1074,12 @@ async fn test_carins_files_list_db_error() {
             let _flock = crate::common::db_rename_flock();
             let state = crate::common::setup_app_state().await;
             let base_url = crate::common::spawn_test_server(state.clone()).await;
-            let tenant_id = crate::common::create_test_tenant(&state.pool, "CFiles").await;
+            let tenant_id = crate::common::create_test_tenant(state.pool(), "CFiles").await;
             let jwt = crate::common::create_test_jwt(tenant_id, "admin");
 
             // RENAME files table
             sqlx::query("ALTER TABLE alc_api.files RENAME TO files_bak")
-                .execute(&state.pool)
+                .execute(state.pool())
                 .await
                 .unwrap();
 
@@ -1114,7 +1114,7 @@ async fn test_carins_files_list_db_error() {
 
             // Restore
             sqlx::query("ALTER TABLE alc_api.files_bak RENAME TO files")
-                .execute(&state.pool)
+                .execute(state.pool())
                 .await
                 .unwrap();
         }
@@ -1130,14 +1130,14 @@ async fn test_carins_files_get_download_db_error() {
         let _flock = crate::common::db_rename_flock();
         let state = crate::common::setup_app_state().await;
         let base_url = crate::common::spawn_test_server(state.clone()).await;
-        let tenant_id = crate::common::create_test_tenant(&state.pool, "CFGet").await;
+        let tenant_id = crate::common::create_test_tenant(state.pool(), "CFGet").await;
         let jwt = crate::common::create_test_jwt(tenant_id, "admin");
 
         let fake_uuid = "00000000-0000-0000-0000-000000000099";
 
         // RENAME files table
         sqlx::query("ALTER TABLE alc_api.files RENAME TO files_bak")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
 
@@ -1163,7 +1163,7 @@ async fn test_carins_files_get_download_db_error() {
 
         // Restore
         sqlx::query("ALTER TABLE alc_api.files_bak RENAME TO files")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
     });
@@ -1178,7 +1178,7 @@ async fn test_carins_files_create_and_download() {
         let _flock = crate::common::db_rename_flock();
         let state = crate::common::setup_app_state().await;
         let base_url = crate::common::spawn_test_server(state.clone()).await;
-        let tenant_id = crate::common::create_test_tenant(&state.pool, "CFCreate").await;
+        let tenant_id = crate::common::create_test_tenant(state.pool(), "CFCreate").await;
         let jwt = crate::common::create_test_jwt(tenant_id, "admin");
 
         let client = reqwest::Client::new();
@@ -1223,7 +1223,7 @@ async fn test_carins_files_create_db_error() {
         let _flock = crate::common::db_rename_flock();
         let state = crate::common::setup_app_state().await;
         let base_url = crate::common::spawn_test_server(state.clone()).await;
-        let tenant_id = crate::common::create_test_tenant(&state.pool, "CFIns").await;
+        let tenant_id = crate::common::create_test_tenant(state.pool(), "CFIns").await;
         let jwt = crate::common::create_test_jwt(tenant_id, "admin");
 
         // Create trigger to reject INSERT on files
@@ -1232,14 +1232,14 @@ async fn test_carins_files_create_db_error() {
                BEGIN RAISE EXCEPTION 'test: files insert blocked'; END;
                $$ LANGUAGE plpgsql"#,
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
         sqlx::query(
             "CREATE TRIGGER reject_files_insert BEFORE INSERT ON alc_api.files \
              FOR EACH ROW EXECUTE FUNCTION alc_api.reject_files_insert()",
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -1261,11 +1261,11 @@ async fn test_carins_files_create_db_error() {
 
         // Cleanup
         sqlx::query("DROP TRIGGER IF EXISTS reject_files_insert ON alc_api.files")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
         sqlx::query("DROP FUNCTION IF EXISTS alc_api.reject_files_insert()")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
     });
@@ -1280,7 +1280,7 @@ async fn test_carins_files_delete_not_found() {
         let _flock = crate::common::db_rename_flock();
         let state = crate::common::setup_app_state().await;
         let base_url = crate::common::spawn_test_server(state.clone()).await;
-        let tenant_id = crate::common::create_test_tenant(&state.pool, "CFDel").await;
+        let tenant_id = crate::common::create_test_tenant(state.pool(), "CFDel").await;
         let jwt = crate::common::create_test_jwt(tenant_id, "admin");
 
         let client = reqwest::Client::new();
@@ -1315,7 +1315,7 @@ async fn test_carins_files_download_not_found() {
         let _flock = crate::common::db_rename_flock();
         let state = crate::common::setup_app_state().await;
         let base_url = crate::common::spawn_test_server(state.clone()).await;
-        let tenant_id = crate::common::create_test_tenant(&state.pool, "CFDnf").await;
+        let tenant_id = crate::common::create_test_tenant(state.pool(), "CFDnf").await;
         let jwt = crate::common::create_test_jwt(tenant_id, "admin");
 
         let client = reqwest::Client::new();
@@ -1343,7 +1343,7 @@ async fn test_carins_files_download_storage_error() {
             let _flock = crate::common::db_rename_flock();
             let state = crate::common::setup_app_state().await;
             let base_url = crate::common::spawn_test_server(state.clone()).await;
-            let tenant_id = crate::common::create_test_tenant(&state.pool, "CFStErr").await;
+            let tenant_id = crate::common::create_test_tenant(state.pool(), "CFStErr").await;
             let jwt = crate::common::create_test_jwt(tenant_id, "admin");
 
             // Insert a file row with s3_key but don't upload to mock storage
@@ -1354,7 +1354,7 @@ async fn test_carins_files_download_storage_error() {
         )
         .bind(file_uuid)
         .bind(tenant_id)
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -1384,7 +1384,7 @@ async fn test_measurements_start_db_error() {
         let _flock = crate::common::db_rename_flock();
         let state = crate::common::setup_app_state().await;
         let base_url = crate::common::spawn_test_server(state.clone()).await;
-        let tenant_id = crate::common::create_test_tenant(&state.pool, "MStart").await;
+        let tenant_id = crate::common::create_test_tenant(state.pool(), "MStart").await;
         let jwt = crate::common::create_test_jwt(tenant_id, "admin");
 
         let emp = crate::common::create_test_employee(
@@ -1399,7 +1399,7 @@ async fn test_measurements_start_db_error() {
 
         // RENAME measurements table
         sqlx::query("ALTER TABLE alc_api.measurements RENAME TO measurements_bak")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
 
@@ -1415,7 +1415,7 @@ async fn test_measurements_start_db_error() {
 
         // Restore
         sqlx::query("ALTER TABLE alc_api.measurements_bak RENAME TO measurements")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
     });
@@ -1430,7 +1430,7 @@ async fn test_measurements_update_deserialize_error() {
         let _flock = crate::common::db_rename_flock();
         let state = crate::common::setup_app_state().await;
         let base_url = crate::common::spawn_test_server(state.clone()).await;
-        let tenant_id = crate::common::create_test_tenant(&state.pool, "MUpDe").await;
+        let tenant_id = crate::common::create_test_tenant(state.pool(), "MUpDe").await;
         let jwt = crate::common::create_test_jwt(tenant_id, "admin");
 
         let client = reqwest::Client::new();
@@ -1476,7 +1476,7 @@ async fn test_measurements_update_db_error() {
         let _flock = crate::common::db_rename_flock();
         let state = crate::common::setup_app_state().await;
         let base_url = crate::common::spawn_test_server(state.clone()).await;
-        let tenant_id = crate::common::create_test_tenant(&state.pool, "MUpDb").await;
+        let tenant_id = crate::common::create_test_tenant(state.pool(), "MUpDb").await;
         let jwt = crate::common::create_test_jwt(tenant_id, "admin");
 
         let client = reqwest::Client::new();
@@ -1500,7 +1500,7 @@ async fn test_measurements_update_db_error() {
 
         // RENAME measurements
         sqlx::query("ALTER TABLE alc_api.measurements RENAME TO measurements_bak")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
 
@@ -1516,7 +1516,7 @@ async fn test_measurements_update_db_error() {
 
         // Restore
         sqlx::query("ALTER TABLE alc_api.measurements_bak RENAME TO measurements")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
     });
@@ -1531,12 +1531,12 @@ async fn test_measurements_list_db_error() {
         let _flock = crate::common::db_rename_flock();
         let state = crate::common::setup_app_state().await;
         let base_url = crate::common::spawn_test_server(state.clone()).await;
-        let tenant_id = crate::common::create_test_tenant(&state.pool, "MList").await;
+        let tenant_id = crate::common::create_test_tenant(state.pool(), "MList").await;
         let jwt = crate::common::create_test_jwt(tenant_id, "admin");
 
         // RENAME measurements
         sqlx::query("ALTER TABLE alc_api.measurements RENAME TO measurements_bak")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
 
@@ -1551,7 +1551,7 @@ async fn test_measurements_list_db_error() {
 
         // Restore
         sqlx::query("ALTER TABLE alc_api.measurements_bak RENAME TO measurements")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
     });
@@ -1566,7 +1566,7 @@ async fn test_measurements_video_proxy() {
         let _flock = crate::common::db_rename_flock();
         let state = crate::common::setup_app_state().await;
         let base_url = crate::common::spawn_test_server(state.clone()).await;
-        let tenant_id = crate::common::create_test_tenant(&state.pool, "MVid").await;
+        let tenant_id = crate::common::create_test_tenant(state.pool(), "MVid").await;
         let jwt = crate::common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -1649,12 +1649,12 @@ async fn test_measurements_video_db_error() {
         let _flock = crate::common::db_rename_flock();
         let state = crate::common::setup_app_state().await;
         let base_url = crate::common::spawn_test_server(state.clone()).await;
-        let tenant_id = crate::common::create_test_tenant(&state.pool, "MVErr").await;
+        let tenant_id = crate::common::create_test_tenant(state.pool(), "MVErr").await;
         let jwt = crate::common::create_test_jwt(tenant_id, "admin");
 
         // RENAME measurements
         sqlx::query("ALTER TABLE alc_api.measurements RENAME TO measurements_bak")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
 
@@ -1670,7 +1670,7 @@ async fn test_measurements_video_db_error() {
 
         // Restore
         sqlx::query("ALTER TABLE alc_api.measurements_bak RENAME TO measurements")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
     });
@@ -1685,7 +1685,7 @@ async fn test_measurements_create_kiosk_db_error() {
         let _flock = crate::common::db_rename_flock();
         let state = crate::common::setup_app_state().await;
         let base_url = crate::common::spawn_test_server(state.clone()).await;
-        let tenant_id = crate::common::create_test_tenant(&state.pool, "MKiosk").await;
+        let tenant_id = crate::common::create_test_tenant(state.pool(), "MKiosk").await;
         let jwt = crate::common::create_test_jwt(tenant_id, "admin");
 
         let client = reqwest::Client::new();
@@ -1701,7 +1701,7 @@ async fn test_measurements_create_kiosk_db_error() {
 
         // RENAME measurements
         sqlx::query("ALTER TABLE alc_api.measurements RENAME TO measurements_bak")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
 
@@ -1724,7 +1724,7 @@ async fn test_measurements_create_kiosk_db_error() {
 
         // Restore
         sqlx::query("ALTER TABLE alc_api.measurements_bak RENAME TO measurements")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
     });
@@ -1743,7 +1743,7 @@ async fn test_tenko_records_csv_with_filters_and_phase2() {
         let _flock = crate::common::db_rename_flock();
         let state = crate::common::setup_app_state().await;
         let base_url = crate::common::spawn_test_server(state.clone()).await;
-        let tenant_id = crate::common::create_test_tenant(&state.pool, "TRCsv").await;
+        let tenant_id = crate::common::create_test_tenant(state.pool(), "TRCsv").await;
         let jwt = crate::common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -1766,7 +1766,7 @@ async fn test_tenko_records_csv_with_filters_and_phase2() {
         .bind(session_id)
         .bind(tenant_id)
         .bind(emp_id)
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -1812,7 +1812,7 @@ async fn test_tenko_records_csv_with_filters_and_phase2() {
         .bind(&self_declaration)
         .bind(&safety_judgment)
         .bind(&daily_inspection)
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -1860,7 +1860,7 @@ async fn test_tenko_records_csv_all_ok_inspection() {
         let _flock = crate::common::db_rename_flock();
         let state = crate::common::setup_app_state().await;
         let base_url = crate::common::spawn_test_server(state.clone()).await;
-        let tenant_id = crate::common::create_test_tenant(&state.pool, "TRCok").await;
+        let tenant_id = crate::common::create_test_tenant(state.pool(), "TRCok").await;
         let jwt = crate::common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -1882,7 +1882,7 @@ async fn test_tenko_records_csv_all_ok_inspection() {
         .bind(session_id)
         .bind(tenant_id)
         .bind(emp_id)
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -1909,7 +1909,7 @@ async fn test_tenko_records_csv_all_ok_inspection() {
         .bind(session_id)
         .bind(emp_id)
         .bind(&daily_inspection)
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -1943,7 +1943,7 @@ async fn test_carins_files_blob_download() {
         let _flock = crate::common::db_rename_flock();
         let state = crate::common::setup_app_state().await;
         let base_url = crate::common::spawn_test_server(state.clone()).await;
-        let tenant_id = crate::common::create_test_tenant(&state.pool, "CFBlob").await;
+        let tenant_id = crate::common::create_test_tenant(state.pool(), "CFBlob").await;
         let jwt = crate::common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -1960,7 +1960,7 @@ async fn test_carins_files_blob_download() {
             .bind(blob_uuid)
             .bind(tenant_id)
             .bind(&blob_b64)
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
 
@@ -1971,7 +1971,7 @@ async fn test_carins_files_blob_download() {
             )
             .bind(no_data_uuid)
             .bind(tenant_id)
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
 
@@ -1999,7 +1999,7 @@ async fn test_carins_files_blob_download() {
         sqlx::query("DELETE FROM alc_api.files WHERE uuid IN ($1, $2)")
             .bind(blob_uuid)
             .bind(no_data_uuid)
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
     });
@@ -2026,7 +2026,7 @@ async fn test_carins_files_upload_storage_error() {
             let state = rust_alc_api::AppState { storage, ..state };
 
             let base_url = crate::common::spawn_test_server(state.clone()).await;
-            let tenant_id = crate::common::create_test_tenant(&state.pool, "CFUpErr").await;
+            let tenant_id = crate::common::create_test_tenant(state.pool(), "CFUpErr").await;
             let jwt = crate::common::create_test_jwt(tenant_id, "admin");
             let client = reqwest::Client::new();
 
@@ -2062,7 +2062,7 @@ async fn test_measurements_create_deserialize_error() {
         let _flock = crate::common::db_rename_flock();
         let state = crate::common::setup_app_state().await;
         let base_url = crate::common::spawn_test_server(state.clone()).await;
-        let tenant_id = crate::common::create_test_tenant(&state.pool, "MDeser").await;
+        let tenant_id = crate::common::create_test_tenant(state.pool(), "MDeser").await;
         let jwt = crate::common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -2087,7 +2087,7 @@ async fn test_measurements_list_date_filters() {
         let _flock = crate::common::db_rename_flock();
         let state = crate::common::setup_app_state().await;
         let base_url = crate::common::spawn_test_server(state.clone()).await;
-        let tenant_id = crate::common::create_test_tenant(&state.pool, "MDateF").await;
+        let tenant_id = crate::common::create_test_tenant(state.pool(), "MDateF").await;
         let jwt = crate::common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -2114,7 +2114,7 @@ async fn test_measurements_face_photo_proxy() {
         let _flock = crate::common::db_rename_flock();
         let state = crate::common::setup_app_state().await;
         let base_url = crate::common::spawn_test_server(state.clone()).await;
-        let tenant_id = crate::common::create_test_tenant(&state.pool, "MFace").await;
+        let tenant_id = crate::common::create_test_tenant(state.pool(), "MFace").await;
         let jwt = crate::common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -2141,7 +2141,7 @@ async fn test_measurements_face_photo_proxy() {
         sqlx::query("UPDATE alc_api.measurements SET face_photo_url = $1 WHERE id = $2::uuid")
             .bind(&face_url)
             .bind(m_id)
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
 
@@ -2161,7 +2161,7 @@ async fn test_measurements_face_photo_proxy() {
             "UPDATE alc_api.measurements SET face_photo_url = 'https://unknown-host/bad-key' WHERE id = $1::uuid",
         )
         .bind(m_id)
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
         let res = client
@@ -2183,7 +2183,7 @@ async fn test_measurements_video_extract_key_error() {
         let _flock = crate::common::db_rename_flock();
         let state = crate::common::setup_app_state().await;
         let base_url = crate::common::spawn_test_server(state.clone()).await;
-        let tenant_id = crate::common::create_test_tenant(&state.pool, "MVidEK").await;
+        let tenant_id = crate::common::create_test_tenant(state.pool(), "MVidEK").await;
         let jwt = crate::common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -2201,7 +2201,7 @@ async fn test_measurements_video_extract_key_error() {
             "UPDATE alc_api.measurements SET video_url = 'https://unknown/bad' WHERE id = $1::uuid",
         )
         .bind(mid)
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
         let res = client
@@ -2218,7 +2218,7 @@ async fn test_measurements_video_extract_key_error() {
         sqlx::query("UPDATE alc_api.measurements SET video_url = $1 WHERE id = $2::uuid")
             .bind(&fake_url)
             .bind(mid)
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
         let res = client
@@ -2242,7 +2242,7 @@ async fn test_guidance_records_crud_full() {
         let _flock = crate::common::db_rename_flock();
         let state = crate::common::setup_app_state().await;
         let base_url = crate::common::spawn_test_server(state.clone()).await;
-        let tenant_id = crate::common::create_test_tenant(&state.pool, "GuidRec").await;
+        let tenant_id = crate::common::create_test_tenant(state.pool(), "GuidRec").await;
         let jwt = crate::common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -2504,7 +2504,7 @@ async fn test_restraint_report_pdf_no_driver() {
         let _flock = crate::common::db_rename_flock();
         let state = crate::common::setup_app_state().await;
         let base_url = crate::common::spawn_test_server(state.clone()).await;
-        let tenant_id = crate::common::create_test_tenant(&state.pool, "PdfNoDr").await;
+        let tenant_id = crate::common::create_test_tenant(state.pool(), "PdfNoDr").await;
         let jwt = crate::common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -2530,7 +2530,7 @@ async fn test_restraint_report_pdf_with_driver() {
         let _flock = crate::common::db_rename_flock();
         let state = crate::common::setup_app_state().await;
         let base_url = crate::common::spawn_test_server(state.clone()).await;
-        let tenant_id = crate::common::create_test_tenant(&state.pool, "PdfDr").await;
+        let tenant_id = crate::common::create_test_tenant(state.pool(), "PdfDr").await;
         let jwt = crate::common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -2570,7 +2570,7 @@ async fn test_restraint_report_pdf_specific_driver() {
         let _flock = crate::common::db_rename_flock();
         let state = crate::common::setup_app_state().await;
         let base_url = crate::common::spawn_test_server(state.clone()).await;
-        let tenant_id = crate::common::create_test_tenant(&state.pool, "PdfSp").await;
+        let tenant_id = crate::common::create_test_tenant(state.pool(), "PdfSp").await;
         let jwt = crate::common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -2601,7 +2601,7 @@ async fn test_restraint_report_pdf_stream() {
         let _flock = crate::common::db_rename_flock();
         let state = crate::common::setup_app_state().await;
         let base_url = crate::common::spawn_test_server(state.clone()).await;
-        let tenant_id = crate::common::create_test_tenant(&state.pool, "PdfStr").await;
+        let tenant_id = crate::common::create_test_tenant(state.pool(), "PdfStr").await;
         let jwt = crate::common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -2640,7 +2640,7 @@ async fn test_restraint_report_pdf_stream_no_driver() {
         let _flock = crate::common::db_rename_flock();
         let state = crate::common::setup_app_state().await;
         let base_url = crate::common::spawn_test_server(state.clone()).await;
-        let tenant_id = crate::common::create_test_tenant(&state.pool, "PdfStrNo").await;
+        let tenant_id = crate::common::create_test_tenant(state.pool(), "PdfStrNo").await;
         let jwt = crate::common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -2669,7 +2669,7 @@ async fn test_restraint_report_pdf_april_fiscal_year() {
         let _flock = crate::common::db_rename_flock();
         let state = crate::common::setup_app_state().await;
         let base_url = crate::common::spawn_test_server(state.clone()).await;
-        let tenant_id = crate::common::create_test_tenant(&state.pool, "PdfApr").await;
+        let tenant_id = crate::common::create_test_tenant(state.pool(), "PdfApr").await;
         let jwt = crate::common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -2698,7 +2698,7 @@ async fn test_restraint_report_pdf_empty_name_driver_skipped() {
         let _flock = crate::common::db_rename_flock();
         let state = crate::common::setup_app_state().await;
         let base_url = crate::common::spawn_test_server(state.clone()).await;
-        let tenant_id = crate::common::create_test_tenant(&state.pool, "PdfEmp").await;
+        let tenant_id = crate::common::create_test_tenant(state.pool(), "PdfEmp").await;
         let jwt = crate::common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -2708,7 +2708,7 @@ async fn test_restraint_report_pdf_empty_name_driver_skipped() {
             "INSERT INTO alc_api.employees (tenant_id, name, code) VALUES ($1, '', 'EMPTY01')",
         )
         .bind(tenant_id)
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -2737,14 +2737,14 @@ async fn test_restraint_report_pdf_db_error() {
         let _flock = crate::common::db_rename_flock();
         let state = crate::common::setup_app_state().await;
         let base_url = crate::common::spawn_test_server(state.clone()).await;
-        let tenant_id = crate::common::create_test_tenant(&state.pool, "PdfDbErr").await;
+        let tenant_id = crate::common::create_test_tenant(state.pool(), "PdfDbErr").await;
         let jwt = crate::common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
 
         // RENAME employees to break the query
         sqlx::query("ALTER TABLE alc_api.employees RENAME TO employees_pdf_bak")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
 
@@ -2760,7 +2760,7 @@ async fn test_restraint_report_pdf_db_error() {
 
         // Restore
         sqlx::query("ALTER TABLE alc_api.employees_pdf_bak RENAME TO employees")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
     });
@@ -2775,14 +2775,14 @@ async fn test_restraint_report_pdf_stream_db_error() {
         let _flock = crate::common::db_rename_flock();
         let state = crate::common::setup_app_state().await;
         let base_url = crate::common::spawn_test_server(state.clone()).await;
-        let tenant_id = crate::common::create_test_tenant(&state.pool, "PdfStrErr").await;
+        let tenant_id = crate::common::create_test_tenant(state.pool(), "PdfStrErr").await;
         let jwt = crate::common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
 
         // RENAME employees to break the query
         sqlx::query("ALTER TABLE alc_api.employees RENAME TO employees_pdf_bak")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
 
@@ -2803,7 +2803,7 @@ async fn test_restraint_report_pdf_stream_db_error() {
 
         // Restore
         sqlx::query("ALTER TABLE alc_api.employees_pdf_bak RENAME TO employees")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
     });
@@ -2821,7 +2821,7 @@ async fn test_restraint_report_pdf_stream_report_build_error() {
             let _flock = crate::common::db_rename_flock();
             let state = crate::common::setup_app_state().await;
             let base_url = crate::common::spawn_test_server(state.clone()).await;
-            let tenant_id = crate::common::create_test_tenant(&state.pool, "PdfSkip").await;
+            let tenant_id = crate::common::create_test_tenant(state.pool(), "PdfSkip").await;
             let jwt = crate::common::create_test_jwt(tenant_id, "admin");
             let auth = format!("Bearer {jwt}");
             let client = reqwest::Client::new();
@@ -2834,7 +2834,7 @@ async fn test_restraint_report_pdf_stream_report_build_error() {
             sqlx::query(
             "ALTER TABLE alc_api.dtako_daily_work_segments RENAME TO dtako_daily_work_segments_bak",
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -2856,7 +2856,7 @@ async fn test_restraint_report_pdf_stream_report_build_error() {
             sqlx::query(
             "ALTER TABLE alc_api.dtako_daily_work_segments_bak RENAME TO dtako_daily_work_segments",
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
         }
@@ -2876,11 +2876,11 @@ async fn test_guidance_records_list_db_error() {
         let _flock = crate::common::db_rename_flock();
         let state = crate::common::setup_app_state().await;
         let base_url = crate::common::spawn_test_server(state.clone()).await;
-        let tenant_id = crate::common::create_test_tenant(&state.pool, "GRLErr").await;
+        let tenant_id = crate::common::create_test_tenant(state.pool(), "GRLErr").await;
         let jwt = crate::common::create_test_jwt(tenant_id, "admin");
 
         sqlx::query("ALTER TABLE alc_api.guidance_records RENAME TO guidance_records_bak")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
 
@@ -2894,7 +2894,7 @@ async fn test_guidance_records_list_db_error() {
         assert_eq!(res.status(), 500);
 
         sqlx::query("ALTER TABLE alc_api.guidance_records_bak RENAME TO guidance_records")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
     });
@@ -2909,7 +2909,7 @@ async fn test_guidance_records_create_db_error() {
         let _flock = crate::common::db_rename_flock();
         let state = crate::common::setup_app_state().await;
         let base_url = crate::common::spawn_test_server(state.clone()).await;
-        let tenant_id = crate::common::create_test_tenant(&state.pool, "GRCErr").await;
+        let tenant_id = crate::common::create_test_tenant(state.pool(), "GRCErr").await;
         let jwt = crate::common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -2921,7 +2921,7 @@ async fn test_guidance_records_create_db_error() {
         let emp_id = emp["id"].as_str().unwrap();
 
         sqlx::query("ALTER TABLE alc_api.guidance_records RENAME TO guidance_records_bak")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
 
@@ -2939,7 +2939,7 @@ async fn test_guidance_records_create_db_error() {
         assert_eq!(res.status(), 500);
 
         sqlx::query("ALTER TABLE alc_api.guidance_records_bak RENAME TO guidance_records")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
     });
@@ -2964,7 +2964,7 @@ async fn test_guidance_records_upload_storage_error() {
         let state = rust_alc_api::AppState { storage, ..state };
 
         let base_url = crate::common::spawn_test_server(state.clone()).await;
-        let tenant_id = crate::common::create_test_tenant(&state.pool, "GRUpErr").await;
+        let tenant_id = crate::common::create_test_tenant(state.pool(), "GRUpErr").await;
         let jwt = crate::common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -3016,7 +3016,7 @@ async fn test_guidance_records_attachment_db_insert_error() {
         let _flock = crate::common::db_rename_flock();
         let state = crate::common::setup_app_state().await;
         let base_url = crate::common::spawn_test_server(state.clone()).await;
-        let tenant_id = crate::common::create_test_tenant(&state.pool, "GRAtErr").await;
+        let tenant_id = crate::common::create_test_tenant(state.pool(), "GRAtErr").await;
         let jwt = crate::common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -3044,7 +3044,7 @@ async fn test_guidance_records_attachment_db_insert_error() {
         sqlx::query(
             "ALTER TABLE alc_api.guidance_record_attachments RENAME TO guidance_record_attachments_bak",
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -3067,7 +3067,7 @@ async fn test_guidance_records_attachment_db_insert_error() {
         sqlx::query(
             "ALTER TABLE alc_api.guidance_record_attachments_bak RENAME TO guidance_record_attachments",
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
     });
@@ -3082,7 +3082,7 @@ async fn test_guidance_records_download_bad_storage_url() {
         let _flock = crate::common::db_rename_flock();
         let state = crate::common::setup_app_state().await;
         let base_url = crate::common::spawn_test_server(state.clone()).await;
-        let tenant_id = crate::common::create_test_tenant(&state.pool, "GRBUrl").await;
+        let tenant_id = crate::common::create_test_tenant(state.pool(), "GRBUrl").await;
         let jwt = crate::common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -3115,7 +3115,7 @@ async fn test_guidance_records_download_bad_storage_url() {
         )
         .bind(att_id)
         .bind(rec_uuid)
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -3140,7 +3140,7 @@ async fn test_guidance_records_download_storage_error() {
         let _flock = crate::common::db_rename_flock();
         let state = crate::common::setup_app_state().await;
         let base_url = crate::common::spawn_test_server(state.clone()).await;
-        let tenant_id = crate::common::create_test_tenant(&state.pool, "GRDlErr").await;
+        let tenant_id = crate::common::create_test_tenant(state.pool(), "GRDlErr").await;
         let jwt = crate::common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -3173,7 +3173,7 @@ async fn test_guidance_records_download_storage_error() {
         )
         .bind(att_id)
         .bind(rec_uuid)
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -3211,7 +3211,7 @@ async fn test_upload_face_photo_storage_error() {
         let state = rust_alc_api::AppState { storage, ..state };
 
         let base_url = crate::common::spawn_test_server(state.clone()).await;
-        let tenant_id = crate::common::create_test_tenant(&state.pool, "UpFace").await;
+        let tenant_id = crate::common::create_test_tenant(state.pool(), "UpFace").await;
         let jwt = crate::common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -3252,7 +3252,7 @@ async fn test_upload_report_audio_storage_error() {
         let state = rust_alc_api::AppState { storage, ..state };
 
         let base_url = crate::common::spawn_test_server(state.clone()).await;
-        let tenant_id = crate::common::create_test_tenant(&state.pool, "UpAudio").await;
+        let tenant_id = crate::common::create_test_tenant(state.pool(), "UpAudio").await;
         let jwt = crate::common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -3293,7 +3293,7 @@ async fn test_upload_blow_video_storage_error() {
         let state = rust_alc_api::AppState { storage, ..state };
 
         let base_url = crate::common::spawn_test_server(state.clone()).await;
-        let tenant_id = crate::common::create_test_tenant(&state.pool, "UpVideo").await;
+        let tenant_id = crate::common::create_test_tenant(state.pool(), "UpVideo").await;
         let jwt = crate::common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -3331,7 +3331,7 @@ async fn test_guidance_records_list_rename_error() {
             let _flock = crate::common::db_rename_flock();
             let state = crate::common::setup_app_state().await;
             let base_url = crate::common::spawn_test_server(state.clone()).await;
-            let tenant_id = crate::common::create_test_tenant(&state.pool, "GrListE").await;
+            let tenant_id = crate::common::create_test_tenant(state.pool(), "GrListE").await;
             let jwt = crate::common::create_test_jwt(tenant_id, "admin");
             let auth = format!("Bearer {jwt}");
             let client = reqwest::Client::new();
@@ -3357,7 +3357,7 @@ async fn test_guidance_records_list_rename_error() {
 
             // employees を RENAME → COUNT は成功するが WITH RECURSIVE の LEFT JOIN employees が失敗
             sqlx::query("ALTER TABLE alc_api.employees RENAME TO employees_bak")
-                .execute(&state.pool)
+                .execute(state.pool())
                 .await
                 .unwrap();
 
@@ -3370,7 +3370,7 @@ async fn test_guidance_records_list_rename_error() {
             assert_eq!(res.status(), 500);
 
             sqlx::query("ALTER TABLE alc_api.employees_bak RENAME TO employees")
-                .execute(&state.pool)
+                .execute(state.pool())
                 .await
                 .unwrap();
         }
@@ -3390,7 +3390,7 @@ async fn test_guidance_records_attachment_extract_key_error() {
         let _flock = crate::common::db_rename_flock();
         let state = crate::common::setup_app_state().await;
         let base_url = crate::common::spawn_test_server(state.clone()).await;
-        let tenant_id = crate::common::create_test_tenant(&state.pool, "GrExtK").await;
+        let tenant_id = crate::common::create_test_tenant(state.pool(), "GrExtK").await;
         let jwt = crate::common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -3424,7 +3424,7 @@ async fn test_guidance_records_attachment_extract_key_error() {
         )
         .bind(att_id)
         .bind(uuid::Uuid::parse_str(rec_id).unwrap())
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 

--- a/tests/coverage/sso_coverage.rs
+++ b/tests/coverage/sso_coverage.rs
@@ -13,12 +13,12 @@ async fn setup_sso_admin() -> (
     let state = common::setup_app_state().await;
     let base_url = common::spawn_test_server(state.clone()).await;
     let tenant_id = common::create_test_tenant(
-        &state.pool,
+        state.pool(),
         &format!("SSO{}", uuid::Uuid::new_v4().simple()),
     )
     .await;
     let (user_id, _) =
-        common::create_test_user_in_db(&state.pool, tenant_id, "ssoadmin@test.com", "admin").await;
+        common::create_test_user_in_db(state.pool(), tenant_id, "ssoadmin@test.com", "admin").await;
     let jwt = common::create_test_jwt_for_user(user_id, tenant_id, "ssoadmin@test.com", "admin");
     let client = reqwest::Client::new();
     (state, base_url, tenant_id, jwt, client)
@@ -64,12 +64,12 @@ async fn test_sso_upsert_encrypt_error() {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
         let tenant_id = common::create_test_tenant(
-            &state.pool,
+            state.pool(),
             &format!("SSOEnc{}", uuid::Uuid::new_v4().simple()),
         )
         .await;
         let (user_id, _) =
-            common::create_test_user_in_db(&state.pool, tenant_id, "ssoenc@test.com", "admin")
+            common::create_test_user_in_db(state.pool(), tenant_id, "ssoenc@test.com", "admin")
                 .await;
         let jwt = common::create_test_jwt_for_user(user_id, tenant_id, "ssoenc@test.com", "admin");
         let client = reqwest::Client::new();
@@ -102,7 +102,7 @@ async fn test_sso_list_configs_db_error() {
         let (state, base_url, _tenant_id, jwt, client) = setup_sso_admin().await;
 
         sqlx::query("ALTER TABLE alc_api.sso_provider_configs RENAME TO sso_provider_configs_bak")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
 
@@ -115,7 +115,7 @@ async fn test_sso_list_configs_db_error() {
         assert_eq!(res.status(), 500);
 
         sqlx::query("ALTER TABLE alc_api.sso_provider_configs_bak RENAME TO sso_provider_configs")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
     });
@@ -135,11 +135,11 @@ async fn test_sso_upsert_db_error() {
             BEGIN RAISE EXCEPTION 'test: sso insert blocked'; END;
             $$ LANGUAGE plpgsql"#,
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
         sqlx::query("CREATE OR REPLACE TRIGGER fail_sso_insert BEFORE INSERT ON alc_api.sso_provider_configs FOR EACH ROW EXECUTE FUNCTION alc_api.fail_sso_insert()")
-            .execute(&state.pool).await.unwrap();
+            .execute(state.pool()).await.unwrap();
 
         let res = client
             .post(format!("{base_url}/api/admin/sso/configs"))
@@ -154,11 +154,11 @@ async fn test_sso_upsert_db_error() {
         assert_eq!(res.status(), 500);
 
         sqlx::query("DROP TRIGGER fail_sso_insert ON alc_api.sso_provider_configs")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
         sqlx::query("DROP FUNCTION alc_api.fail_sso_insert")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
     });
@@ -174,7 +174,7 @@ async fn test_sso_delete_db_error() {
         let (state, base_url, _tenant_id, jwt, client) = setup_sso_admin().await;
 
         sqlx::query("ALTER TABLE alc_api.sso_provider_configs RENAME TO sso_provider_configs_bak")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
 
@@ -188,7 +188,7 @@ async fn test_sso_delete_db_error() {
         assert_eq!(res.status(), 500);
 
         sqlx::query("ALTER TABLE alc_api.sso_provider_configs_bak RENAME TO sso_provider_configs")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
     });

--- a/tests/coverage/tenko_call_coverage.rs
+++ b/tests/coverage/tenko_call_coverage.rs
@@ -11,7 +11,7 @@ async fn test_tenko_call_register_pool_closed() {
     test_case!("register: pool closed → 500 + register_err カバー", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        state.pool.close().await;
+        state.pool().close().await;
 
         let client = reqwest::Client::new();
         let res = client
@@ -41,13 +41,13 @@ async fn test_tenko_call_register_trigger_error() {
         let _flock = crate::common::db_rename_flock();
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "TkRegTrig").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "TkRegTrig").await;
 
         let call_num = format!("err-reg-{}", uuid::Uuid::new_v4().simple());
         sqlx::query("INSERT INTO tenko_call_numbers (call_number, tenant_id) VALUES ($1, $2)")
             .bind(&call_num)
             .bind(tenant_id.to_string())
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
 
@@ -57,13 +57,13 @@ async fn test_tenko_call_register_trigger_error() {
                BEGIN RAISE EXCEPTION 'test: blocked'; END;
                $$ LANGUAGE plpgsql"#,
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
         sqlx::query(
             "CREATE TRIGGER reject_tenko_driver BEFORE INSERT OR UPDATE ON alc_api.tenko_call_drivers FOR EACH ROW EXECUTE FUNCTION alc_api.reject_tenko_driver_fn()",
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -82,11 +82,11 @@ async fn test_tenko_call_register_trigger_error() {
 
         // Cleanup
         sqlx::query("DROP TRIGGER reject_tenko_driver ON alc_api.tenko_call_drivers")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
         sqlx::query("DROP FUNCTION alc_api.reject_tenko_driver_fn()")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
     });
@@ -103,7 +103,7 @@ async fn test_tenko_call_tenko_pool_closed() {
     test_case!("tenko: pool closed → 500", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        state.pool.close().await;
+        state.pool().close().await;
 
         let client = reqwest::Client::new();
         let res = client
@@ -134,7 +134,7 @@ async fn test_tenko_call_tenko_trigger_error() {
         let _flock = crate::common::db_rename_flock();
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "TkTenkoTrig").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "TkTenkoTrig").await;
 
         let call_num = format!("err-tk-{}", uuid::Uuid::new_v4().simple());
         let phone = format!("090-tk-{}", uuid::Uuid::new_v4().simple());
@@ -142,13 +142,13 @@ async fn test_tenko_call_tenko_trigger_error() {
         sqlx::query("INSERT INTO tenko_call_numbers (call_number, tenant_id) VALUES ($1, $2)")
             .bind(&call_num)
             .bind(tenant_id.to_string())
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
 
         sqlx::query("SELECT set_current_tenant($1)")
             .bind(tenant_id.to_string())
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
         sqlx::query(
@@ -158,7 +158,7 @@ async fn test_tenko_call_tenko_trigger_error() {
         .bind("テンコテスト")
         .bind(&call_num)
         .bind(tenant_id.to_string())
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -168,13 +168,13 @@ async fn test_tenko_call_tenko_trigger_error() {
                BEGIN RAISE EXCEPTION 'test: blocked'; END;
                $$ LANGUAGE plpgsql"#,
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
         sqlx::query(
             "CREATE TRIGGER reject_tenko_log BEFORE INSERT ON alc_api.tenko_call_logs FOR EACH ROW EXECUTE FUNCTION alc_api.reject_tenko_log_fn()",
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -194,11 +194,11 @@ async fn test_tenko_call_tenko_trigger_error() {
 
         // Cleanup
         sqlx::query("DROP TRIGGER reject_tenko_log ON alc_api.tenko_call_logs")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
         sqlx::query("DROP FUNCTION alc_api.reject_tenko_log_fn()")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
     });
@@ -219,7 +219,7 @@ async fn test_tenko_call_register_master_lookup_rename() {
         let base_url = common::spawn_test_server(state.clone()).await;
 
         sqlx::query("ALTER TABLE alc_api.tenko_call_numbers RENAME TO tenko_call_numbers_bak3")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
 
@@ -237,7 +237,7 @@ async fn test_tenko_call_register_master_lookup_rename() {
         assert_eq!(res.status(), 500);
 
         sqlx::query("ALTER TABLE alc_api.tenko_call_numbers_bak3 RENAME TO tenko_call_numbers")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
     });
@@ -256,13 +256,13 @@ async fn test_tenko_call_register_set_tenant_error() {
         let _flock = crate::common::db_rename_flock();
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "TkSetTenErr").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "TkSetTenErr").await;
 
         let call_num = format!("err-st-{}", uuid::Uuid::new_v4().simple());
         sqlx::query("INSERT INTO tenko_call_numbers (call_number, tenant_id) VALUES ($1, $2)")
             .bind(&call_num)
             .bind(tenant_id.to_string())
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
 
@@ -270,7 +270,7 @@ async fn test_tenko_call_register_set_tenant_error() {
         sqlx::query(
             "ALTER FUNCTION alc_api.set_current_tenant(text) RENAME TO set_current_tenant_bak",
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -290,7 +290,7 @@ async fn test_tenko_call_register_set_tenant_error() {
         sqlx::query(
             "ALTER FUNCTION alc_api.set_current_tenant_bak(text) RENAME TO set_current_tenant",
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
     });
@@ -311,7 +311,7 @@ async fn test_tenko_call_tenko_driver_lookup_rename() {
         let base_url = common::spawn_test_server(state.clone()).await;
 
         sqlx::query("ALTER TABLE alc_api.tenko_call_drivers RENAME TO tenko_call_drivers_bak3")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
 
@@ -330,7 +330,7 @@ async fn test_tenko_call_tenko_driver_lookup_rename() {
         assert_eq!(res.status(), 500);
 
         sqlx::query("ALTER TABLE alc_api.tenko_call_drivers_bak3 RENAME TO tenko_call_drivers")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
     });
@@ -349,7 +349,7 @@ async fn test_tenko_call_tenko_set_tenant_error() {
         let _flock = crate::common::db_rename_flock();
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "TkTkSetTenErr").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "TkTkSetTenErr").await;
 
         let call_num = format!("err-tkst-{}", uuid::Uuid::new_v4().simple());
         let phone = format!("090-tkst-{}", uuid::Uuid::new_v4().simple());
@@ -357,13 +357,13 @@ async fn test_tenko_call_tenko_set_tenant_error() {
         sqlx::query("INSERT INTO tenko_call_numbers (call_number, tenant_id) VALUES ($1, $2)")
             .bind(&call_num)
             .bind(tenant_id.to_string())
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
 
         sqlx::query("SELECT set_current_tenant($1)")
             .bind(tenant_id.to_string())
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
         sqlx::query(
@@ -373,7 +373,7 @@ async fn test_tenko_call_tenko_set_tenant_error() {
         .bind("SetTenantテスト")
         .bind(&call_num)
         .bind(tenant_id.to_string())
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -381,7 +381,7 @@ async fn test_tenko_call_tenko_set_tenant_error() {
         sqlx::query(
             "ALTER FUNCTION alc_api.set_current_tenant(text) RENAME TO set_current_tenant_bak",
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -402,7 +402,7 @@ async fn test_tenko_call_tenko_set_tenant_error() {
         sqlx::query(
             "ALTER FUNCTION alc_api.set_current_tenant_bak(text) RENAME TO set_current_tenant",
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
     });
@@ -421,13 +421,13 @@ async fn test_tenko_call_register_commit_error() {
         let _flock = crate::common::db_rename_flock();
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "TkCommitErr").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "TkCommitErr").await;
 
         let call_num = format!("err-cm-{}", uuid::Uuid::new_v4().simple());
         sqlx::query("INSERT INTO tenko_call_numbers (call_number, tenant_id) VALUES ($1, $2)")
             .bind(&call_num)
             .bind(tenant_id.to_string())
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
 
@@ -437,13 +437,13 @@ async fn test_tenko_call_register_commit_error() {
                BEGIN RAISE EXCEPTION 'test: commit blocked'; END;
                $$ LANGUAGE plpgsql"#,
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
         sqlx::query(
             "CREATE CONSTRAINT TRIGGER reject_commit_driver AFTER INSERT OR UPDATE ON alc_api.tenko_call_drivers DEFERRABLE INITIALLY DEFERRED FOR EACH ROW EXECUTE FUNCTION alc_api.reject_commit_driver_fn()",
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -462,11 +462,11 @@ async fn test_tenko_call_register_commit_error() {
 
         // Cleanup
         sqlx::query("DROP TRIGGER reject_commit_driver ON alc_api.tenko_call_drivers")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
         sqlx::query("DROP FUNCTION alc_api.reject_commit_driver_fn()")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
     });
@@ -485,7 +485,7 @@ async fn test_tenko_call_tenko_commit_error() {
         let _flock = crate::common::db_rename_flock();
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "TkTkCommitErr").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "TkTkCommitErr").await;
 
         let call_num = format!("err-tkcm-{}", uuid::Uuid::new_v4().simple());
         let phone = format!("090-tkcm-{}", uuid::Uuid::new_v4().simple());
@@ -493,13 +493,13 @@ async fn test_tenko_call_tenko_commit_error() {
         sqlx::query("INSERT INTO tenko_call_numbers (call_number, tenant_id) VALUES ($1, $2)")
             .bind(&call_num)
             .bind(tenant_id.to_string())
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
 
         sqlx::query("SELECT set_current_tenant($1)")
             .bind(tenant_id.to_string())
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
         sqlx::query(
@@ -509,7 +509,7 @@ async fn test_tenko_call_tenko_commit_error() {
         .bind("コミットテスト")
         .bind(&call_num)
         .bind(tenant_id.to_string())
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -519,13 +519,13 @@ async fn test_tenko_call_tenko_commit_error() {
                BEGIN RAISE EXCEPTION 'test: commit blocked'; END;
                $$ LANGUAGE plpgsql"#,
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
         sqlx::query(
             "CREATE CONSTRAINT TRIGGER reject_commit_log AFTER INSERT ON alc_api.tenko_call_logs DEFERRABLE INITIALLY DEFERRED FOR EACH ROW EXECUTE FUNCTION alc_api.reject_commit_log_fn()",
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -545,11 +545,11 @@ async fn test_tenko_call_tenko_commit_error() {
 
         // Cleanup
         sqlx::query("DROP TRIGGER reject_commit_log ON alc_api.tenko_call_logs")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
         sqlx::query("DROP FUNCTION alc_api.reject_commit_log_fn()")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
     });
@@ -565,10 +565,10 @@ async fn test_tenko_call_list_numbers_db_error() {
     test_group!("tenko_call カバレッジ");
     test_case!("list_numbers: pool closed → 500", {
         let state = common::setup_app_state().await;
-        let tenant_id = common::create_test_tenant(&state.pool, "TkListNumErr").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "TkListNumErr").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let base_url = common::spawn_test_server(state.clone()).await;
-        state.pool.close().await;
+        state.pool().close().await;
 
         let client = reqwest::Client::new();
         let res = client
@@ -587,10 +587,10 @@ async fn test_tenko_call_create_number_db_error() {
     test_group!("tenko_call カバレッジ");
     test_case!("create_number: pool closed → 500", {
         let state = common::setup_app_state().await;
-        let tenant_id = common::create_test_tenant(&state.pool, "TkCreateNumErr").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "TkCreateNumErr").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let base_url = common::spawn_test_server(state.clone()).await;
-        state.pool.close().await;
+        state.pool().close().await;
 
         let client = reqwest::Client::new();
         let res = client
@@ -613,10 +613,10 @@ async fn test_tenko_call_delete_number_db_error() {
     test_group!("tenko_call カバレッジ");
     test_case!("delete_number: pool closed → 500", {
         let state = common::setup_app_state().await;
-        let tenant_id = common::create_test_tenant(&state.pool, "TkDelNumErr").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "TkDelNumErr").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let base_url = common::spawn_test_server(state.clone()).await;
-        state.pool.close().await;
+        state.pool().close().await;
 
         let client = reqwest::Client::new();
         let res = client
@@ -635,10 +635,10 @@ async fn test_tenko_call_list_drivers_db_error() {
     test_group!("tenko_call カバレッジ");
     test_case!("list_drivers: pool closed → 500", {
         let state = common::setup_app_state().await;
-        let tenant_id = common::create_test_tenant(&state.pool, "TkListDrvErr").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "TkListDrvErr").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let base_url = common::spawn_test_server(state.clone()).await;
-        state.pool.close().await;
+        state.pool().close().await;
 
         let client = reqwest::Client::new();
         let res = client

--- a/tests/coverage/timecard_coverage.rs
+++ b/tests/coverage/timecard_coverage.rs
@@ -13,7 +13,7 @@ async fn test_timecard_punch_db_error() {
         let _flock = crate::common::db_rename_flock();
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "TcPunchErr").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "TcPunchErr").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -42,14 +42,14 @@ async fn test_timecard_punch_db_error() {
                BEGIN RAISE EXCEPTION 'test: time_punches insert blocked'; END;
                $$ LANGUAGE plpgsql"#,
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
         sqlx::query(
             "CREATE TRIGGER reject_time_punch BEFORE INSERT ON alc_api.time_punches \
              FOR EACH ROW EXECUTE FUNCTION alc_api.reject_time_punch()",
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -66,11 +66,11 @@ async fn test_timecard_punch_db_error() {
 
         // Cleanup
         sqlx::query("DROP TRIGGER reject_time_punch ON alc_api.time_punches")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
         sqlx::query("DROP FUNCTION alc_api.reject_time_punch()")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
     });
@@ -85,7 +85,7 @@ async fn test_timecard_create_card_db_error() {
         let _flock = crate::common::db_rename_flock();
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "TcCardErr").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "TcCardErr").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -100,14 +100,14 @@ async fn test_timecard_create_card_db_error() {
                BEGIN RAISE EXCEPTION 'test: timecard_cards insert blocked'; END;
                $$ LANGUAGE plpgsql"#,
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
         sqlx::query(
             "CREATE TRIGGER reject_timecard_card BEFORE INSERT ON alc_api.timecard_cards \
              FOR EACH ROW EXECUTE FUNCTION alc_api.reject_timecard_card()",
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -126,11 +126,11 @@ async fn test_timecard_create_card_db_error() {
 
         // Cleanup
         sqlx::query("DROP TRIGGER reject_timecard_card ON alc_api.timecard_cards")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
         sqlx::query("DROP FUNCTION alc_api.reject_timecard_card()")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
     });

--- a/tests/devices_test.rs
+++ b/tests/devices_test.rs
@@ -9,12 +9,12 @@ use serde_json::Value;
 
 async fn setup_tenant_with_user(state: &rust_alc_api::AppState) -> (uuid::Uuid, String) {
     let tenant_id = common::create_test_tenant(
-        &state.pool,
+        state.pool(),
         &format!("Dev{}", uuid::Uuid::new_v4().simple()),
     )
     .await;
     let (user_id, _) =
-        common::create_test_user_in_db(&state.pool, tenant_id, "dev@test.com", "admin").await;
+        common::create_test_user_in_db(state.pool(), tenant_id, "dev@test.com", "admin").await;
     let jwt = common::create_test_jwt_for_user(user_id, tenant_id, "dev@test.com", "admin");
     (tenant_id, jwt)
 }
@@ -197,7 +197,7 @@ async fn test_url_flow_create_token() {
         {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "URL Token").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "URL Token").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
             let client = reqwest::Client::new();
 
@@ -230,7 +230,7 @@ async fn test_url_flow_claim() {
         {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "URL Claim").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "URL Claim").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
             let auth = format!("Bearer {jwt}");
             let client = reqwest::Client::new();
@@ -255,7 +255,7 @@ async fn test_url_flow_device_in_list() {
         {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "URL List").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "URL List").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
             let auth = format!("Bearer {jwt}");
             let client = reqwest::Client::new();
@@ -294,7 +294,7 @@ async fn test_qr_permanent_create() {
     test_case!("管理者がQR永久コードを生成できる", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "QR Perm Create").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "QR Perm Create").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -327,7 +327,7 @@ async fn test_qr_permanent_claim() {
         {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "QR Perm Claim").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "QR Perm Claim").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
             let client = reqwest::Client::new();
 
@@ -378,7 +378,7 @@ async fn test_qr_permanent_in_pending() {
         {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "QR Perm Pending").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "QR Perm Pending").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
             let auth = format!("Bearer {jwt}");
             let client = reqwest::Client::new();
@@ -523,7 +523,7 @@ async fn test_list_devices_returns_ok() {
     test_case!("デバイス一覧が200で返る", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "Empty Devices").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "Empty Devices").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -618,7 +618,7 @@ async fn test_reject_device() {
     test_case!("登録リクエストを拒否できる", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "Reject Dev").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "Reject Dev").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -680,7 +680,7 @@ async fn test_reject_not_found() {
     test_case!("存在しないリクエストIDの拒否で404が返る", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "Reject NF").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "Reject NF").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -707,7 +707,7 @@ async fn test_disable_enable() {
     test_case!("デバイスの無効化と有効化ができる", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "Disable Enable").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "Disable Enable").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -748,7 +748,7 @@ async fn test_delete_device() {
         {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "Delete Dev").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "Delete Dev").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
             let auth = format!("Bearer {jwt}");
             let client = reqwest::Client::new();
@@ -786,7 +786,7 @@ async fn test_delete_not_found() {
     test_case!("存在しないデバイスIDの削除で404が返る", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "Del NF Dev").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "Del NF Dev").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -820,8 +820,8 @@ async fn test_device_operations_from_different_tenant() {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
 
-            let tenant_a = common::create_test_tenant(&state.pool, "Dev Iso A").await;
-            let tenant_b = common::create_test_tenant(&state.pool, "Dev Iso B").await;
+            let tenant_a = common::create_test_tenant(state.pool(), "Dev Iso A").await;
+            let tenant_b = common::create_test_tenant(state.pool(), "Dev Iso B").await;
 
             let jwt_a = common::create_test_jwt(tenant_a, "admin");
             let _jwt_b = common::create_test_jwt(tenant_b, "admin");
@@ -866,7 +866,7 @@ async fn test_register_fcm_token() {
     test_case!("FCMトークンを登録できる", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "FCM Token").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "FCM Token").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -898,7 +898,7 @@ async fn test_update_last_login() {
     test_case!("最終ログイン情報を更新できる", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "Last Login").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "Last Login").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -943,7 +943,7 @@ async fn test_report_version() {
     test_case!("バージョン情報を報告できる", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "Version").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "Version").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -976,7 +976,7 @@ async fn test_report_watchdog() {
     test_case!("Watchdog状態を報告できる", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "Watchdog").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "Watchdog").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -1040,7 +1040,7 @@ async fn test_fcm_notify_call_with_token() {
         {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "FCM Notify Token").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "FCM Notify Token").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
             let auth = format!("Bearer {jwt}");
             let client = reqwest::Client::new();
@@ -1089,7 +1089,7 @@ async fn test_fcm_notify_call_with_exclude() {
         {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "FCM Exclude").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "FCM Exclude").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
             let auth = format!("Bearer {jwt}");
             let client = reqwest::Client::new();
@@ -1140,7 +1140,7 @@ async fn test_fcm_notify_call_with_schedule() {
         {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "FCM Schedule").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "FCM Schedule").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
             let auth = format!("Bearer {jwt}");
             let client = reqwest::Client::new();
@@ -1203,7 +1203,7 @@ async fn test_fcm_notify_call_disabled() {
         {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "FCM Disabled").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "FCM Disabled").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
             let auth = format!("Bearer {jwt}");
             let client = reqwest::Client::new();
@@ -1242,7 +1242,7 @@ async fn test_device_owner_flow() {
         {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "Dev Owner").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "Dev Owner").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
             let auth = format!("Bearer {jwt}");
             let client = reqwest::Client::new();
@@ -1298,7 +1298,7 @@ async fn test_device_settings_after_creation() {
         {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "Settings Test").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "Settings Test").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
             let auth = format!("Bearer {jwt}");
             let client = reqwest::Client::new();
@@ -1332,7 +1332,7 @@ async fn test_update_call_settings() {
     test_case!("着信設定を更新できる", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "Call Settings").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "Call Settings").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -1380,7 +1380,7 @@ async fn test_fcm_dismiss_test_no_fcm_configured() {
     test_case!("MockFcmSenderでfcm-dismiss-testが成功する", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "FCM Dismiss").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "FCM Dismiss").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -1493,7 +1493,7 @@ async fn test_device_owner_claim_and_verify_in_list() {
         {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "DO Verify").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "DO Verify").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
             let auth = format!("Bearer {jwt}");
             let client = reqwest::Client::new();
@@ -1577,7 +1577,7 @@ async fn test_update_call_settings_not_found() {
         {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "Call NF").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "Call NF").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
             let client = reqwest::Client::new();
 
@@ -1645,7 +1645,7 @@ async fn test_trigger_update_dev_with_secret() {
             std::env::set_var("FCM_INTERNAL_SECRET", "test-internal-secret");
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "TrigDevSec").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "TrigDevSec").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
             let auth = format!("Bearer {jwt}");
             let client = reqwest::Client::new();
@@ -1696,7 +1696,7 @@ async fn test_trigger_update_already_updated() {
         {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "TrigAlready").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "TrigAlready").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
             let auth = format!("Bearer {jwt}");
             let client = reqwest::Client::new();
@@ -1742,7 +1742,7 @@ async fn test_trigger_update_with_device_ids_filter() {
         {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "TrigFilter").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "TrigFilter").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
             let auth = format!("Bearer {jwt}");
             let client = reqwest::Client::new();
@@ -1814,7 +1814,7 @@ async fn test_test_fcm_all_with_token() {
         {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "FcmAllToken").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "FcmAllToken").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
             let auth = format!("Bearer {jwt}");
             let client = reqwest::Client::new();
@@ -1853,7 +1853,7 @@ async fn test_trigger_update_with_jwt() {
     test_case!("JWT認証でtrigger-updateが呼べる", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "TriggerUpd").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "TriggerUpd").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -1930,7 +1930,7 @@ async fn test_trigger_update() {
         {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "TrigUpd").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "TrigUpd").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
             let client = reqwest::Client::new();
 
@@ -1972,7 +1972,7 @@ async fn test_test_fcm_for_device() {
         {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "FcmDev").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "FcmDev").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
             let auth = format!("Bearer {jwt}");
             let client = reqwest::Client::new();
@@ -2016,7 +2016,7 @@ async fn test_test_fcm_all() {
     test_case!("test-fcm-allが正常に動作する", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "FcmAll").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "FcmAll").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -2051,7 +2051,7 @@ async fn test_create_registration_request_db_error() {
     let _flock_guard = common::db_rename_flock();
     let state = common::setup_app_state().await;
     let base_url = common::spawn_test_server(state.clone()).await;
-    state.pool.close().await;
+    state.pool().close().await;
     let client = reqwest::Client::new();
 
     let res = client
@@ -2075,7 +2075,7 @@ async fn test_check_registration_status_db_error() {
     let _flock_guard = common::db_rename_flock();
     let state = common::setup_app_state().await;
     let base_url = common::spawn_test_server(state.clone()).await;
-    state.pool.close().await;
+    state.pool().close().await;
     let client = reqwest::Client::new();
 
     let res = client
@@ -2110,7 +2110,7 @@ async fn test_check_registration_status_expired() {
         "#,
     )
     .bind(&code)
-    .execute(&state.pool)
+    .execute(state.pool())
     .await
     .unwrap();
 
@@ -2148,7 +2148,7 @@ async fn test_check_registration_status_no_expires_at() {
         "#,
     )
     .bind(&code)
-    .execute(&state.pool)
+    .execute(state.pool())
     .await
     .unwrap();
 
@@ -2174,7 +2174,7 @@ async fn test_claim_registration_db_error() {
     let _flock_guard = common::db_rename_flock();
     let state = common::setup_app_state().await;
     let base_url = common::spawn_test_server(state.clone()).await;
-    state.pool.close().await;
+    state.pool().close().await;
     let client = reqwest::Client::new();
 
     let res = client
@@ -2235,7 +2235,7 @@ async fn test_claim_registration_already_used() {
     let _flock_guard = common::db_rename_flock();
     let state = common::setup_app_state().await;
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "ClaimUsed").await;
+    let tenant_id = common::create_test_tenant(state.pool(), "ClaimUsed").await;
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let auth = format!("Bearer {jwt}");
     let client = reqwest::Client::new();
@@ -2273,7 +2273,7 @@ async fn test_claim_registration_unknown_flow_type() {
 
     // CHECK制約を一時的にDROP
     sqlx::query("ALTER TABLE alc_api.device_registration_requests DROP CONSTRAINT IF EXISTS device_registration_requests_flow_type_check")
-        .execute(&state.pool).await.unwrap();
+        .execute(state.pool()).await.unwrap();
 
     let code = format!("UNK{}", uuid::Uuid::new_v4().simple());
     sqlx::query(
@@ -2284,7 +2284,7 @@ async fn test_claim_registration_unknown_flow_type() {
         "#,
     )
     .bind(&code)
-    .execute(&state.pool)
+    .execute(state.pool())
     .await
     .unwrap();
 
@@ -2308,11 +2308,11 @@ async fn test_claim_registration_unknown_flow_type() {
     sqlx::query(
         "DELETE FROM alc_api.device_registration_requests WHERE flow_type = 'unknown_flow'",
     )
-    .execute(&state.pool)
+    .execute(state.pool())
     .await
     .unwrap();
     sqlx::query("ALTER TABLE alc_api.device_registration_requests ADD CONSTRAINT device_registration_requests_flow_type_check CHECK (flow_type IN ('qr_temp', 'qr_permanent', 'url', 'device_owner'))")
-        .execute(&state.pool).await.unwrap();
+        .execute(state.pool()).await.unwrap();
 }
 
 // ============================================================
@@ -2346,13 +2346,13 @@ async fn test_list_devices_db_error() {
     let _flock = common::db_rename_flock();
     let state = common::setup_app_state().await;
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "DevListErr").await;
+    let tenant_id = common::create_test_tenant(state.pool(), "DevListErr").await;
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let client = reqwest::Client::new();
 
-    ensure_table_exists(&state.pool, "devices").await;
+    ensure_table_exists(state.pool(), "devices").await;
     sqlx::query("ALTER TABLE alc_api.devices RENAME TO devices_bak")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -2365,7 +2365,7 @@ async fn test_list_devices_db_error() {
     assert_eq!(res.status(), 500);
 
     sqlx::query("ALTER TABLE alc_api.devices_bak RENAME TO devices")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 }
@@ -2380,13 +2380,13 @@ async fn test_list_pending_db_error() {
     let _flock = common::db_rename_flock();
     let state = common::setup_app_state().await;
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "DevPendErr").await;
+    let tenant_id = common::create_test_tenant(state.pool(), "DevPendErr").await;
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let client = reqwest::Client::new();
 
-    ensure_table_exists(&state.pool, "device_registration_requests").await;
+    ensure_table_exists(state.pool(), "device_registration_requests").await;
     sqlx::query("ALTER TABLE alc_api.device_registration_requests RENAME TO device_registration_requests_bak")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -2399,7 +2399,7 @@ async fn test_list_pending_db_error() {
     assert_eq!(res.status(), 500);
 
     sqlx::query("ALTER TABLE alc_api.device_registration_requests_bak RENAME TO device_registration_requests")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 }
@@ -2414,7 +2414,7 @@ async fn test_create_url_token_db_error() {
     let _flock = common::db_rename_flock();
     let state = common::setup_app_state().await;
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "UrlTokErr").await;
+    let tenant_id = common::create_test_tenant(state.pool(), "UrlTokErr").await;
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let client = reqwest::Client::new();
 
@@ -2422,11 +2422,11 @@ async fn test_create_url_token_db_error() {
         r#"CREATE OR REPLACE FUNCTION alc_api.fail_drr_ins_url() RETURNS trigger AS $$
         BEGIN RAISE EXCEPTION 'test error'; END; $$ LANGUAGE plpgsql"#,
     )
-    .execute(&state.pool)
+    .execute(state.pool())
     .await
     .unwrap();
     sqlx::query("CREATE OR REPLACE TRIGGER fail_drr_ins_url BEFORE INSERT ON alc_api.device_registration_requests FOR EACH ROW EXECUTE FUNCTION alc_api.fail_drr_ins_url()")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -2440,11 +2440,11 @@ async fn test_create_url_token_db_error() {
     assert_eq!(res.status(), 500);
 
     sqlx::query("DROP TRIGGER fail_drr_ins_url ON alc_api.device_registration_requests")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
     sqlx::query("DROP FUNCTION alc_api.fail_drr_ins_url")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 }
@@ -2459,7 +2459,7 @@ async fn test_create_device_owner_token_db_error() {
     let _flock = common::db_rename_flock();
     let state = common::setup_app_state().await;
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "DOTokErr").await;
+    let tenant_id = common::create_test_tenant(state.pool(), "DOTokErr").await;
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let client = reqwest::Client::new();
 
@@ -2467,11 +2467,11 @@ async fn test_create_device_owner_token_db_error() {
         r#"CREATE OR REPLACE FUNCTION alc_api.fail_drr_ins_do() RETURNS trigger AS $$
         BEGIN RAISE EXCEPTION 'test error'; END; $$ LANGUAGE plpgsql"#,
     )
-    .execute(&state.pool)
+    .execute(state.pool())
     .await
     .unwrap();
     sqlx::query("CREATE OR REPLACE TRIGGER fail_drr_ins_do BEFORE INSERT ON alc_api.device_registration_requests FOR EACH ROW EXECUTE FUNCTION alc_api.fail_drr_ins_do()")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -2487,11 +2487,11 @@ async fn test_create_device_owner_token_db_error() {
     assert_eq!(res.status(), 500);
 
     sqlx::query("DROP TRIGGER fail_drr_ins_do ON alc_api.device_registration_requests")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
     sqlx::query("DROP FUNCTION alc_api.fail_drr_ins_do")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 }
@@ -2506,7 +2506,7 @@ async fn test_create_permanent_qr_db_error() {
     let _flock = common::db_rename_flock();
     let state = common::setup_app_state().await;
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "PQRErr").await;
+    let tenant_id = common::create_test_tenant(state.pool(), "PQRErr").await;
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let client = reqwest::Client::new();
 
@@ -2514,11 +2514,11 @@ async fn test_create_permanent_qr_db_error() {
         r#"CREATE OR REPLACE FUNCTION alc_api.fail_drr_ins_pqr() RETURNS trigger AS $$
         BEGIN RAISE EXCEPTION 'test error'; END; $$ LANGUAGE plpgsql"#,
     )
-    .execute(&state.pool)
+    .execute(state.pool())
     .await
     .unwrap();
     sqlx::query("CREATE OR REPLACE TRIGGER fail_drr_ins_pqr BEFORE INSERT ON alc_api.device_registration_requests FOR EACH ROW EXECUTE FUNCTION alc_api.fail_drr_ins_pqr()")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -2534,11 +2534,11 @@ async fn test_create_permanent_qr_db_error() {
     assert_eq!(res.status(), 500);
 
     sqlx::query("DROP TRIGGER fail_drr_ins_pqr ON alc_api.device_registration_requests")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
     sqlx::query("DROP FUNCTION alc_api.fail_drr_ins_pqr")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 }
@@ -2553,15 +2553,15 @@ async fn test_approve_device_db_error() {
     let _flock = common::db_rename_flock();
     let state = common::setup_app_state().await;
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "AppDevErr").await;
+    let tenant_id = common::create_test_tenant(state.pool(), "AppDevErr").await;
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let client = reqwest::Client::new();
 
     let fake_id = uuid::Uuid::new_v4();
 
-    ensure_table_exists(&state.pool, "device_registration_requests").await;
+    ensure_table_exists(state.pool(), "device_registration_requests").await;
     sqlx::query("ALTER TABLE alc_api.device_registration_requests RENAME TO device_registration_requests_bak")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -2575,7 +2575,7 @@ async fn test_approve_device_db_error() {
     assert_eq!(res.status(), 500);
 
     sqlx::query("ALTER TABLE alc_api.device_registration_requests_bak RENAME TO device_registration_requests")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 }
@@ -2590,13 +2590,13 @@ async fn test_approve_by_code_db_error() {
     let _flock = common::db_rename_flock();
     let state = common::setup_app_state().await;
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "AppCodeErr").await;
+    let tenant_id = common::create_test_tenant(state.pool(), "AppCodeErr").await;
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let client = reqwest::Client::new();
 
-    ensure_table_exists(&state.pool, "device_registration_requests").await;
+    ensure_table_exists(state.pool(), "device_registration_requests").await;
     sqlx::query("ALTER TABLE alc_api.device_registration_requests RENAME TO device_registration_requests_bak")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -2609,7 +2609,7 @@ async fn test_approve_by_code_db_error() {
     assert_eq!(res.status(), 500);
 
     sqlx::query("ALTER TABLE alc_api.device_registration_requests_bak RENAME TO device_registration_requests")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 }
@@ -2624,7 +2624,7 @@ async fn test_reject_device_db_error() {
     let _flock = common::db_rename_flock();
     let state = common::setup_app_state().await;
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "RejDevErr").await;
+    let tenant_id = common::create_test_tenant(state.pool(), "RejDevErr").await;
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let auth = format!("Bearer {jwt}");
     let client = reqwest::Client::new();
@@ -2671,11 +2671,11 @@ async fn test_reject_device_db_error() {
         r#"CREATE OR REPLACE FUNCTION alc_api.fail_drr_upd_rej() RETURNS trigger AS $$
         BEGIN RAISE EXCEPTION 'test error'; END; $$ LANGUAGE plpgsql"#,
     )
-    .execute(&state.pool)
+    .execute(state.pool())
     .await
     .unwrap();
     sqlx::query("CREATE OR REPLACE TRIGGER fail_drr_upd_rej BEFORE UPDATE ON alc_api.device_registration_requests FOR EACH ROW EXECUTE FUNCTION alc_api.fail_drr_upd_rej()")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -2688,11 +2688,11 @@ async fn test_reject_device_db_error() {
     assert_eq!(res.status(), 500);
 
     sqlx::query("DROP TRIGGER fail_drr_upd_rej ON alc_api.device_registration_requests")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
     sqlx::query("DROP FUNCTION alc_api.fail_drr_upd_rej")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 }
@@ -2707,7 +2707,7 @@ async fn test_disable_device_db_error() {
     let _flock = common::db_rename_flock();
     let state = common::setup_app_state().await;
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "DisDevErr").await;
+    let tenant_id = common::create_test_tenant(state.pool(), "DisDevErr").await;
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let auth = format!("Bearer {jwt}");
     let client = reqwest::Client::new();
@@ -2718,11 +2718,11 @@ async fn test_disable_device_db_error() {
         r#"CREATE OR REPLACE FUNCTION alc_api.fail_dev_upd_dis() RETURNS trigger AS $$
         BEGIN RAISE EXCEPTION 'test error'; END; $$ LANGUAGE plpgsql"#,
     )
-    .execute(&state.pool)
+    .execute(state.pool())
     .await
     .unwrap();
     sqlx::query("CREATE OR REPLACE TRIGGER fail_dev_upd_dis BEFORE UPDATE ON alc_api.devices FOR EACH ROW EXECUTE FUNCTION alc_api.fail_dev_upd_dis()")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -2735,11 +2735,11 @@ async fn test_disable_device_db_error() {
     assert_eq!(res.status(), 500);
 
     sqlx::query("DROP TRIGGER fail_dev_upd_dis ON alc_api.devices")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
     sqlx::query("DROP FUNCTION alc_api.fail_dev_upd_dis")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 }
@@ -2754,7 +2754,7 @@ async fn test_enable_device_db_error() {
     let _flock = common::db_rename_flock();
     let state = common::setup_app_state().await;
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "EnDevErr").await;
+    let tenant_id = common::create_test_tenant(state.pool(), "EnDevErr").await;
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let auth = format!("Bearer {jwt}");
     let client = reqwest::Client::new();
@@ -2773,11 +2773,11 @@ async fn test_enable_device_db_error() {
         r#"CREATE OR REPLACE FUNCTION alc_api.fail_dev_upd_en() RETURNS trigger AS $$
         BEGIN RAISE EXCEPTION 'test error'; END; $$ LANGUAGE plpgsql"#,
     )
-    .execute(&state.pool)
+    .execute(state.pool())
     .await
     .unwrap();
     sqlx::query("CREATE OR REPLACE TRIGGER fail_dev_upd_en BEFORE UPDATE ON alc_api.devices FOR EACH ROW EXECUTE FUNCTION alc_api.fail_dev_upd_en()")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -2790,11 +2790,11 @@ async fn test_enable_device_db_error() {
     assert_eq!(res.status(), 500);
 
     sqlx::query("DROP TRIGGER fail_dev_upd_en ON alc_api.devices")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
     sqlx::query("DROP FUNCTION alc_api.fail_dev_upd_en")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 }
@@ -2809,7 +2809,7 @@ async fn test_delete_device_db_error() {
     let _flock = common::db_rename_flock();
     let state = common::setup_app_state().await;
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "DelDevErr").await;
+    let tenant_id = common::create_test_tenant(state.pool(), "DelDevErr").await;
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let auth = format!("Bearer {jwt}");
     let client = reqwest::Client::new();
@@ -2820,11 +2820,11 @@ async fn test_delete_device_db_error() {
         r#"CREATE OR REPLACE FUNCTION alc_api.fail_dev_del() RETURNS trigger AS $$
         BEGIN RAISE EXCEPTION 'test error'; END; $$ LANGUAGE plpgsql"#,
     )
-    .execute(&state.pool)
+    .execute(state.pool())
     .await
     .unwrap();
     sqlx::query("CREATE OR REPLACE TRIGGER fail_dev_del BEFORE DELETE ON alc_api.devices FOR EACH ROW EXECUTE FUNCTION alc_api.fail_dev_del()")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -2837,11 +2837,11 @@ async fn test_delete_device_db_error() {
     assert_eq!(res.status(), 500);
 
     sqlx::query("DROP TRIGGER fail_dev_del ON alc_api.devices")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
     sqlx::query("DROP FUNCTION alc_api.fail_dev_del")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 }
@@ -2856,7 +2856,7 @@ async fn test_update_call_settings_db_error() {
     let _flock = common::db_rename_flock();
     let state = common::setup_app_state().await;
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "CallSetErr").await;
+    let tenant_id = common::create_test_tenant(state.pool(), "CallSetErr").await;
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let auth = format!("Bearer {jwt}");
     let client = reqwest::Client::new();
@@ -2867,11 +2867,11 @@ async fn test_update_call_settings_db_error() {
         r#"CREATE OR REPLACE FUNCTION alc_api.fail_dev_upd_call() RETURNS trigger AS $$
         BEGIN RAISE EXCEPTION 'test error'; END; $$ LANGUAGE plpgsql"#,
     )
-    .execute(&state.pool)
+    .execute(state.pool())
     .await
     .unwrap();
     sqlx::query("CREATE OR REPLACE TRIGGER fail_dev_upd_call BEFORE UPDATE ON alc_api.devices FOR EACH ROW EXECUTE FUNCTION alc_api.fail_dev_upd_call()")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -2885,11 +2885,11 @@ async fn test_update_call_settings_db_error() {
     assert_eq!(res.status(), 500);
 
     sqlx::query("DROP TRIGGER fail_dev_upd_call ON alc_api.devices")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
     sqlx::query("DROP FUNCTION alc_api.fail_dev_upd_call")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 }
@@ -2909,9 +2909,9 @@ async fn test_report_watchdog_state_db_error() {
     let fake_id = uuid::Uuid::new_v4();
 
     // RENAME devices so lookup_device_tenant function fails
-    ensure_table_exists(&state.pool, "devices").await;
+    ensure_table_exists(state.pool(), "devices").await;
     sqlx::query("ALTER TABLE alc_api.devices RENAME TO devices_bak")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -2924,7 +2924,7 @@ async fn test_report_watchdog_state_db_error() {
     assert_eq!(res.status(), 500);
 
     sqlx::query("ALTER TABLE alc_api.devices_bak RENAME TO devices")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 }
@@ -2943,9 +2943,9 @@ async fn test_register_fcm_token_db_error() {
 
     let fake_id = uuid::Uuid::new_v4();
 
-    ensure_table_exists(&state.pool, "devices").await;
+    ensure_table_exists(state.pool(), "devices").await;
     sqlx::query("ALTER TABLE alc_api.devices RENAME TO devices_bak")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -2958,7 +2958,7 @@ async fn test_register_fcm_token_db_error() {
     assert_eq!(res.status(), 500);
 
     sqlx::query("ALTER TABLE alc_api.devices_bak RENAME TO devices")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 }
@@ -2977,9 +2977,9 @@ async fn test_update_last_login_db_error() {
 
     let fake_id = uuid::Uuid::new_v4();
 
-    ensure_table_exists(&state.pool, "devices").await;
+    ensure_table_exists(state.pool(), "devices").await;
     sqlx::query("ALTER TABLE alc_api.devices RENAME TO devices_bak")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -2997,7 +2997,7 @@ async fn test_update_last_login_db_error() {
     assert_eq!(res.status(), 500);
 
     sqlx::query("ALTER TABLE alc_api.devices_bak RENAME TO devices")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 }
@@ -3016,9 +3016,9 @@ async fn test_report_version_db_error() {
 
     let fake_id = uuid::Uuid::new_v4();
 
-    ensure_table_exists(&state.pool, "devices").await;
+    ensure_table_exists(state.pool(), "devices").await;
     sqlx::query("ALTER TABLE alc_api.devices RENAME TO devices_bak")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -3035,7 +3035,7 @@ async fn test_report_version_db_error() {
     assert_eq!(res.status(), 500);
 
     sqlx::query("ALTER TABLE alc_api.devices_bak RENAME TO devices")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 }
@@ -3054,9 +3054,9 @@ async fn test_get_device_settings_db_error() {
 
     let fake_id = uuid::Uuid::new_v4();
 
-    ensure_table_exists(&state.pool, "devices").await;
+    ensure_table_exists(state.pool(), "devices").await;
     sqlx::query("ALTER TABLE alc_api.devices RENAME TO devices_bak")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -3068,7 +3068,7 @@ async fn test_get_device_settings_db_error() {
     assert_eq!(res.status(), 500);
 
     sqlx::query("ALTER TABLE alc_api.devices_bak RENAME TO devices")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 }
@@ -3085,9 +3085,9 @@ async fn test_fcm_notify_call_db_error() {
     let base_url = common::spawn_test_server(state.clone()).await;
     let client = reqwest::Client::new();
 
-    ensure_table_exists(&state.pool, "devices").await;
+    ensure_table_exists(state.pool(), "devices").await;
     sqlx::query("ALTER TABLE alc_api.devices RENAME TO devices_bak")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -3100,7 +3100,7 @@ async fn test_fcm_notify_call_db_error() {
     assert_eq!(res.status(), 500);
 
     sqlx::query("ALTER TABLE alc_api.devices_bak RENAME TO devices")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 }
@@ -3119,9 +3119,9 @@ async fn test_fcm_dismiss_test_db_error() {
 
     let fake_id = uuid::Uuid::new_v4();
 
-    ensure_table_exists(&state.pool, "devices").await;
+    ensure_table_exists(state.pool(), "devices").await;
     sqlx::query("ALTER TABLE alc_api.devices RENAME TO devices_bak")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -3134,7 +3134,7 @@ async fn test_fcm_dismiss_test_db_error() {
     assert_eq!(res.status(), 500);
 
     sqlx::query("ALTER TABLE alc_api.devices_bak RENAME TO devices")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 }
@@ -3151,9 +3151,9 @@ async fn test_test_fcm_all_exclude_db_error() {
     let base_url = common::spawn_test_server(state.clone()).await;
     let client = reqwest::Client::new();
 
-    ensure_table_exists(&state.pool, "devices").await;
+    ensure_table_exists(state.pool(), "devices").await;
     sqlx::query("ALTER TABLE alc_api.devices RENAME TO devices_bak")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -3166,7 +3166,7 @@ async fn test_test_fcm_all_exclude_db_error() {
     assert_eq!(res.status(), 500);
 
     sqlx::query("ALTER TABLE alc_api.devices_bak RENAME TO devices")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 }
@@ -3181,15 +3181,15 @@ async fn test_test_fcm_db_error() {
     let _flock = common::db_rename_flock();
     let state = common::setup_app_state().await;
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "FcmTestErr").await;
+    let tenant_id = common::create_test_tenant(state.pool(), "FcmTestErr").await;
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let client = reqwest::Client::new();
 
     let fake_id = uuid::Uuid::new_v4();
 
-    ensure_table_exists(&state.pool, "devices").await;
+    ensure_table_exists(state.pool(), "devices").await;
     sqlx::query("ALTER TABLE alc_api.devices RENAME TO devices_bak")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -3202,7 +3202,7 @@ async fn test_test_fcm_db_error() {
     assert_eq!(res.status(), 500);
 
     sqlx::query("ALTER TABLE alc_api.devices_bak RENAME TO devices")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 }
@@ -3217,13 +3217,13 @@ async fn test_test_fcm_all_db_error() {
     let _flock = common::db_rename_flock();
     let state = common::setup_app_state().await;
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "FcmAllErr").await;
+    let tenant_id = common::create_test_tenant(state.pool(), "FcmAllErr").await;
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let client = reqwest::Client::new();
 
-    ensure_table_exists(&state.pool, "devices").await;
+    ensure_table_exists(state.pool(), "devices").await;
     sqlx::query("ALTER TABLE alc_api.devices RENAME TO devices_bak")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -3236,7 +3236,7 @@ async fn test_test_fcm_all_db_error() {
     assert_eq!(res.status(), 500);
 
     sqlx::query("ALTER TABLE alc_api.devices_bak RENAME TO devices")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 }
@@ -3251,13 +3251,13 @@ async fn test_trigger_update_db_error() {
     let _flock = common::db_rename_flock();
     let state = common::setup_app_state().await;
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "TrigUpdErr").await;
+    let tenant_id = common::create_test_tenant(state.pool(), "TrigUpdErr").await;
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let client = reqwest::Client::new();
 
-    ensure_table_exists(&state.pool, "devices").await;
+    ensure_table_exists(state.pool(), "devices").await;
     sqlx::query("ALTER TABLE alc_api.devices RENAME TO devices_bak")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -3271,7 +3271,7 @@ async fn test_trigger_update_db_error() {
     assert_eq!(res.status(), 500);
 
     sqlx::query("ALTER TABLE alc_api.devices_bak RENAME TO devices")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 }
@@ -3291,9 +3291,9 @@ async fn test_trigger_update_dev_db_error() {
     std::env::set_var("FCM_INTERNAL_SECRET", "test-secret-dev-err");
 
     // RENAME devices so the tenant query in trigger_update_dev fails
-    ensure_table_exists(&state.pool, "devices").await;
+    ensure_table_exists(state.pool(), "devices").await;
     sqlx::query("ALTER TABLE alc_api.devices RENAME TO devices_bak")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -3307,7 +3307,7 @@ async fn test_trigger_update_dev_db_error() {
     assert_eq!(res.status(), 500);
 
     sqlx::query("ALTER TABLE alc_api.devices_bak RENAME TO devices")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 }
@@ -3328,7 +3328,7 @@ async fn test_disable_device_not_found() {
     let _flock_guard = common::db_rename_flock();
     let state = common::setup_app_state().await;
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "DisNF").await;
+    let tenant_id = common::create_test_tenant(state.pool(), "DisNF").await;
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let client = reqwest::Client::new();
 
@@ -3354,7 +3354,7 @@ async fn test_enable_device_not_found() {
     let _flock_guard = common::db_rename_flock();
     let state = common::setup_app_state().await;
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "EnNF").await;
+    let tenant_id = common::create_test_tenant(state.pool(), "EnNF").await;
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let client = reqwest::Client::new();
 
@@ -3509,7 +3509,7 @@ async fn test_test_fcm_not_found() {
     let _flock_guard = common::db_rename_flock();
     let state = common::setup_app_state().await;
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "FcmNF").await;
+    let tenant_id = common::create_test_tenant(state.pool(), "FcmNF").await;
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let client = reqwest::Client::new();
 
@@ -3535,7 +3535,7 @@ async fn test_test_fcm_no_token() {
     let _flock_guard = common::db_rename_flock();
     let state = common::setup_app_state().await;
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "FcmNoTok").await;
+    let tenant_id = common::create_test_tenant(state.pool(), "FcmNoTok").await;
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let auth = format!("Bearer {jwt}");
     let client = reqwest::Client::new();
@@ -3588,7 +3588,7 @@ async fn test_approve_device_not_found() {
     let _flock_guard = common::db_rename_flock();
     let state = common::setup_app_state().await;
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "AppNF").await;
+    let tenant_id = common::create_test_tenant(state.pool(), "AppNF").await;
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let client = reqwest::Client::new();
 
@@ -3615,7 +3615,7 @@ async fn test_approve_by_code_not_found() {
     let _flock_guard = common::db_rename_flock();
     let state = common::setup_app_state().await;
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "AppCodeNF").await;
+    let tenant_id = common::create_test_tenant(state.pool(), "AppCodeNF").await;
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let client = reqwest::Client::new();
 
@@ -3667,7 +3667,7 @@ async fn test_fcm_notify_schedule_enabled_false() {
     let _flock_guard = common::db_rename_flock();
     let state = common::setup_app_state().await;
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "SchedEnF").await;
+    let tenant_id = common::create_test_tenant(state.pool(), "SchedEnF").await;
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let auth = format!("Bearer {jwt}");
     let client = reqwest::Client::new();
@@ -3713,7 +3713,7 @@ async fn test_fcm_notify_schedule_wrong_day() {
     let _flock_guard = common::db_rename_flock();
     let state = common::setup_app_state().await;
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "SchedDay").await;
+    let tenant_id = common::create_test_tenant(state.pool(), "SchedDay").await;
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let auth = format!("Bearer {jwt}");
     let client = reqwest::Client::new();
@@ -3778,7 +3778,7 @@ async fn test_fcm_notify_schedule_overnight_pass() {
     let _flock_guard = common::db_rename_flock();
     let state = common::setup_app_state().await;
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "SchedOvn").await;
+    let tenant_id = common::create_test_tenant(state.pool(), "SchedOvn").await;
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let auth = format!("Bearer {jwt}");
     let client = reqwest::Client::new();
@@ -3833,7 +3833,7 @@ async fn test_update_call_settings_always_on_fcm() {
     let _flock_guard = common::db_rename_flock();
     let state = common::setup_app_state().await;
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "AlwaysOnFcm").await;
+    let tenant_id = common::create_test_tenant(state.pool(), "AlwaysOnFcm").await;
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let auth = format!("Bearer {jwt}");
     let client = reqwest::Client::new();
@@ -3874,7 +3874,7 @@ async fn test_generate_unique_code_db_error() {
     let _flock_guard = common::db_rename_flock();
     let state = common::setup_app_state().await;
     let base_url = common::spawn_test_server(state.clone()).await;
-    state.pool.close().await;
+    state.pool().close().await;
     let client = reqwest::Client::new();
 
     // create_registration_request calls generate_unique_code which will fail
@@ -3926,7 +3926,7 @@ async fn test_test_fcm_no_fcm_configured() {
     let _flock_guard = common::db_rename_flock();
     let state = common::setup_app_state_no_fcm().await;
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "FcmNoCfg").await;
+    let tenant_id = common::create_test_tenant(state.pool(), "FcmNoCfg").await;
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let client = reqwest::Client::new();
 
@@ -3952,7 +3952,7 @@ async fn test_test_fcm_all_no_fcm_configured() {
     let _flock_guard = common::db_rename_flock();
     let state = common::setup_app_state_no_fcm().await;
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "FcmAllNoCfg").await;
+    let tenant_id = common::create_test_tenant(state.pool(), "FcmAllNoCfg").await;
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let client = reqwest::Client::new();
 
@@ -4024,7 +4024,7 @@ async fn test_trigger_update_no_fcm_configured() {
     let _flock_guard = common::db_rename_flock();
     let state = common::setup_app_state_no_fcm().await;
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "TrigNoFcm").await;
+    let tenant_id = common::create_test_tenant(state.pool(), "TrigNoFcm").await;
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let client = reqwest::Client::new();
 
@@ -4054,7 +4054,7 @@ async fn test_fcm_notify_call_send_failure() {
     let _flock_guard = common::db_rename_flock();
     let state = common::setup_app_state_failing_fcm().await;
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "FcmFail").await;
+    let tenant_id = common::create_test_tenant(state.pool(), "FcmFail").await;
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let auth = format!("Bearer {jwt}");
     let client = reqwest::Client::new();
@@ -4097,7 +4097,7 @@ async fn test_test_fcm_send_failure() {
     let _flock_guard = common::db_rename_flock();
     let state = common::setup_app_state_failing_fcm().await;
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "FcmTestFail").await;
+    let tenant_id = common::create_test_tenant(state.pool(), "FcmTestFail").await;
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let auth = format!("Bearer {jwt}");
     let client = reqwest::Client::new();
@@ -4134,7 +4134,7 @@ async fn test_test_fcm_all_send_failure() {
     let _flock_guard = common::db_rename_flock();
     let state = common::setup_app_state_failing_fcm().await;
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "FcmAllFail").await;
+    let tenant_id = common::create_test_tenant(state.pool(), "FcmAllFail").await;
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let auth = format!("Bearer {jwt}");
     let client = reqwest::Client::new();
@@ -4170,7 +4170,7 @@ async fn test_test_fcm_all_exclude_send_failure() {
     let _flock_guard = common::db_rename_flock();
     let state = common::setup_app_state_failing_fcm().await;
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "FcmExFail").await;
+    let tenant_id = common::create_test_tenant(state.pool(), "FcmExFail").await;
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let auth = format!("Bearer {jwt}");
     let client = reqwest::Client::new();
@@ -4231,7 +4231,7 @@ async fn test_trigger_update_send_failure() {
     let _flock_guard = common::db_rename_flock();
     let state = common::setup_app_state_failing_fcm().await;
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "TrigFail").await;
+    let tenant_id = common::create_test_tenant(state.pool(), "TrigFail").await;
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let auth = format!("Bearer {jwt}");
     let client = reqwest::Client::new();
@@ -4268,7 +4268,7 @@ async fn test_fcm_dismiss_test_with_tokens() {
     let _flock_guard = common::db_rename_flock();
     let state = common::setup_app_state().await;
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "DismissTok").await;
+    let tenant_id = common::create_test_tenant(state.pool(), "DismissTok").await;
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let auth = format!("Bearer {jwt}");
     let client = reqwest::Client::new();
@@ -4316,7 +4316,7 @@ async fn test_claim_url_create_device_db_error() {
     let _flock = common::db_rename_flock();
     let state = common::setup_app_state().await;
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "ClmUrlInsErr").await;
+    let tenant_id = common::create_test_tenant(state.pool(), "ClmUrlInsErr").await;
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let client = reqwest::Client::new();
 
@@ -4336,11 +4336,11 @@ async fn test_claim_url_create_device_db_error() {
         r#"CREATE OR REPLACE FUNCTION alc_api.fail_dev_ins_clm_url() RETURNS trigger AS $$
         BEGIN RAISE EXCEPTION 'test error claim url insert'; END; $$ LANGUAGE plpgsql"#,
     )
-    .execute(&state.pool)
+    .execute(state.pool())
     .await
     .unwrap();
     sqlx::query("CREATE OR REPLACE TRIGGER fail_dev_ins_clm_url BEFORE INSERT ON alc_api.devices FOR EACH ROW EXECUTE FUNCTION alc_api.fail_dev_ins_clm_url()")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -4358,11 +4358,11 @@ async fn test_claim_url_create_device_db_error() {
     assert_eq!(body["success"], false);
 
     sqlx::query("DROP TRIGGER fail_dev_ins_clm_url ON alc_api.devices")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
     sqlx::query("DROP FUNCTION alc_api.fail_dev_ins_clm_url")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 }
@@ -4377,7 +4377,7 @@ async fn test_claim_device_owner_create_device_db_error() {
     let _flock = common::db_rename_flock();
     let state = common::setup_app_state().await;
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "ClmDOInsErr").await;
+    let tenant_id = common::create_test_tenant(state.pool(), "ClmDOInsErr").await;
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let auth = format!("Bearer {jwt}");
     let client = reqwest::Client::new();
@@ -4400,11 +4400,11 @@ async fn test_claim_device_owner_create_device_db_error() {
         r#"CREATE OR REPLACE FUNCTION alc_api.fail_dev_ins_clm_do() RETURNS trigger AS $$
         BEGIN RAISE EXCEPTION 'test error claim do insert'; END; $$ LANGUAGE plpgsql"#,
     )
-    .execute(&state.pool)
+    .execute(state.pool())
     .await
     .unwrap();
     sqlx::query("CREATE OR REPLACE TRIGGER fail_dev_ins_clm_do BEFORE INSERT ON alc_api.devices FOR EACH ROW EXECUTE FUNCTION alc_api.fail_dev_ins_clm_do()")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -4421,11 +4421,11 @@ async fn test_claim_device_owner_create_device_db_error() {
     assert_eq!(body["success"], false);
 
     sqlx::query("DROP TRIGGER fail_dev_ins_clm_do ON alc_api.devices")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
     sqlx::query("DROP FUNCTION alc_api.fail_dev_ins_clm_do")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 }
@@ -4440,7 +4440,7 @@ async fn test_claim_qr_permanent_update_db_error() {
     let _flock = common::db_rename_flock();
     let state = common::setup_app_state().await;
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "ClmPQRUpdErr").await;
+    let tenant_id = common::create_test_tenant(state.pool(), "ClmPQRUpdErr").await;
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let auth = format!("Bearer {jwt}");
     let client = reqwest::Client::new();
@@ -4463,11 +4463,11 @@ async fn test_claim_qr_permanent_update_db_error() {
         r#"CREATE OR REPLACE FUNCTION alc_api.fail_drr_upd_clm_pqr() RETURNS trigger AS $$
         BEGIN RAISE EXCEPTION 'test error claim pqr update'; END; $$ LANGUAGE plpgsql"#,
     )
-    .execute(&state.pool)
+    .execute(state.pool())
     .await
     .unwrap();
     sqlx::query("CREATE OR REPLACE TRIGGER fail_drr_upd_clm_pqr BEFORE UPDATE ON alc_api.device_registration_requests FOR EACH ROW EXECUTE FUNCTION alc_api.fail_drr_upd_clm_pqr()")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -4484,11 +4484,11 @@ async fn test_claim_qr_permanent_update_db_error() {
     assert_eq!(body["success"], false);
 
     sqlx::query("DROP TRIGGER fail_drr_upd_clm_pqr ON alc_api.device_registration_requests")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
     sqlx::query("DROP FUNCTION alc_api.fail_drr_upd_clm_pqr")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 }
@@ -4552,11 +4552,11 @@ async fn test_approve_device_create_device_db_error() {
         r#"CREATE OR REPLACE FUNCTION alc_api.fail_dev_ins_appr() RETURNS trigger AS $$
         BEGIN RAISE EXCEPTION 'test error approve insert'; END; $$ LANGUAGE plpgsql"#,
     )
-    .execute(&state.pool)
+    .execute(state.pool())
     .await
     .unwrap();
     sqlx::query("CREATE OR REPLACE TRIGGER fail_dev_ins_appr BEFORE INSERT ON alc_api.devices FOR EACH ROW EXECUTE FUNCTION alc_api.fail_dev_ins_appr()")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -4570,11 +4570,11 @@ async fn test_approve_device_create_device_db_error() {
     assert_eq!(res.status(), 500);
 
     sqlx::query("DROP TRIGGER fail_dev_ins_appr ON alc_api.devices")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
     sqlx::query("DROP FUNCTION alc_api.fail_dev_ins_appr")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 }
@@ -4608,11 +4608,11 @@ async fn test_approve_by_code_create_device_db_error() {
         r#"CREATE OR REPLACE FUNCTION alc_api.fail_dev_ins_appr_code() RETURNS trigger AS $$
         BEGIN RAISE EXCEPTION 'test error approve_by_code insert'; END; $$ LANGUAGE plpgsql"#,
     )
-    .execute(&state.pool)
+    .execute(state.pool())
     .await
     .unwrap();
     sqlx::query("CREATE OR REPLACE TRIGGER fail_dev_ins_appr_code BEFORE INSERT ON alc_api.devices FOR EACH ROW EXECUTE FUNCTION alc_api.fail_dev_ins_appr_code()")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -4625,11 +4625,11 @@ async fn test_approve_by_code_create_device_db_error() {
     assert_eq!(res.status(), 500);
 
     sqlx::query("DROP TRIGGER fail_dev_ins_appr_code ON alc_api.devices")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
     sqlx::query("DROP FUNCTION alc_api.fail_dev_ins_appr_code")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 }
@@ -4648,7 +4648,7 @@ async fn test_report_watchdog_state_update_error() {
     let _flock = common::db_rename_flock();
     let state = common::setup_app_state().await;
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "WdgUpdErr").await;
+    let tenant_id = common::create_test_tenant(state.pool(), "WdgUpdErr").await;
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let auth = format!("Bearer {jwt}");
     let client = reqwest::Client::new();
@@ -4659,11 +4659,11 @@ async fn test_report_watchdog_state_update_error() {
         r#"CREATE OR REPLACE FUNCTION alc_api.fail_dev_upd_wdg() RETURNS trigger AS $$
         BEGIN RAISE EXCEPTION 'test error watchdog update'; END; $$ LANGUAGE plpgsql"#,
     )
-    .execute(&state.pool)
+    .execute(state.pool())
     .await
     .unwrap();
     sqlx::query("CREATE OR REPLACE TRIGGER fail_dev_upd_wdg BEFORE UPDATE ON alc_api.devices FOR EACH ROW EXECUTE FUNCTION alc_api.fail_dev_upd_wdg()")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -4676,11 +4676,11 @@ async fn test_report_watchdog_state_update_error() {
     assert_eq!(res.status(), 500);
 
     sqlx::query("DROP TRIGGER fail_dev_upd_wdg ON alc_api.devices")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
     sqlx::query("DROP FUNCTION alc_api.fail_dev_upd_wdg")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 }
@@ -4695,7 +4695,7 @@ async fn test_register_fcm_token_update_error() {
     let _flock = common::db_rename_flock();
     let state = common::setup_app_state().await;
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "FcmTokUpdErr").await;
+    let tenant_id = common::create_test_tenant(state.pool(), "FcmTokUpdErr").await;
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let auth = format!("Bearer {jwt}");
     let client = reqwest::Client::new();
@@ -4706,11 +4706,11 @@ async fn test_register_fcm_token_update_error() {
         r#"CREATE OR REPLACE FUNCTION alc_api.fail_dev_upd_fcm() RETURNS trigger AS $$
         BEGIN RAISE EXCEPTION 'test error fcm token update'; END; $$ LANGUAGE plpgsql"#,
     )
-    .execute(&state.pool)
+    .execute(state.pool())
     .await
     .unwrap();
     sqlx::query("CREATE OR REPLACE TRIGGER fail_dev_upd_fcm BEFORE UPDATE ON alc_api.devices FOR EACH ROW EXECUTE FUNCTION alc_api.fail_dev_upd_fcm()")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -4723,11 +4723,11 @@ async fn test_register_fcm_token_update_error() {
     assert_eq!(res.status(), 500);
 
     sqlx::query("DROP TRIGGER fail_dev_upd_fcm ON alc_api.devices")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
     sqlx::query("DROP FUNCTION alc_api.fail_dev_upd_fcm")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 }
@@ -4742,7 +4742,7 @@ async fn test_update_last_login_update_error() {
     let _flock = common::db_rename_flock();
     let state = common::setup_app_state().await;
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "LastLogUpdErr").await;
+    let tenant_id = common::create_test_tenant(state.pool(), "LastLogUpdErr").await;
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let auth = format!("Bearer {jwt}");
     let client = reqwest::Client::new();
@@ -4753,11 +4753,11 @@ async fn test_update_last_login_update_error() {
         r#"CREATE OR REPLACE FUNCTION alc_api.fail_dev_upd_login() RETURNS trigger AS $$
         BEGIN RAISE EXCEPTION 'test error last login update'; END; $$ LANGUAGE plpgsql"#,
     )
-    .execute(&state.pool)
+    .execute(state.pool())
     .await
     .unwrap();
     sqlx::query("CREATE OR REPLACE TRIGGER fail_dev_upd_login BEFORE UPDATE ON alc_api.devices FOR EACH ROW EXECUTE FUNCTION alc_api.fail_dev_upd_login()")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -4775,11 +4775,11 @@ async fn test_update_last_login_update_error() {
     assert_eq!(res.status(), 500);
 
     sqlx::query("DROP TRIGGER fail_dev_upd_login ON alc_api.devices")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
     sqlx::query("DROP FUNCTION alc_api.fail_dev_upd_login")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 }
@@ -4794,7 +4794,7 @@ async fn test_report_version_update_error() {
     let _flock = common::db_rename_flock();
     let state = common::setup_app_state().await;
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "VerUpdErr").await;
+    let tenant_id = common::create_test_tenant(state.pool(), "VerUpdErr").await;
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let auth = format!("Bearer {jwt}");
     let client = reqwest::Client::new();
@@ -4805,11 +4805,11 @@ async fn test_report_version_update_error() {
         r#"CREATE OR REPLACE FUNCTION alc_api.fail_dev_upd_ver() RETURNS trigger AS $$
         BEGIN RAISE EXCEPTION 'test error version update'; END; $$ LANGUAGE plpgsql"#,
     )
-    .execute(&state.pool)
+    .execute(state.pool())
     .await
     .unwrap();
     sqlx::query("CREATE OR REPLACE TRIGGER fail_dev_upd_ver BEFORE UPDATE ON alc_api.devices FOR EACH ROW EXECUTE FUNCTION alc_api.fail_dev_upd_ver()")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -4826,11 +4826,11 @@ async fn test_report_version_update_error() {
     assert_eq!(res.status(), 500);
 
     sqlx::query("DROP TRIGGER fail_dev_upd_ver ON alc_api.devices")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
     sqlx::query("DROP FUNCTION alc_api.fail_dev_upd_ver")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 }
@@ -4890,11 +4890,11 @@ async fn test_approve_device_update_request_db_error() {
         r#"CREATE OR REPLACE FUNCTION alc_api.fail_drr_upd_appr() RETURNS trigger AS $$
         BEGIN RAISE EXCEPTION 'test error approve update request'; END; $$ LANGUAGE plpgsql"#,
     )
-    .execute(&state.pool)
+    .execute(state.pool())
     .await
     .unwrap();
     sqlx::query("CREATE OR REPLACE TRIGGER fail_drr_upd_appr BEFORE UPDATE ON alc_api.device_registration_requests FOR EACH ROW EXECUTE FUNCTION alc_api.fail_drr_upd_appr()")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -4908,11 +4908,11 @@ async fn test_approve_device_update_request_db_error() {
     assert_eq!(res.status(), 500);
 
     sqlx::query("DROP TRIGGER fail_drr_upd_appr ON alc_api.device_registration_requests")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
     sqlx::query("DROP FUNCTION alc_api.fail_drr_upd_appr")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 }
@@ -4946,11 +4946,11 @@ async fn test_approve_by_code_update_request_db_error() {
         r#"CREATE OR REPLACE FUNCTION alc_api.fail_drr_upd_appr_code() RETURNS trigger AS $$
         BEGIN RAISE EXCEPTION 'test error approve_by_code update'; END; $$ LANGUAGE plpgsql"#,
     )
-    .execute(&state.pool)
+    .execute(state.pool())
     .await
     .unwrap();
     sqlx::query("CREATE OR REPLACE TRIGGER fail_drr_upd_appr_code BEFORE UPDATE ON alc_api.device_registration_requests FOR EACH ROW EXECUTE FUNCTION alc_api.fail_drr_upd_appr_code()")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -4963,11 +4963,11 @@ async fn test_approve_by_code_update_request_db_error() {
     assert_eq!(res.status(), 500);
 
     sqlx::query("DROP TRIGGER fail_drr_upd_appr_code ON alc_api.device_registration_requests")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
     sqlx::query("DROP FUNCTION alc_api.fail_drr_upd_appr_code")
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 }
@@ -4984,7 +4984,7 @@ async fn test_update_call_settings_fcm_send_failure() {
     let _flock_guard = common::db_rename_flock();
     let state = common::setup_app_state_failing_fcm().await;
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "CallFcmFail").await;
+    let tenant_id = common::create_test_tenant(state.pool(), "CallFcmFail").await;
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let auth = format!("Bearer {jwt}");
     let client = reqwest::Client::new();

--- a/tests/dtako_test.rs
+++ b/tests/dtako_test.rs
@@ -14,7 +14,7 @@ async fn test_dtako_upload_zip() {
     test_case!("正常なZIPをアップロードして成功する", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "DtakoZip").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "DtakoZip").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -58,7 +58,7 @@ async fn test_dtako_upload_invalid_zip() {
     test_case!("不正なZIPで400エラーを返す", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "DtakoBadZip").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "DtakoBadZip").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -85,7 +85,7 @@ async fn test_dtako_upload_no_file_field() {
     test_case!("fileフィールドなしで400を返す", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "DtakoNoFile").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "DtakoNoFile").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
 
         let form = reqwest::multipart::Form::new().text("other_field", "value");
@@ -106,7 +106,7 @@ async fn test_dtako_internal_download_after_upload() {
     test_case!("アップロード後にダウンロードする", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "DtakoDown").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "DtakoDown").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -147,7 +147,7 @@ async fn test_dtako_internal_rerun() {
     test_case!("アップロード後にrerunで再処理する", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "DtakoRerun").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "DtakoRerun").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -187,7 +187,7 @@ async fn test_dtako_internal_rerun_not_found() {
     test_case!("存在しないIDでrerunが404を返す", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "DtakoRerunNF").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "DtakoRerunNF").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
 
         let fake_id = Uuid::new_v4();
@@ -207,7 +207,7 @@ async fn test_dtako_split_csv_handler() {
     test_case!("アップロード後にsplit-csvを実行する", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "DtakoSplit").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "DtakoSplit").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -231,7 +231,7 @@ async fn test_dtako_split_csv_handler() {
         // r2_zip_key を設定 + MockStorage に ZIP 配置
         let r2_key = format!("{}/zips/{}.zip", tenant_id, upload_id);
         {
-            let mut conn = state.pool.acquire().await.unwrap();
+            let mut conn = state.pool().acquire().await.unwrap();
             sqlx::query(
                 "UPDATE alc_api.dtako_upload_history SET r2_zip_key = $1 WHERE id = $2::uuid",
             )
@@ -266,7 +266,7 @@ async fn test_dtako_split_csv_all_handler() {
     test_case!("split-csv-allでSSEストリームを消費する", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "DtakoSplitAll").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "DtakoSplitAll").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -288,7 +288,7 @@ async fn test_dtako_split_csv_all_handler() {
 
         // r2_zip_key と has_kudgivt を設定して split-csv-all が内部ループに入るようにする
         {
-            let mut conn = state.pool.acquire().await.unwrap();
+            let mut conn = state.pool().acquire().await.unwrap();
             sqlx::query("SELECT set_config('app.current_tenant_id', $1, true)")
                 .bind(tenant_id.to_string())
                 .execute(&mut *conn)
@@ -344,7 +344,7 @@ async fn test_dtako_list_pending_with_data() {
     test_case!("pending一覧にデータが表示される", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "DtakoPending").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "DtakoPending").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -380,7 +380,7 @@ async fn test_dtako_recalculate_all_with_data() {
     test_case!("実データありで全ドライバー再計算する", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "DtakoRecalcAll").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "DtakoRecalcAll").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -390,7 +390,7 @@ async fn test_dtako_recalculate_all_with_data() {
             common::create_test_employee(&client, &base_url, &auth, "RecalcAllDrv", "RA01").await;
         let emp_id: Uuid = emp["id"].as_str().unwrap().parse().unwrap();
         {
-            let mut conn = state.pool.acquire().await.unwrap();
+            let mut conn = state.pool().acquire().await.unwrap();
             sqlx::query("SELECT set_config('app.current_tenant_id', $1, true)")
                 .bind(tenant_id.to_string())
                 .execute(&mut *conn)
@@ -437,7 +437,7 @@ async fn test_dtako_recalculate_drivers_batch_with_data() {
     test_case!("実データありでバッチ再計算する", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "DtakoBatchData").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "DtakoBatchData").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -446,7 +446,7 @@ async fn test_dtako_recalculate_drivers_batch_with_data() {
         let emp = common::create_test_employee(&client, &base_url, &auth, "BatchDrv", "BD01").await;
         let emp_id: Uuid = emp["id"].as_str().unwrap().parse().unwrap();
         {
-            let mut conn = state.pool.acquire().await.unwrap();
+            let mut conn = state.pool().acquire().await.unwrap();
             sqlx::query("SELECT set_config('app.current_tenant_id', $1, true)")
                 .bind(tenant_id.to_string())
                 .execute(&mut *conn)
@@ -498,7 +498,7 @@ async fn test_dtako_recalculate_driver() {
     test_case!("ドライバー再計算SSEが200を返す", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "DtakoRecalc").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "DtakoRecalc").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -544,7 +544,7 @@ async fn test_dtako_drivers_list() {
     test_case!("ドライバー一覧が200を返す", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "DtakoDrivers").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "DtakoDrivers").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -564,7 +564,7 @@ async fn test_dtako_vehicles_list() {
     test_case!("車両一覧が200を返す", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "DtakoVehicles").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "DtakoVehicles").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -584,7 +584,7 @@ async fn test_dtako_operations_list() {
     test_case!("運行一覧が200を返す", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "DtakoOps").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "DtakoOps").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -604,7 +604,7 @@ async fn test_dtako_operations_calendar() {
     test_case!("運行カレンダーが200を返す", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "DtakoCal").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "DtakoCal").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -626,7 +626,7 @@ async fn test_dtako_daily_hours_list() {
     test_case!("日別時間一覧が200を返す", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "DtakoDH").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "DtakoDH").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -646,7 +646,7 @@ async fn test_dtako_work_times_list() {
     test_case!("作業時間一覧が200を返す", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "DtakoWT").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "DtakoWT").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -666,7 +666,7 @@ async fn test_dtako_event_classifications_list() {
     test_case!("イベント分類一覧が200を返す", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "DtakoEC").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "DtakoEC").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -690,7 +690,7 @@ async fn test_dtako_restraint_report_list() {
     test_case!("拘束時間レポート一覧を取得する", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "DtakoReport").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "DtakoReport").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -720,7 +720,7 @@ async fn test_dtako_list_uploads() {
     test_case!("アップロード一覧が200を返す", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "DtakoUploads").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "DtakoUploads").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -740,7 +740,7 @@ async fn test_dtako_list_pending_uploads() {
     test_case!("pending一覧が200を返す", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "DtakoPending").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "DtakoPending").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -766,7 +766,7 @@ async fn test_dtako_restraint_report_for_driver() {
         {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "DtakoRR").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "DtakoRR").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
             let client = reqwest::Client::new();
 
@@ -795,7 +795,7 @@ async fn test_dtako_restraint_report_json() {
     test_case!("JSONレポートを取得する", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "DtakoRRJson").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "DtakoRRJson").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -830,7 +830,7 @@ async fn test_dtako_restraint_report_json_with_data() {
     test_case!("実データありでJSONレポートを取得する", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "DtakoRRData").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "DtakoRRData").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -888,7 +888,7 @@ async fn test_dtako_compare_csv_empty() {
     test_case!("空のCSV比較で400エラーを返す", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "DtakoCmpCSV").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "DtakoCmpCSV").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -921,7 +921,7 @@ async fn test_dtako_recalculate_drivers_batch() {
     test_case!("空バッチ再計算が200を返す", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "DtakoRecalcBatch").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "DtakoRecalcBatch").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -943,7 +943,7 @@ async fn test_dtako_split_csv_all() {
     test_case!("split-csv-allが200を返す", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "DtakoSplitAll").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "DtakoSplitAll").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -967,7 +967,7 @@ async fn test_dtako_restraint_report_full_month() {
     test_case!("1ヶ月分のレポートを生成する", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "DtakoRRFull").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "DtakoRRFull").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -1034,7 +1034,7 @@ async fn test_dtako_daily_hours_with_driver_filter() {
         {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "DtakoDHF").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "DtakoDHF").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
             let client = reqwest::Client::new();
 
@@ -1059,7 +1059,7 @@ async fn test_dtako_get_operation_by_unko_no() {
     test_case!("unko_noで運行を取得する", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "DtakoGetOp").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "DtakoGetOp").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -1104,7 +1104,7 @@ async fn test_dtako_get_operation_not_found() {
     test_case!("存在しないunko_noで404を返す", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "DtakoGetOpNF").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "DtakoGetOpNF").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -1124,7 +1124,7 @@ async fn test_dtako_delete_operation_by_unko_no() {
     test_case!("unko_noで運行を削除する", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "DtakoDelOp").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "DtakoDelOp").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -1181,7 +1181,7 @@ async fn test_dtako_delete_operation_not_found() {
     test_case!("存在しないunko_noで削除が404を返す", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "DtakoDelNF").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "DtakoDelNF").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -1205,7 +1205,7 @@ async fn test_dtako_restraint_report_after_upload() {
     test_case!("アップロード後にレポートを取得する", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "DtakoRRUp").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "DtakoRRUp").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -1272,7 +1272,7 @@ async fn test_dtako_split_csv() {
     test_case!("アップロード後にsplit-csvを実行する", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "DtakoSplit").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "DtakoSplit").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -1322,7 +1322,7 @@ async fn test_dtako_recalculate_all() {
     test_case!("全ドライバー再計算SSEが200を返す", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "DtakoRecAll").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "DtakoRecAll").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -1352,7 +1352,7 @@ async fn test_dtako_internal_download() {
     test_case!("アップロード後にダウンロードする", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "DtakoDL").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "DtakoDL").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -1397,7 +1397,7 @@ async fn test_dtako_internal_download_not_found() {
     test_case!("存在しないIDでダウンロードが404を返す", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "DtakoDLNF").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "DtakoDLNF").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -1426,7 +1426,7 @@ async fn test_dtako_restraint_report_pdf() {
     test_case!("PDFレポートを生成する", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "DtakoRRPdf").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "DtakoRRPdf").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -1482,7 +1482,7 @@ async fn test_dtako_restraint_report_pdf_all_drivers() {
     test_case!("全ドライバーPDFを生成する", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "DtakoRRPdfAll").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "DtakoRRPdfAll").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -1509,7 +1509,7 @@ async fn test_dtako_restraint_report_pdf_stream() {
     test_case!("PDFストリームが200を返す", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "DtakoRRStream").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "DtakoRRStream").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -1534,7 +1534,7 @@ async fn test_dtako_restraint_report_pdf_not_found() {
     test_case!("存在しないドライバーでPDFが404/500を返す", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "DtakoRRPdfNF").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "DtakoRRPdfNF").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -1562,7 +1562,7 @@ async fn test_dtako_restraint_report_pdf_with_data() {
     test_case!("実データありでPDFを生成する", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "DtakoRRPdfData").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "DtakoRRPdfData").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -1573,7 +1573,7 @@ async fn test_dtako_restraint_report_pdf_with_data() {
 
         // 1週間分のデータを INSERT (dwh + segments)
         {
-            let mut conn = state.pool.acquire().await.unwrap();
+            let mut conn = state.pool().acquire().await.unwrap();
             sqlx::query("SELECT set_config('app.current_tenant_id', $1, true)")
                 .bind(tenant_id.to_string())
                 .execute(&mut *conn)
@@ -1688,7 +1688,7 @@ async fn test_dtako_restraint_report_pdf_stream_with_data() {
     test_case!("実データありでPDFストリームを生成する", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "DtakoRRStreamData").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "DtakoRRStreamData").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -1705,7 +1705,7 @@ async fn test_dtako_restraint_report_pdf_stream_with_data() {
 
         // 3日分のデータ
         {
-            let mut conn = state.pool.acquire().await.unwrap();
+            let mut conn = state.pool().acquire().await.unwrap();
             sqlx::query("SELECT set_config('app.current_tenant_id', $1, true)")
                 .bind(tenant_id.to_string())
                 .execute(&mut *conn)
@@ -1779,7 +1779,7 @@ async fn test_dtako_restraint_report_with_driver_id() {
     test_case!("ドライバーIDでレポートを取得する", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "DtakoRRDrv").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "DtakoRRDrv").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -1856,7 +1856,7 @@ async fn test_recalculate_driver_core_with_data() {
 
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "RecalcCore").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "RecalcCore").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
             let client = reqwest::Client::new();
 
@@ -1868,7 +1868,7 @@ async fn test_recalculate_driver_core_with_data() {
             let employee_id: Uuid = emp["id"].as_str().unwrap().parse().unwrap();
 
             {
-                let mut conn = state.pool.acquire().await.unwrap();
+                let mut conn = state.pool().acquire().await.unwrap();
                 sqlx::query("SELECT set_config('app.current_tenant_id', $1, true)")
                     .bind(tenant_id.to_string())
                     .execute(&mut *conn)
@@ -1909,7 +1909,7 @@ async fn test_recalculate_driver_core_with_data() {
             assert!(total >= 1, "Expected at least 1 operation, got {total}");
 
             // 4. DB に daily_work_hours が INSERT されたか確認
-            let mut conn = state.pool.acquire().await.unwrap();
+            let mut conn = state.pool().acquire().await.unwrap();
             sqlx::query("SELECT set_config('app.current_tenant_id', $1, true)")
                 .bind(tenant_id.to_string())
                 .execute(&mut *conn)
@@ -1941,7 +1941,7 @@ async fn test_recalculate_driver_core_no_driver() {
 
         let state = common::setup_app_state().await;
         let _base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "RecalcNoDriver").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "RecalcNoDriver").await;
 
         let fake_id = Uuid::new_v4();
         let result = recalculate_driver_core(&state, tenant_id, fake_id, 2026, 3, None).await;
@@ -1962,7 +1962,7 @@ async fn test_recalculate_driver_core_no_operations() {
 
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "RecalcNoOps").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "RecalcNoOps").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -1972,7 +1972,7 @@ async fn test_recalculate_driver_core_no_operations() {
                 .await;
         let employee_id: Uuid = emp["id"].as_str().unwrap().parse().unwrap();
         {
-            let mut conn = state.pool.acquire().await.unwrap();
+            let mut conn = state.pool().acquire().await.unwrap();
             sqlx::query("SELECT set_config('app.current_tenant_id', $1, true)")
                 .bind(tenant_id.to_string())
                 .execute(&mut *conn)
@@ -2007,7 +2007,7 @@ async fn test_dtako_upload_zip_rich() {
         {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "DtakoRich").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "DtakoRich").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
             let auth = format!("Bearer {jwt}");
             let client = reqwest::Client::new();
@@ -2022,7 +2022,7 @@ async fn test_dtako_upload_zip_rich() {
 
             // driver_cd 設定
             {
-                let mut conn = state.pool.acquire().await.unwrap();
+                let mut conn = state.pool().acquire().await.unwrap();
                 sqlx::query("SELECT set_config('app.current_tenant_id', $1, true)")
                     .bind(tenant_id.to_string())
                     .execute(&mut *conn)
@@ -2065,7 +2065,7 @@ async fn test_dtako_upload_zip_rich() {
             );
 
             // DB 検証: daily_work_hours
-            let mut conn = state.pool.acquire().await.unwrap();
+            let mut conn = state.pool().acquire().await.unwrap();
             sqlx::query("SELECT set_config('app.current_tenant_id', $1, true)")
                 .bind(tenant_id.to_string())
                 .execute(&mut *conn)
@@ -2115,7 +2115,7 @@ async fn test_dtako_upload_zip_reupload() {
         {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "DtakoReup").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "DtakoReup").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
             let auth = format!("Bearer {jwt}");
             let client = reqwest::Client::new();
@@ -2125,7 +2125,7 @@ async fn test_dtako_upload_zip_reupload() {
                 common::create_test_employee(&client, &base_url, &auth, "ReupDriver", "RU01").await;
             let emp_id: Uuid = emp["id"].as_str().unwrap().parse().unwrap();
             {
-                let mut conn = state.pool.acquire().await.unwrap();
+                let mut conn = state.pool().acquire().await.unwrap();
                 sqlx::query("SELECT set_config('app.current_tenant_id', $1, true)")
                     .bind(tenant_id.to_string())
                     .execute(&mut *conn)
@@ -2155,7 +2155,7 @@ async fn test_dtako_upload_zip_reupload() {
             assert_eq!(res.status(), 200);
 
             // 件数取得
-            let mut conn = state.pool.acquire().await.unwrap();
+            let mut conn = state.pool().acquire().await.unwrap();
             sqlx::query("SELECT set_config('app.current_tenant_id', $1, true)")
                 .bind(tenant_id.to_string())
                 .execute(&mut *conn)
@@ -2203,7 +2203,7 @@ async fn test_recalculate_driver_core_rich_data() {
 
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "RecalcRich").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "RecalcRich").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
             let auth = format!("Bearer {jwt}");
             let client = reqwest::Client::new();
@@ -2212,7 +2212,7 @@ async fn test_recalculate_driver_core_rich_data() {
                 common::create_test_employee(&client, &base_url, &auth, "運転者A", "RA01").await;
             let emp_id: Uuid = emp["id"].as_str().unwrap().parse().unwrap();
             {
-                let mut conn = state.pool.acquire().await.unwrap();
+                let mut conn = state.pool().acquire().await.unwrap();
                 sqlx::query("SELECT set_config('app.current_tenant_id', $1, true)")
                     .bind(tenant_id.to_string())
                     .execute(&mut *conn)
@@ -2248,7 +2248,7 @@ async fn test_recalculate_driver_core_rich_data() {
             assert!(total >= 2, "Expected 2+ operations for DR01 (2 days)");
 
             // daily_work_hours が再生成されたか確認
-            let mut conn = state.pool.acquire().await.unwrap();
+            let mut conn = state.pool().acquire().await.unwrap();
             sqlx::query("SELECT set_config('app.current_tenant_id', $1, true)")
                 .bind(tenant_id.to_string())
                 .execute(&mut *conn)
@@ -2275,7 +2275,7 @@ async fn test_recalculate_driver_core_with_ferry() {
 
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "RecalcFerry").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "RecalcFerry").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -2284,7 +2284,7 @@ async fn test_recalculate_driver_core_with_ferry() {
             common::create_test_employee(&client, &base_url, &auth, "FerryDriver", "FD01").await;
         let emp_id: Uuid = emp["id"].as_str().unwrap().parse().unwrap();
         {
-            let mut conn = state.pool.acquire().await.unwrap();
+            let mut conn = state.pool().acquire().await.unwrap();
             sqlx::query("SELECT set_config('app.current_tenant_id', $1, true)")
                 .bind(tenant_id.to_string())
                 .execute(&mut *conn)
@@ -2346,7 +2346,7 @@ async fn test_recalculate_driver_core_invalid_month() {
 
         let state = common::setup_app_state().await;
         let _base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "RecalcBadMonth").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "RecalcBadMonth").await;
 
         let fake_id = Uuid::new_v4();
         let result = recalculate_driver_core(&state, tenant_id, fake_id, 2026, 13, None).await;
@@ -2387,7 +2387,7 @@ async fn insert_dwh_and_get_report(
         i32,  // cargo_minutes
     )],
 ) -> Value {
-    let mut conn = state.pool.acquire().await.unwrap();
+    let mut conn = state.pool().acquire().await.unwrap();
     sqlx::query("SELECT set_config('app.current_tenant_id', $1, true)")
         .bind(tenant_id.to_string())
         .execute(&mut *conn)
@@ -2472,7 +2472,7 @@ async fn test_restraint_report_basic_calculation() {
     test_case!("基本計算(drive/cargo/is_holiday)を検証する", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "RRBasic").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "RRBasic").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -2523,7 +2523,7 @@ async fn test_restraint_report_holiday_handling() {
     test_case!("休日と連続休日を正しく処理する", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "RRHoliday").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "RRHoliday").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -2568,7 +2568,7 @@ async fn test_restraint_report_weekly_subtotals() {
     test_case!("週次小計を正しく計算する", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "RRWeekly").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "RRWeekly").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -2650,7 +2650,7 @@ async fn test_restraint_report_overtime_calculation() {
     test_case!("時間外・深夜計算を検証する", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "RROvertime").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "RROvertime").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -2697,7 +2697,7 @@ async fn test_restraint_report_overlap_fields() {
         {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "RROverlap").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "RROverlap").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
             let auth = format!("Bearer {jwt}");
             let client = reqwest::Client::new();
@@ -2744,7 +2744,7 @@ async fn test_restraint_report_multiple_dwh_same_day() {
     test_case!("同日の複数DWH行を処理する", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "RRMultiDWH").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "RRMultiDWH").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -2806,7 +2806,7 @@ async fn test_restraint_report_drive_avg_before() {
     test_case!("前日運転平均を正しく計算する", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "RRDriveAvg").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "RRDriveAvg").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -2816,7 +2816,7 @@ async fn test_restraint_report_drive_avg_before() {
 
         // 前月末 (2/28) にデータ INSERT + 当月 (3/1) にデータ INSERT
         {
-            let mut conn = state.pool.acquire().await.unwrap();
+            let mut conn = state.pool().acquire().await.unwrap();
             sqlx::query("SELECT set_config('app.current_tenant_id', $1, true)")
                 .bind(tenant_id.to_string())
                 .execute(&mut *conn)
@@ -2878,7 +2878,7 @@ async fn test_restraint_report_fiscal_year_cumulative() {
     test_case!("年度累計を正しく計算する", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "RRFiscal").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "RRFiscal").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -2888,7 +2888,7 @@ async fn test_restraint_report_fiscal_year_cumulative() {
 
         // 前年度 (2025年4月-12月) のデータを INSERT
         {
-            let mut conn = state.pool.acquire().await.unwrap();
+            let mut conn = state.pool().acquire().await.unwrap();
             sqlx::query("SELECT set_config('app.current_tenant_id', $1, true)")
                 .bind(tenant_id.to_string())
                 .execute(&mut *conn)
@@ -2963,7 +2963,7 @@ async fn test_restraint_report_with_operations() {
     test_case!("operationsデータありでレポートを生成する", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "RROps").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "RROps").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -2973,7 +2973,7 @@ async fn test_restraint_report_with_operations() {
 
         // dtako_operations を直接 INSERT
         {
-            let mut conn = state.pool.acquire().await.unwrap();
+            let mut conn = state.pool().acquire().await.unwrap();
             sqlx::query("SELECT set_config('app.current_tenant_id', $1, true)")
                 .bind(tenant_id.to_string())
                 .execute(&mut *conn)
@@ -3114,7 +3114,7 @@ async fn test_restraint_report_after_rich_upload() {
     test_case!("リッチZIP後にレポートとPDFを生成する", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "RRRichUp").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "RRRichUp").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -3123,7 +3123,7 @@ async fn test_restraint_report_after_rich_upload() {
         let emp = common::create_test_employee(&client, &base_url, &auth, "運転者A", "RA01").await;
         let emp_id: Uuid = emp["id"].as_str().unwrap().parse().unwrap();
         {
-            let mut conn = state.pool.acquire().await.unwrap();
+            let mut conn = state.pool().acquire().await.unwrap();
             sqlx::query("SELECT set_config('app.current_tenant_id', $1, true)")
                 .bind(tenant_id.to_string())
                 .execute(&mut *conn)
@@ -3203,7 +3203,7 @@ async fn test_dtako_split_csv_not_found() {
     test_case!("存在しないupload_idで500を返す", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "SplitNF").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "SplitNF").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
 
         let fake_id = Uuid::new_v4();
@@ -3223,7 +3223,7 @@ async fn test_dtako_internal_download_r2_missing() {
     test_case!("R2にZIPがない場合に500を返す", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "DownR2Miss").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "DownR2Miss").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -3247,7 +3247,7 @@ async fn test_dtako_internal_download_r2_missing() {
 
         // r2_zip_key を設定するが MockStorage には置かない
         {
-            let mut conn = state.pool.acquire().await.unwrap();
+            let mut conn = state.pool().acquire().await.unwrap();
             sqlx::query("UPDATE alc_api.dtako_upload_history SET r2_zip_key = 'nonexistent-key' WHERE id = $1::uuid")
                 .bind(upload_id).execute(&mut *conn).await.unwrap();
         }
@@ -3268,7 +3268,7 @@ async fn test_dtako_internal_rerun_bad_zip() {
     test_case!("壊れたZIPでrerunが400を返す", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "RerunBad").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "RerunBad").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -3293,7 +3293,7 @@ async fn test_dtako_internal_rerun_bad_zip() {
         // r2_zip_key に壊れた ZIP を配置
         let r2_key = format!("{}/bad/{}.zip", tenant_id, upload_id);
         {
-            let mut conn = state.pool.acquire().await.unwrap();
+            let mut conn = state.pool().acquire().await.unwrap();
             sqlx::query(
                 "UPDATE alc_api.dtako_upload_history SET r2_zip_key = $1 WHERE id = $2::uuid",
             )
@@ -3329,7 +3329,7 @@ async fn test_dtako_recalculate_driver_error_event() {
         {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "RecalcErr").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "RecalcErr").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
 
             let fake_id = Uuid::new_v4();
@@ -3357,7 +3357,7 @@ async fn test_dtako_recalculate_drivers_batch_invalid_month() {
     test_case!("無効な月でSSEエラーを返す", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "BatchInvMonth").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "BatchInvMonth").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
 
         let res = reqwest::Client::new()
@@ -3382,7 +3382,7 @@ async fn test_dtako_recalculate_drivers_batch_driver_not_found() {
     test_case!("存在しないドライバーでバッチ完了する", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "BatchNoDriver").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "BatchNoDriver").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
 
         let fake_id = Uuid::new_v4();
@@ -3406,7 +3406,7 @@ async fn test_dtako_internal_rerun_r2_download_fail() {
     test_case!("R2ダウンロード失敗でrerunが500を返す", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "RerunR2Fail").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "RerunR2Fail").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -3429,7 +3429,7 @@ async fn test_dtako_internal_rerun_r2_download_fail() {
 
         // r2_zip_key を存在しないキーに設定 (MockStorage にはアップロードしない)
         {
-            let mut conn = state.pool.acquire().await.unwrap();
+            let mut conn = state.pool().acquire().await.unwrap();
             sqlx::query("UPDATE alc_api.dtako_upload_history SET r2_zip_key = 'nonexistent-key' WHERE id = $1::uuid")
                 .bind(upload_id).execute(&mut *conn).await.unwrap();
         }
@@ -3450,7 +3450,7 @@ async fn test_dtako_internal_download_unicode_filename() {
     test_case!("Unicodeファイル名でダウンロードする", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "DownUnicode").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "DownUnicode").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -3475,7 +3475,7 @@ async fn test_dtako_internal_download_unicode_filename() {
         // r2_zip_key 設定 + storage に配置
         let r2_key = format!("{}/unicode/{}.zip", tenant_id, upload_id);
         {
-            let mut conn = state.pool.acquire().await.unwrap();
+            let mut conn = state.pool().acquire().await.unwrap();
             sqlx::query(
                 "UPDATE alc_api.dtako_upload_history SET r2_zip_key = $1 WHERE id = $2::uuid",
             )
@@ -3565,7 +3565,7 @@ async fn test_dtako_mark_upload_failed_success() {
         use rust_alc_api::routes::dtako_upload::mark_upload_failed;
         let state = common::setup_app_state().await;
         let _base = common::spawn_test_server(state.clone()).await;
-        let mut conn = state.pool.acquire().await.unwrap();
+        let mut conn = state.pool().acquire().await.unwrap();
         mark_upload_failed(&mut conn, Uuid::new_v4(), "test error").await;
     });
 }
@@ -3577,7 +3577,7 @@ async fn test_dtako_mark_upload_failed_db_error() {
         use rust_alc_api::routes::dtako_upload::mark_upload_failed;
         let state = common::setup_app_state().await;
         let _base = common::spawn_test_server(state.clone()).await;
-        let mut conn = state.pool.acquire().await.unwrap();
+        let mut conn = state.pool().acquire().await.unwrap();
         // BEGIN → RENAME → テスト → ROLLBACK (PostgreSQL は DDL も ROLLBACK 可能)
         sqlx::query("BEGIN").execute(&mut *conn).await.unwrap();
         sqlx::query("ALTER TABLE alc_api.dtako_upload_history RENAME TO dtako_upload_history_bak")
@@ -3596,7 +3596,7 @@ async fn test_recalculate_all_core_invalid_month() {
         use rust_alc_api::routes::dtako_upload::recalculate_all_core;
         let state = common::setup_app_state().await;
         let _base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "RecAllInv").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "RecAllInv").await;
         let result = recalculate_all_core(&state, tenant_id, 2026, 13, None).await;
         assert!(result.is_err());
         assert!(result
@@ -3615,7 +3615,7 @@ async fn test_recalculate_all_core_no_kudgivt() {
             use rust_alc_api::routes::dtako_upload::recalculate_all_core;
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "RecAllNoKG").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "RecAllNoKG").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
             let auth = format!("Bearer {jwt}");
             let client = reqwest::Client::new();
@@ -3624,7 +3624,7 @@ async fn test_recalculate_all_core_no_kudgivt() {
                 common::create_test_employee(&client, &base_url, &auth, "NoKGDrv", "NK01").await;
             let emp_id: Uuid = emp["id"].as_str().unwrap().parse().unwrap();
             {
-                let mut conn = state.pool.acquire().await.unwrap();
+                let mut conn = state.pool().acquire().await.unwrap();
                 sqlx::query("SELECT set_config('app.current_tenant_id', $1, true)")
                     .bind(tenant_id.to_string())
                     .execute(&mut *conn)
@@ -3654,7 +3654,7 @@ async fn test_recalculate_all_core_december() {
         use rust_alc_api::routes::dtako_upload::recalculate_all_core;
         let state = common::setup_app_state().await;
         let _base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "RecAllDec").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "RecAllDec").await;
         // operations なし → 0件で成功
         let result = recalculate_all_core(&state, tenant_id, 2025, 12, None).await;
         assert!(result.is_ok());
@@ -3670,7 +3670,7 @@ async fn test_dtako_internal_download_all_japanese_filename() {
         {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "DownJP").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "DownJP").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
             let auth = format!("Bearer {jwt}");
             let client = reqwest::Client::new();
@@ -3694,7 +3694,7 @@ async fn test_dtako_internal_download_all_japanese_filename() {
 
             let r2_key = format!("{}/jp/{}.zip", tenant_id, upload_id);
             {
-                let mut conn = state.pool.acquire().await.unwrap();
+                let mut conn = state.pool().acquire().await.unwrap();
                 sqlx::query(
                     "UPDATE alc_api.dtako_upload_history SET r2_zip_key = $1 WHERE id = $2::uuid",
                 )
@@ -3739,7 +3739,7 @@ async fn test_dtako_recalculate_all_invalid_month() {
     test_case!("recalculate-all SSEが無効な月でエラーを返す", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "RecalcAllInv").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "RecalcAllInv").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
 
         let res = reqwest::Client::new()
@@ -3763,7 +3763,7 @@ async fn test_dtako_recalculate_drivers_batch_december() {
     test_case!("12月のバッチ再計算が成功する", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "BatchDec").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "BatchDec").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
 
         let res = reqwest::Client::new()
@@ -3787,7 +3787,7 @@ async fn test_recalculate_driver_core_december() {
 
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "RecalcDec").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "RecalcDec").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -3795,7 +3795,7 @@ async fn test_recalculate_driver_core_december() {
             common::create_test_employee(&client, &base_url, &auth, "DecDriver", "DC01").await;
         let emp_id: Uuid = emp["id"].as_str().unwrap().parse().unwrap();
         {
-            let mut conn = state.pool.acquire().await.unwrap();
+            let mut conn = state.pool().acquire().await.unwrap();
             sqlx::query("SELECT set_config('app.current_tenant_id', $1, true)")
                 .bind(tenant_id.to_string())
                 .execute(&mut *conn)
@@ -3821,7 +3821,7 @@ async fn test_dtako_recalculate_driver_sse_done() {
         {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "RecalcSSE").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "RecalcSSE").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
             let auth = format!("Bearer {jwt}");
             let client = reqwest::Client::new();
@@ -3830,7 +3830,7 @@ async fn test_dtako_recalculate_driver_sse_done() {
                 common::create_test_employee(&client, &base_url, &auth, "SSEDrv", "SD01").await;
             let emp_id: Uuid = emp["id"].as_str().unwrap().parse().unwrap();
             {
-                let mut conn = state.pool.acquire().await.unwrap();
+                let mut conn = state.pool().acquire().await.unwrap();
                 sqlx::query("SELECT set_config('app.current_tenant_id', $1, true)")
                     .bind(tenant_id.to_string())
                     .execute(&mut *conn)
@@ -3886,7 +3886,7 @@ async fn test_dtako_recalculate_all_no_kudgivt() {
         {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "RecalcNoKGVT").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "RecalcNoKGVT").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
             let auth = format!("Bearer {jwt}");
             let client = reqwest::Client::new();
@@ -3895,7 +3895,7 @@ async fn test_dtako_recalculate_all_no_kudgivt() {
                 common::create_test_employee(&client, &base_url, &auth, "NoKGVTDrv", "NK01").await;
             let emp_id: Uuid = emp["id"].as_str().unwrap().parse().unwrap();
             {
-                let mut conn = state.pool.acquire().await.unwrap();
+                let mut conn = state.pool().acquire().await.unwrap();
                 sqlx::query("SELECT set_config('app.current_tenant_id', $1, true)")
                     .bind(tenant_id.to_string())
                     .execute(&mut *conn)
@@ -3937,7 +3937,7 @@ async fn test_dtako_split_csv_all_empty() {
     test_case!("operationsなしでsplit-csv-allが即done返す", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "SplitAllEmpty").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "SplitAllEmpty").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
 
         // upload も operations もなし → total=0 → 即 done
@@ -3965,7 +3965,7 @@ async fn test_dtako_upload_empty_kudguri() {
 
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "EmptyKud").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "EmptyKud").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
 
@@ -4019,7 +4019,7 @@ async fn test_dtako_upload_empty_cd_fields() {
 
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "EmptyCD").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "EmptyCD").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
             let auth = format!("Bearer {jwt}");
 
@@ -4068,7 +4068,7 @@ async fn test_dtako_upload_edge_cases_302_and_ferry_format() {
 
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "Edge302").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "Edge302").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -4077,7 +4077,7 @@ async fn test_dtako_upload_edge_cases_302_and_ferry_format() {
             common::create_test_employee(&client, &base_url, &auth, "Edge302Drv", "E302").await;
         let emp_id: Uuid = emp["id"].as_str().unwrap().parse().unwrap();
         {
-            let mut conn = state.pool.acquire().await.unwrap();
+            let mut conn = state.pool().acquire().await.unwrap();
             sqlx::query("SELECT set_config('app.current_tenant_id', $1, true)")
                 .bind(tenant_id.to_string())
                 .execute(&mut *conn)
@@ -4156,7 +4156,7 @@ async fn test_dtako_internal_rerun_with_r2_key() {
     test_case!("R2キーありでrerunが成功する", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "RerunR2").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "RerunR2").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -4181,7 +4181,7 @@ async fn test_dtako_internal_rerun_with_r2_key() {
         // r2_zip_key を設定 + MockStorage に ZIP 配置
         let r2_key = format!("{}/zips/{}.zip", tenant_id, upload_id);
         {
-            let mut conn = state.pool.acquire().await.unwrap();
+            let mut conn = state.pool().acquire().await.unwrap();
             sqlx::query(
                 "UPDATE alc_api.dtako_upload_history SET r2_zip_key = $1 WHERE id = $2::uuid",
             )
@@ -4223,7 +4223,7 @@ async fn test_recalculate_drivers_batch_core_invalid_month() {
         use rust_alc_api::routes::dtako_upload::recalculate_drivers_batch_core;
         let state = common::setup_app_state().await;
         let _base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "BatchCoreInv").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "BatchCoreInv").await;
         let result = recalculate_drivers_batch_core(&state, tenant_id, 2026, 13, &[]).await;
         assert!(result.is_err());
     });
@@ -4238,7 +4238,7 @@ async fn test_recalculate_drivers_batch_core_driver_error() {
             use rust_alc_api::routes::dtako_upload::recalculate_drivers_batch_core;
             let state = common::setup_app_state().await;
             let _base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "BatchCoreErr").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "BatchCoreErr").await;
             let fake = Uuid::new_v4();
             let result = recalculate_drivers_batch_core(&state, tenant_id, 2026, 3, &[fake]).await;
             assert!(result.is_ok());
@@ -4256,7 +4256,7 @@ async fn test_split_csv_all_core_empty() {
         use rust_alc_api::routes::dtako_upload::split_csv_all_core;
         let state = common::setup_app_state().await;
         let _base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "SplitCoreEmpty").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "SplitCoreEmpty").await;
         let result = split_csv_all_core(&state, tenant_id).await;
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), (0, 0));
@@ -4270,7 +4270,7 @@ async fn test_split_csv_all_core_with_failures() {
         use rust_alc_api::routes::dtako_upload::split_csv_all_core;
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "SplitCoreFail").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "SplitCoreFail").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -4290,7 +4290,7 @@ async fn test_split_csv_all_core_with_failures() {
             .unwrap();
 
         {
-            let mut conn = state.pool.acquire().await.unwrap();
+            let mut conn = state.pool().acquire().await.unwrap();
             sqlx::query("SELECT set_config('app.current_tenant_id', $1, true)")
                 .bind(tenant_id.to_string())
                 .execute(&mut *conn)
@@ -4335,14 +4335,14 @@ async fn test_recalculate_with_zero_duration_ferry() {
         use rust_alc_api::routes::dtako_upload::recalculate_driver_core;
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "ZeroFerry").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "ZeroFerry").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
         let emp = common::create_test_employee(&client, &base_url, &auth, "ZFDrv", "ZF01").await;
         let emp_id: Uuid = emp["id"].as_str().unwrap().parse().unwrap();
         {
-            let mut conn = state.pool.acquire().await.unwrap();
+            let mut conn = state.pool().acquire().await.unwrap();
             sqlx::query("SELECT set_config('app.current_tenant_id', $1, true)")
                 .bind(tenant_id.to_string())
                 .execute(&mut *conn)
@@ -4395,10 +4395,10 @@ async fn test_dtako_split_csv_all_core_db_error() {
         use rust_alc_api::routes::dtako_upload::split_csv_all_core;
         let state = common::setup_app_state().await;
         let _base = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "SplitDBErr").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "SplitDBErr").await;
 
         // BEGIN → RENAME → split_csv_all_core (Err) → ROLLBACK
-        let mut conn = state.pool.acquire().await.unwrap();
+        let mut conn = state.pool().acquire().await.unwrap();
         sqlx::query("BEGIN").execute(&mut *conn).await.unwrap();
         sqlx::query("ALTER TABLE alc_api.dtako_operations RENAME TO dtako_operations_txerr")
             .execute(&mut *conn)
@@ -4423,7 +4423,7 @@ async fn test_dtako_upload_split_csv_fails_gracefully() {
         use std::io::Write;
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "SplitFail").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "SplitFail").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
 
@@ -4453,7 +4453,7 @@ async fn test_recalculate_with_corrupted_zip_in_r2() {
         use rust_alc_api::routes::dtako_upload::recalculate_driver_core;
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "CorruptZip").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "CorruptZip").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -4462,7 +4462,7 @@ async fn test_recalculate_with_corrupted_zip_in_r2() {
             common::create_test_employee(&client, &base_url, &auth, "CorruptDrv", "CZ01").await;
         let emp_id: Uuid = emp["id"].as_str().unwrap().parse().unwrap();
         {
-            let mut conn = state.pool.acquire().await.unwrap();
+            let mut conn = state.pool().acquire().await.unwrap();
             sqlx::query("SELECT set_config('app.current_tenant_id', $1, true)")
                 .bind(tenant_id.to_string())
                 .execute(&mut *conn)
@@ -4492,7 +4492,7 @@ async fn test_recalculate_with_corrupted_zip_in_r2() {
 
         // upload_history に壊れた ZIP の r2_zip_key を設定
         {
-            let mut conn = state.pool.acquire().await.unwrap();
+            let mut conn = state.pool().acquire().await.unwrap();
             sqlx::query("SELECT set_config('app.current_tenant_id', $1, true)")
                 .bind(tenant_id.to_string())
                 .execute(&mut *conn)
@@ -4524,7 +4524,7 @@ async fn test_recalculate_all_core_bad_kudgivt_csv() {
         use rust_alc_api::routes::dtako_upload::recalculate_all_core;
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "BadKGVTcsv").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "BadKGVTcsv").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -4533,7 +4533,7 @@ async fn test_recalculate_all_core_bad_kudgivt_csv() {
             common::create_test_employee(&client, &base_url, &auth, "BadCsvDrv", "BC01").await;
         let emp_id: Uuid = emp["id"].as_str().unwrap().parse().unwrap();
         {
-            let mut conn = state.pool.acquire().await.unwrap();
+            let mut conn = state.pool().acquire().await.unwrap();
             sqlx::query("SELECT set_config('app.current_tenant_id', $1, true)")
                 .bind(tenant_id.to_string())
                 .execute(&mut *conn)
@@ -4573,7 +4573,7 @@ async fn test_recalculate_with_bad_ferry_data() {
         use rust_alc_api::routes::dtako_upload::recalculate_driver_core;
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "BadFerry").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "BadFerry").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -4582,7 +4582,7 @@ async fn test_recalculate_with_bad_ferry_data() {
             common::create_test_employee(&client, &base_url, &auth, "BadFerryDrv", "BF01").await;
         let emp_id: Uuid = emp["id"].as_str().unwrap().parse().unwrap();
         {
-            let mut conn = state.pool.acquire().await.unwrap();
+            let mut conn = state.pool().acquire().await.unwrap();
             sqlx::query("SELECT set_config('app.current_tenant_id', $1, true)")
                 .bind(tenant_id.to_string())
                 .execute(&mut *conn)
@@ -4633,7 +4633,7 @@ async fn test_recalculate_with_duplicate_zip_keys() {
         use rust_alc_api::routes::dtako_upload::recalculate_driver_core;
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "DupZip").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "DupZip").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -4642,7 +4642,7 @@ async fn test_recalculate_with_duplicate_zip_keys() {
             common::create_test_employee(&client, &base_url, &auth, "DupZipDrv", "DZ01").await;
         let emp_id: Uuid = emp["id"].as_str().unwrap().parse().unwrap();
         {
-            let mut conn = state.pool.acquire().await.unwrap();
+            let mut conn = state.pool().acquire().await.unwrap();
             sqlx::query("SELECT set_config('app.current_tenant_id', $1, true)")
                 .bind(tenant_id.to_string())
                 .execute(&mut *conn)
@@ -4673,7 +4673,7 @@ async fn test_recalculate_with_duplicate_zip_keys() {
         }
         // 同じ r2_zip_key を設定
         {
-            let mut conn = state.pool.acquire().await.unwrap();
+            let mut conn = state.pool().acquire().await.unwrap();
             sqlx::query("SELECT set_config('app.current_tenant_id', $1, true)")
                 .bind(tenant_id.to_string())
                 .execute(&mut *conn)
@@ -4705,7 +4705,7 @@ async fn test_dtako_split_csv_all_with_bad_zip() {
     test_case!("壊れたZIPでsplit-csv-allのSSEイベントを返す", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "SplitBad").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "SplitBad").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -4727,7 +4727,7 @@ async fn test_dtako_split_csv_all_with_bad_zip() {
 
         // r2_zip_key に壊れた ZIP を配置 + has_kudgivt=false
         {
-            let mut conn = state.pool.acquire().await.unwrap();
+            let mut conn = state.pool().acquire().await.unwrap();
             sqlx::query("SELECT set_config('app.current_tenant_id', $1, true)")
                 .bind(tenant_id.to_string())
                 .execute(&mut *conn)
@@ -4815,7 +4815,7 @@ async fn test_upload_triggers_split_failure() {
     test_case!("split失敗でもアップロードは成功する", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "SplitFail2").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "SplitFail2").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
 
@@ -4848,7 +4848,7 @@ async fn test_load_kudgivt_error_paths() {
         use rust_alc_api::routes::dtako_upload::recalculate_driver_core;
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "KGVTErr").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "KGVTErr").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -4857,7 +4857,7 @@ async fn test_load_kudgivt_error_paths() {
             common::create_test_employee(&client, &base_url, &auth, "KGVTErrDrv", "KE01").await;
         let emp_id: Uuid = emp["id"].as_str().unwrap().parse().unwrap();
         {
-            let mut conn = state.pool.acquire().await.unwrap();
+            let mut conn = state.pool().acquire().await.unwrap();
             sqlx::query("SELECT set_config('app.current_tenant_id', $1, true)")
                 .bind(tenant_id.to_string())
                 .execute(&mut *conn)
@@ -4887,7 +4887,7 @@ async fn test_load_kudgivt_error_paths() {
 
         // upload_history に 3つの r2_zip_key を設定: 壊れた ZIP, 存在しないキー, KUDGIVT なし ZIP
         {
-            let mut conn = state.pool.acquire().await.unwrap();
+            let mut conn = state.pool().acquire().await.unwrap();
             sqlx::query("SELECT set_config('app.current_tenant_id', $1, true)")
                 .bind(tenant_id.to_string())
                 .execute(&mut *conn)
@@ -4937,7 +4937,7 @@ async fn test_split_csv_no_kudgivt_in_zip() {
         let _flock = common::db_rename_flock();
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "SplitNoKGVT").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "SplitNoKGVT").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -4965,7 +4965,7 @@ async fn test_split_csv_no_kudgivt_in_zip() {
         // r2_zip_key に KUDGURI のみ ZIP を配置 (KUDGIVT なし)
         let r2_key = format!("{}/nokgvt/{}.zip", tenant_id, upload_id);
         {
-            let mut conn = state.pool.acquire().await.unwrap();
+            let mut conn = state.pool().acquire().await.unwrap();
             sqlx::query(
                 "UPDATE alc_api.dtako_upload_history SET r2_zip_key = $1 WHERE id = $2::uuid",
             )
@@ -5007,7 +5007,7 @@ async fn test_load_kudgivt_parse_error_in_valid_zip() {
             use rust_alc_api::routes::dtako_upload::recalculate_driver_core;
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "KGVTParse").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "KGVTParse").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
             let auth = format!("Bearer {jwt}");
             let client = reqwest::Client::new();
@@ -5017,7 +5017,7 @@ async fn test_load_kudgivt_parse_error_in_valid_zip() {
                     .await;
             let emp_id: Uuid = emp["id"].as_str().unwrap().parse().unwrap();
             {
-                let mut conn = state.pool.acquire().await.unwrap();
+                let mut conn = state.pool().acquire().await.unwrap();
                 sqlx::query("SELECT set_config('app.current_tenant_id', $1, true)")
                     .bind(tenant_id.to_string())
                     .execute(&mut *conn)
@@ -5051,7 +5051,7 @@ async fn test_load_kudgivt_parse_error_in_valid_zip() {
 
             // upload_history に bad_kudgivt_zip を登録
             {
-                let mut conn = state.pool.acquire().await.unwrap();
+                let mut conn = state.pool().acquire().await.unwrap();
                 sqlx::query("SELECT set_config('app.current_tenant_id', $1, true)")
                     .bind(tenant_id.to_string())
                     .execute(&mut *conn)
@@ -5078,7 +5078,7 @@ async fn test_classification_insert_db_error() {
             use rust_alc_api::routes::dtako_upload::recalculate_driver_core;
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "ClsInsErr").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "ClsInsErr").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
             let auth = format!("Bearer {jwt}");
             let client = reqwest::Client::new();
@@ -5087,7 +5087,7 @@ async fn test_classification_insert_db_error() {
                 common::create_test_employee(&client, &base_url, &auth, "ClsErrDrv", "CE01").await;
             let emp_id: Uuid = emp["id"].as_str().unwrap().parse().unwrap();
             {
-                let mut conn = state.pool.acquire().await.unwrap();
+                let mut conn = state.pool().acquire().await.unwrap();
                 sqlx::query("SELECT set_config('app.current_tenant_id', $1, true)")
                     .bind(tenant_id.to_string())
                     .execute(&mut *conn)
@@ -5117,7 +5117,7 @@ async fn test_classification_insert_db_error() {
 
             // 既存の分類を削除 (新イベントとして再登録させるため)
             {
-                let mut conn = state.pool.acquire().await.unwrap();
+                let mut conn = state.pool().acquire().await.unwrap();
                 sqlx::query("DELETE FROM alc_api.dtako_event_classifications WHERE tenant_id = $1")
                     .bind(tenant_id)
                     .execute(&mut *conn)
@@ -5131,12 +5131,12 @@ async fn test_classification_insert_db_error() {
                BEGIN RAISE EXCEPTION 'test: classification insert blocked'; END;
                $$ LANGUAGE plpgsql"#,
             )
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
             sqlx::query(
             "CREATE TRIGGER reject_cls_insert BEFORE INSERT ON alc_api.dtako_event_classifications FOR EACH ROW EXECUTE FUNCTION alc_api.reject_cls_insert()"
-        ).execute(&state.pool).await.unwrap();
+        ).execute(state.pool()).await.unwrap();
 
             // recalculate → load_or_init_classifications → INSERT 失敗 → error log (line 960)
             // 関数は INSERT 失敗を if let Err で捕捉してログ出力、処理は続行
@@ -5146,11 +5146,11 @@ async fn test_classification_insert_db_error() {
 
             // trigger を削除
             sqlx::query("DROP TRIGGER reject_cls_insert ON alc_api.dtako_event_classifications")
-                .execute(&state.pool)
+                .execute(state.pool())
                 .await
                 .unwrap();
             sqlx::query("DROP FUNCTION alc_api.reject_cls_insert()")
-                .execute(&state.pool)
+                .execute(state.pool())
                 .await
                 .unwrap();
         }
@@ -5163,7 +5163,7 @@ async fn test_has_kudgivt_update_error() {
     test_case!("has_kudgivt UPDATE失敗時にログ出力する", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "HasKGVTErr").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "HasKGVTErr").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -5188,7 +5188,7 @@ async fn test_has_kudgivt_update_error() {
 
         // has_kudgivt を FALSE にリセット (split-csv で TRUE に変更させるため)
         {
-            let mut conn = state.pool.acquire().await.unwrap();
+            let mut conn = state.pool().acquire().await.unwrap();
             sqlx::query("SELECT set_config('app.current_tenant_id', $1, true)")
                 .bind(tenant_id.to_string())
                 .execute(&mut *conn)
@@ -5214,12 +5214,12 @@ async fn test_has_kudgivt_update_error() {
                END;
                $$ LANGUAGE plpgsql"#,
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
         sqlx::query(
             "CREATE TRIGGER reject_ops_update BEFORE UPDATE ON alc_api.dtako_operations FOR EACH ROW EXECUTE FUNCTION alc_api.reject_ops_update()"
-        ).execute(&state.pool).await.unwrap();
+        ).execute(state.pool()).await.unwrap();
 
         // split-csv → KUDGIVT あり → has_kudgivt UPDATE → trigger で拒否 → error log (line 1117)
         let res = client
@@ -5233,11 +5233,11 @@ async fn test_has_kudgivt_update_error() {
 
         // trigger を削除
         sqlx::query("DROP TRIGGER reject_ops_update ON alc_api.dtako_operations")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
         sqlx::query("DROP FUNCTION alc_api.reject_ops_update()")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
     });
@@ -5250,13 +5250,13 @@ async fn test_split_csv_all_sse_error_path() {
         "split_csv_all_coreのErrでSSEエラーイベントを返す",
         {
             let state = common::setup_app_state().await;
-            let tenant_id = common::create_test_tenant(&state.pool, "SSESplitErr").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "SSESplitErr").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
             let auth = format!("Bearer {jwt}");
             let base_url = common::spawn_test_server(state.clone()).await;
 
             // pool を閉じて DB エラーを発生させる (他テストに影響しない)
-            state.pool.close().await;
+            state.pool().close().await;
 
             let client = reqwest::Client::new();
             // SSE エンドポイント呼び出し
@@ -5280,7 +5280,7 @@ async fn test_ferry_no_matching_kudgivt_events() {
         use rust_alc_api::routes::dtako_upload::recalculate_driver_core;
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "FerryNoKGVT").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "FerryNoKGVT").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -5289,7 +5289,7 @@ async fn test_ferry_no_matching_kudgivt_events() {
             common::create_test_employee(&client, &base_url, &auth, "FerryNoKDrv", "FK01").await;
         let emp_id: Uuid = emp["id"].as_str().unwrap().parse().unwrap();
         {
-            let mut conn = state.pool.acquire().await.unwrap();
+            let mut conn = state.pool().acquire().await.unwrap();
             sqlx::query("SELECT set_config('app.current_tenant_id', $1, true)")
                 .bind(tenant_id.to_string())
                 .execute(&mut *conn)
@@ -5319,7 +5319,7 @@ async fn test_ferry_no_matching_kudgivt_events() {
 
         // unko_no=9999 の operation を追加 (KUDGIVT にはイベントなし)
         {
-            let mut conn = state.pool.acquire().await.unwrap();
+            let mut conn = state.pool().acquire().await.unwrap();
             sqlx::query("SELECT set_config('app.current_tenant_id', $1, true)")
                 .bind(tenant_id.to_string())
                 .execute(&mut *conn)
@@ -5360,7 +5360,7 @@ async fn test_ferry_parse_invalid_datetime() {
         use rust_alc_api::routes::dtako_upload::recalculate_driver_core;
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "FerryBadDT").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "FerryBadDT").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -5369,7 +5369,7 @@ async fn test_ferry_parse_invalid_datetime() {
             common::create_test_employee(&client, &base_url, &auth, "FerryBadDTDrv", "FD01").await;
         let emp_id: Uuid = emp["id"].as_str().unwrap().parse().unwrap();
         {
-            let mut conn = state.pool.acquire().await.unwrap();
+            let mut conn = state.pool().acquire().await.unwrap();
             sqlx::query("SELECT set_config('app.current_tenant_id', $1, true)")
                 .bind(tenant_id.to_string())
                 .execute(&mut *conn)
@@ -5424,7 +5424,7 @@ async fn test_split_csv_with_kudgivt_zip() {
         let _flock = common::db_rename_flock();
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "SplitKGVT").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "SplitKGVT").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -5465,7 +5465,7 @@ async fn test_ferry_short_columns() {
         use rust_alc_api::routes::dtako_upload::recalculate_driver_core;
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "FerryShort").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "FerryShort").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -5474,7 +5474,7 @@ async fn test_ferry_short_columns() {
             common::create_test_employee(&client, &base_url, &auth, "FerryShortDrv", "FS01").await;
         let emp_id: Uuid = emp["id"].as_str().unwrap().parse().unwrap();
         {
-            let mut conn = state.pool.acquire().await.unwrap();
+            let mut conn = state.pool().acquire().await.unwrap();
             sqlx::query("SELECT set_config('app.current_tenant_id', $1, true)")
                 .bind(tenant_id.to_string())
                 .execute(&mut *conn)
@@ -5527,7 +5527,7 @@ async fn test_split_csv_with_non_csv_file_in_zip() {
         use std::io::Write;
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "SplitNonCSV").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "SplitNonCSV").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -5593,7 +5593,7 @@ async fn test_upload_split_csv_from_r2_error_via_trigger() {
             let _flock = common::db_rename_flock();
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "SplitTrig").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "SplitTrig").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
             let auth = format!("Bearer {jwt}");
             let client = reqwest::Client::new();
@@ -5609,12 +5609,12 @@ async fn test_upload_split_csv_from_r2_error_via_trigger() {
                END;
                $$ LANGUAGE plpgsql"#,
             )
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
             sqlx::query(
                 "CREATE TRIGGER corrupt_r2_key BEFORE UPDATE ON alc_api.dtako_upload_history FOR EACH ROW EXECUTE FUNCTION alc_api.corrupt_r2_key()"
-            ).execute(&state.pool).await.unwrap();
+            ).execute(state.pool()).await.unwrap();
 
             // upload → process_zip 成功 → status='completed' UPDATE → trigger が r2_zip_key を壊す
             // → try_split_csv 内の split_csv_from_r2 が壊れたキーで download 試行 → Err → warn log
@@ -5635,11 +5635,11 @@ async fn test_upload_split_csv_from_r2_error_via_trigger() {
 
             // trigger を削除
             sqlx::query("DROP TRIGGER corrupt_r2_key ON alc_api.dtako_upload_history")
-                .execute(&state.pool)
+                .execute(state.pool())
                 .await
                 .unwrap();
             sqlx::query("DROP FUNCTION alc_api.corrupt_r2_key()")
-                .execute(&state.pool)
+                .execute(state.pool())
                 .await
                 .unwrap();
         }
@@ -5651,7 +5651,7 @@ async fn test_upload_split_csv_from_r2_error() {
     test_case!("存在しないR2キーでsplit-csvが500を返す", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "SplitR2Err").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "SplitR2Err").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -5692,7 +5692,7 @@ async fn test_upload_split_csv_from_r2_error() {
 
         // r2_zip_key を存在しないキーに更新 → split-csv endpoint で download 失敗
         {
-            let mut conn = state.pool.acquire().await.unwrap();
+            let mut conn = state.pool().acquire().await.unwrap();
             sqlx::query("UPDATE alc_api.dtako_upload_history SET r2_zip_key = 'nonexistent-r2-key' WHERE id = $1::uuid")
                 .bind(&upload_id).execute(&mut *conn).await.unwrap();
         }
@@ -5717,7 +5717,7 @@ async fn test_restraint_report_invalid_year_month() {
     test_case!("無効な year/month → 400 BAD_REQUEST (L221)", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "RRInvMonth").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "RRInvMonth").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -5760,7 +5760,7 @@ async fn test_restraint_report_december() {
     test_case!("month=12 → 年越し処理 (L224)", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "RRDec").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "RRDec").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -5796,7 +5796,7 @@ async fn test_restraint_report_db_error_internal_err() {
         let _flock = common::db_rename_flock();
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "RRDbErr").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "RRDbErr").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -5810,7 +5810,7 @@ async fn test_restraint_report_db_error_internal_err() {
         sqlx::query(
             "ALTER TABLE alc_api.dtako_daily_work_segments RENAME TO dtako_daily_work_segments_bak",
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -5833,7 +5833,7 @@ async fn test_restraint_report_db_error_internal_err() {
         sqlx::query(
             "ALTER TABLE alc_api.dtako_daily_work_segments_bak RENAME TO dtako_daily_work_segments",
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
     });
@@ -5845,7 +5845,7 @@ async fn test_restraint_report_compare_csv_upload() {
     test_case!("multipart CSV アップロード (L719-731)", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "RRCmpCSV").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "RRCmpCSV").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -5903,7 +5903,7 @@ async fn test_restraint_report_compare_csv_with_driver_filter() {
     test_case!("driver_cd フィルター付き CSV 比較", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "RRCmpFilt").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "RRCmpFilt").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -5916,7 +5916,7 @@ async fn test_restraint_report_compare_csv_with_driver_filter() {
         // driver_cd を設定
         sqlx::query("UPDATE alc_api.employees SET driver_cd = 'FILT01' WHERE id = $1::uuid")
             .bind(emp_id)
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
 
@@ -6018,7 +6018,7 @@ async fn test_restraint_report_last_day_drive_avg_and_weekly_subtotal() {
         {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "RRLastDay").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "RRLastDay").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
             let auth = format!("Bearer {jwt}");
             let client = reqwest::Client::new();
@@ -6030,7 +6030,7 @@ async fn test_restraint_report_last_day_drive_avg_and_weekly_subtotal() {
             let emp_id: uuid::Uuid = emp["id"].as_str().unwrap().parse().unwrap();
 
             // 平日 (2026-03-02=月, 03=火) に直接 DB INSERT
-            let mut conn = state.pool.acquire().await.unwrap();
+            let mut conn = state.pool().acquire().await.unwrap();
             sqlx::query(&format!(
                 "SELECT set_config('app.current_tenant_id', '{}', false)",
                 tenant_id
@@ -6128,7 +6128,7 @@ async fn test_restraint_report_empty_dwh_list() {
         {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "RRNoDwh").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "RRNoDwh").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
             let auth = format!("Bearer {jwt}");
             let client = reqwest::Client::new();
@@ -6142,7 +6142,7 @@ async fn test_restraint_report_empty_dwh_list() {
 
             // segments を直接 INSERT (dwh は INSERT しない) → dwh_list = None → vec![None]
             {
-                let mut conn = state.pool.acquire().await.unwrap();
+                let mut conn = state.pool().acquire().await.unwrap();
                 sqlx::query("SELECT set_config('app.current_tenant_id', $1, false)")
                     .bind(tenant_id.to_string())
                     .execute(&mut *conn)

--- a/tests/employees_test.rs
+++ b/tests/employees_test.rs
@@ -16,8 +16,8 @@ async fn test_tenant_isolation() {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
 
-            let tenant_a = common::create_test_tenant(&state.pool, "Tenant A").await;
-            let tenant_b = common::create_test_tenant(&state.pool, "Tenant B").await;
+            let tenant_a = common::create_test_tenant(state.pool(), "Tenant A").await;
+            let tenant_b = common::create_test_tenant(state.pool(), "Tenant B").await;
 
             let jwt_a = common::create_test_jwt(tenant_a, "admin");
             let jwt_b = common::create_test_jwt(tenant_b, "admin");
@@ -76,7 +76,7 @@ async fn test_kiosk_mode_with_tenant_header() {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
 
-            let tenant_id = common::create_test_tenant(&state.pool, "Kiosk Tenant").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "Kiosk Tenant").await;
 
             let client = reqwest::Client::new();
 
@@ -102,7 +102,7 @@ async fn test_create_employee() {
     test_case!("従業員を作成できること", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "Create Emp").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "Create Emp").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -130,7 +130,7 @@ async fn test_create_employee_with_optional_fields() {
         {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "Opt Fields").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "Opt Fields").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
             let client = reqwest::Client::new();
 
@@ -164,7 +164,7 @@ async fn test_list_employees_empty() {
         {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "Empty List").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "Empty List").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
             let client = reqwest::Client::new();
 
@@ -187,7 +187,7 @@ async fn test_list_employees_returns_created() {
     test_case!("作成した従業員が一覧に表示されること", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "List Emp").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "List Emp").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -216,7 +216,7 @@ async fn test_get_employee_by_id() {
     test_case!("IDで従業員を取得できること", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "Get Emp").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "Get Emp").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -242,7 +242,7 @@ async fn test_get_employee_not_found() {
     test_case!("存在しない従業員IDで404を返すこと", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "Not Found").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "Not Found").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -263,7 +263,7 @@ async fn test_update_employee() {
     test_case!("従業員情報を更新できること", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "Update Emp").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "Update Emp").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -291,7 +291,7 @@ async fn test_delete_employee() {
     test_case!("従業員を削除できること", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "Delete Emp").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "Delete Emp").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -324,7 +324,7 @@ async fn test_delete_employee_not_found() {
     test_case!("存在しない従業員の削除で404を返すこと", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "Del NF").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "Del NF").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -345,7 +345,7 @@ async fn test_get_employee_by_nfc() {
     test_case!("NFC IDで従業員を取得できること", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "NFC Emp").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "NFC Emp").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -379,7 +379,7 @@ async fn test_get_employee_by_code() {
     test_case!("コードで従業員を取得できること", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "Code Emp").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "Code Emp").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -408,7 +408,7 @@ async fn test_update_nfc_id() {
     test_case!("NFC IDを更新できること", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "NfcUpdate").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "NfcUpdate").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -435,7 +435,7 @@ async fn test_update_license() {
     test_case!("免許情報を更新できること", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "LicUpdate").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "LicUpdate").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -463,7 +463,7 @@ async fn test_update_face_invalid_embedding() {
     test_case!("不正な次元のembeddingで400を返すこと", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "FaceInv").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "FaceInv").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -493,7 +493,7 @@ async fn test_update_face_and_approve() {
         {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "FaceApprove").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "FaceApprove").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
             let auth = format!("Bearer {jwt}");
             let client = reqwest::Client::new();
@@ -549,7 +549,7 @@ async fn test_update_face_and_reject() {
     test_case!("顔登録して却下できること", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "FaceReject").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "FaceReject").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -589,7 +589,7 @@ async fn test_list_face_data_empty() {
         {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "Face Data").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "Face Data").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
             let client = reqwest::Client::new();
 
@@ -618,7 +618,7 @@ async fn test_update_face_valid_embedding_pending() {
         {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "FacePend").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "FacePend").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
             let auth = format!("Bearer {jwt}");
             let client = reqwest::Client::new();
@@ -663,7 +663,7 @@ async fn test_face_approve_visible_in_face_data() {
     test_case!("承認後にface-dataに表示されること", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "FaceVis").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "FaceVis").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -720,7 +720,7 @@ async fn test_face_reject_not_in_face_data() {
         {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "FaceRejND").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "FaceRejND").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
             let auth = format!("Bearer {jwt}");
             let client = reqwest::Client::new();
@@ -776,7 +776,7 @@ async fn test_face_approve_non_pending_returns_404() {
     test_case!("pending以外の従業員の承認で404を返すこと", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "FaceAppNP").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "FaceAppNP").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -802,7 +802,7 @@ async fn test_face_reject_non_pending_returns_404() {
     test_case!("pending以外の従業員の却下で404を返すこと", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "FaceRejNP").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "FaceRejNP").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -829,7 +829,7 @@ async fn test_face_reregister_resets_to_pending() {
         {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "FaceReReg").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "FaceReReg").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
             let auth = format!("Bearer {jwt}");
             let client = reqwest::Client::new();
@@ -899,7 +899,7 @@ async fn test_update_face_nonexistent_employee() {
         {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "FaceNE").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "FaceNE").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
             let client = reqwest::Client::new();
 
@@ -928,7 +928,7 @@ async fn test_update_face_photo_only_no_status_change() {
         {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "FacePhoto").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "FacePhoto").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
             let auth = format!("Bearer {jwt}");
             let client = reqwest::Client::new();
@@ -970,7 +970,7 @@ async fn test_update_employee_code_conflict() {
     test_case!("重複コードで更新すると409", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "CodeConflict").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "CodeConflict").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();

--- a/tests/measurements_test.rs
+++ b/tests/measurements_test.rs
@@ -16,7 +16,7 @@ async fn setup() -> (
 ) {
     let state = common::setup_app_state().await;
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "Meas Test").await;
+    let tenant_id = common::create_test_tenant(state.pool(), "Meas Test").await;
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let client = reqwest::Client::new();
     (state, base_url, tenant_id, jwt, client)
@@ -405,8 +405,8 @@ async fn test_measurement_tenant_isolation() {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
 
-        let tenant_a = common::create_test_tenant(&state.pool, "Meas Iso A").await;
-        let tenant_b = common::create_test_tenant(&state.pool, "Meas Iso B").await;
+        let tenant_a = common::create_test_tenant(state.pool(), "Meas Iso A").await;
+        let tenant_b = common::create_test_tenant(state.pool(), "Meas Iso B").await;
 
         let jwt_a = common::create_test_jwt(tenant_a, "admin");
         let jwt_b = common::create_test_jwt(tenant_b, "admin");

--- a/tests/misc_routes_test.rs
+++ b/tests/misc_routes_test.rs
@@ -13,7 +13,7 @@ async fn test_tenko_call_list_numbers() {
     test_case!("電話番号マスタ一覧を取得できる", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "Tenko Call").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "Tenko Call").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -39,7 +39,7 @@ async fn test_tenko_call_list_drivers() {
     test_case!("登録運転者一覧を取得できる", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "Tenko Drivers").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "Tenko Drivers").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -62,7 +62,7 @@ async fn test_tenko_call_register_driver() {
         {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "Tenko Reg").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "Tenko Reg").await;
             let client = reqwest::Client::new();
 
             // 電話番号マスタを直接 DB に INSERT (ユニーク制約のためランダム化)
@@ -74,7 +74,7 @@ async fn test_tenko_call_register_driver() {
             .bind(&call_number)
             .bind(tenant_id.to_string())
             .bind("営業所")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
 
@@ -110,7 +110,7 @@ async fn test_timecard_cards_crud() {
     test_case!("カードのCRUD操作ができる", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "Timecard").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "Timecard").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -192,7 +192,7 @@ async fn test_timecard_punch() {
     test_case!("カードIDで打刻できる", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "Punch").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "Punch").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -232,7 +232,7 @@ async fn test_timecard_punches_list() {
     test_case!("打刻一覧を取得できる", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "Punches List").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "Punches List").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -257,7 +257,7 @@ async fn test_tenko_schedules_list() {
     test_case!("スケジュール一覧を取得できる", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "Tenko Sched").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "Tenko Sched").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -281,7 +281,7 @@ async fn test_tenko_sessions_list() {
     test_case!("セッション一覧を取得できる", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "Tenko Sess").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "Tenko Sess").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -305,7 +305,7 @@ async fn test_tenko_records_list() {
     test_case!("点呼記録一覧を取得できる", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "Tenko Rec").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "Tenko Rec").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -329,7 +329,7 @@ async fn test_health_baselines_list() {
     test_case!("健康基準値一覧を取得できる", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "Health BL").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "Health BL").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -353,7 +353,7 @@ async fn test_equipment_failures_list() {
     test_case!("機器故障一覧を取得できる", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "Equip Fail").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "Equip Fail").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -377,7 +377,7 @@ async fn test_tenko_webhooks_list() {
     test_case!("Webhook一覧を取得できる", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "Webhooks").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "Webhooks").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -401,7 +401,7 @@ async fn test_carrying_items_crud() {
     test_case!("携行品目のCRUD操作ができる", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "Carry CRUD").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "Carry CRUD").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -447,7 +447,7 @@ async fn test_communication_items_crud() {
         let _flock = common::db_rename_flock();
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "Comm CRUD").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "Comm CRUD").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -508,7 +508,7 @@ async fn test_carrying_items_list() {
     test_case!("携行品目一覧を取得できる", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "Carrying").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "Carrying").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -532,7 +532,7 @@ async fn test_communication_items_list() {
     test_case!("連絡事項一覧を取得できる", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "Comms").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "Comms").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -556,7 +556,7 @@ async fn test_guidance_records_crud() {
     test_case!("指導記録のCRUD操作ができる", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "Guidance").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "Guidance").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -651,7 +651,7 @@ async fn test_guidance_records_upload_attachment() {
         {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "GuidAtt").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "GuidAtt").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
             let auth = format!("Bearer {jwt}");
             let client = reqwest::Client::new();
@@ -717,7 +717,7 @@ async fn test_guidance_records_list_with_date_filter() {
         {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "GuidDate").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "GuidDate").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
             let auth = format!("Bearer {jwt}");
             let client = reqwest::Client::new();
@@ -741,9 +741,9 @@ async fn test_tenant_users_list() {
     test_case!("テナントユーザー一覧を取得できる", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "TenantUsers").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "TenantUsers").await;
         let (user_id, _) =
-            common::create_test_user_in_db(&state.pool, tenant_id, "tu@test.com", "admin").await;
+            common::create_test_user_in_db(state.pool(), tenant_id, "tu@test.com", "admin").await;
         let jwt = common::create_test_jwt_for_user(user_id, tenant_id, "tu@test.com", "admin");
         let client = reqwest::Client::new();
 
@@ -769,9 +769,9 @@ async fn test_tenant_users_invite_and_delete() {
         {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "TUInvite").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "TUInvite").await;
             let (user_id, _) = common::create_test_user_in_db(
-                &state.pool,
+                state.pool(),
                 tenant_id,
                 "admin-tu@test.com",
                 "admin",
@@ -831,7 +831,7 @@ async fn test_tenant_users_invite_and_delete() {
             // delete user
             // 他のユーザーを作成して削除
             let (other_id, _) = common::create_test_user_in_db(
-                &state.pool,
+                state.pool(),
                 tenant_id,
                 "other-tu@test.com",
                 "viewer",
@@ -858,7 +858,7 @@ async fn test_daily_health_status() {
     test_case!("日次健康状態を取得できる", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "DailyHealth").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "DailyHealth").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -878,7 +878,7 @@ async fn test_daily_health_status_with_date() {
     test_case!("日付指定で日次健康状態を取得できる", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "DailyHealthD").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "DailyHealthD").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -904,7 +904,7 @@ async fn test_driver_info() {
     test_case!("従業員IDで運転者情報を取得できる", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "DriverInfo").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "DriverInfo").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -932,7 +932,7 @@ async fn test_timecard_punches_csv() {
     test_case!("打刻データをCSVエクスポートできる", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "CSV Punch").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "CSV Punch").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -978,7 +978,7 @@ async fn test_timecard_punches_with_filter() {
         {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "FilterPunch").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "FilterPunch").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
             let auth = format!("Bearer {jwt}");
             let client = reqwest::Client::new();
@@ -1013,7 +1013,7 @@ async fn test_carins_files_delete_then_download() {
     test_case!("ファイル削除後に一覧から除外される", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "CarinsDel").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "CarinsDel").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -1081,7 +1081,7 @@ async fn test_timecard_punch_nfc_fallback() {
         {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "NfcPunch").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "NfcPunch").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
             let auth = format!("Bearer {jwt}");
             let client = reqwest::Client::new();
@@ -1099,7 +1099,7 @@ async fn test_timecard_punch_nfc_fallback() {
             sqlx::query("UPDATE alc_api.employees SET nfc_id = $1 WHERE id = $2::uuid")
                 .bind(&nfc_id)
                 .bind(emp_id)
-                .execute(&state.pool)
+                .execute(state.pool())
                 .await
                 .unwrap();
 
@@ -1128,7 +1128,7 @@ async fn test_timecard_get_card_by_card_id_not_found() {
     test_case!("存在しないcard_idで取得すると404を返す", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "CardNotFound").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "CardNotFound").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -1157,7 +1157,7 @@ async fn test_timecard_csv_with_employee_filter() {
         {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "CsvFilter").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "CsvFilter").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
             let auth = format!("Bearer {jwt}");
             let client = reqwest::Client::new();
@@ -1216,7 +1216,7 @@ async fn test_communication_items_create_all_fields_and_list_active() {
         {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "CommAll").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "CommAll").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
             let auth = format!("Bearer {jwt}");
             let client = reqwest::Client::new();
@@ -1300,7 +1300,7 @@ async fn test_health_baselines_update_with_put() {
     test_case!("POST作成後にPUTで部分更新できる", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "HBUpdate").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "HBUpdate").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -1364,7 +1364,7 @@ async fn test_health_baselines_upsert_twice_no_duplicate() {
     test_case!("同一従業員に2回upsertしても重複しない", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "HBUpsert").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "HBUpsert").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -1432,7 +1432,7 @@ async fn test_tenko_call_tenko() {
         {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "TenkoSend").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "TenkoSend").await;
             let client = reqwest::Client::new();
 
             // 電話番号マスタ + ドライバー登録
@@ -1442,7 +1442,7 @@ async fn test_tenko_call_tenko() {
             sqlx::query("INSERT INTO tenko_call_numbers (call_number, tenant_id) VALUES ($1, $2)")
                 .bind(&call_num)
                 .bind(tenant_id.to_string())
-                .execute(&state.pool)
+                .execute(state.pool())
                 .await
                 .unwrap();
 
@@ -1482,7 +1482,7 @@ async fn test_tenko_call_delete_number() {
     test_case!("電話番号マスタを削除できる", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "TenkoDelNum").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "TenkoDelNum").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -1493,7 +1493,7 @@ async fn test_tenko_call_delete_number() {
         )
         .bind(&call_num)
         .bind(tenant_id.to_string())
-        .fetch_one(&state.pool)
+        .fetch_one(state.pool())
         .await
         .unwrap();
 
@@ -1517,7 +1517,7 @@ async fn test_car_inspections_current() {
     test_case!("有効な車検証一覧を取得できる", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "CarIns").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "CarIns").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -1537,7 +1537,7 @@ async fn test_car_inspections_expired() {
     test_case!("期限切れ車検証一覧を取得できる", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "CarInsExp").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "CarInsExp").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -1557,7 +1557,7 @@ async fn test_car_inspections_renew() {
     test_case!("更新対象の車検証一覧を取得できる", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "CarInsRen").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "CarInsRen").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -1577,7 +1577,7 @@ async fn test_car_inspections_vehicle_categories() {
     test_case!("車両カテゴリ一覧を取得できる", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "VehCat").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "VehCat").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -1601,7 +1601,7 @@ async fn test_car_inspection_files_current() {
     test_case!("有効な車検証ファイル一覧を取得できる", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "CarInsFiles").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "CarInsFiles").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -1627,7 +1627,7 @@ async fn test_guidance_records_child_record() {
         {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "GuidChild").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "GuidChild").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
             let auth = format!("Bearer {jwt}");
             let client = reqwest::Client::new();
@@ -1709,7 +1709,7 @@ async fn test_guidance_records_attachments_empty_after_creation() {
     test_case!("作成直後の添付ファイル一覧は空である", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "GuidAtt").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "GuidAtt").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -1764,7 +1764,7 @@ async fn test_guidance_records_filter_by_guidance_type() {
         {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "GuidType").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "GuidType").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
             let auth = format!("Bearer {jwt}");
             let client = reqwest::Client::new();
@@ -1870,7 +1870,7 @@ async fn test_carrying_items_with_vehicle_conditions() {
         {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "CarryVC").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "CarryVC").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
             let auth = format!("Bearer {jwt}");
             let client = reqwest::Client::new();
@@ -1969,7 +1969,7 @@ async fn test_car_inspections_get_by_fake_id_returns_404() {
         {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "CarIns404").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "CarIns404").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
             let client = reqwest::Client::new();
 
@@ -1997,9 +1997,9 @@ async fn test_bot_admin_update_config() {
         std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "BotUpd").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "BotUpd").await;
         let (user_id, _) =
-            common::create_test_user_in_db(&state.pool, tenant_id, "botupd@test.com", "admin")
+            common::create_test_user_in_db(state.pool(), tenant_id, "botupd@test.com", "admin")
                 .await;
         let jwt = common::create_test_jwt_for_user(user_id, tenant_id, "botupd@test.com", "admin");
         let auth = format!("Bearer {jwt}");
@@ -2041,7 +2041,7 @@ async fn test_nfc_tags_list() {
     test_case!("NFCタグ一覧を取得できる", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "NFC Tags").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "NFC Tags").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -2067,7 +2067,7 @@ async fn test_timecard_punches_with_date_filter() {
         {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "PunchDateF").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "PunchDateF").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
             let auth = format!("Bearer {jwt}");
             let client = reqwest::Client::new();
@@ -2123,7 +2123,7 @@ async fn test_timecard_csv_with_date_filter() {
         {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "CsvDateF").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "CsvDateF").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
             let auth = format!("Bearer {jwt}");
             let client = reqwest::Client::new();
@@ -2181,7 +2181,7 @@ async fn test_tenko_call_register_invalid_call_number() {
         {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let _tenant_id = common::create_test_tenant(&state.pool, "TenkoBadReg").await;
+            let _tenant_id = common::create_test_tenant(state.pool(), "TenkoBadReg").await;
             let client = reqwest::Client::new();
 
             // 存在しない call_number で登録 → 400
@@ -2214,7 +2214,7 @@ async fn test_tenko_call_tenko_unregistered_phone() {
     test_case!("未登録の電話番号で点呼すると404を返す", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let _tenant_id = common::create_test_tenant(&state.pool, "TenkoNoPhone").await;
+        let _tenant_id = common::create_test_tenant(state.pool(), "TenkoNoPhone").await;
         let client = reqwest::Client::new();
 
         // 未登録の電話番号で点呼 → 404
@@ -2244,7 +2244,7 @@ async fn test_tenko_webhook_deliveries() {
     test_case!("Webhook作成後にdeliveries一覧を取得できる", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "WhDeliv").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "WhDeliv").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -2302,14 +2302,14 @@ async fn test_nfc_tags_crud() {
     test_case!("NFCタグの登録・検索・削除ができる", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "NFC CRUD").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "NFC CRUD").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
 
         // car_inspection テーブルに最小行を INSERT (NFC タグの FK に必要)
         // RLS を通すために set_current_tenant してから INSERT
-        let mut conn = state.pool.acquire().await.unwrap();
+        let mut conn = state.pool().acquire().await.unwrap();
         sqlx::query("SELECT set_config('app.current_tenant_id', $1, true)")
             .bind(tenant_id.to_string())
             .execute(&mut *conn)
@@ -2499,13 +2499,13 @@ async fn test_nfc_tags_upsert() {
         {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "NFC Upsert").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "NFC Upsert").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
             let auth = format!("Bearer {jwt}");
             let client = reqwest::Client::new();
 
             // Insert 2 car_inspection rows for the upsert test
-            let mut conn = state.pool.acquire().await.unwrap();
+            let mut conn = state.pool().acquire().await.unwrap();
             sqlx::query("SELECT set_config('app.current_tenant_id', $1, true)")
                 .bind(tenant_id.to_string())
                 .execute(&mut *conn)
@@ -2651,7 +2651,7 @@ async fn tenko_completed_classifications_after_upload_and_update() {
         {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "EC Update").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "EC Update").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
             let auth = format!("Bearer {jwt}");
             let client = reqwest::Client::new();
@@ -2742,7 +2742,7 @@ async fn test_dtako_csv_proxy_kudguri() {
     test_case!("KUDGURI CSVをJSON形式で取得できる", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "CsvProxy").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "CsvProxy").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -2790,7 +2790,7 @@ async fn test_dtako_csv_proxy_kudgivt() {
         {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
-            let tenant_id = common::create_test_tenant(&state.pool, "CsvProxyEvt").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "CsvProxyEvt").await;
             let jwt = common::create_test_jwt(tenant_id, "admin");
             let auth = format!("Bearer {jwt}");
             let client = reqwest::Client::new();
@@ -2839,10 +2839,10 @@ async fn test_webhook_deliver_connection_error() {
             use rust_alc_api::db::models::WebhookConfig;
 
             let state = common::setup_app_state().await;
-            let tenant_id = common::create_test_tenant(&state.pool, "WhConnErr").await;
+            let tenant_id = common::create_test_tenant(state.pool(), "WhConnErr").await;
 
             // set tenant for inserts
-            let mut conn = state.pool.acquire().await.unwrap();
+            let mut conn = state.pool().acquire().await.unwrap();
             rust_alc_api::db::tenant::set_current_tenant(&mut conn, &tenant_id.to_string())
                 .await
                 .unwrap();
@@ -2875,7 +2875,7 @@ async fn test_webhook_deliver_connection_error() {
 
             // deliver_webhook should retry 3 times and return Ok(()) even on failure
             let result = rust_alc_api::webhook::deliver_webhook(
-                &state.pool,
+                state.pool(),
                 &config,
                 "tenko_completed",
                 &payload,
@@ -2884,7 +2884,7 @@ async fn test_webhook_deliver_connection_error() {
             assert!(result.is_ok());
 
             // Check that delivery logs were recorded (3 attempts, all failed)
-            let mut conn = state.pool.acquire().await.unwrap();
+            let mut conn = state.pool().acquire().await.unwrap();
             rust_alc_api::db::tenant::set_current_tenant(&mut conn, &tenant_id.to_string())
                 .await
                 .unwrap();
@@ -2905,10 +2905,10 @@ async fn test_webhook_fire_event_delivery_error_logged() {
     test_group!("Webhook配信");
     test_case!("fire_event でエラー時にログ記録される", {
         let state = common::setup_app_state().await;
-        let tenant_id = common::create_test_tenant(&state.pool, "WhFireErr").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "WhFireErr").await;
 
         // set tenant for inserts
-        let mut conn = state.pool.acquire().await.unwrap();
+        let mut conn = state.pool().acquire().await.unwrap();
         rust_alc_api::db::tenant::set_current_tenant(&mut conn, &tenant_id.to_string())
             .await
             .unwrap();
@@ -2930,7 +2930,7 @@ async fn test_webhook_fire_event_delivery_error_logged() {
 
         // fire_event spawns deliver_webhook in background; itself returns Ok
         let result =
-            rust_alc_api::webhook::fire_event(&state.pool, tenant_id, "tenko_overdue", payload)
+            rust_alc_api::webhook::fire_event(state.pool(), tenant_id, "tenko_overdue", payload)
                 .await;
         assert!(result.is_ok());
 
@@ -2939,7 +2939,7 @@ async fn test_webhook_fire_event_delivery_error_logged() {
         tokio::time::sleep(std::time::Duration::from_secs(3)).await;
 
         // Verify delivery attempts were logged
-        let mut conn = state.pool.acquire().await.unwrap();
+        let mut conn = state.pool().acquire().await.unwrap();
         rust_alc_api::db::tenant::set_current_tenant(&mut conn, &tenant_id.to_string())
             .await
             .unwrap();
@@ -2968,7 +2968,7 @@ async fn test_timecard_create_card_conflict() {
     test_case!("重複カードIDで409を返す", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "TC Conflict").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "TC Conflict").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -3011,7 +3011,7 @@ async fn test_timecard_list_cards_with_employee_filter() {
     test_case!("employee_idフィルター付きカード一覧", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "TC Filter").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "TC Filter").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -3061,7 +3061,7 @@ async fn test_timecard_delete_card_not_found() {
     test_case!("存在しないカード削除で404", {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "TC DelNF").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "TC DelNF").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let client = reqwest::Client::new();
 
@@ -3090,7 +3090,7 @@ async fn test_communication_items_get_by_id() {
         let _flock = common::db_rename_flock();
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "CommGetId").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "CommGetId").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -3133,7 +3133,7 @@ async fn test_communication_items_get_by_id_not_found() {
         let _flock = common::db_rename_flock();
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "CommNF").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "CommNF").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -3157,7 +3157,7 @@ async fn test_communication_items_update_not_found() {
         let _flock = common::db_rename_flock();
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "CommUpdNF").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "CommUpdNF").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -3182,7 +3182,7 @@ async fn test_communication_items_delete_not_found() {
         let _flock = common::db_rename_flock();
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "CommDelNF").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "CommDelNF").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -3207,13 +3207,13 @@ async fn test_communication_items_list_db_error() {
         let _flock = common::db_rename_flock();
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "CommListErr").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "CommListErr").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
 
         sqlx::query("ALTER TABLE alc_api.communication_items RENAME TO communication_items_bak")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
 
@@ -3234,7 +3234,7 @@ async fn test_communication_items_list_db_error() {
         assert_eq!(res.status(), 500, "active should fail");
 
         sqlx::query("ALTER TABLE alc_api.communication_items_bak RENAME TO communication_items")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
     });
@@ -3249,7 +3249,7 @@ async fn test_communication_items_create_db_error() {
         let _flock = common::db_rename_flock();
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "CommCreateErr").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "CommCreateErr").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -3259,11 +3259,11 @@ async fn test_communication_items_create_db_error() {
             BEGIN RAISE EXCEPTION 'test: communication_items insert blocked'; END;
             $$ LANGUAGE plpgsql"#,
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
         sqlx::query("CREATE OR REPLACE TRIGGER fail_comm_insert BEFORE INSERT ON alc_api.communication_items FOR EACH ROW EXECUTE FUNCTION alc_api.fail_comm_insert()")
-            .execute(&state.pool).await.unwrap();
+            .execute(state.pool()).await.unwrap();
 
         let res = client.post(format!("{base_url}/api/communication-items"))
             .header("Authorization", &auth)
@@ -3272,11 +3272,11 @@ async fn test_communication_items_create_db_error() {
         assert_eq!(res.status(), 500);
 
         sqlx::query("DROP TRIGGER fail_comm_insert ON alc_api.communication_items")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
         sqlx::query("DROP FUNCTION alc_api.fail_comm_insert")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
     });

--- a/tests/mock_auth_test.rs
+++ b/tests/mock_auth_test.rs
@@ -2,11 +2,12 @@
 mod common;
 mod mock_helpers;
 
+use uuid::Uuid;
+
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use serde_json::Value;
-use uuid::Uuid;
 
 use mock_helpers::app_state::setup_mock_app_state;
 use mock_helpers::{mock_user, MockAuthRepository};
@@ -29,7 +30,7 @@ async fn test_google_login_existing_user() {
     let mock = Arc::new(MockAuthRepository::default());
     *mock.return_user.lock().unwrap() = Some(user.clone());
 
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.auth = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -62,7 +63,7 @@ async fn test_google_login_new_user_new_tenant() {
 
     // return_user = None → no invitation → no domain tenant → create new tenant + user
     let mock = Arc::new(MockAuthRepository::default());
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.auth = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -101,7 +102,7 @@ async fn test_google_login_new_user_via_invitation() {
         created_at: chrono::Utc::now(),
     });
 
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.auth = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -138,7 +139,7 @@ async fn test_google_login_new_user_via_email_domain() {
         created_at: chrono::Utc::now(),
     });
 
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.auth = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -166,7 +167,7 @@ async fn test_google_login_invalid_token() {
     std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockAuthRepository::default());
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.auth = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -192,7 +193,7 @@ async fn test_google_login_db_error() {
 
     let mock = Arc::new(MockAuthRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.auth = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -222,7 +223,7 @@ async fn test_refresh_token_success() {
     let mock = Arc::new(MockAuthRepository::default());
     *mock.return_refresh_user.lock().unwrap() = Some(user);
 
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.auth = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -251,7 +252,7 @@ async fn test_refresh_token_invalid() {
 
     // return_refresh_user = None → user not found → 401
     let mock = Arc::new(MockAuthRepository::default());
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.auth = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -277,7 +278,7 @@ async fn test_refresh_token_db_error() {
 
     let mock = Arc::new(MockAuthRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.auth = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -303,7 +304,7 @@ async fn test_me_success() {
 
     let tenant_id = Uuid::new_v4();
     let mock = Arc::new(MockAuthRepository::default());
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.auth = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -333,7 +334,7 @@ async fn test_me_unauthorized() {
     std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockAuthRepository::default());
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.auth = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -358,7 +359,7 @@ async fn test_logout_success() {
 
     let tenant_id = Uuid::new_v4();
     let mock = Arc::new(MockAuthRepository::default());
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.auth = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -384,7 +385,7 @@ async fn test_logout_unauthorized() {
     std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockAuthRepository::default());
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.auth = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -410,7 +411,7 @@ async fn test_logout_db_error() {
     let tenant_id = Uuid::new_v4();
     let mock = Arc::new(MockAuthRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.auth = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -445,7 +446,7 @@ async fn test_my_orgs_success() {
         created_at: chrono::Utc::now(),
     });
 
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.auth = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -479,7 +480,7 @@ async fn test_my_orgs_empty() {
     let tenant_id = Uuid::new_v4();
     // return_tenant = None → empty organizations
     let mock = Arc::new(MockAuthRepository::default());
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.auth = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -510,7 +511,7 @@ async fn test_my_orgs_db_error() {
     let tenant_id = Uuid::new_v4();
     let mock = Arc::new(MockAuthRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.auth = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -536,7 +537,7 @@ async fn test_my_orgs_unauthorized() {
     std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockAuthRepository::default());
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.auth = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -561,7 +562,7 @@ async fn test_create_tenant_success() {
     std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockAuthRepository::default());
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.auth = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -590,7 +591,7 @@ async fn test_create_tenant_db_error() {
 
     let mock = Arc::new(MockAuthRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.auth = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -623,7 +624,7 @@ async fn test_woff_config_success() {
         woff_id: Some("woff-12345".to_string()),
     });
 
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.auth = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -652,7 +653,7 @@ async fn test_woff_config_not_found() {
 
     // return_sso_config = None → 404
     let mock = Arc::new(MockAuthRepository::default());
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.auth = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -686,7 +687,7 @@ async fn test_woff_config_no_woff_id() {
         woff_id: None, // no woff_id configured
     });
 
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.auth = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -713,7 +714,7 @@ async fn test_woff_config_db_error() {
 
     let mock = Arc::new(MockAuthRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.auth = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -739,7 +740,7 @@ async fn test_woff_config_missing_domain() {
     std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockAuthRepository::default());
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.auth = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -765,7 +766,7 @@ async fn test_google_code_login_valid_code() {
 
     // GoogleTokenVerifier in test mode accepts "test-valid-code"
     let mock = Arc::new(MockAuthRepository::default());
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.auth = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -796,7 +797,7 @@ async fn test_google_code_login_invalid_code() {
     std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockAuthRepository::default());
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.auth = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -825,7 +826,7 @@ async fn test_lineworks_redirect_missing_domain() {
     std::env::set_var("OAUTH_STATE_SECRET", "test-state-secret");
 
     let mock = Arc::new(MockAuthRepository::default());
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.auth = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -857,7 +858,7 @@ async fn test_lineworks_redirect_sso_not_found() {
 
     // return_sso_config = None → 404
     let mock = Arc::new(MockAuthRepository::default());
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.auth = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -895,7 +896,7 @@ async fn test_lineworks_redirect_success() {
         woff_id: None,
     });
 
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.auth = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -936,7 +937,7 @@ async fn test_lineworks_redirect_with_address() {
         woff_id: None,
     });
 
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.auth = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -968,7 +969,7 @@ async fn test_lineworks_redirect_db_error() {
 
     let mock = Arc::new(MockAuthRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.auth = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -998,7 +999,7 @@ async fn test_google_redirect_success() {
     std::env::set_var("OAUTH_STATE_SECRET", "test-state-secret");
 
     let mock = Arc::new(MockAuthRepository::default());
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.auth = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -1031,7 +1032,7 @@ async fn test_google_redirect_missing_state_secret() {
     std::env::remove_var("OAUTH_STATE_SECRET");
 
     let mock = Arc::new(MockAuthRepository::default());
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.auth = mock;
     let base_url = common::spawn_test_server(state).await;
 

--- a/tests/mock_bot_admin_test.rs
+++ b/tests/mock_bot_admin_test.rs
@@ -2,11 +2,12 @@
 mod common;
 mod mock_helpers;
 
+use uuid::Uuid;
+
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use serde_json::Value;
-use uuid::Uuid;
 
 use mock_helpers::app_state::setup_mock_app_state;
 use mock_helpers::MockBotAdminRepository;
@@ -23,7 +24,7 @@ async fn test_list_configs_success() {
         std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
 
         let mock = Arc::new(MockBotAdminRepository::default());
-        let mut state = setup_mock_app_state().await;
+        let mut state = setup_mock_app_state();
         state.bot_admin = mock;
         let base_url = common::spawn_test_server(state).await;
 
@@ -51,7 +52,7 @@ async fn test_list_configs_forbidden_for_viewer() {
         std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
 
         let mock = Arc::new(MockBotAdminRepository::default());
-        let mut state = setup_mock_app_state().await;
+        let mut state = setup_mock_app_state();
         state.bot_admin = mock;
         let base_url = common::spawn_test_server(state).await;
 
@@ -78,7 +79,7 @@ async fn test_list_configs_db_error() {
 
         let mock = Arc::new(MockBotAdminRepository::default());
         mock.fail_next.store(true, Ordering::SeqCst);
-        let mut state = setup_mock_app_state().await;
+        let mut state = setup_mock_app_state();
         state.bot_admin = mock;
         let base_url = common::spawn_test_server(state).await;
 
@@ -108,7 +109,7 @@ async fn test_create_config_success() {
         std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
 
         let mock = Arc::new(MockBotAdminRepository::default());
-        let mut state = setup_mock_app_state().await;
+        let mut state = setup_mock_app_state();
         state.bot_admin = mock;
         let base_url = common::spawn_test_server(state).await;
 
@@ -150,7 +151,7 @@ async fn test_create_config_with_explicit_provider_and_disabled() {
         std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
 
         let mock = Arc::new(MockBotAdminRepository::default());
-        let mut state = setup_mock_app_state().await;
+        let mut state = setup_mock_app_state();
         state.bot_admin = mock;
         let base_url = common::spawn_test_server(state).await;
 
@@ -187,7 +188,7 @@ async fn test_create_config_forbidden_for_viewer() {
         std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
 
         let mock = Arc::new(MockBotAdminRepository::default());
-        let mut state = setup_mock_app_state().await;
+        let mut state = setup_mock_app_state();
         state.bot_admin = mock;
         let base_url = common::spawn_test_server(state).await;
 
@@ -220,7 +221,7 @@ async fn test_create_config_db_error() {
 
         let mock = Arc::new(MockBotAdminRepository::default());
         mock.fail_next.store(true, Ordering::SeqCst);
-        let mut state = setup_mock_app_state().await;
+        let mut state = setup_mock_app_state();
         state.bot_admin = mock;
         let base_url = common::spawn_test_server(state).await;
 
@@ -256,7 +257,7 @@ async fn test_update_config_success() {
         std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
 
         let mock = Arc::new(MockBotAdminRepository::default());
-        let mut state = setup_mock_app_state().await;
+        let mut state = setup_mock_app_state();
         state.bot_admin = mock;
         let base_url = common::spawn_test_server(state).await;
 
@@ -295,7 +296,7 @@ async fn test_update_config_with_secrets() {
         std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
 
         let mock = Arc::new(MockBotAdminRepository::default());
-        let mut state = setup_mock_app_state().await;
+        let mut state = setup_mock_app_state();
         state.bot_admin = mock;
         let base_url = common::spawn_test_server(state).await;
 
@@ -333,7 +334,7 @@ async fn test_update_config_with_empty_secrets() {
             std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
 
             let mock = Arc::new(MockBotAdminRepository::default());
-            let mut state = setup_mock_app_state().await;
+            let mut state = setup_mock_app_state();
             state.bot_admin = mock;
             let base_url = common::spawn_test_server(state).await;
 
@@ -370,7 +371,7 @@ async fn test_update_config_invalid_uuid() {
         std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
 
         let mock = Arc::new(MockBotAdminRepository::default());
-        let mut state = setup_mock_app_state().await;
+        let mut state = setup_mock_app_state();
         state.bot_admin = mock;
         let base_url = common::spawn_test_server(state).await;
 
@@ -403,7 +404,7 @@ async fn test_update_config_forbidden_for_viewer() {
         std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
 
         let mock = Arc::new(MockBotAdminRepository::default());
-        let mut state = setup_mock_app_state().await;
+        let mut state = setup_mock_app_state();
         state.bot_admin = mock;
         let base_url = common::spawn_test_server(state).await;
 
@@ -437,7 +438,7 @@ async fn test_update_config_db_error() {
 
         let mock = Arc::new(MockBotAdminRepository::default());
         mock.fail_next.store(true, Ordering::SeqCst);
-        let mut state = setup_mock_app_state().await;
+        let mut state = setup_mock_app_state();
         state.bot_admin = mock;
         let base_url = common::spawn_test_server(state).await;
 
@@ -477,7 +478,7 @@ async fn test_upsert_no_encryption_key() {
         std::env::remove_var("SSO_ENCRYPTION_KEY");
 
         let mock = Arc::new(MockBotAdminRepository::default());
-        let mut state = setup_mock_app_state().await;
+        let mut state = setup_mock_app_state();
         state.bot_admin = mock;
         let base_url = common::spawn_test_server(state).await;
 
@@ -518,7 +519,7 @@ async fn test_delete_config_success() {
         std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
 
         let mock = Arc::new(MockBotAdminRepository::default());
-        let mut state = setup_mock_app_state().await;
+        let mut state = setup_mock_app_state();
         state.bot_admin = mock;
         let base_url = common::spawn_test_server(state).await;
 
@@ -547,7 +548,7 @@ async fn test_delete_config_invalid_uuid() {
         std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
 
         let mock = Arc::new(MockBotAdminRepository::default());
-        let mut state = setup_mock_app_state().await;
+        let mut state = setup_mock_app_state();
         state.bot_admin = mock;
         let base_url = common::spawn_test_server(state).await;
 
@@ -576,7 +577,7 @@ async fn test_delete_config_forbidden_for_viewer() {
         std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
 
         let mock = Arc::new(MockBotAdminRepository::default());
-        let mut state = setup_mock_app_state().await;
+        let mut state = setup_mock_app_state();
         state.bot_admin = mock;
         let base_url = common::spawn_test_server(state).await;
 
@@ -606,7 +607,7 @@ async fn test_delete_config_db_error() {
 
         let mock = Arc::new(MockBotAdminRepository::default());
         mock.fail_next.store(true, Ordering::SeqCst);
-        let mut state = setup_mock_app_state().await;
+        let mut state = setup_mock_app_state();
         state.bot_admin = mock;
         let base_url = common::spawn_test_server(state).await;
 

--- a/tests/mock_car_inspection_files_test.rs
+++ b/tests/mock_car_inspection_files_test.rs
@@ -1,6 +1,8 @@
 mod common;
 mod mock_helpers;
 
+use uuid::Uuid;
+
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
@@ -13,9 +15,9 @@ use mock_helpers::MockCarInspectionRepository;
 
 #[tokio::test]
 async fn test_list_current_files_success_empty() {
-    let state = setup_mock_app_state().await;
+    let state = setup_mock_app_state();
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "MockCIFEmpty").await;
+    let tenant_id = Uuid::new_v4();
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let client = reqwest::Client::new();
 
@@ -38,7 +40,7 @@ async fn test_list_current_files_success_empty() {
 
 #[tokio::test]
 async fn test_list_current_files_no_auth() {
-    let state = setup_mock_app_state().await;
+    let state = setup_mock_app_state();
     let base_url = common::spawn_test_server(state).await;
     let client = reqwest::Client::new();
 
@@ -57,9 +59,9 @@ async fn test_list_current_files_no_auth() {
 
 #[tokio::test]
 async fn test_list_current_files_tenant_header() {
-    let state = setup_mock_app_state().await;
+    let state = setup_mock_app_state();
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "MockCIFTenant").await;
+    let tenant_id = Uuid::new_v4();
     let client = reqwest::Client::new();
 
     let res = client
@@ -80,14 +82,14 @@ async fn test_list_current_files_tenant_header() {
 
 #[tokio::test]
 async fn test_list_current_files_db_error() {
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
 
     let mock = Arc::new(MockCarInspectionRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
     state.car_inspections = mock;
 
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "MockCIFErr").await;
+    let tenant_id = Uuid::new_v4();
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let client = reqwest::Client::new();
 
@@ -107,9 +109,9 @@ async fn test_list_current_files_db_error() {
 
 #[tokio::test]
 async fn test_list_current_files_viewer_allowed() {
-    let state = setup_mock_app_state().await;
+    let state = setup_mock_app_state();
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "MockCIFViewer").await;
+    let tenant_id = Uuid::new_v4();
     let jwt = common::create_test_jwt(tenant_id, "viewer");
     let client = reqwest::Client::new();
 

--- a/tests/mock_car_inspections_test.rs
+++ b/tests/mock_car_inspections_test.rs
@@ -2,11 +2,12 @@
 mod common;
 mod mock_helpers;
 
+use uuid::Uuid;
+
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use serde_json::Value;
-use uuid::Uuid;
 
 use rust_alc_api::db::repository::car_inspections::{
     CarInspectionFile, CarInspectionRepository, VehicleCategories,
@@ -100,7 +101,7 @@ async fn spawn_with_mock(mock: Arc<dyn CarInspectionRepository>) -> (String, Str
     let tenant_id = Uuid::new_v4();
     let jwt = common::create_test_jwt(tenant_id, "admin");
 
-    let mut state = mock_helpers::app_state::setup_mock_app_state().await;
+    let mut state = mock_helpers::app_state::setup_mock_app_state();
     state.car_inspections = mock;
     let base_url = common::spawn_test_server(state).await;
 

--- a/tests/mock_carins_files_test.rs
+++ b/tests/mock_carins_files_test.rs
@@ -1,6 +1,8 @@
 mod common;
 mod mock_helpers;
 
+use uuid::Uuid;
+
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
@@ -9,7 +11,6 @@ use mock_helpers::app_state::setup_mock_app_state;
 use mock_helpers::MockCarinsFilesRepository;
 use rust_alc_api::routes::carins_files::FileRow;
 use rust_alc_api::storage::StorageBackend;
-use uuid::Uuid;
 
 fn test_tenant_id() -> Uuid {
     Uuid::parse_str("11111111-1111-1111-1111-111111111111").unwrap()
@@ -49,7 +50,7 @@ fn make_file_row(uuid: &str, s3_key: Option<&str>, blob: Option<&str>) -> FileRo
 
 #[tokio::test]
 async fn test_list_files_success_empty() {
-    let state = setup_mock_app_state().await;
+    let state = setup_mock_app_state();
     let base_url = common::spawn_test_server(state).await;
     let client = reqwest::Client::new();
 
@@ -71,7 +72,7 @@ async fn test_list_files_success_empty() {
 
 #[tokio::test]
 async fn test_list_files_with_type_filter() {
-    let state = setup_mock_app_state().await;
+    let state = setup_mock_app_state();
     let base_url = common::spawn_test_server(state).await;
     let client = reqwest::Client::new();
 
@@ -96,7 +97,7 @@ async fn test_list_files_db_error() {
     let mock_repo = Arc::new(MockCarinsFilesRepository::default());
     mock_repo.fail_next.store(true, Ordering::SeqCst);
 
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.carins_files = mock_repo;
 
     let base_url = common::spawn_test_server(state).await;
@@ -118,7 +119,7 @@ async fn test_list_files_db_error() {
 
 #[tokio::test]
 async fn test_create_file_success() {
-    let state = setup_mock_app_state().await;
+    let state = setup_mock_app_state();
     let base_url = common::spawn_test_server(state).await;
     let client = reqwest::Client::new();
 
@@ -150,7 +151,7 @@ async fn test_create_file_success() {
 
 #[tokio::test]
 async fn test_create_file_invalid_base64() {
-    let state = setup_mock_app_state().await;
+    let state = setup_mock_app_state();
     let base_url = common::spawn_test_server(state).await;
     let client = reqwest::Client::new();
 
@@ -178,7 +179,7 @@ async fn test_create_file_db_error() {
     let mock_repo = Arc::new(MockCarinsFilesRepository::default());
     mock_repo.fail_next.store(true, Ordering::SeqCst);
 
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.carins_files = mock_repo;
 
     let base_url = common::spawn_test_server(state).await;
@@ -211,7 +212,7 @@ async fn test_create_file_storage_error() {
     let mock_storage = Arc::new(MockStorage::new("test-bucket"));
     mock_storage.fail_upload.store(true, Ordering::SeqCst);
 
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.storage = mock_storage;
 
     let base_url = common::spawn_test_server(state).await;
@@ -241,7 +242,7 @@ async fn test_create_file_storage_error() {
 
 #[tokio::test]
 async fn test_list_recent_success() {
-    let state = setup_mock_app_state().await;
+    let state = setup_mock_app_state();
     let base_url = common::spawn_test_server(state).await;
     let client = reqwest::Client::new();
 
@@ -266,7 +267,7 @@ async fn test_list_recent_db_error() {
     let mock_repo = Arc::new(MockCarinsFilesRepository::default());
     mock_repo.fail_next.store(true, Ordering::SeqCst);
 
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.carins_files = mock_repo;
 
     let base_url = common::spawn_test_server(state).await;
@@ -288,7 +289,7 @@ async fn test_list_recent_db_error() {
 
 #[tokio::test]
 async fn test_list_not_attached_success() {
-    let state = setup_mock_app_state().await;
+    let state = setup_mock_app_state();
     let base_url = common::spawn_test_server(state).await;
     let client = reqwest::Client::new();
 
@@ -313,7 +314,7 @@ async fn test_list_not_attached_db_error() {
     let mock_repo = Arc::new(MockCarinsFilesRepository::default());
     mock_repo.fail_next.store(true, Ordering::SeqCst);
 
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.carins_files = mock_repo;
 
     let base_url = common::spawn_test_server(state).await;
@@ -339,7 +340,7 @@ async fn test_get_file_found() {
     let mock_repo = Arc::new(MockCarinsFilesRepository::default());
     *mock_repo.return_file.lock().unwrap() = Some(make_file_row(&file_uuid, None, None));
 
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.carins_files = mock_repo;
 
     let base_url = common::spawn_test_server(state).await;
@@ -364,7 +365,7 @@ async fn test_get_file_found() {
 
 #[tokio::test]
 async fn test_get_file_not_found() {
-    let state = setup_mock_app_state().await;
+    let state = setup_mock_app_state();
     let base_url = common::spawn_test_server(state).await;
     let client = reqwest::Client::new();
 
@@ -387,7 +388,7 @@ async fn test_get_file_db_error() {
     let mock_repo = Arc::new(MockCarinsFilesRepository::default());
     mock_repo.fail_next.store(true, Ordering::SeqCst);
 
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.carins_files = mock_repo;
 
     let base_url = common::spawn_test_server(state).await;
@@ -421,7 +422,7 @@ async fn test_download_file_s3_key_carins_storage() {
         .await
         .unwrap();
 
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.carins_files = mock_repo;
     state.carins_storage = Some(carins_storage);
 
@@ -470,7 +471,7 @@ async fn test_download_file_s3_key_fallback_storage() {
         .await
         .unwrap();
 
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.carins_files = mock_repo;
     state.storage = main_storage;
     // carins_storage remains None, so fallback to state.storage
@@ -504,7 +505,7 @@ async fn test_download_file_blob() {
     *mock_repo.return_file.lock().unwrap() =
         Some(make_file_row("file-uuid-3", None, Some(&blob_b64)));
 
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.carins_files = mock_repo;
 
     let base_url = common::spawn_test_server(state).await;
@@ -528,7 +529,7 @@ async fn test_download_file_blob() {
 
 #[tokio::test]
 async fn test_download_file_not_found() {
-    let state = setup_mock_app_state().await;
+    let state = setup_mock_app_state();
     let base_url = common::spawn_test_server(state).await;
     let client = reqwest::Client::new();
 
@@ -551,7 +552,7 @@ async fn test_download_file_no_s3_key_no_blob() {
     let mock_repo = Arc::new(MockCarinsFilesRepository::default());
     *mock_repo.return_file.lock().unwrap() = Some(make_file_row("file-uuid-empty", None, None));
 
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.carins_files = mock_repo;
 
     let base_url = common::spawn_test_server(state).await;
@@ -576,7 +577,7 @@ async fn test_download_file_db_error() {
     let mock_repo = Arc::new(MockCarinsFilesRepository::default());
     mock_repo.fail_next.store(true, Ordering::SeqCst);
 
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.carins_files = mock_repo;
 
     let base_url = common::spawn_test_server(state).await;
@@ -605,7 +606,7 @@ async fn test_download_file_storage_error() {
         Some(make_file_row("file-uuid-err", Some(s3_key), None));
 
     // Do NOT upload the file to storage, so download will fail
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.carins_files = mock_repo;
 
     let base_url = common::spawn_test_server(state).await;
@@ -630,7 +631,7 @@ async fn test_delete_file_success() {
     let mock_repo = Arc::new(MockCarinsFilesRepository::default());
     *mock_repo.return_affected.lock().unwrap() = true;
 
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.carins_files = mock_repo;
 
     let base_url = common::spawn_test_server(state).await;
@@ -653,7 +654,7 @@ async fn test_delete_file_success() {
 #[tokio::test]
 async fn test_delete_file_not_found() {
     // default return_affected is false
-    let state = setup_mock_app_state().await;
+    let state = setup_mock_app_state();
     let base_url = common::spawn_test_server(state).await;
     let client = reqwest::Client::new();
 
@@ -676,7 +677,7 @@ async fn test_delete_file_db_error() {
     let mock_repo = Arc::new(MockCarinsFilesRepository::default());
     mock_repo.fail_next.store(true, Ordering::SeqCst);
 
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.carins_files = mock_repo;
 
     let base_url = common::spawn_test_server(state).await;
@@ -701,7 +702,7 @@ async fn test_restore_file_success() {
     let mock_repo = Arc::new(MockCarinsFilesRepository::default());
     *mock_repo.return_affected.lock().unwrap() = true;
 
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.carins_files = mock_repo;
 
     let base_url = common::spawn_test_server(state).await;
@@ -723,7 +724,7 @@ async fn test_restore_file_success() {
 
 #[tokio::test]
 async fn test_restore_file_not_found() {
-    let state = setup_mock_app_state().await;
+    let state = setup_mock_app_state();
     let base_url = common::spawn_test_server(state).await;
     let client = reqwest::Client::new();
 
@@ -746,7 +747,7 @@ async fn test_restore_file_db_error() {
     let mock_repo = Arc::new(MockCarinsFilesRepository::default());
     mock_repo.fail_next.store(true, Ordering::SeqCst);
 
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.carins_files = mock_repo;
 
     let base_url = common::spawn_test_server(state).await;
@@ -768,7 +769,7 @@ async fn test_restore_file_db_error() {
 
 #[tokio::test]
 async fn test_no_auth_returns_401() {
-    let state = setup_mock_app_state().await;
+    let state = setup_mock_app_state();
     let base_url = common::spawn_test_server(state).await;
     let client = reqwest::Client::new();
 

--- a/tests/mock_carrying_items_test.rs
+++ b/tests/mock_carrying_items_test.rs
@@ -2,12 +2,13 @@
 mod common;
 mod mock_helpers;
 
+use uuid::Uuid;
+
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use chrono::Utc;
 use serde_json::Value;
-use uuid::Uuid;
 
 use rust_alc_api::db::models::{CarryingItem, CarryingItemVehicleCondition};
 use rust_alc_api::db::repository::carrying_items::CarryingItemsRepository;
@@ -147,7 +148,7 @@ async fn spawn_with_mock(mock: Arc<dyn CarryingItemsRepository>) -> (String, Str
     let tenant_id = Uuid::new_v4();
     let jwt = common::create_test_jwt(tenant_id, "admin");
 
-    let mut state = mock_helpers::app_state::setup_mock_app_state().await;
+    let mut state = mock_helpers::app_state::setup_mock_app_state();
     state.carrying_items = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -927,7 +928,7 @@ async fn test_no_auth_returns_401() {
     test_group!("carrying_items — auth");
     test_case!("All endpoints return 401 without JWT", {
         let mock = Arc::new(mock_helpers::MockCarryingItemsRepository::default());
-        let mut state = mock_helpers::app_state::setup_mock_app_state().await;
+        let mut state = mock_helpers::app_state::setup_mock_app_state();
         state.carrying_items = mock;
         let base_url = common::spawn_test_server(state).await;
         let client = reqwest::Client::new();

--- a/tests/mock_communication_items_test.rs
+++ b/tests/mock_communication_items_test.rs
@@ -2,12 +2,13 @@
 mod common;
 mod mock_helpers;
 
+use uuid::Uuid;
+
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use chrono::Utc;
 use serde_json::Value;
-use uuid::Uuid;
 
 use rust_alc_api::db::models::{
     CommunicationItem, CreateCommunicationItem, UpdateCommunicationItem,
@@ -149,7 +150,7 @@ async fn spawn_with_mock(mock: Arc<dyn CommunicationItemsRepository>) -> (String
     let tenant_id = Uuid::new_v4();
     let jwt = common::create_test_jwt(tenant_id, "admin");
 
-    let mut state = mock_helpers::app_state::setup_mock_app_state().await;
+    let mut state = mock_helpers::app_state::setup_mock_app_state();
     state.communication_items = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -579,7 +580,7 @@ async fn test_delete_item_db_error() {
 #[tokio::test]
 async fn test_no_auth_returns_401() {
     let mock = Arc::new(mock_helpers::MockCommunicationItemsRepository::default());
-    let mut state = mock_helpers::app_state::setup_mock_app_state().await;
+    let mut state = mock_helpers::app_state::setup_mock_app_state();
     state.communication_items = mock;
     let base_url = common::spawn_test_server(state).await;
     let client = reqwest::Client::new();

--- a/tests/mock_daily_health_test.rs
+++ b/tests/mock_daily_health_test.rs
@@ -1,6 +1,8 @@
 mod common;
 mod mock_helpers;
 
+use uuid::Uuid;
+
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
@@ -13,9 +15,9 @@ use mock_helpers::MockDailyHealthRepository;
 
 #[tokio::test]
 async fn test_daily_health_status_success_empty() {
-    let state = setup_mock_app_state().await;
+    let state = setup_mock_app_state();
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "MockDHEmpty").await;
+    let tenant_id = Uuid::new_v4();
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let client = reqwest::Client::new();
 
@@ -48,9 +50,9 @@ async fn test_daily_health_status_success_empty() {
 
 #[tokio::test]
 async fn test_daily_health_status_with_date_param() {
-    let state = setup_mock_app_state().await;
+    let state = setup_mock_app_state();
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "MockDHDate").await;
+    let tenant_id = Uuid::new_v4();
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let client = reqwest::Client::new();
 
@@ -75,7 +77,7 @@ async fn test_daily_health_status_with_date_param() {
 
 #[tokio::test]
 async fn test_daily_health_status_no_auth() {
-    let state = setup_mock_app_state().await;
+    let state = setup_mock_app_state();
     let base_url = common::spawn_test_server(state).await;
     let client = reqwest::Client::new();
 
@@ -94,9 +96,9 @@ async fn test_daily_health_status_no_auth() {
 
 #[tokio::test]
 async fn test_daily_health_status_tenant_header() {
-    let state = setup_mock_app_state().await;
+    let state = setup_mock_app_state();
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "MockDHTenant").await;
+    let tenant_id = Uuid::new_v4();
     let client = reqwest::Client::new();
 
     let res = client
@@ -118,7 +120,7 @@ async fn test_daily_health_status_tenant_header() {
 
 #[tokio::test]
 async fn test_daily_health_status_db_error() {
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
 
     // Replace daily_health with a mock that will fail on next call
     let mock = Arc::new(MockDailyHealthRepository::default());
@@ -126,7 +128,7 @@ async fn test_daily_health_status_db_error() {
     state.daily_health = mock;
 
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "MockDHErr").await;
+    let tenant_id = Uuid::new_v4();
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let client = reqwest::Client::new();
 
@@ -148,9 +150,8 @@ async fn test_daily_health_status_db_error() {
 async fn test_daily_health_status_with_safety_judgment() {
     use rust_alc_api::routes::daily_health::DailyHealthRow;
     use serde_json::json;
-    use uuid::Uuid;
 
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
 
     // Build mock data with safety_judgment pass, fail, and a checked record without judgment
     let rows = vec![
@@ -238,7 +239,7 @@ async fn test_daily_health_status_with_safety_judgment() {
     state.daily_health = mock;
 
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "MockDHJudge").await;
+    let tenant_id = Uuid::new_v4();
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let client = reqwest::Client::new();
 
@@ -266,9 +267,9 @@ async fn test_daily_health_status_with_safety_judgment() {
 
 #[tokio::test]
 async fn test_daily_health_status_invalid_date() {
-    let state = setup_mock_app_state().await;
+    let state = setup_mock_app_state();
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "MockDHBadDate").await;
+    let tenant_id = Uuid::new_v4();
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let client = reqwest::Client::new();
 

--- a/tests/mock_devices_test.rs
+++ b/tests/mock_devices_test.rs
@@ -2,11 +2,12 @@
 mod common;
 mod mock_helpers;
 
+use uuid::Uuid;
+
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use serde_json::Value;
-use uuid::Uuid;
 
 use mock_helpers::app_state::setup_mock_app_state;
 use mock_helpers::MockDeviceRepository;
@@ -21,7 +22,7 @@ async fn test_register_request_success() {
     std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.devices = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -44,7 +45,7 @@ async fn test_register_request_no_device_name() {
     std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.devices = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -65,7 +66,7 @@ async fn test_register_request_db_error() {
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.devices = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -90,7 +91,7 @@ async fn test_registration_status_found() {
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst);
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.devices = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -112,7 +113,7 @@ async fn test_registration_status_not_found() {
 
     let mock = Arc::new(MockDeviceRepository::default());
     // return_data=false -> None -> 404
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.devices = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -132,7 +133,7 @@ async fn test_registration_status_db_error() {
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.devices = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -156,7 +157,7 @@ async fn test_claim_url_flow_success() {
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst);
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.devices = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -186,7 +187,7 @@ async fn test_claim_not_found() {
 
     let mock = Arc::new(MockDeviceRepository::default());
     // return_data=false -> None -> error
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.devices = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -211,7 +212,7 @@ async fn test_claim_db_error() {
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.devices = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -240,7 +241,7 @@ async fn test_device_settings_found() {
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst);
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.devices = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -264,7 +265,7 @@ async fn test_device_settings_not_found() {
     std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.devices = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -289,7 +290,7 @@ async fn test_register_fcm_token_success() {
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst); // lookup_device_tenant returns Some
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.devices = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -313,7 +314,7 @@ async fn test_register_fcm_token_device_not_found() {
 
     let mock = Arc::new(MockDeviceRepository::default());
     // return_data=false -> lookup_device_tenant returns None -> 404
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.devices = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -341,7 +342,7 @@ async fn test_report_version_success() {
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst);
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.devices = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -367,7 +368,7 @@ async fn test_report_version_device_not_found() {
     std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.devices = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -396,7 +397,7 @@ async fn test_report_watchdog_success() {
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst);
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.devices = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -419,7 +420,7 @@ async fn test_report_watchdog_device_not_found() {
     std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.devices = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -447,7 +448,7 @@ async fn test_update_last_login_success() {
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst);
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.devices = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -477,7 +478,7 @@ async fn test_fcm_notify_call_no_fcm() {
     std::env::remove_var("FCM_INTERNAL_SECRET");
 
     let mock = Arc::new(MockDeviceRepository::default());
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.devices = mock;
     // fcm = None
     let base_url = common::spawn_test_server(state).await;
@@ -501,7 +502,7 @@ async fn test_fcm_notify_call_empty_rooms() {
     std::env::remove_var("FCM_INTERNAL_SECRET");
 
     let mock = Arc::new(MockDeviceRepository::default());
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.devices = mock;
     state.fcm = Some(Arc::new(common::MockFcmSender::new()));
     let base_url = common::spawn_test_server(state).await;
@@ -530,7 +531,7 @@ async fn test_fcm_notify_call_with_devices() {
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst);
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.devices = mock;
     state.fcm = Some(Arc::new(common::MockFcmSender::new()));
     let base_url = common::spawn_test_server(state).await;
@@ -557,7 +558,7 @@ async fn test_fcm_notify_call_with_internal_secret_check() {
     std::env::set_var("FCM_INTERNAL_SECRET", "my-secret-123");
 
     let mock = Arc::new(MockDeviceRepository::default());
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.devices = mock;
     state.fcm = Some(Arc::new(common::MockFcmSender::new()));
     let base_url = common::spawn_test_server(state).await;
@@ -596,7 +597,7 @@ async fn test_fcm_dismiss_test_no_fcm() {
     std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.devices = mock;
     // fcm = None
     let base_url = common::spawn_test_server(state).await;
@@ -618,7 +619,7 @@ async fn test_fcm_dismiss_test_device_not_found() {
 
     let mock = Arc::new(MockDeviceRepository::default());
     // return_data=false -> get_device_tenant_active returns None -> 404
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.devices = mock;
     state.fcm = Some(Arc::new(common::MockFcmSender::new()));
     let base_url = common::spawn_test_server(state).await;
@@ -640,7 +641,7 @@ async fn test_fcm_dismiss_test_success() {
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst);
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.devices = mock;
     state.fcm = Some(Arc::new(common::MockFcmSender::new()));
     let base_url = common::spawn_test_server(state).await;
@@ -667,7 +668,7 @@ async fn test_fcm_all_exclude_no_fcm() {
     std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.devices = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -692,7 +693,7 @@ async fn test_list_devices_empty() {
     std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.devices = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -717,7 +718,7 @@ async fn test_list_devices_no_auth() {
     std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.devices = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -737,7 +738,7 @@ async fn test_list_devices_db_error() {
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.devices = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -761,7 +762,7 @@ async fn test_list_pending_empty() {
     std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.devices = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -787,7 +788,7 @@ async fn test_create_url_token_success() {
     std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.devices = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -817,7 +818,7 @@ async fn test_create_url_token_no_auth() {
     std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.devices = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -838,7 +839,7 @@ async fn test_create_permanent_qr_success() {
     std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.devices = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -867,7 +868,7 @@ async fn test_create_device_owner_token_success() {
     std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.devices = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -897,7 +898,7 @@ async fn test_approve_device_success() {
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst);
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.devices = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -926,7 +927,7 @@ async fn test_approve_device_not_found() {
 
     let mock = Arc::new(MockDeviceRepository::default());
     // return_data=false -> find_approve_request returns None -> 404
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.devices = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -953,7 +954,7 @@ async fn test_approve_by_code_success() {
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst);
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.devices = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -978,7 +979,7 @@ async fn test_approve_by_code_not_found() {
     std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.devices = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -1003,7 +1004,7 @@ async fn test_reject_device_success() {
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst);
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.devices = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -1027,7 +1028,7 @@ async fn test_reject_device_not_found() {
     std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.devices = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -1053,7 +1054,7 @@ async fn test_disable_device_success() {
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst);
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.devices = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -1079,7 +1080,7 @@ async fn test_enable_device_success() {
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst);
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.devices = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -1105,7 +1106,7 @@ async fn test_delete_device_success() {
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst);
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.devices = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -1129,7 +1130,7 @@ async fn test_delete_device_not_found() {
     std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.devices = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -1155,7 +1156,7 @@ async fn test_update_call_settings_success() {
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst);
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.devices = mock;
     state.fcm = Some(Arc::new(common::MockFcmSender::new()));
     let base_url = common::spawn_test_server(state).await;
@@ -1185,7 +1186,7 @@ async fn test_update_call_settings_not_found() {
     std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.devices = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -1214,7 +1215,7 @@ async fn test_fcm_single_device_success() {
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst);
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.devices = mock;
     state.fcm = Some(Arc::new(common::MockFcmSender::new()));
     let base_url = common::spawn_test_server(state).await;
@@ -1241,7 +1242,7 @@ async fn test_fcm_single_device_no_fcm() {
     std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.devices = mock;
     // fcm = None
     let base_url = common::spawn_test_server(state).await;
@@ -1267,7 +1268,7 @@ async fn test_fcm_single_device_not_found() {
 
     let mock = Arc::new(MockDeviceRepository::default());
     // return_data=false -> get_device_fcm_token returns None -> 404
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.devices = mock;
     state.fcm = Some(Arc::new(common::MockFcmSender::new()));
     let base_url = common::spawn_test_server(state).await;
@@ -1293,7 +1294,7 @@ async fn test_fcm_single_device_failing_sender() {
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst);
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.devices = mock;
     state.fcm = Some(Arc::new(common::FailingFcmSender));
     let base_url = common::spawn_test_server(state).await;
@@ -1323,7 +1324,7 @@ async fn test_fcm_all_success() {
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst);
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.devices = mock;
     state.fcm = Some(Arc::new(common::MockFcmSender::new()));
     let base_url = common::spawn_test_server(state).await;
@@ -1353,7 +1354,7 @@ async fn test_fcm_all_no_fcm() {
     std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.devices = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -1378,7 +1379,7 @@ async fn test_trigger_update_success() {
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst);
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.devices = mock;
     state.fcm = Some(Arc::new(common::MockFcmSender::new()));
     let base_url = common::spawn_test_server(state).await;
@@ -1410,7 +1411,7 @@ async fn test_trigger_update_already_updated() {
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst);
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.devices = mock;
     state.fcm = Some(Arc::new(common::MockFcmSender::new()));
     let base_url = common::spawn_test_server(state).await;
@@ -1444,7 +1445,7 @@ async fn test_trigger_update_dev_no_secret() {
     std::env::remove_var("FCM_INTERNAL_SECRET");
 
     let mock = Arc::new(MockDeviceRepository::default());
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.devices = mock;
     state.fcm = Some(Arc::new(common::MockFcmSender::new()));
     let base_url = common::spawn_test_server(state).await;
@@ -1467,7 +1468,7 @@ async fn test_trigger_update_dev_wrong_secret() {
     std::env::set_var("FCM_INTERNAL_SECRET", "correct-secret");
 
     let mock = Arc::new(MockDeviceRepository::default());
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.devices = mock;
     state.fcm = Some(Arc::new(common::MockFcmSender::new()));
     let base_url = common::spawn_test_server(state).await;
@@ -1492,7 +1493,7 @@ async fn test_trigger_update_dev_success() {
 
     let mock = Arc::new(MockDeviceRepository::default());
     // return_data=false -> list_dev_device_tenant_ids returns empty vec -> no devices
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.devices = mock;
     state.fcm = Some(Arc::new(common::MockFcmSender::new()));
     let base_url = common::spawn_test_server(state).await;
@@ -1521,7 +1522,7 @@ async fn test_list_devices_with_x_tenant_id() {
     std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.devices = mock;
     let base_url = common::spawn_test_server(state).await;
 

--- a/tests/mock_driver_info_test.rs
+++ b/tests/mock_driver_info_test.rs
@@ -1,11 +1,12 @@
 mod common;
 mod mock_helpers;
 
+use uuid::Uuid;
+
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use chrono::Utc;
-use uuid::Uuid;
 
 use mock_helpers::app_state::setup_mock_app_state;
 use rust_alc_api::db::models::*;
@@ -154,7 +155,7 @@ impl DriverInfoRepository for MockDriverInfoWithEmployee {
 // ============================================================
 
 async fn setup_state_with_employee(tenant_id: Uuid, employee_id: Uuid) -> rust_alc_api::AppState {
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.driver_info = Arc::new(MockDriverInfoWithEmployee::new(tenant_id, employee_id));
     state
 }
@@ -222,7 +223,7 @@ async fn test_get_driver_info_employee_not_found() {
 /// GET /api/tenko/driver-info/{employee_id} — no auth → 401
 #[tokio::test]
 async fn test_get_driver_info_no_auth() {
-    let state = setup_mock_app_state().await;
+    let state = setup_mock_app_state();
     let base_url = common::spawn_test_server(state).await;
 
     let employee_id = Uuid::new_v4();
@@ -265,7 +266,7 @@ async fn test_get_driver_info_db_error_get_employee() {
     let mock = Arc::new(MockDriverInfoWithEmployee::new(tenant_id, employee_id));
     mock.fail_get_employee.store(true, Ordering::SeqCst);
 
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.driver_info = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -289,7 +290,7 @@ async fn test_get_driver_info_db_error_get_health_baseline() {
     let mock = Arc::new(MockDriverInfoWithEmployee::new(tenant_id, employee_id));
     mock.fail_get_health_baseline.store(true, Ordering::SeqCst);
 
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.driver_info = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -314,7 +315,7 @@ async fn test_get_driver_info_db_error_get_recent_measurements() {
     mock.fail_get_recent_measurements
         .store(true, Ordering::SeqCst);
 
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.driver_info = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -334,7 +335,7 @@ async fn test_get_driver_info_db_error_get_recent_measurements() {
 #[tokio::test]
 async fn test_get_driver_info_invalid_uuid() {
     let tenant_id = Uuid::new_v4();
-    let state = setup_mock_app_state().await;
+    let state = setup_mock_app_state();
     let base_url = common::spawn_test_server(state).await;
 
     let jwt = common::create_test_jwt(tenant_id, "admin");

--- a/tests/mock_dtako_csv_proxy_test.rs
+++ b/tests/mock_dtako_csv_proxy_test.rs
@@ -1,6 +1,8 @@
 mod common;
 mod mock_helpers;
 
+use uuid::Uuid;
+
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
@@ -48,7 +50,7 @@ fn test_auth_header() -> String {
 
 #[tokio::test]
 async fn test_csv_proxy_kudguri() {
-    let state = setup_mock_app_state().await;
+    let state = setup_mock_app_state();
     let tenant_id = test_tenant_id();
     let storage = state.dtako_storage.as_ref().unwrap();
     upload_csv_to_mock_storage(
@@ -82,7 +84,7 @@ async fn test_csv_proxy_kudguri() {
 
 #[tokio::test]
 async fn test_csv_proxy_kudgivt_alias() {
-    let state = setup_mock_app_state().await;
+    let state = setup_mock_app_state();
     let tenant_id = test_tenant_id();
     let storage = state.dtako_storage.as_ref().unwrap();
     upload_csv_to_mock_storage(
@@ -107,7 +109,7 @@ async fn test_csv_proxy_kudgivt_alias() {
 
 #[tokio::test]
 async fn test_csv_proxy_events_alias() {
-    let state = setup_mock_app_state().await;
+    let state = setup_mock_app_state();
     let tenant_id = test_tenant_id();
     let storage = state.dtako_storage.as_ref().unwrap();
     upload_csv_to_mock_storage(&**storage, &tenant_id, "2002", "KUDGIVT.csv", "x\n1\n").await;
@@ -124,7 +126,7 @@ async fn test_csv_proxy_events_alias() {
 
 #[tokio::test]
 async fn test_csv_proxy_ferry_aliases() {
-    let state = setup_mock_app_state().await;
+    let state = setup_mock_app_state();
     let tenant_id = test_tenant_id();
     let storage = state.dtako_storage.as_ref().unwrap();
     upload_csv_to_mock_storage(&**storage, &tenant_id, "3001", "KUDGFRY.csv", "f1\nfv1\n").await;
@@ -148,7 +150,7 @@ async fn test_csv_proxy_ferry_aliases() {
 
 #[tokio::test]
 async fn test_csv_proxy_tolls_aliases() {
-    let state = setup_mock_app_state().await;
+    let state = setup_mock_app_state();
     let tenant_id = test_tenant_id();
     let storage = state.dtako_storage.as_ref().unwrap();
     upload_csv_to_mock_storage(&**storage, &tenant_id, "4001", "KUDGSIR.csv", "t1\ntv1\n").await;
@@ -171,7 +173,7 @@ async fn test_csv_proxy_tolls_aliases() {
 
 #[tokio::test]
 async fn test_csv_proxy_speed_aliases() {
-    let state = setup_mock_app_state().await;
+    let state = setup_mock_app_state();
     let tenant_id = test_tenant_id();
     let storage = state.dtako_storage.as_ref().unwrap();
     upload_csv_to_mock_storage(
@@ -217,7 +219,7 @@ async fn test_csv_proxy_with_r2_prefix() {
         return_prefix: std::sync::Mutex::new(Some("custom/prefix".to_string())),
     });
 
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     // Upload CSV at the key that Some(prefix) branch will construct
     let storage = state.dtako_storage.as_ref().unwrap();
     storage
@@ -250,7 +252,7 @@ async fn test_csv_proxy_with_r2_prefix() {
 
 #[tokio::test]
 async fn test_csv_proxy_empty_csv() {
-    let state = setup_mock_app_state().await;
+    let state = setup_mock_app_state();
     let tenant_id = test_tenant_id();
     let storage = state.dtako_storage.as_ref().unwrap();
     upload_csv_to_mock_storage(&**storage, &tenant_id, "6001", "KUDGURI.csv", "h1,h2\n").await;
@@ -270,7 +272,7 @@ async fn test_csv_proxy_empty_csv() {
 
 #[tokio::test]
 async fn test_csv_proxy_multirow_csv() {
-    let state = setup_mock_app_state().await;
+    let state = setup_mock_app_state();
     let tenant_id = test_tenant_id();
     let storage = state.dtako_storage.as_ref().unwrap();
     let csv = "name,age,city\nAlice,30,Tokyo\nBob,25,Osaka\nCharlie,35,Nagoya\n";
@@ -293,7 +295,7 @@ async fn test_csv_proxy_multirow_csv() {
 
 #[tokio::test]
 async fn test_csv_proxy_empty_body() {
-    let state = setup_mock_app_state().await;
+    let state = setup_mock_app_state();
     let tenant_id = test_tenant_id();
     let storage = state.dtako_storage.as_ref().unwrap();
     upload_csv_to_mock_storage(&**storage, &tenant_id, "6003", "KUDGURI.csv", "").await;
@@ -318,7 +320,7 @@ async fn test_csv_proxy_empty_body() {
 
 #[tokio::test]
 async fn test_csv_proxy_invalid_type_returns_400() {
-    let state = setup_mock_app_state().await;
+    let state = setup_mock_app_state();
     let base_url = common::spawn_test_server(state).await;
 
     let res = reqwest::Client::new()
@@ -332,7 +334,7 @@ async fn test_csv_proxy_invalid_type_returns_400() {
 
 #[tokio::test]
 async fn test_csv_proxy_file_not_found_returns_404() {
-    let state = setup_mock_app_state().await;
+    let state = setup_mock_app_state();
     // MockStorage にファイルを配置しない → download で NotFound
     let base_url = common::spawn_test_server(state).await;
 
@@ -347,7 +349,7 @@ async fn test_csv_proxy_file_not_found_returns_404() {
 
 #[tokio::test]
 async fn test_csv_proxy_no_auth_returns_401() {
-    let state = setup_mock_app_state().await;
+    let state = setup_mock_app_state();
     let base_url = common::spawn_test_server(state).await;
 
     let res = reqwest::Client::new()
@@ -363,7 +365,7 @@ async fn test_csv_proxy_db_error_returns_500() {
     let mock_repo = Arc::new(MockDtakoCsvProxyRepository::default());
     mock_repo.fail_next.store(true, Ordering::SeqCst);
 
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.dtako_csv_proxy = mock_repo;
 
     let base_url = common::spawn_test_server(state).await;
@@ -379,7 +381,7 @@ async fn test_csv_proxy_db_error_returns_500() {
 
 #[tokio::test]
 async fn test_csv_proxy_no_dtako_storage_returns_500() {
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.dtako_storage = None;
 
     let base_url = common::spawn_test_server(state).await;
@@ -399,7 +401,7 @@ async fn test_csv_proxy_no_dtako_storage_returns_500() {
 
 #[tokio::test]
 async fn test_csv_proxy_case_insensitive() {
-    let state = setup_mock_app_state().await;
+    let state = setup_mock_app_state();
     let tenant_id = test_tenant_id();
     let storage = state.dtako_storage.as_ref().unwrap();
     upload_csv_to_mock_storage(&**storage, &tenant_id, "7001", "KUDGURI.csv", "x\n1\n").await;

--- a/tests/mock_dtako_daily_hours_test.rs
+++ b/tests/mock_dtako_daily_hours_test.rs
@@ -1,17 +1,18 @@
 mod common;
 mod mock_helpers;
 
+use uuid::Uuid;
+
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use mock_helpers::app_state::setup_mock_app_state;
 use mock_helpers::MockDtakoDailyHoursRepository;
-use uuid::Uuid;
 
 /// Build mock AppState with a shared MockDtakoDailyHoursRepository reference
 /// so we can toggle `fail_next` from test code.
 async fn setup_with_shared_repo() -> (rust_alc_api::AppState, Arc<MockDtakoDailyHoursRepository>) {
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     let repo = Arc::new(MockDtakoDailyHoursRepository::default());
     state.dtako_daily_hours = repo.clone();
     (state, repo)
@@ -29,7 +30,7 @@ fn auth_header(tenant_id: Uuid) -> String {
 #[tokio::test]
 async fn test_list_daily_hours_success() {
     let (state, _repo) = setup_with_shared_repo().await;
-    let tenant_id = common::create_test_tenant(&state.pool, "dh-list-ok").await;
+    let tenant_id = Uuid::new_v4();
     let base = common::spawn_test_server(state).await;
     let client = reqwest::Client::new();
     let auth = auth_header(tenant_id);
@@ -115,7 +116,7 @@ async fn test_list_daily_hours_no_auth() {
 #[tokio::test]
 async fn test_list_daily_hours_db_error_count() {
     let (state, repo) = setup_with_shared_repo().await;
-    let tenant_id = common::create_test_tenant(&state.pool, "dh-list-err-count").await;
+    let tenant_id = Uuid::new_v4();
     let base = common::spawn_test_server(state).await;
     let client = reqwest::Client::new();
     let auth = auth_header(tenant_id);
@@ -134,7 +135,7 @@ async fn test_list_daily_hours_db_error_count() {
 #[tokio::test]
 async fn test_list_daily_hours_db_error_list() {
     let (state, repo) = setup_with_shared_repo().await;
-    let tenant_id = common::create_test_tenant(&state.pool, "dh-list-err-list").await;
+    let tenant_id = Uuid::new_v4();
     let base = common::spawn_test_server(state).await;
     let client = reqwest::Client::new();
     let auth = auth_header(tenant_id);
@@ -169,7 +170,7 @@ async fn test_list_daily_hours_db_error_list() {
 #[tokio::test]
 async fn test_get_daily_segments_success() {
     let (state, _repo) = setup_with_shared_repo().await;
-    let tenant_id = common::create_test_tenant(&state.pool, "dh-seg-ok").await;
+    let tenant_id = Uuid::new_v4();
     let base = common::spawn_test_server(state).await;
     let client = reqwest::Client::new();
     let auth = auth_header(tenant_id);
@@ -208,7 +209,7 @@ async fn test_get_daily_segments_no_auth() {
 #[tokio::test]
 async fn test_get_daily_segments_db_error() {
     let (state, repo) = setup_with_shared_repo().await;
-    let tenant_id = common::create_test_tenant(&state.pool, "dh-seg-err").await;
+    let tenant_id = Uuid::new_v4();
     let base = common::spawn_test_server(state).await;
     let client = reqwest::Client::new();
     let auth = auth_header(tenant_id);
@@ -229,7 +230,7 @@ async fn test_get_daily_segments_db_error() {
 #[tokio::test]
 async fn test_get_daily_segments_invalid_date() {
     let (state, _repo) = setup_with_shared_repo().await;
-    let tenant_id = common::create_test_tenant(&state.pool, "dh-seg-bad-date").await;
+    let tenant_id = Uuid::new_v4();
     let base = common::spawn_test_server(state).await;
     let client = reqwest::Client::new();
     let auth = auth_header(tenant_id);
@@ -254,7 +255,7 @@ async fn test_get_daily_segments_invalid_date() {
 #[tokio::test]
 async fn test_get_daily_segments_invalid_driver_id() {
     let (state, _repo) = setup_with_shared_repo().await;
-    let tenant_id = common::create_test_tenant(&state.pool, "dh-seg-bad-id").await;
+    let tenant_id = Uuid::new_v4();
     let base = common::spawn_test_server(state).await;
     let client = reqwest::Client::new();
     let auth = auth_header(tenant_id);
@@ -281,7 +282,7 @@ async fn test_get_daily_segments_invalid_driver_id() {
 #[tokio::test]
 async fn test_list_daily_hours_with_tenant_header() {
     let (state, _repo) = setup_with_shared_repo().await;
-    let tenant_id = common::create_test_tenant(&state.pool, "dh-tenant-hdr").await;
+    let tenant_id = Uuid::new_v4();
     let base = common::spawn_test_server(state).await;
     let client = reqwest::Client::new();
 
@@ -299,7 +300,7 @@ async fn test_list_daily_hours_with_tenant_header() {
 #[tokio::test]
 async fn test_get_segments_with_tenant_header() {
     let (state, _repo) = setup_with_shared_repo().await;
-    let tenant_id = common::create_test_tenant(&state.pool, "dh-seg-tenant-hdr").await;
+    let tenant_id = Uuid::new_v4();
     let base = common::spawn_test_server(state).await;
     let client = reqwest::Client::new();
     let driver_id = Uuid::new_v4();

--- a/tests/mock_dtako_drivers_test.rs
+++ b/tests/mock_dtako_drivers_test.rs
@@ -1,6 +1,8 @@
 mod common;
 mod mock_helpers;
 
+use uuid::Uuid;
+
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
@@ -10,7 +12,7 @@ use mock_helpers::MockDtakoDriversRepository;
 /// GET /api/drivers — success: returns empty list (mock returns vec![])
 #[tokio::test]
 async fn list_drivers_success_returns_empty() {
-    let state = setup_mock_app_state().await;
+    let state = setup_mock_app_state();
     let base_url = common::spawn_test_server(state).await;
     let client = reqwest::Client::new();
     let tenant_id = uuid::Uuid::new_v4();
@@ -31,7 +33,7 @@ async fn list_drivers_success_returns_empty() {
 /// GET /api/drivers — no auth: returns 401
 #[tokio::test]
 async fn list_drivers_no_auth_returns_401() {
-    let state = setup_mock_app_state().await;
+    let state = setup_mock_app_state();
     let base_url = common::spawn_test_server(state).await;
     let client = reqwest::Client::new();
 
@@ -50,7 +52,7 @@ async fn list_drivers_db_error_returns_500() {
     let mock_drivers = Arc::new(MockDtakoDriversRepository::default());
     mock_drivers.fail_next.store(true, Ordering::SeqCst);
 
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.dtako_drivers = mock_drivers;
 
     let base_url = common::spawn_test_server(state).await;
@@ -71,7 +73,7 @@ async fn list_drivers_db_error_returns_500() {
 /// GET /api/drivers — X-Tenant-ID header fallback (no JWT): returns 200
 #[tokio::test]
 async fn list_drivers_with_tenant_header_returns_200() {
-    let state = setup_mock_app_state().await;
+    let state = setup_mock_app_state();
     let base_url = common::spawn_test_server(state).await;
     let client = reqwest::Client::new();
     let tenant_id = uuid::Uuid::new_v4();

--- a/tests/mock_dtako_event_classifications_test.rs
+++ b/tests/mock_dtako_event_classifications_test.rs
@@ -1,12 +1,13 @@
 mod common;
 mod mock_helpers;
 
+use uuid::Uuid;
+
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use mock_helpers::app_state::setup_mock_app_state;
 use mock_helpers::MockDtakoEventClassificationsRepository;
-use uuid::Uuid;
 
 use chrono::Utc;
 use rust_alc_api::db::models::DtakoEventClassification;
@@ -15,11 +16,11 @@ use common::{create_test_jwt, spawn_test_server};
 
 /// helper: build mock AppState with a shared mock repo reference
 async fn setup_with_mock() -> (String, String, Arc<MockDtakoEventClassificationsRepository>) {
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     let mock_repo = Arc::new(MockDtakoEventClassificationsRepository::default());
     state.dtako_event_classifications = mock_repo.clone();
 
-    let tenant_id = common::create_test_tenant(&state.pool, "ec-test").await;
+    let tenant_id = Uuid::new_v4();
     let jwt = create_test_jwt(tenant_id, "admin");
     let base_url = spawn_test_server(state).await;
     (base_url, format!("Bearer {jwt}"), mock_repo)
@@ -200,8 +201,8 @@ async fn test_update_classification_missing_body() {
 
 #[tokio::test]
 async fn test_update_classification_success() {
-    let mut state = setup_mock_app_state().await;
-    let tenant_id = common::create_test_tenant(&state.pool, "ec-update-ok").await;
+    let mut state = setup_mock_app_state();
+    let tenant_id = Uuid::new_v4();
 
     let mock_repo = Arc::new(MockDtakoEventClassificationsRepository {
         update_result: std::sync::Mutex::new(Some(DtakoEventClassification {

--- a/tests/mock_dtako_operations_test.rs
+++ b/tests/mock_dtako_operations_test.rs
@@ -1,11 +1,12 @@
 mod common;
 mod mock_helpers;
 
+use uuid::Uuid;
+
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use chrono::{NaiveDate, Utc};
-use uuid::Uuid;
 
 use mock_helpers::app_state::setup_mock_app_state;
 use mock_helpers::MockDtakoOperationsRepository;
@@ -48,9 +49,9 @@ fn make_operation(unko_no: &str) -> DtakoOperation {
 
 #[tokio::test]
 async fn test_list_operations_success() {
-    let state = setup_mock_app_state().await;
+    let state = setup_mock_app_state();
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "MockOps1").await;
+    let tenant_id = Uuid::new_v4();
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let client = reqwest::Client::new();
 
@@ -75,7 +76,7 @@ async fn test_list_operations_success() {
 
 #[tokio::test]
 async fn test_list_operations_no_auth() {
-    let state = setup_mock_app_state().await;
+    let state = setup_mock_app_state();
     let base_url = common::spawn_test_server(state).await;
     let client = reqwest::Client::new();
 
@@ -94,9 +95,9 @@ async fn test_list_operations_no_auth() {
 
 #[tokio::test]
 async fn test_list_operations_tenant_header() {
-    let state = setup_mock_app_state().await;
+    let state = setup_mock_app_state();
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "MockOps2").await;
+    let tenant_id = Uuid::new_v4();
     let client = reqwest::Client::new();
 
     let res = client
@@ -115,13 +116,13 @@ async fn test_list_operations_tenant_header() {
 
 #[tokio::test]
 async fn test_list_operations_db_error() {
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     let mock = Arc::new(MockDtakoOperationsRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
     state.dtako_operations = mock;
 
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "MockOpsErr1").await;
+    let tenant_id = Uuid::new_v4();
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let client = reqwest::Client::new();
 
@@ -141,9 +142,9 @@ async fn test_list_operations_db_error() {
 
 #[tokio::test]
 async fn test_calendar_dates_success_empty() {
-    let state = setup_mock_app_state().await;
+    let state = setup_mock_app_state();
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "MockCal1").await;
+    let tenant_id = Uuid::new_v4();
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let client = reqwest::Client::new();
 
@@ -169,7 +170,7 @@ async fn test_calendar_dates_success_empty() {
 
 #[tokio::test]
 async fn test_calendar_dates_success_with_data() {
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     let mock = Arc::new(MockDtakoOperationsRepository::default());
     *mock.calendar_dates_result.lock().unwrap() = vec![
         (NaiveDate::from_ymd_opt(2026, 3, 1).unwrap(), 5),
@@ -178,7 +179,7 @@ async fn test_calendar_dates_success_with_data() {
     state.dtako_operations = mock;
 
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "MockCal2").await;
+    let tenant_id = Uuid::new_v4();
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let client = reqwest::Client::new();
 
@@ -205,9 +206,9 @@ async fn test_calendar_dates_success_with_data() {
 
 #[tokio::test]
 async fn test_calendar_dates_december() {
-    let state = setup_mock_app_state().await;
+    let state = setup_mock_app_state();
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "MockCalDec").await;
+    let tenant_id = Uuid::new_v4();
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let client = reqwest::Client::new();
 
@@ -232,9 +233,9 @@ async fn test_calendar_dates_december() {
 
 #[tokio::test]
 async fn test_calendar_dates_invalid_month_zero() {
-    let state = setup_mock_app_state().await;
+    let state = setup_mock_app_state();
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "MockCalBad1").await;
+    let tenant_id = Uuid::new_v4();
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let client = reqwest::Client::new();
 
@@ -256,9 +257,9 @@ async fn test_calendar_dates_invalid_month_zero() {
 
 #[tokio::test]
 async fn test_calendar_dates_invalid_month_13() {
-    let state = setup_mock_app_state().await;
+    let state = setup_mock_app_state();
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "MockCalBad2").await;
+    let tenant_id = Uuid::new_v4();
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let client = reqwest::Client::new();
 
@@ -280,7 +281,7 @@ async fn test_calendar_dates_invalid_month_13() {
 
 #[tokio::test]
 async fn test_calendar_dates_no_auth() {
-    let state = setup_mock_app_state().await;
+    let state = setup_mock_app_state();
     let base_url = common::spawn_test_server(state).await;
     let client = reqwest::Client::new();
 
@@ -301,13 +302,13 @@ async fn test_calendar_dates_no_auth() {
 
 #[tokio::test]
 async fn test_calendar_dates_db_error() {
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     let mock = Arc::new(MockDtakoOperationsRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
     state.dtako_operations = mock;
 
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "MockCalErr").await;
+    let tenant_id = Uuid::new_v4();
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let client = reqwest::Client::new();
 
@@ -329,13 +330,13 @@ async fn test_calendar_dates_db_error() {
 
 #[tokio::test]
 async fn test_get_operation_success() {
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     let mock = Arc::new(MockDtakoOperationsRepository::default());
     *mock.get_result.lock().unwrap() = vec![make_operation("1001")];
     state.dtako_operations = mock;
 
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "MockGet1").await;
+    let tenant_id = Uuid::new_v4();
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let client = reqwest::Client::new();
 
@@ -359,9 +360,9 @@ async fn test_get_operation_success() {
 
 #[tokio::test]
 async fn test_get_operation_not_found() {
-    let state = setup_mock_app_state().await;
+    let state = setup_mock_app_state();
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "MockGet2").await;
+    let tenant_id = Uuid::new_v4();
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let client = reqwest::Client::new();
 
@@ -381,7 +382,7 @@ async fn test_get_operation_not_found() {
 
 #[tokio::test]
 async fn test_get_operation_no_auth() {
-    let state = setup_mock_app_state().await;
+    let state = setup_mock_app_state();
     let base_url = common::spawn_test_server(state).await;
     let client = reqwest::Client::new();
 
@@ -400,13 +401,13 @@ async fn test_get_operation_no_auth() {
 
 #[tokio::test]
 async fn test_get_operation_db_error() {
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     let mock = Arc::new(MockDtakoOperationsRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
     state.dtako_operations = mock;
 
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "MockGetErr").await;
+    let tenant_id = Uuid::new_v4();
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let client = reqwest::Client::new();
 
@@ -426,13 +427,13 @@ async fn test_get_operation_db_error() {
 
 #[tokio::test]
 async fn test_delete_operation_success() {
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     let mock = Arc::new(MockDtakoOperationsRepository::default());
     *mock.delete_rows_affected.lock().unwrap() = 1;
     state.dtako_operations = mock;
 
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "MockDel1").await;
+    let tenant_id = Uuid::new_v4();
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let client = reqwest::Client::new();
 
@@ -452,9 +453,9 @@ async fn test_delete_operation_success() {
 
 #[tokio::test]
 async fn test_delete_operation_not_found() {
-    let state = setup_mock_app_state().await;
+    let state = setup_mock_app_state();
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "MockDel2").await;
+    let tenant_id = Uuid::new_v4();
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let client = reqwest::Client::new();
 
@@ -474,7 +475,7 @@ async fn test_delete_operation_not_found() {
 
 #[tokio::test]
 async fn test_delete_operation_no_auth() {
-    let state = setup_mock_app_state().await;
+    let state = setup_mock_app_state();
     let base_url = common::spawn_test_server(state).await;
     let client = reqwest::Client::new();
 
@@ -493,13 +494,13 @@ async fn test_delete_operation_no_auth() {
 
 #[tokio::test]
 async fn test_delete_operation_db_error() {
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     let mock = Arc::new(MockDtakoOperationsRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
     state.dtako_operations = mock;
 
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "MockDelErr").await;
+    let tenant_id = Uuid::new_v4();
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let client = reqwest::Client::new();
 

--- a/tests/mock_dtako_restraint_report_pdf_test.rs
+++ b/tests/mock_dtako_restraint_report_pdf_test.rs
@@ -1,13 +1,14 @@
 mod common;
 mod mock_helpers;
 
+use uuid::Uuid;
+
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use mock_helpers::app_state::setup_mock_app_state;
 use mock_helpers::{MockDtakoRestraintReportPdfRepository, MockDtakoRestraintReportRepository};
 use rust_alc_api::db::repository::dtako_restraint_report_pdf::PdfDriver;
-use uuid::Uuid;
 
 /// Build mock AppState with shared MockDtakoRestraintReportRepository and
 /// MockDtakoRestraintReportPdfRepository references so we can toggle
@@ -17,7 +18,7 @@ async fn setup_with_shared_repos() -> (
     Arc<MockDtakoRestraintReportRepository>,
     Arc<MockDtakoRestraintReportPdfRepository>,
 ) {
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     let report_repo = Arc::new(MockDtakoRestraintReportRepository::default());
     let pdf_repo = Arc::new(MockDtakoRestraintReportPdfRepository::default());
     state.dtako_restraint_report = report_repo.clone();

--- a/tests/mock_dtako_restraint_report_test.rs
+++ b/tests/mock_dtako_restraint_report_test.rs
@@ -2,11 +2,12 @@
 mod common;
 mod mock_helpers;
 
+use uuid::Uuid;
+
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use serde_json::Value;
-use uuid::Uuid;
 
 use rust_alc_api::db::repository::dtako_restraint_report::DtakoRestraintReportRepository;
 
@@ -18,7 +19,7 @@ async fn spawn_with_mock(mock: Arc<dyn DtakoRestraintReportRepository>) -> (Stri
     let tenant_id = Uuid::new_v4();
     let jwt = common::create_test_jwt(tenant_id, "admin");
 
-    let mut state = mock_helpers::app_state::setup_mock_app_state().await;
+    let mut state = mock_helpers::app_state::setup_mock_app_state();
     state.dtako_restraint_report = mock;
     let base_url = common::spawn_test_server(state).await;
 

--- a/tests/mock_dtako_scraper_test.rs
+++ b/tests/mock_dtako_scraper_test.rs
@@ -2,12 +2,13 @@
 mod common;
 mod mock_helpers;
 
+use uuid::Uuid;
+
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use chrono::{NaiveDate, Utc};
 use serde_json::Value;
-use uuid::Uuid;
 
 use mock_helpers::app_state::setup_mock_app_state;
 use mock_helpers::MockDtakoScraperRepository;
@@ -23,7 +24,7 @@ async fn test_get_scrape_history_success_empty() {
     std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDtakoScraperRepository::default());
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.dtako_scraper = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -62,7 +63,7 @@ async fn test_get_scrape_history_with_data() {
 
     let mock = Arc::new(MockDtakoScraperRepository::default());
     mock.history_data.lock().unwrap().push(item);
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.dtako_scraper = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -95,7 +96,7 @@ async fn test_get_scrape_history_with_query_params() {
     std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDtakoScraperRepository::default());
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.dtako_scraper = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -123,7 +124,7 @@ async fn test_get_scrape_history_db_error() {
 
     let mock = Arc::new(MockDtakoScraperRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.dtako_scraper = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -150,7 +151,7 @@ async fn test_get_scrape_history_unauthorized() {
     std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDtakoScraperRepository::default());
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.dtako_scraper = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -176,7 +177,7 @@ async fn test_trigger_scrape_connection_refused() {
     std::env::set_var("GCP_METADATA_URL", "http://127.0.0.1:1");
 
     let mock = Arc::new(MockDtakoScraperRepository::default());
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.dtako_scraper = mock;
     // Use port 1 which is guaranteed to refuse connections
     let base_url = common::spawn_test_server_with_scraper(state, "http://127.0.0.1:1").await;
@@ -211,7 +212,7 @@ async fn test_trigger_scrape_with_all_fields() {
     std::env::set_var("GCP_METADATA_URL", "http://127.0.0.1:1");
 
     let mock = Arc::new(MockDtakoScraperRepository::default());
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.dtako_scraper = mock;
     let base_url = common::spawn_test_server_with_scraper(state, "http://127.0.0.1:1").await;
 
@@ -246,7 +247,7 @@ async fn test_trigger_scrape_empty_body() {
     std::env::set_var("GCP_METADATA_URL", "http://127.0.0.1:1");
 
     let mock = Arc::new(MockDtakoScraperRepository::default());
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.dtako_scraper = mock;
     let base_url = common::spawn_test_server_with_scraper(state, "http://127.0.0.1:1").await;
 
@@ -276,7 +277,7 @@ async fn test_trigger_scrape_no_body() {
     std::env::set_var("GCP_METADATA_URL", "http://127.0.0.1:1");
 
     let mock = Arc::new(MockDtakoScraperRepository::default());
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.dtako_scraper = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -307,7 +308,7 @@ async fn test_trigger_scrape_unauthorized() {
     std::env::set_var("GCP_METADATA_URL", "http://127.0.0.1:1");
 
     let mock = Arc::new(MockDtakoScraperRepository::default());
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.dtako_scraper = mock;
     let base_url = common::spawn_test_server(state).await;
 

--- a/tests/mock_dtako_upload_test.rs
+++ b/tests/mock_dtako_upload_test.rs
@@ -1,17 +1,18 @@
 mod common;
 mod mock_helpers;
 
+use uuid::Uuid;
+
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use mock_helpers::app_state::setup_mock_app_state;
 use mock_helpers::MockDtakoUploadRepository;
-use uuid::Uuid;
 
 /// Helper: set up mock AppState + spawn test server + create JWT.
 /// Returns (base_url, auth_header, tenant_id, state).
 async fn setup() -> (String, String, Uuid) {
-    let state = setup_mock_app_state().await;
+    let state = setup_mock_app_state();
     let tenant_id = Uuid::new_v4();
     let base_url = common::spawn_test_server(state).await;
     let jwt = common::create_test_jwt(tenant_id, "admin");
@@ -98,7 +99,7 @@ async fn test_dtako_upload_invalid_zip() {
 
 #[tokio::test]
 async fn test_dtako_upload_db_error() {
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     let mock = Arc::new(MockDtakoUploadRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
     state.dtako_upload = mock;
@@ -173,7 +174,7 @@ async fn test_dtako_list_uploads_success() {
 
 #[tokio::test]
 async fn test_dtako_list_uploads_db_error() {
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     let mock = Arc::new(MockDtakoUploadRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
     state.dtako_upload = mock;
@@ -220,7 +221,7 @@ async fn test_dtako_list_pending_success() {
 
 #[tokio::test]
 async fn test_dtako_list_pending_db_error() {
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     let mock = Arc::new(MockDtakoUploadRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
     state.dtako_upload = mock;
@@ -268,7 +269,7 @@ async fn test_dtako_download_not_found() {
 
 #[tokio::test]
 async fn test_dtako_download_db_error() {
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     let mock = Arc::new(MockDtakoUploadRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
     state.dtako_upload = mock;
@@ -316,7 +317,7 @@ async fn test_dtako_rerun_not_found() {
 
 #[tokio::test]
 async fn test_dtako_rerun_db_error() {
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     let mock = Arc::new(MockDtakoUploadRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
     state.dtako_upload = mock;
@@ -362,7 +363,7 @@ async fn test_dtako_split_csv_not_found() {
 
 #[tokio::test]
 async fn test_dtako_split_csv_db_error() {
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     let mock = Arc::new(MockDtakoUploadRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
     state.dtako_upload = mock;
@@ -411,7 +412,7 @@ async fn test_dtako_split_csv_all_success() {
 
 #[tokio::test]
 async fn test_dtako_split_csv_all_db_error() {
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     let mock = Arc::new(MockDtakoUploadRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
     state.dtako_upload = mock;
@@ -466,7 +467,7 @@ async fn test_dtako_recalculate_driver_success() {
 
 #[tokio::test]
 async fn test_dtako_recalculate_driver_db_error() {
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     let mock = Arc::new(MockDtakoUploadRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
     state.dtako_upload = mock;
@@ -528,7 +529,7 @@ async fn test_dtako_recalculate_drivers_success() {
 
 #[tokio::test]
 async fn test_dtako_recalculate_drivers_db_error() {
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     let mock = Arc::new(MockDtakoUploadRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
     state.dtako_upload = mock;
@@ -589,7 +590,7 @@ async fn test_dtako_recalculate_success() {
 
 #[tokio::test]
 async fn test_dtako_recalculate_db_error() {
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     let mock = Arc::new(MockDtakoUploadRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
     state.dtako_upload = mock;
@@ -656,7 +657,7 @@ async fn test_dtako_upload_invalid_multipart() {
 
 #[tokio::test]
 async fn test_dtako_upload_with_tenant_header() {
-    let state = setup_mock_app_state().await;
+    let state = setup_mock_app_state();
     let tenant_id = Uuid::new_v4();
     let base_url = common::spawn_test_server(state).await;
     let client = reqwest::Client::new();

--- a/tests/mock_dtako_vehicles_test.rs
+++ b/tests/mock_dtako_vehicles_test.rs
@@ -1,6 +1,8 @@
 mod common;
 mod mock_helpers;
 
+use uuid::Uuid;
+
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
@@ -13,9 +15,9 @@ use mock_helpers::MockDtakoVehiclesRepository;
 
 #[tokio::test]
 async fn test_list_vehicles_success() {
-    let state = setup_mock_app_state().await;
+    let state = setup_mock_app_state();
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "MockVehicles").await;
+    let tenant_id = Uuid::new_v4();
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let client = reqwest::Client::new();
 
@@ -38,7 +40,7 @@ async fn test_list_vehicles_success() {
 
 #[tokio::test]
 async fn test_list_vehicles_no_auth() {
-    let state = setup_mock_app_state().await;
+    let state = setup_mock_app_state();
     let base_url = common::spawn_test_server(state).await;
     let client = reqwest::Client::new();
 
@@ -57,9 +59,9 @@ async fn test_list_vehicles_no_auth() {
 
 #[tokio::test]
 async fn test_list_vehicles_tenant_header() {
-    let state = setup_mock_app_state().await;
+    let state = setup_mock_app_state();
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "MockVehiclesTenant").await;
+    let tenant_id = Uuid::new_v4();
     let client = reqwest::Client::new();
 
     let res = client
@@ -80,7 +82,7 @@ async fn test_list_vehicles_tenant_header() {
 
 #[tokio::test]
 async fn test_list_vehicles_db_error() {
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
 
     // Replace dtako_vehicles with a mock that will fail on next call
     let mock = Arc::new(MockDtakoVehiclesRepository::default());
@@ -88,7 +90,7 @@ async fn test_list_vehicles_db_error() {
     state.dtako_vehicles = mock;
 
     let base_url = common::spawn_test_server(state.clone()).await;
-    let tenant_id = common::create_test_tenant(&state.pool, "MockVehiclesErr").await;
+    let tenant_id = Uuid::new_v4();
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let client = reqwest::Client::new();
 

--- a/tests/mock_dtako_work_times_test.rs
+++ b/tests/mock_dtako_work_times_test.rs
@@ -1,6 +1,8 @@
 mod common;
 mod mock_helpers;
 
+use uuid::Uuid;
+
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
@@ -11,7 +13,7 @@ use mock_helpers::MockDtakoWorkTimesRepository;
 // Helper: build mock AppState and return a handle to the work_times mock
 // ---------------------------------------------------------------------------
 async fn setup() -> (rust_alc_api::AppState, Arc<MockDtakoWorkTimesRepository>) {
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     let mock_wt = Arc::new(MockDtakoWorkTimesRepository::default());
     state.dtako_work_times = mock_wt.clone();
     (state, mock_wt)
@@ -23,7 +25,7 @@ async fn setup() -> (rust_alc_api::AppState, Arc<MockDtakoWorkTimesRepository>) 
 #[tokio::test]
 async fn mock_list_work_times_success_empty() {
     let (state, _mock_wt) = setup().await;
-    let tenant_id = common::create_test_tenant(&state.pool, "wt-tenant-ok").await;
+    let tenant_id = Uuid::new_v4();
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let base_url = common::spawn_test_server(state).await;
     let client = reqwest::Client::new();
@@ -49,7 +51,7 @@ async fn mock_list_work_times_success_empty() {
 #[tokio::test]
 async fn mock_list_work_times_with_query_params() {
     let (state, _mock_wt) = setup().await;
-    let tenant_id = common::create_test_tenant(&state.pool, "wt-tenant-qp").await;
+    let tenant_id = Uuid::new_v4();
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let base_url = common::spawn_test_server(state).await;
     let client = reqwest::Client::new();
@@ -78,7 +80,7 @@ async fn mock_list_work_times_with_query_params() {
 #[tokio::test]
 async fn mock_list_work_times_per_page_max() {
     let (state, _mock_wt) = setup().await;
-    let tenant_id = common::create_test_tenant(&state.pool, "wt-tenant-max").await;
+    let tenant_id = Uuid::new_v4();
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let base_url = common::spawn_test_server(state).await;
     let client = reqwest::Client::new();
@@ -102,7 +104,7 @@ async fn mock_list_work_times_per_page_max() {
 #[tokio::test]
 async fn mock_list_work_times_page_min() {
     let (state, _mock_wt) = setup().await;
-    let tenant_id = common::create_test_tenant(&state.pool, "wt-tenant-pmin").await;
+    let tenant_id = Uuid::new_v4();
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let base_url = common::spawn_test_server(state).await;
     let client = reqwest::Client::new();
@@ -144,7 +146,7 @@ async fn mock_list_work_times_no_auth() {
 #[tokio::test]
 async fn mock_list_work_times_x_tenant_id() {
     let (state, _mock_wt) = setup().await;
-    let tenant_id = common::create_test_tenant(&state.pool, "wt-tenant-xt").await;
+    let tenant_id = Uuid::new_v4();
     let base_url = common::spawn_test_server(state).await;
     let client = reqwest::Client::new();
 
@@ -166,7 +168,7 @@ async fn mock_list_work_times_x_tenant_id() {
 #[tokio::test]
 async fn mock_list_work_times_count_db_error() {
     let (state, mock_wt) = setup().await;
-    let tenant_id = common::create_test_tenant(&state.pool, "wt-tenant-cerr").await;
+    let tenant_id = Uuid::new_v4();
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let base_url = common::spawn_test_server(state).await;
     let client = reqwest::Client::new();
@@ -190,7 +192,7 @@ async fn mock_list_work_times_count_db_error() {
 #[tokio::test]
 async fn mock_list_work_times_list_db_error() {
     let (state, mock_wt) = setup().await;
-    let tenant_id = common::create_test_tenant(&state.pool, "wt-tenant-lerr").await;
+    let tenant_id = Uuid::new_v4();
     let jwt = common::create_test_jwt(tenant_id, "admin");
 
     // We need count to succeed and list to fail.

--- a/tests/mock_employees_test.rs
+++ b/tests/mock_employees_test.rs
@@ -1,6 +1,8 @@
 mod common;
 mod mock_helpers;
 
+use uuid::Uuid;
+
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
@@ -11,8 +13,8 @@ use mock_helpers::MockEmployeeRepository;
 // ---------------------------------------------------------------------------
 
 async fn setup() -> (String, String) {
-    let state = mock_helpers::app_state::setup_mock_app_state().await;
-    let tenant_id = common::create_test_tenant(&state.pool, "emp-test").await;
+    let state = mock_helpers::app_state::setup_mock_app_state();
+    let tenant_id = Uuid::new_v4();
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let base = common::spawn_test_server(state).await;
     let auth = format!("Bearer {jwt}");
@@ -21,8 +23,8 @@ async fn setup() -> (String, String) {
 
 /// spawn server with a custom employees mock
 async fn setup_with_mock(mock: Arc<MockEmployeeRepository>) -> (String, String) {
-    let mut state = mock_helpers::app_state::setup_mock_app_state().await;
-    let tenant_id = common::create_test_tenant(&state.pool, "emp-custom").await;
+    let mut state = mock_helpers::app_state::setup_mock_app_state();
+    let tenant_id = Uuid::new_v4();
     let jwt = common::create_test_jwt(tenant_id, "admin");
     state.employees = mock;
     let base = common::spawn_test_server(state).await;
@@ -34,8 +36,8 @@ async fn setup_with_mock(mock: Arc<MockEmployeeRepository>) -> (String, String) 
 async fn setup_failing() -> (String, String) {
     let mock = Arc::new(MockEmployeeRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
-    let mut state = mock_helpers::app_state::setup_mock_app_state().await;
-    let tenant_id = common::create_test_tenant(&state.pool, "emp-fail").await;
+    let mut state = mock_helpers::app_state::setup_mock_app_state();
+    let tenant_id = Uuid::new_v4();
     let jwt = common::create_test_jwt(tenant_id, "admin");
     state.employees = mock;
     let base = common::spawn_test_server(state).await;
@@ -669,7 +671,7 @@ async fn get_employee_by_code_db_error_returns_500() {
 
 #[tokio::test]
 async fn employees_unauthorized_without_jwt() {
-    let state = mock_helpers::app_state::setup_mock_app_state().await;
+    let state = mock_helpers::app_state::setup_mock_app_state();
     let base = common::spawn_test_server(state).await;
 
     // GET /api/employees without Authorization header

--- a/tests/mock_equipment_failures_test.rs
+++ b/tests/mock_equipment_failures_test.rs
@@ -1,6 +1,8 @@
 mod common;
 mod mock_helpers;
 
+use uuid::Uuid;
+
 use std::sync::Arc;
 
 use chrono::Utc;
@@ -12,8 +14,8 @@ use rust_alc_api::db::models::EquipmentFailure;
 // ---------------------------------------------------------------------------
 
 async fn setup() -> (String, String) {
-    let state = mock_helpers::app_state::setup_mock_app_state().await;
-    let tenant_id = common::create_test_tenant(&state.pool, "ef-test").await;
+    let state = mock_helpers::app_state::setup_mock_app_state();
+    let tenant_id = Uuid::new_v4();
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let base = common::spawn_test_server(state).await;
     let auth = format!("Bearer {jwt}");
@@ -22,8 +24,8 @@ async fn setup() -> (String, String) {
 
 /// spawn server with a custom equipment_failures mock
 async fn setup_with_mock(mock: Arc<MockEquipmentFailuresRepository>) -> (String, String) {
-    let mut state = mock_helpers::app_state::setup_mock_app_state().await;
-    let tenant_id = common::create_test_tenant(&state.pool, "ef-custom").await;
+    let mut state = mock_helpers::app_state::setup_mock_app_state();
+    let tenant_id = Uuid::new_v4();
     let jwt = common::create_test_jwt(tenant_id, "admin");
     state.equipment_failures = mock;
     let base = common::spawn_test_server(state).await;
@@ -53,8 +55,8 @@ async fn setup_failing() -> (String, String) {
     let mock = Arc::new(MockEquipmentFailuresRepository::default());
     mock.fail_next
         .store(true, std::sync::atomic::Ordering::SeqCst);
-    let mut state = mock_helpers::app_state::setup_mock_app_state().await;
-    let tenant_id = common::create_test_tenant(&state.pool, "ef-fail").await;
+    let mut state = mock_helpers::app_state::setup_mock_app_state();
+    let tenant_id = Uuid::new_v4();
     let jwt = common::create_test_jwt(tenant_id, "admin");
     state.equipment_failures = mock;
     let base = common::spawn_test_server(state).await;

--- a/tests/mock_guidance_records_test.rs
+++ b/tests/mock_guidance_records_test.rs
@@ -1,6 +1,8 @@
 mod common;
 mod mock_helpers;
 
+use uuid::Uuid;
+
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
@@ -10,7 +12,6 @@ use mock_helpers::MockGuidanceRecordsRepository;
 use rust_alc_api::db::models::{GuidanceRecord, GuidanceRecordAttachment};
 use rust_alc_api::db::repository::guidance_records::GuidanceRecordWithName;
 use rust_alc_api::storage::StorageBackend;
-use uuid::Uuid;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -64,7 +65,7 @@ fn make_attachment(record_id: Uuid, storage_url: &str) -> GuidanceRecordAttachme
 }
 
 async fn setup() -> (String, String, Uuid) {
-    let state = mock_helpers::app_state::setup_mock_app_state().await;
+    let state = mock_helpers::app_state::setup_mock_app_state();
     let tenant_id = Uuid::new_v4();
     let base_url = common::spawn_test_server(state).await;
     let jwt = common::create_test_jwt(tenant_id, "admin");
@@ -73,7 +74,7 @@ async fn setup() -> (String, String, Uuid) {
 }
 
 async fn setup_with_mock(mock: Arc<MockGuidanceRecordsRepository>) -> (String, String, Uuid) {
-    let mut state = mock_helpers::app_state::setup_mock_app_state().await;
+    let mut state = mock_helpers::app_state::setup_mock_app_state();
     let tenant_id = Uuid::new_v4();
     let jwt = common::create_test_jwt(tenant_id, "admin");
     state.guidance_records = mock;
@@ -86,7 +87,7 @@ async fn setup_with_mock_and_storage(
     mock: Arc<MockGuidanceRecordsRepository>,
     storage: Arc<MockStorage>,
 ) -> (String, String, Uuid) {
-    let mut state = mock_helpers::app_state::setup_mock_app_state().await;
+    let mut state = mock_helpers::app_state::setup_mock_app_state();
     let tenant_id = Uuid::new_v4();
     let jwt = common::create_test_jwt(tenant_id, "admin");
     state.guidance_records = mock;

--- a/tests/mock_health_baselines_test.rs
+++ b/tests/mock_health_baselines_test.rs
@@ -1,6 +1,8 @@
 mod common;
 mod mock_helpers;
 
+use uuid::Uuid;
+
 use std::sync::Arc;
 
 use chrono::Utc;
@@ -12,8 +14,8 @@ use rust_alc_api::db::models::EmployeeHealthBaseline;
 // ---------------------------------------------------------------------------
 
 async fn setup() -> (String, String) {
-    let state = mock_helpers::app_state::setup_mock_app_state().await;
-    let tenant_id = common::create_test_tenant(&state.pool, "hb-test").await;
+    let state = mock_helpers::app_state::setup_mock_app_state();
+    let tenant_id = Uuid::new_v4();
     let jwt = common::create_test_jwt(tenant_id, "admin");
     let base = common::spawn_test_server(state).await;
     let auth = format!("Bearer {jwt}");
@@ -22,8 +24,8 @@ async fn setup() -> (String, String) {
 
 /// spawn server with a custom health_baselines mock
 async fn setup_with_mock(mock: Arc<MockHealthBaselinesRepository>) -> (String, String) {
-    let mut state = mock_helpers::app_state::setup_mock_app_state().await;
-    let tenant_id = common::create_test_tenant(&state.pool, "hb-custom").await;
+    let mut state = mock_helpers::app_state::setup_mock_app_state();
+    let tenant_id = Uuid::new_v4();
     let jwt = common::create_test_jwt(tenant_id, "admin");
     state.health_baselines = mock;
     let base = common::spawn_test_server(state).await;
@@ -36,8 +38,8 @@ async fn setup_failing() -> (String, String) {
     let mock = Arc::new(MockHealthBaselinesRepository::default());
     mock.fail_next
         .store(true, std::sync::atomic::Ordering::SeqCst);
-    let mut state = mock_helpers::app_state::setup_mock_app_state().await;
-    let tenant_id = common::create_test_tenant(&state.pool, "hb-fail").await;
+    let mut state = mock_helpers::app_state::setup_mock_app_state();
+    let tenant_id = Uuid::new_v4();
     let jwt = common::create_test_jwt(tenant_id, "admin");
     state.health_baselines = mock;
     let base = common::spawn_test_server(state).await;
@@ -449,8 +451,8 @@ async fn delete_baseline_no_auth_returns_401() {
 
 #[tokio::test]
 async fn list_baselines_with_tenant_header() {
-    let state = mock_helpers::app_state::setup_mock_app_state().await;
-    let tenant_id = common::create_test_tenant(&state.pool, "hb-header").await;
+    let state = mock_helpers::app_state::setup_mock_app_state();
+    let tenant_id = Uuid::new_v4();
     let base = common::spawn_test_server(state).await;
 
     let res = client()

--- a/tests/mock_health_test.rs
+++ b/tests/mock_health_test.rs
@@ -9,7 +9,7 @@ use mock_helpers::app_state::setup_mock_app_state;
 
 #[tokio::test]
 async fn test_health_check_returns_ok() {
-    let state = setup_mock_app_state().await;
+    let state = setup_mock_app_state();
     let base_url = common::spawn_test_server(state).await;
     let client = reqwest::Client::new();
 

--- a/tests/mock_helpers/app_state.rs
+++ b/tests/mock_helpers/app_state.rs
@@ -6,26 +6,14 @@ use super::*;
 use crate::common::mock_storage::MockStorage;
 
 /// DB 不要の mock AppState を構築。
-/// pool は dummy (mock repo が先にハンドルするため使われない)。
+/// pool: None — mock repo が全ハンドラを処理するため DB 接続不要。
 /// テスト側で `state.xxx` の `fail_next` を設定して DB エラー注入可能。
-pub async fn setup_mock_app_state() -> AppState {
+pub fn setup_mock_app_state() -> AppState {
     // tracing 初期化 (1回だけ)
     let _ = tracing_subscriber::fmt()
         .with_env_filter("warn")
         .with_test_writer()
         .try_init();
-
-    // テスト DB に接続 (一部ルートが pool を直接使う可能性があるため)
-    let pool = sqlx::postgres::PgPoolOptions::new()
-        .max_connections(2)
-        .connect(&crate::common::test_database_url())
-        .await
-        .expect("Failed to connect to test DB");
-
-    sqlx::migrate!("./migrations")
-        .run(&pool)
-        .await
-        .expect("Failed to run migrations");
 
     let storage: Arc<dyn rust_alc_api::storage::StorageBackend> =
         Arc::new(MockStorage::new("test-bucket"));
@@ -34,7 +22,7 @@ pub async fn setup_mock_app_state() -> AppState {
         Arc::new(MockStorage::new("dtako-bucket"));
 
     AppState {
-        pool,
+        pool: None,
         auth: Arc::new(MockAuthRepository::default()),
         bot_admin: Arc::new(MockBotAdminRepository::default()),
         car_inspections: Arc::new(MockCarInspectionRepository::default()),

--- a/tests/mock_measurements_test.rs
+++ b/tests/mock_measurements_test.rs
@@ -1,13 +1,14 @@
 mod common;
 mod mock_helpers;
 
+use uuid::Uuid;
+
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use common::mock_storage::MockStorage;
 use mock_helpers::MockMeasurementsRepository;
 use serde_json::Value;
-use uuid::Uuid;
 
 // =========================================================================
 // POST /api/measurements — success (201)
@@ -18,7 +19,7 @@ async fn test_create_measurement_success() {
     let _guard = common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
 
-    let state = mock_helpers::app_state::setup_mock_app_state().await;
+    let state = mock_helpers::app_state::setup_mock_app_state();
     let tenant_id = Uuid::new_v4();
     let base_url = common::spawn_test_server(state).await;
     let jwt = common::create_test_jwt(tenant_id, "admin");
@@ -55,7 +56,7 @@ async fn test_create_measurement_db_error() {
     let mock = Arc::new(MockMeasurementsRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
 
-    let mut state = mock_helpers::app_state::setup_mock_app_state().await;
+    let mut state = mock_helpers::app_state::setup_mock_app_state();
     state.measurements = mock;
 
     let tenant_id = Uuid::new_v4();
@@ -89,7 +90,7 @@ async fn test_create_measurement_invalid_result_type() {
     let _guard = common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
 
-    let state = mock_helpers::app_state::setup_mock_app_state().await;
+    let state = mock_helpers::app_state::setup_mock_app_state();
     let tenant_id = Uuid::new_v4();
     let base_url = common::spawn_test_server(state).await;
     let jwt = common::create_test_jwt(tenant_id, "admin");
@@ -121,7 +122,7 @@ async fn test_create_measurement_invalid_json() {
     let _guard = common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
 
-    let state = mock_helpers::app_state::setup_mock_app_state().await;
+    let state = mock_helpers::app_state::setup_mock_app_state();
     let tenant_id = Uuid::new_v4();
     let base_url = common::spawn_test_server(state).await;
     let jwt = common::create_test_jwt(tenant_id, "admin");
@@ -148,7 +149,7 @@ async fn test_start_measurement_success() {
     let _guard = common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
 
-    let state = mock_helpers::app_state::setup_mock_app_state().await;
+    let state = mock_helpers::app_state::setup_mock_app_state();
     let tenant_id = Uuid::new_v4();
     let base_url = common::spawn_test_server(state).await;
     let jwt = common::create_test_jwt(tenant_id, "admin");
@@ -183,7 +184,7 @@ async fn test_start_measurement_db_error() {
     let mock = Arc::new(MockMeasurementsRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
 
-    let mut state = mock_helpers::app_state::setup_mock_app_state().await;
+    let mut state = mock_helpers::app_state::setup_mock_app_state();
     state.measurements = mock;
 
     let tenant_id = Uuid::new_v4();
@@ -215,7 +216,7 @@ async fn test_list_measurements_success() {
     let _guard = common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
 
-    let state = mock_helpers::app_state::setup_mock_app_state().await;
+    let state = mock_helpers::app_state::setup_mock_app_state();
     let tenant_id = Uuid::new_v4();
     let base_url = common::spawn_test_server(state).await;
     let jwt = common::create_test_jwt(tenant_id, "admin");
@@ -248,7 +249,7 @@ async fn test_list_measurements_db_error() {
     let mock = Arc::new(MockMeasurementsRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
 
-    let mut state = mock_helpers::app_state::setup_mock_app_state().await;
+    let mut state = mock_helpers::app_state::setup_mock_app_state();
     state.measurements = mock;
 
     let tenant_id = Uuid::new_v4();
@@ -275,7 +276,7 @@ async fn test_get_measurement_not_found() {
     let _guard = common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
 
-    let state = mock_helpers::app_state::setup_mock_app_state().await;
+    let state = mock_helpers::app_state::setup_mock_app_state();
     let tenant_id = Uuid::new_v4();
     let base_url = common::spawn_test_server(state).await;
     let jwt = common::create_test_jwt(tenant_id, "admin");
@@ -304,7 +305,7 @@ async fn test_get_measurement_found() {
     let mock = Arc::new(MockMeasurementsRepository::default());
     mock.return_some.store(true, Ordering::SeqCst);
 
-    let mut state = mock_helpers::app_state::setup_mock_app_state().await;
+    let mut state = mock_helpers::app_state::setup_mock_app_state();
     state.measurements = mock;
 
     let tenant_id = Uuid::new_v4();
@@ -337,7 +338,7 @@ async fn test_get_measurement_db_error() {
     let mock = Arc::new(MockMeasurementsRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
 
-    let mut state = mock_helpers::app_state::setup_mock_app_state().await;
+    let mut state = mock_helpers::app_state::setup_mock_app_state();
     state.measurements = mock;
 
     let tenant_id = Uuid::new_v4();
@@ -368,7 +369,7 @@ async fn test_update_measurement_success() {
     let mock = Arc::new(MockMeasurementsRepository::default());
     mock.return_some.store(true, Ordering::SeqCst);
 
-    let mut state = mock_helpers::app_state::setup_mock_app_state().await;
+    let mut state = mock_helpers::app_state::setup_mock_app_state();
     state.measurements = mock;
 
     let tenant_id = Uuid::new_v4();
@@ -406,7 +407,7 @@ async fn test_update_measurement_not_found() {
     std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
 
     // return_some defaults to false → update returns None → 404
-    let state = mock_helpers::app_state::setup_mock_app_state().await;
+    let state = mock_helpers::app_state::setup_mock_app_state();
     let tenant_id = Uuid::new_v4();
     let base_url = common::spawn_test_server(state).await;
     let jwt = common::create_test_jwt(tenant_id, "admin");
@@ -440,7 +441,7 @@ async fn test_update_measurement_db_error() {
     let mock = Arc::new(MockMeasurementsRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
 
-    let mut state = mock_helpers::app_state::setup_mock_app_state().await;
+    let mut state = mock_helpers::app_state::setup_mock_app_state();
     state.measurements = mock;
 
     let tenant_id = Uuid::new_v4();
@@ -473,7 +474,7 @@ async fn test_update_measurement_invalid_result_type() {
     let _guard = common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
 
-    let state = mock_helpers::app_state::setup_mock_app_state().await;
+    let state = mock_helpers::app_state::setup_mock_app_state();
     let tenant_id = Uuid::new_v4();
     let base_url = common::spawn_test_server(state).await;
     let jwt = common::create_test_jwt(tenant_id, "admin");
@@ -504,7 +505,7 @@ async fn test_update_measurement_invalid_status() {
     let _guard = common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
 
-    let state = mock_helpers::app_state::setup_mock_app_state().await;
+    let state = mock_helpers::app_state::setup_mock_app_state();
     let tenant_id = Uuid::new_v4();
     let base_url = common::spawn_test_server(state).await;
     let jwt = common::create_test_jwt(tenant_id, "admin");
@@ -535,7 +536,7 @@ async fn test_update_measurement_invalid_json() {
     let _guard = common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
 
-    let state = mock_helpers::app_state::setup_mock_app_state().await;
+    let state = mock_helpers::app_state::setup_mock_app_state();
     let tenant_id = Uuid::new_v4();
     let base_url = common::spawn_test_server(state).await;
     let jwt = common::create_test_jwt(tenant_id, "admin");
@@ -572,7 +573,7 @@ async fn test_get_face_photo_success() {
     mock_repo.return_some.store(true, Ordering::SeqCst);
     *mock_repo.face_photo_url.lock().unwrap() = Some(photo_url);
 
-    let mut state = mock_helpers::app_state::setup_mock_app_state().await;
+    let mut state = mock_helpers::app_state::setup_mock_app_state();
     state.measurements = mock_repo;
     state.storage = mock_storage;
 
@@ -608,7 +609,7 @@ async fn test_get_face_photo_no_url() {
     mock_repo.return_some.store(true, Ordering::SeqCst);
     // face_photo_url is None by default
 
-    let mut state = mock_helpers::app_state::setup_mock_app_state().await;
+    let mut state = mock_helpers::app_state::setup_mock_app_state();
     state.measurements = mock_repo;
 
     let tenant_id = Uuid::new_v4();
@@ -637,7 +638,7 @@ async fn test_get_face_photo_measurement_not_found() {
     std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
 
     // return_some defaults to false → get returns None → 404
-    let state = mock_helpers::app_state::setup_mock_app_state().await;
+    let state = mock_helpers::app_state::setup_mock_app_state();
     let tenant_id = Uuid::new_v4();
     let base_url = common::spawn_test_server(state).await;
     let jwt = common::create_test_jwt(tenant_id, "admin");
@@ -666,7 +667,7 @@ async fn test_get_face_photo_db_error() {
     let mock_repo = Arc::new(MockMeasurementsRepository::default());
     mock_repo.fail_next.store(true, Ordering::SeqCst);
 
-    let mut state = mock_helpers::app_state::setup_mock_app_state().await;
+    let mut state = mock_helpers::app_state::setup_mock_app_state();
     state.measurements = mock_repo;
 
     let tenant_id = Uuid::new_v4();
@@ -703,7 +704,7 @@ async fn test_get_video_success() {
     mock_repo.return_some.store(true, Ordering::SeqCst);
     *mock_repo.video_url.lock().unwrap() = Some(video_url);
 
-    let mut state = mock_helpers::app_state::setup_mock_app_state().await;
+    let mut state = mock_helpers::app_state::setup_mock_app_state();
     state.measurements = mock_repo;
     state.storage = mock_storage;
 
@@ -739,7 +740,7 @@ async fn test_get_video_no_url() {
     mock_repo.return_some.store(true, Ordering::SeqCst);
     // video_url is None by default
 
-    let mut state = mock_helpers::app_state::setup_mock_app_state().await;
+    let mut state = mock_helpers::app_state::setup_mock_app_state();
     state.measurements = mock_repo;
 
     let tenant_id = Uuid::new_v4();
@@ -768,7 +769,7 @@ async fn test_get_video_measurement_not_found() {
     std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
 
     // return_some defaults to false → get returns None → 404
-    let state = mock_helpers::app_state::setup_mock_app_state().await;
+    let state = mock_helpers::app_state::setup_mock_app_state();
     let tenant_id = Uuid::new_v4();
     let base_url = common::spawn_test_server(state).await;
     let jwt = common::create_test_jwt(tenant_id, "admin");
@@ -797,7 +798,7 @@ async fn test_get_video_db_error() {
     let mock_repo = Arc::new(MockMeasurementsRepository::default());
     mock_repo.fail_next.store(true, Ordering::SeqCst);
 
-    let mut state = mock_helpers::app_state::setup_mock_app_state().await;
+    let mut state = mock_helpers::app_state::setup_mock_app_state();
     state.measurements = mock_repo;
 
     let tenant_id = Uuid::new_v4();
@@ -825,7 +826,7 @@ async fn test_measurements_no_auth() {
     let _guard = common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
 
-    let state = mock_helpers::app_state::setup_mock_app_state().await;
+    let state = mock_helpers::app_state::setup_mock_app_state();
     let base_url = common::spawn_test_server(state).await;
     let client = reqwest::Client::new();
 
@@ -908,7 +909,7 @@ async fn test_get_face_photo_storage_download_error() {
     mock_repo.return_some.store(true, Ordering::SeqCst);
     *mock_repo.face_photo_url.lock().unwrap() = Some(missing_url);
 
-    let mut state = mock_helpers::app_state::setup_mock_app_state().await;
+    let mut state = mock_helpers::app_state::setup_mock_app_state();
     state.measurements = mock_repo;
     state.storage = mock_storage;
 
@@ -944,7 +945,7 @@ async fn test_get_video_storage_download_error() {
     mock_repo.return_some.store(true, Ordering::SeqCst);
     *mock_repo.video_url.lock().unwrap() = Some(missing_url);
 
-    let mut state = mock_helpers::app_state::setup_mock_app_state().await;
+    let mut state = mock_helpers::app_state::setup_mock_app_state();
     state.measurements = mock_repo;
     state.storage = mock_storage;
 
@@ -980,7 +981,7 @@ async fn test_get_face_photo_extract_key_fails() {
     *mock_repo.face_photo_url.lock().unwrap() =
         Some("https://other-storage.example.com/photo.jpg".to_string());
 
-    let mut state = mock_helpers::app_state::setup_mock_app_state().await;
+    let mut state = mock_helpers::app_state::setup_mock_app_state();
     state.measurements = mock_repo;
 
     let tenant_id = Uuid::new_v4();
@@ -1013,7 +1014,7 @@ async fn test_get_video_extract_key_fails() {
     *mock_repo.video_url.lock().unwrap() =
         Some("https://other-storage.example.com/video.webm".to_string());
 
-    let mut state = mock_helpers::app_state::setup_mock_app_state().await;
+    let mut state = mock_helpers::app_state::setup_mock_app_state();
     state.measurements = mock_repo;
 
     let tenant_id = Uuid::new_v4();
@@ -1041,7 +1042,7 @@ async fn test_measurements_with_tenant_header() {
     let _guard = common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
 
-    let state = mock_helpers::app_state::setup_mock_app_state().await;
+    let state = mock_helpers::app_state::setup_mock_app_state();
     let tenant_id = Uuid::new_v4();
     let base_url = common::spawn_test_server(state).await;
     let client = reqwest::Client::new();

--- a/tests/mock_nfc_tags_test.rs
+++ b/tests/mock_nfc_tags_test.rs
@@ -2,12 +2,13 @@
 mod common;
 mod mock_helpers;
 
+use uuid::Uuid;
+
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use chrono::Utc;
 use serde_json::Value;
-use uuid::Uuid;
 
 use rust_alc_api::db::models::NfcTag;
 use rust_alc_api::db::repository::nfc_tags::NfcTagRepository;
@@ -20,7 +21,7 @@ async fn spawn_with_mock(mock: Arc<dyn NfcTagRepository>) -> (String, String) {
     let tenant_id = Uuid::new_v4();
     let jwt = common::create_test_jwt(tenant_id, "admin");
 
-    let mut state = mock_helpers::app_state::setup_mock_app_state().await;
+    let mut state = mock_helpers::app_state::setup_mock_app_state();
     state.nfc_tags = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -419,7 +420,7 @@ async fn test_delete_tag_db_error() {
 #[tokio::test]
 async fn test_no_auth_returns_401() {
     let mock = Arc::new(mock_helpers::MockNfcTagRepository::default());
-    let mut state = mock_helpers::app_state::setup_mock_app_state().await;
+    let mut state = mock_helpers::app_state::setup_mock_app_state();
     state.nfc_tags = mock;
     let base_url = common::spawn_test_server(state).await;
     let client = reqwest::Client::new();

--- a/tests/mock_sso_admin_test.rs
+++ b/tests/mock_sso_admin_test.rs
@@ -1,6 +1,8 @@
 mod common;
 mod mock_helpers;
 
+use uuid::Uuid;
+
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
@@ -9,7 +11,7 @@ use mock_helpers::MockSsoAdminRepository;
 /// Helper: set up mock AppState and spawn test server with admin JWT.
 /// Returns (base_url, auth_header).
 async fn setup() -> (String, String) {
-    let state = mock_helpers::app_state::setup_mock_app_state().await;
+    let state = mock_helpers::app_state::setup_mock_app_state();
     let tenant_id = uuid::Uuid::new_v4();
     let base_url = common::spawn_test_server(state).await;
     let jwt = common::create_test_jwt(tenant_id, "admin");
@@ -21,7 +23,7 @@ async fn setup() -> (String, String) {
 async fn setup_failing() -> (String, String) {
     let mock = Arc::new(MockSsoAdminRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
-    let mut state = mock_helpers::app_state::setup_mock_app_state().await;
+    let mut state = mock_helpers::app_state::setup_mock_app_state();
     state.sso_admin = mock;
     let tenant_id = uuid::Uuid::new_v4();
     let base_url = common::spawn_test_server(state).await;
@@ -53,7 +55,7 @@ async fn test_list_configs_success() {
 
 #[tokio::test]
 async fn test_list_configs_forbidden_for_viewer() {
-    let state = mock_helpers::app_state::setup_mock_app_state().await;
+    let state = mock_helpers::app_state::setup_mock_app_state();
     let tenant_id = uuid::Uuid::new_v4();
     let base_url = common::spawn_test_server(state).await;
     let jwt = common::create_test_jwt(tenant_id, "viewer");
@@ -71,7 +73,7 @@ async fn test_list_configs_forbidden_for_viewer() {
 
 #[tokio::test]
 async fn test_list_configs_no_auth() {
-    let state = mock_helpers::app_state::setup_mock_app_state().await;
+    let state = mock_helpers::app_state::setup_mock_app_state();
     let base_url = common::spawn_test_server(state).await;
     let client = reqwest::Client::new();
 
@@ -210,7 +212,7 @@ async fn test_upsert_config_with_woff_id() {
 
 #[tokio::test]
 async fn test_upsert_config_forbidden_for_viewer() {
-    let state = mock_helpers::app_state::setup_mock_app_state().await;
+    let state = mock_helpers::app_state::setup_mock_app_state();
     let tenant_id = uuid::Uuid::new_v4();
     let base_url = common::spawn_test_server(state).await;
     let jwt = common::create_test_jwt(tenant_id, "viewer");
@@ -233,7 +235,7 @@ async fn test_upsert_config_forbidden_for_viewer() {
 
 #[tokio::test]
 async fn test_upsert_config_no_auth() {
-    let state = mock_helpers::app_state::setup_mock_app_state().await;
+    let state = mock_helpers::app_state::setup_mock_app_state();
     let base_url = common::spawn_test_server(state).await;
     let client = reqwest::Client::new();
 
@@ -273,7 +275,7 @@ async fn test_upsert_config_without_secret_db_error() {
 async fn test_upsert_config_with_secret_db_error() {
     let mock = Arc::new(MockSsoAdminRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
-    let mut state = mock_helpers::app_state::setup_mock_app_state().await;
+    let mut state = mock_helpers::app_state::setup_mock_app_state();
     state.sso_admin = mock;
     let tenant_id = uuid::Uuid::new_v4();
     let base_url = common::spawn_test_server(state).await;
@@ -345,7 +347,7 @@ async fn test_delete_config_success() {
 
 #[tokio::test]
 async fn test_delete_config_forbidden_for_viewer() {
-    let state = mock_helpers::app_state::setup_mock_app_state().await;
+    let state = mock_helpers::app_state::setup_mock_app_state();
     let tenant_id = uuid::Uuid::new_v4();
     let base_url = common::spawn_test_server(state).await;
     let jwt = common::create_test_jwt(tenant_id, "viewer");
@@ -364,7 +366,7 @@ async fn test_delete_config_forbidden_for_viewer() {
 
 #[tokio::test]
 async fn test_delete_config_no_auth() {
-    let state = mock_helpers::app_state::setup_mock_app_state().await;
+    let state = mock_helpers::app_state::setup_mock_app_state();
     let base_url = common::spawn_test_server(state).await;
     let client = reqwest::Client::new();
 

--- a/tests/mock_tenant_users_test.rs
+++ b/tests/mock_tenant_users_test.rs
@@ -1,6 +1,8 @@
 mod common;
 mod mock_helpers;
 
+use uuid::Uuid;
+
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
@@ -9,7 +11,7 @@ use mock_helpers::MockTenantUsersRepository;
 /// Helper: set up mock AppState and spawn test server with admin JWT.
 /// Returns (base_url, auth_header, user_id, tenant_id).
 async fn setup() -> (String, String, uuid::Uuid, uuid::Uuid) {
-    let state = mock_helpers::app_state::setup_mock_app_state().await;
+    let state = mock_helpers::app_state::setup_mock_app_state();
     let tenant_id = uuid::Uuid::new_v4();
     let user_id = uuid::Uuid::new_v4();
     let base_url = common::spawn_test_server(state).await;
@@ -22,7 +24,7 @@ async fn setup() -> (String, String, uuid::Uuid, uuid::Uuid) {
 async fn setup_failing() -> (String, String, uuid::Uuid, uuid::Uuid) {
     let mock = Arc::new(MockTenantUsersRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
-    let mut state = mock_helpers::app_state::setup_mock_app_state().await;
+    let mut state = mock_helpers::app_state::setup_mock_app_state();
     state.tenant_users = mock;
     let tenant_id = uuid::Uuid::new_v4();
     let user_id = uuid::Uuid::new_v4();
@@ -55,7 +57,7 @@ async fn test_list_users_success() {
 
 #[tokio::test]
 async fn test_list_users_forbidden_for_viewer() {
-    let state = mock_helpers::app_state::setup_mock_app_state().await;
+    let state = mock_helpers::app_state::setup_mock_app_state();
     let tenant_id = uuid::Uuid::new_v4();
     let base_url = common::spawn_test_server(state).await;
     let jwt = common::create_test_jwt(tenant_id, "viewer");
@@ -73,7 +75,7 @@ async fn test_list_users_forbidden_for_viewer() {
 
 #[tokio::test]
 async fn test_list_users_no_auth() {
-    let state = mock_helpers::app_state::setup_mock_app_state().await;
+    let state = mock_helpers::app_state::setup_mock_app_state();
     let base_url = common::spawn_test_server(state).await;
     let client = reqwest::Client::new();
 
@@ -122,7 +124,7 @@ async fn test_list_invitations_success() {
 
 #[tokio::test]
 async fn test_list_invitations_forbidden_for_viewer() {
-    let state = mock_helpers::app_state::setup_mock_app_state().await;
+    let state = mock_helpers::app_state::setup_mock_app_state();
     let tenant_id = uuid::Uuid::new_v4();
     let base_url = common::spawn_test_server(state).await;
     let jwt = common::create_test_jwt(tenant_id, "viewer");
@@ -140,7 +142,7 @@ async fn test_list_invitations_forbidden_for_viewer() {
 
 #[tokio::test]
 async fn test_list_invitations_no_auth() {
-    let state = mock_helpers::app_state::setup_mock_app_state().await;
+    let state = mock_helpers::app_state::setup_mock_app_state();
     let base_url = common::spawn_test_server(state).await;
     let client = reqwest::Client::new();
 
@@ -156,7 +158,7 @@ async fn test_list_invitations_no_auth() {
 async fn test_list_invitations_db_error() {
     let mock = Arc::new(MockTenantUsersRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
-    let mut state = mock_helpers::app_state::setup_mock_app_state().await;
+    let mut state = mock_helpers::app_state::setup_mock_app_state();
     state.tenant_users = mock;
     let tenant_id = uuid::Uuid::new_v4();
     let base_url = common::spawn_test_server(state).await;
@@ -259,7 +261,7 @@ async fn test_invite_user_invalid_role() {
 
 #[tokio::test]
 async fn test_invite_user_forbidden_for_viewer() {
-    let state = mock_helpers::app_state::setup_mock_app_state().await;
+    let state = mock_helpers::app_state::setup_mock_app_state();
     let tenant_id = uuid::Uuid::new_v4();
     let base_url = common::spawn_test_server(state).await;
     let jwt = common::create_test_jwt(tenant_id, "viewer");
@@ -280,7 +282,7 @@ async fn test_invite_user_forbidden_for_viewer() {
 
 #[tokio::test]
 async fn test_invite_user_no_auth() {
-    let state = mock_helpers::app_state::setup_mock_app_state().await;
+    let state = mock_helpers::app_state::setup_mock_app_state();
     let base_url = common::spawn_test_server(state).await;
     let client = reqwest::Client::new();
 
@@ -299,7 +301,7 @@ async fn test_invite_user_no_auth() {
 async fn test_invite_user_db_error() {
     let mock = Arc::new(MockTenantUsersRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
-    let mut state = mock_helpers::app_state::setup_mock_app_state().await;
+    let mut state = mock_helpers::app_state::setup_mock_app_state();
     state.tenant_users = mock;
     let tenant_id = uuid::Uuid::new_v4();
     let base_url = common::spawn_test_server(state).await;
@@ -340,7 +342,7 @@ async fn test_delete_invitation_success() {
 
 #[tokio::test]
 async fn test_delete_invitation_forbidden_for_viewer() {
-    let state = mock_helpers::app_state::setup_mock_app_state().await;
+    let state = mock_helpers::app_state::setup_mock_app_state();
     let tenant_id = uuid::Uuid::new_v4();
     let base_url = common::spawn_test_server(state).await;
     let jwt = common::create_test_jwt(tenant_id, "viewer");
@@ -359,7 +361,7 @@ async fn test_delete_invitation_forbidden_for_viewer() {
 
 #[tokio::test]
 async fn test_delete_invitation_no_auth() {
-    let state = mock_helpers::app_state::setup_mock_app_state().await;
+    let state = mock_helpers::app_state::setup_mock_app_state();
     let base_url = common::spawn_test_server(state).await;
     let client = reqwest::Client::new();
     let id = uuid::Uuid::new_v4();
@@ -376,7 +378,7 @@ async fn test_delete_invitation_no_auth() {
 async fn test_delete_invitation_db_error() {
     let mock = Arc::new(MockTenantUsersRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
-    let mut state = mock_helpers::app_state::setup_mock_app_state().await;
+    let mut state = mock_helpers::app_state::setup_mock_app_state();
     state.tenant_users = mock;
     let tenant_id = uuid::Uuid::new_v4();
     let base_url = common::spawn_test_server(state).await;
@@ -429,7 +431,7 @@ async fn test_delete_user_cannot_delete_self() {
 
 #[tokio::test]
 async fn test_delete_user_forbidden_for_viewer() {
-    let state = mock_helpers::app_state::setup_mock_app_state().await;
+    let state = mock_helpers::app_state::setup_mock_app_state();
     let tenant_id = uuid::Uuid::new_v4();
     let base_url = common::spawn_test_server(state).await;
     let jwt = common::create_test_jwt(tenant_id, "viewer");
@@ -448,7 +450,7 @@ async fn test_delete_user_forbidden_for_viewer() {
 
 #[tokio::test]
 async fn test_delete_user_no_auth() {
-    let state = mock_helpers::app_state::setup_mock_app_state().await;
+    let state = mock_helpers::app_state::setup_mock_app_state();
     let base_url = common::spawn_test_server(state).await;
     let client = reqwest::Client::new();
     let id = uuid::Uuid::new_v4();
@@ -465,7 +467,7 @@ async fn test_delete_user_no_auth() {
 async fn test_delete_user_db_error() {
     let mock = Arc::new(MockTenantUsersRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
-    let mut state = mock_helpers::app_state::setup_mock_app_state().await;
+    let mut state = mock_helpers::app_state::setup_mock_app_state();
     state.tenant_users = mock;
     let tenant_id = uuid::Uuid::new_v4();
     let user_id = uuid::Uuid::new_v4();
@@ -492,8 +494,8 @@ async fn test_delete_user_db_error() {
 async fn test_list_users_with_data() {
     use rust_alc_api::db::repository::tenant_users::UserRow;
 
-    let mut state = mock_helpers::app_state::setup_mock_app_state().await;
-    let tenant_id = common::create_test_tenant(&state.pool, "MockTUData").await;
+    let mut state = mock_helpers::app_state::setup_mock_app_state();
+    let tenant_id = Uuid::new_v4();
 
     let mock = std::sync::Arc::new(mock_helpers::MockTenantUsersRepository::default());
     *mock.users.lock().unwrap() = vec![UserRow {

--- a/tests/mock_tenko_call_test.rs
+++ b/tests/mock_tenko_call_test.rs
@@ -2,11 +2,12 @@
 mod common;
 mod mock_helpers;
 
+use uuid::Uuid;
+
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use serde_json::Value;
-use uuid::Uuid;
 
 use mock_helpers::app_state::setup_mock_app_state;
 use mock_helpers::MockTenkoCallRepository;
@@ -24,7 +25,7 @@ async fn test_register_success() {
 
         let mock = Arc::new(MockTenkoCallRepository::default());
         mock.return_some.store(true, Ordering::SeqCst);
-        let mut state = setup_mock_app_state().await;
+        let mut state = setup_mock_app_state();
         state.tenko_call = mock;
         let base_url = common::spawn_test_server(state).await;
 
@@ -58,7 +59,7 @@ async fn test_register_without_employee_code() {
 
         let mock = Arc::new(MockTenkoCallRepository::default());
         mock.return_some.store(true, Ordering::SeqCst);
-        let mut state = setup_mock_app_state().await;
+        let mut state = setup_mock_app_state();
         state.tenko_call = mock;
         let base_url = common::spawn_test_server(state).await;
 
@@ -89,7 +90,7 @@ async fn test_register_unknown_call_number() {
 
         let mock = Arc::new(MockTenkoCallRepository::default());
         // return_some = false (default) → Ok(None) → BAD_REQUEST
-        let mut state = setup_mock_app_state().await;
+        let mut state = setup_mock_app_state();
         state.tenko_call = mock;
         let base_url = common::spawn_test_server(state).await;
 
@@ -121,7 +122,7 @@ async fn test_register_db_error() {
 
         let mock = Arc::new(MockTenkoCallRepository::default());
         mock.fail_next.store(true, Ordering::SeqCst);
-        let mut state = setup_mock_app_state().await;
+        let mut state = setup_mock_app_state();
         state.tenko_call = mock;
         let base_url = common::spawn_test_server(state).await;
 
@@ -156,7 +157,7 @@ async fn test_tenko_success() {
 
         let mock = Arc::new(MockTenkoCallRepository::default());
         mock.return_some.store(true, Ordering::SeqCst);
-        let mut state = setup_mock_app_state().await;
+        let mut state = setup_mock_app_state();
         state.tenko_call = mock;
         let base_url = common::spawn_test_server(state).await;
 
@@ -188,7 +189,7 @@ async fn test_tenko_driver_not_found() {
 
         let mock = Arc::new(MockTenkoCallRepository::default());
         // return_some = false (default) → Ok(None) → NOT_FOUND
-        let mut state = setup_mock_app_state().await;
+        let mut state = setup_mock_app_state();
         state.tenko_call = mock;
         let base_url = common::spawn_test_server(state).await;
 
@@ -217,7 +218,7 @@ async fn test_tenko_db_error() {
 
         let mock = Arc::new(MockTenkoCallRepository::default());
         mock.fail_next.store(true, Ordering::SeqCst);
-        let mut state = setup_mock_app_state().await;
+        let mut state = setup_mock_app_state();
         state.tenko_call = mock;
         let base_url = common::spawn_test_server(state).await;
 
@@ -249,7 +250,7 @@ async fn test_list_numbers_empty() {
         std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
 
         let mock = Arc::new(MockTenkoCallRepository::default());
-        let mut state = setup_mock_app_state().await;
+        let mut state = setup_mock_app_state();
         state.tenko_call = mock;
         let base_url = common::spawn_test_server(state).await;
 
@@ -278,7 +279,7 @@ async fn test_list_numbers_with_data() {
 
         let mock = Arc::new(MockTenkoCallRepository::default());
         mock.return_data.store(true, Ordering::SeqCst);
-        let mut state = setup_mock_app_state().await;
+        let mut state = setup_mock_app_state();
         state.tenko_call = mock;
         let base_url = common::spawn_test_server(state).await;
 
@@ -312,7 +313,7 @@ async fn test_list_numbers_with_x_tenant_id() {
         std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
 
         let mock = Arc::new(MockTenkoCallRepository::default());
-        let mut state = setup_mock_app_state().await;
+        let mut state = setup_mock_app_state();
         state.tenko_call = mock;
         let base_url = common::spawn_test_server(state).await;
 
@@ -335,7 +336,7 @@ async fn test_list_numbers_no_auth() {
         std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
 
         let mock = Arc::new(MockTenkoCallRepository::default());
-        let mut state = setup_mock_app_state().await;
+        let mut state = setup_mock_app_state();
         state.tenko_call = mock;
         let base_url = common::spawn_test_server(state).await;
 
@@ -358,7 +359,7 @@ async fn test_list_numbers_db_error() {
 
         let mock = Arc::new(MockTenkoCallRepository::default());
         mock.fail_next.store(true, Ordering::SeqCst);
-        let mut state = setup_mock_app_state().await;
+        let mut state = setup_mock_app_state();
         state.tenko_call = mock;
         let base_url = common::spawn_test_server(state).await;
 
@@ -388,7 +389,7 @@ async fn test_create_number_success() {
         std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
 
         let mock = Arc::new(MockTenkoCallRepository::default());
-        let mut state = setup_mock_app_state().await;
+        let mut state = setup_mock_app_state();
         state.tenko_call = mock;
         let base_url = common::spawn_test_server(state).await;
 
@@ -422,7 +423,7 @@ async fn test_create_number_without_tenant_id() {
         std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
 
         let mock = Arc::new(MockTenkoCallRepository::default());
-        let mut state = setup_mock_app_state().await;
+        let mut state = setup_mock_app_state();
         state.tenko_call = mock;
         let base_url = common::spawn_test_server(state).await;
 
@@ -454,7 +455,7 @@ async fn test_create_number_without_label() {
         std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
 
         let mock = Arc::new(MockTenkoCallRepository::default());
-        let mut state = setup_mock_app_state().await;
+        let mut state = setup_mock_app_state();
         state.tenko_call = mock;
         let base_url = common::spawn_test_server(state).await;
 
@@ -486,7 +487,7 @@ async fn test_create_number_no_auth() {
         std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
 
         let mock = Arc::new(MockTenkoCallRepository::default());
-        let mut state = setup_mock_app_state().await;
+        let mut state = setup_mock_app_state();
         state.tenko_call = mock;
         let base_url = common::spawn_test_server(state).await;
 
@@ -512,7 +513,7 @@ async fn test_create_number_db_error() {
 
         let mock = Arc::new(MockTenkoCallRepository::default());
         mock.fail_next.store(true, Ordering::SeqCst);
-        let mut state = setup_mock_app_state().await;
+        let mut state = setup_mock_app_state();
         state.tenko_call = mock;
         let base_url = common::spawn_test_server(state).await;
 
@@ -545,7 +546,7 @@ async fn test_delete_number_success() {
         std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
 
         let mock = Arc::new(MockTenkoCallRepository::default());
-        let mut state = setup_mock_app_state().await;
+        let mut state = setup_mock_app_state();
         state.tenko_call = mock;
         let base_url = common::spawn_test_server(state).await;
 
@@ -571,7 +572,7 @@ async fn test_delete_number_no_auth() {
         std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
 
         let mock = Arc::new(MockTenkoCallRepository::default());
-        let mut state = setup_mock_app_state().await;
+        let mut state = setup_mock_app_state();
         state.tenko_call = mock;
         let base_url = common::spawn_test_server(state).await;
 
@@ -594,7 +595,7 @@ async fn test_delete_number_db_error() {
 
         let mock = Arc::new(MockTenkoCallRepository::default());
         mock.fail_next.store(true, Ordering::SeqCst);
-        let mut state = setup_mock_app_state().await;
+        let mut state = setup_mock_app_state();
         state.tenko_call = mock;
         let base_url = common::spawn_test_server(state).await;
 
@@ -624,7 +625,7 @@ async fn test_list_drivers_empty() {
         std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
 
         let mock = Arc::new(MockTenkoCallRepository::default());
-        let mut state = setup_mock_app_state().await;
+        let mut state = setup_mock_app_state();
         state.tenko_call = mock;
         let base_url = common::spawn_test_server(state).await;
 
@@ -653,7 +654,7 @@ async fn test_list_drivers_with_data() {
 
         let mock = Arc::new(MockTenkoCallRepository::default());
         mock.return_data.store(true, Ordering::SeqCst);
-        let mut state = setup_mock_app_state().await;
+        let mut state = setup_mock_app_state();
         state.tenko_call = mock;
         let base_url = common::spawn_test_server(state).await;
 
@@ -689,7 +690,7 @@ async fn test_list_drivers_no_auth() {
         std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
 
         let mock = Arc::new(MockTenkoCallRepository::default());
-        let mut state = setup_mock_app_state().await;
+        let mut state = setup_mock_app_state();
         state.tenko_call = mock;
         let base_url = common::spawn_test_server(state).await;
 
@@ -712,7 +713,7 @@ async fn test_list_drivers_db_error() {
 
         let mock = Arc::new(MockTenkoCallRepository::default());
         mock.fail_next.store(true, Ordering::SeqCst);
-        let mut state = setup_mock_app_state().await;
+        let mut state = setup_mock_app_state();
         state.tenko_call = mock;
         let base_url = common::spawn_test_server(state).await;
 

--- a/tests/mock_tenko_records_test.rs
+++ b/tests/mock_tenko_records_test.rs
@@ -1,6 +1,8 @@
 mod common;
 mod mock_helpers;
 
+use uuid::Uuid;
+
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
@@ -9,7 +11,7 @@ use mock_helpers::MockTenkoRecordsRepository;
 /// Helper: set up mock AppState and spawn test server with admin JWT.
 /// Returns (base_url, auth_header, tenant_id).
 async fn setup() -> (String, String, uuid::Uuid) {
-    let state = mock_helpers::app_state::setup_mock_app_state().await;
+    let state = mock_helpers::app_state::setup_mock_app_state();
     let tenant_id = uuid::Uuid::new_v4();
     let base_url = common::spawn_test_server(state).await;
     let jwt = common::create_test_jwt(tenant_id, "admin");
@@ -21,7 +23,7 @@ async fn setup() -> (String, String, uuid::Uuid) {
 async fn setup_failing() -> (String, String) {
     let mock = Arc::new(MockTenkoRecordsRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
-    let mut state = mock_helpers::app_state::setup_mock_app_state().await;
+    let mut state = mock_helpers::app_state::setup_mock_app_state();
     state.tenko_records = mock;
     let tenant_id = uuid::Uuid::new_v4();
     let base_url = common::spawn_test_server(state).await;
@@ -34,7 +36,7 @@ async fn setup_failing() -> (String, String) {
 async fn setup_found() -> (String, String) {
     let mock = Arc::new(MockTenkoRecordsRepository::default());
     mock.return_some.store(true, Ordering::SeqCst);
-    let mut state = mock_helpers::app_state::setup_mock_app_state().await;
+    let mut state = mock_helpers::app_state::setup_mock_app_state();
     state.tenko_records = mock;
     let tenant_id = uuid::Uuid::new_v4();
     let base_url = common::spawn_test_server(state).await;
@@ -47,7 +49,7 @@ async fn setup_found() -> (String, String) {
 async fn setup_with_data() -> (String, String) {
     let mock = Arc::new(MockTenkoRecordsRepository::default());
     mock.return_data.store(true, Ordering::SeqCst);
-    let mut state = mock_helpers::app_state::setup_mock_app_state().await;
+    let mut state = mock_helpers::app_state::setup_mock_app_state();
     state.tenko_records = mock;
     let tenant_id = uuid::Uuid::new_v4();
     let base_url = common::spawn_test_server(state).await;
@@ -449,7 +451,7 @@ async fn test_export_csv_with_ng_daily_inspection() {
     // Test that daily_inspection with an "ng" item produces "ng" in CSV
     let mock = Arc::new(MockTenkoRecordsRepository::default());
     mock.return_data.store(true, Ordering::SeqCst);
-    let mut state = mock_helpers::app_state::setup_mock_app_state().await;
+    let mut state = mock_helpers::app_state::setup_mock_app_state();
     state.tenko_records = mock;
     let tenant_id = uuid::Uuid::new_v4();
     let base_url = common::spawn_test_server(state).await;

--- a/tests/mock_tenko_schedules_test.rs
+++ b/tests/mock_tenko_schedules_test.rs
@@ -1,6 +1,8 @@
 mod common;
 mod mock_helpers;
 
+use uuid::Uuid;
+
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
@@ -9,7 +11,7 @@ use mock_helpers::MockTenkoSchedulesRepository;
 /// Helper: set up mock AppState and spawn test server with admin JWT.
 /// Returns (base_url, auth_header, tenant_id).
 async fn setup() -> (String, String, uuid::Uuid) {
-    let state = mock_helpers::app_state::setup_mock_app_state().await;
+    let state = mock_helpers::app_state::setup_mock_app_state();
     let tenant_id = uuid::Uuid::new_v4();
     let base_url = common::spawn_test_server(state).await;
     let jwt = common::create_test_jwt(tenant_id, "admin");
@@ -21,7 +23,7 @@ async fn setup() -> (String, String, uuid::Uuid) {
 async fn setup_failing() -> (String, String) {
     let mock = Arc::new(MockTenkoSchedulesRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
-    let mut state = mock_helpers::app_state::setup_mock_app_state().await;
+    let mut state = mock_helpers::app_state::setup_mock_app_state();
     state.tenko_schedules = mock;
     let tenant_id = uuid::Uuid::new_v4();
     let base_url = common::spawn_test_server(state).await;
@@ -34,7 +36,7 @@ async fn setup_failing() -> (String, String) {
 async fn setup_not_found() -> (String, String) {
     let mock = Arc::new(MockTenkoSchedulesRepository::default());
     mock.return_none.store(true, Ordering::SeqCst);
-    let mut state = mock_helpers::app_state::setup_mock_app_state().await;
+    let mut state = mock_helpers::app_state::setup_mock_app_state();
     state.tenko_schedules = mock;
     let tenant_id = uuid::Uuid::new_v4();
     let base_url = common::spawn_test_server(state).await;

--- a/tests/mock_tenko_sessions_test.rs
+++ b/tests/mock_tenko_sessions_test.rs
@@ -1,11 +1,12 @@
 mod common;
 mod mock_helpers;
 
+use uuid::Uuid;
+
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use mock_helpers::MockTenkoSessionRepository;
-use uuid::Uuid;
 
 // =========================================================================
 // Helpers
@@ -13,7 +14,7 @@ use uuid::Uuid;
 
 /// Default setup: session returned with identity_verified + pre_operation.
 async fn setup() -> (String, String, uuid::Uuid) {
-    let state = mock_helpers::app_state::setup_mock_app_state().await;
+    let state = mock_helpers::app_state::setup_mock_app_state();
     let tenant_id = uuid::Uuid::new_v4();
     let base_url = common::spawn_test_server(state).await;
     let jwt = common::create_test_jwt(tenant_id, "admin");
@@ -23,7 +24,7 @@ async fn setup() -> (String, String, uuid::Uuid) {
 
 /// Setup with a custom MockTenkoSessionRepository.
 async fn setup_with_mock(mock: Arc<MockTenkoSessionRepository>) -> (String, String, uuid::Uuid) {
-    let mut state = mock_helpers::app_state::setup_mock_app_state().await;
+    let mut state = mock_helpers::app_state::setup_mock_app_state();
     state.tenko_sessions = mock;
     let tenant_id = uuid::Uuid::new_v4();
     let base_url = common::spawn_test_server(state).await;
@@ -36,7 +37,7 @@ async fn setup_with_mock(mock: Arc<MockTenkoSessionRepository>) -> (String, Stri
 async fn setup_with_mock_and_user(
     mock: Arc<MockTenkoSessionRepository>,
 ) -> (String, String, uuid::Uuid, uuid::Uuid) {
-    let mut state = mock_helpers::app_state::setup_mock_app_state().await;
+    let mut state = mock_helpers::app_state::setup_mock_app_state();
     state.tenko_sessions = mock;
     let tenant_id = uuid::Uuid::new_v4();
     let user_id = uuid::Uuid::new_v4();
@@ -50,7 +51,7 @@ async fn setup_with_mock_and_user(
 async fn setup_failing() -> (String, String) {
     let mock = Arc::new(MockTenkoSessionRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
-    let mut state = mock_helpers::app_state::setup_mock_app_state().await;
+    let mut state = mock_helpers::app_state::setup_mock_app_state();
     state.tenko_sessions = mock;
     let tenant_id = uuid::Uuid::new_v4();
     let base_url = common::spawn_test_server(state).await;
@@ -912,8 +913,8 @@ async fn test_submit_self_declaration_success() {
 
     assert_eq!(res.status(), 200);
     let body: serde_json::Value = res.json().await.unwrap();
-    // Safety judgment passes (no baseline = default pass) -> daily_inspection_pending
-    assert_eq!(body["status"], "daily_inspection_pending");
+    // Safety judgment skipped (pool=None) — status stays at self_declaration_pending
+    assert_eq!(body["status"], "self_declaration_pending");
 }
 
 #[tokio::test]
@@ -1646,7 +1647,7 @@ async fn test_resume_session_not_found() {
 async fn test_resume_session_db_error() {
     let mock = Arc::new(MockTenkoSessionRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
-    let mut state = mock_helpers::app_state::setup_mock_app_state().await;
+    let mut state = mock_helpers::app_state::setup_mock_app_state();
     state.tenko_sessions = mock;
     let tenant_id = uuid::Uuid::new_v4();
     let user_id = uuid::Uuid::new_v4();

--- a/tests/mock_tenko_webhooks_test.rs
+++ b/tests/mock_tenko_webhooks_test.rs
@@ -1,11 +1,12 @@
 mod common;
 mod mock_helpers;
 
+use uuid::Uuid;
+
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use serde_json::Value;
-use uuid::Uuid;
 
 use mock_helpers::app_state::setup_mock_app_state;
 use mock_helpers::MockTenkoWebhooksRepository;
@@ -15,7 +16,7 @@ use mock_helpers::MockTenkoWebhooksRepository;
 // =========================================================================
 
 async fn setup() -> (String, String) {
-    let state = setup_mock_app_state().await;
+    let state = setup_mock_app_state();
     let tenant_id = Uuid::new_v4();
     let base_url = common::spawn_test_server(state).await;
     let jwt = common::create_test_jwt(tenant_id, "admin");
@@ -23,7 +24,7 @@ async fn setup() -> (String, String) {
 }
 
 async fn setup_with_mock(mock: Arc<MockTenkoWebhooksRepository>) -> (String, String) {
-    let mut state = setup_mock_app_state().await;
+    let mut state = setup_mock_app_state();
     state.tenko_webhooks = mock;
     let tenant_id = Uuid::new_v4();
     let base_url = common::spawn_test_server(state).await;
@@ -157,7 +158,7 @@ async fn test_upsert_webhook_invalid_event_type() {
 
 #[tokio::test]
 async fn test_upsert_webhook_no_auth() {
-    let state = setup_mock_app_state().await;
+    let state = setup_mock_app_state();
     let base_url = common::spawn_test_server(state).await;
     let client = reqwest::Client::new();
 
@@ -172,7 +173,7 @@ async fn test_upsert_webhook_no_auth() {
 
 #[tokio::test]
 async fn test_upsert_webhook_with_x_tenant_id() {
-    let state = setup_mock_app_state().await;
+    let state = setup_mock_app_state();
     let base_url = common::spawn_test_server(state).await;
     let tenant_id = Uuid::new_v4();
     let client = reqwest::Client::new();
@@ -226,7 +227,7 @@ async fn test_list_webhooks_success() {
 
 #[tokio::test]
 async fn test_list_webhooks_no_auth() {
-    let state = setup_mock_app_state().await;
+    let state = setup_mock_app_state();
     let base_url = common::spawn_test_server(state).await;
     let client = reqwest::Client::new();
 
@@ -240,7 +241,7 @@ async fn test_list_webhooks_no_auth() {
 
 #[tokio::test]
 async fn test_list_webhooks_with_x_tenant_id() {
-    let state = setup_mock_app_state().await;
+    let state = setup_mock_app_state();
     let base_url = common::spawn_test_server(state).await;
     let tenant_id = Uuid::new_v4();
     let client = reqwest::Client::new();
@@ -311,7 +312,7 @@ async fn test_get_webhook_not_found() {
 
 #[tokio::test]
 async fn test_get_webhook_no_auth() {
-    let state = setup_mock_app_state().await;
+    let state = setup_mock_app_state();
     let base_url = common::spawn_test_server(state).await;
     let client = reqwest::Client::new();
 
@@ -379,7 +380,7 @@ async fn test_delete_webhook_not_found() {
 
 #[tokio::test]
 async fn test_delete_webhook_no_auth() {
-    let state = setup_mock_app_state().await;
+    let state = setup_mock_app_state();
     let base_url = common::spawn_test_server(state).await;
     let client = reqwest::Client::new();
 
@@ -432,7 +433,7 @@ async fn test_list_deliveries_success() {
 
 #[tokio::test]
 async fn test_list_deliveries_no_auth() {
-    let state = setup_mock_app_state().await;
+    let state = setup_mock_app_state();
     let base_url = common::spawn_test_server(state).await;
     let client = reqwest::Client::new();
 
@@ -447,7 +448,7 @@ async fn test_list_deliveries_no_auth() {
 
 #[tokio::test]
 async fn test_list_deliveries_with_x_tenant_id() {
-    let state = setup_mock_app_state().await;
+    let state = setup_mock_app_state();
     let base_url = common::spawn_test_server(state).await;
     let tenant_id = Uuid::new_v4();
     let client = reqwest::Client::new();

--- a/tests/mock_timecard_test.rs
+++ b/tests/mock_timecard_test.rs
@@ -2,12 +2,13 @@
 mod common;
 mod mock_helpers;
 
+use uuid::Uuid;
+
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use chrono::{TimeZone, Utc};
 use serde_json::Value;
-use uuid::Uuid;
 
 use rust_alc_api::db::models::TimecardCard;
 use rust_alc_api::db::repository::timecard::{TimePunchCsvRow, TimecardRepository};
@@ -20,7 +21,7 @@ async fn spawn_with_mock(mock: Arc<dyn TimecardRepository>) -> (String, String) 
     let tenant_id = Uuid::new_v4();
     let jwt = common::create_test_jwt(tenant_id, "admin");
 
-    let mut state = mock_helpers::app_state::setup_mock_app_state().await;
+    let mut state = mock_helpers::app_state::setup_mock_app_state();
     state.timecard = mock;
     let base_url = common::spawn_test_server(state).await;
 
@@ -1599,7 +1600,7 @@ async fn test_export_csv_db_error() {
 #[tokio::test]
 async fn test_no_auth_returns_401() {
     let mock = Arc::new(mock_helpers::MockTimecardRepository::default());
-    let mut state = mock_helpers::app_state::setup_mock_app_state().await;
+    let mut state = mock_helpers::app_state::setup_mock_app_state();
     state.timecard = mock;
     let base_url = common::spawn_test_server(state).await;
     let client = reqwest::Client::new();

--- a/tests/mock_upload_test.rs
+++ b/tests/mock_upload_test.rs
@@ -1,16 +1,17 @@
 mod common;
 mod mock_helpers;
 
+use uuid::Uuid;
+
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use common::mock_storage::MockStorage;
-use uuid::Uuid;
 
 /// Helper: set up mock AppState and spawn test server with JWT.
 /// Returns (base_url, auth_header, tenant_id).
 async fn setup() -> (String, String, Uuid) {
-    let state = mock_helpers::app_state::setup_mock_app_state().await;
+    let state = mock_helpers::app_state::setup_mock_app_state();
     let tenant_id = Uuid::new_v4();
     let base_url = common::spawn_test_server(state).await;
     let jwt = common::create_test_jwt(tenant_id, "admin");
@@ -24,7 +25,7 @@ async fn setup_failing_storage() -> (String, String) {
     let mock_storage = Arc::new(MockStorage::new("test-bucket"));
     mock_storage.fail_upload.store(true, Ordering::SeqCst);
 
-    let mut state = mock_helpers::app_state::setup_mock_app_state().await;
+    let mut state = mock_helpers::app_state::setup_mock_app_state();
     state.storage = mock_storage;
 
     let tenant_id = Uuid::new_v4();
@@ -418,7 +419,7 @@ async fn test_upload_blow_video_invalid_multipart() {
 
 #[tokio::test]
 async fn test_upload_face_photo_with_tenant_header() {
-    let state = mock_helpers::app_state::setup_mock_app_state().await;
+    let state = mock_helpers::app_state::setup_mock_app_state();
     let tenant_id = Uuid::new_v4();
     let base_url = common::spawn_test_server(state).await;
     let client = reqwest::Client::new();

--- a/tests/tenko_test.rs
+++ b/tests/tenko_test.rs
@@ -27,7 +27,7 @@ async fn setup_tenko() -> (String, String, String, reqwest::Client) {
     let state = common::setup_app_state().await;
     let base_url = common::spawn_test_server(state.clone()).await;
     let tenant_id = common::create_test_tenant(
-        &state.pool,
+        state.pool(),
         &format!("Tenko{}", uuid::Uuid::new_v4().simple()),
     )
     .await;
@@ -1307,7 +1307,7 @@ async fn test_alcohol_fail_fires_webhook() {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
         let tenant_id = common::create_test_tenant(
-            &state.pool,
+            state.pool(),
             &format!("AlcWH{}", uuid::Uuid::new_v4().simple()),
         )
         .await;
@@ -1375,7 +1375,7 @@ async fn test_self_declaration_with_illness_interrupts() {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
         let tenant_id = common::create_test_tenant(
-            &state.pool,
+            state.pool(),
             &format!("SelfDecl{}", uuid::Uuid::new_v4().simple()),
         )
         .await;
@@ -3099,13 +3099,13 @@ async fn test_fire_event_no_config() {
         let state = common::setup_app_state().await;
         let _base_url = common::spawn_test_server(state.clone()).await;
         let tenant_id = common::create_test_tenant(
-            &state.pool,
+            state.pool(),
             &format!("WHNone{}", uuid::Uuid::new_v4().simple()),
         )
         .await;
 
         let result = rust_alc_api::webhook::fire_event(
-            &state.pool,
+            state.pool(),
             tenant_id,
             "alcohol_detected",
             serde_json::json!({"test": true}),
@@ -3128,7 +3128,7 @@ async fn test_fire_event_with_config_delivers() {
         let state = common::setup_app_state().await;
         let _base_url = common::spawn_test_server(state.clone()).await;
         let tenant_id = common::create_test_tenant(
-            &state.pool,
+            state.pool(),
             &format!("WHDeliv{}", uuid::Uuid::new_v4().simple()),
         )
         .await;
@@ -3171,7 +3171,7 @@ async fn test_fire_event_with_config_delivers() {
 
         // fire_event
         rust_alc_api::webhook::fire_event(
-            &state.pool,
+            state.pool(),
             tenant_id,
             "alcohol_detected",
             serde_json::json!({"employee_id": "test", "value": 0.15}),
@@ -3187,7 +3187,7 @@ async fn test_fire_event_with_config_delivers() {
         );
 
         // webhook_deliveries にログが記録されたか確認
-        let mut conn = state.pool.acquire().await.unwrap();
+        let mut conn = state.pool().acquire().await.unwrap();
         sqlx::query("SELECT set_config('app.current_tenant_id', $1, true)")
             .bind(tenant_id.to_string())
             .execute(&mut *conn)
@@ -3222,7 +3222,7 @@ async fn test_fire_event_delivery_failure_retries() {
             let state = common::setup_app_state().await;
             let _base_url = common::spawn_test_server(state.clone()).await;
             let tenant_id = common::create_test_tenant(
-                &state.pool,
+                state.pool(),
                 &format!("WHFail{}", uuid::Uuid::new_v4().simple()),
             )
             .await;
@@ -3259,7 +3259,7 @@ async fn test_fire_event_delivery_failure_retries() {
 
             // fire → リトライ (1s + 5s + 25s = 遅いが、500エラーは即返るのでsleep分のみ)
             rust_alc_api::webhook::fire_event(
-                &state.pool,
+                state.pool(),
                 tenant_id,
                 "tenko_completed",
                 serde_json::json!({"session_id": "test"}),
@@ -3270,7 +3270,7 @@ async fn test_fire_event_delivery_failure_retries() {
             // リトライは非同期なので少し待つ (最初のリトライ1sだけ待てば少なくとも2回の配信ログがある)
             tokio::time::sleep(std::time::Duration::from_millis(2000)).await;
 
-            let mut conn = state.pool.acquire().await.unwrap();
+            let mut conn = state.pool().acquire().await.unwrap();
             sqlx::query("SELECT set_config('app.current_tenant_id', $1, true)")
                 .bind(tenant_id.to_string())
                 .execute(&mut *conn)
@@ -3302,7 +3302,7 @@ async fn test_check_overdue_no_config() {
         let state = common::setup_app_state().await;
         let _base_url = common::spawn_test_server(state.clone()).await;
 
-        let result = rust_alc_api::webhook::check_overdue_schedules(&state.pool).await;
+        let result = rust_alc_api::webhook::check_overdue_schedules(state.pool()).await;
         assert!(result.is_ok());
     });
 }
@@ -3326,7 +3326,7 @@ async fn test_safety_judgment_fail_with_baseline() {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
             let tenant_id = common::create_test_tenant(
-                &state.pool,
+                state.pool(),
                 &format!("SJFail{}", uuid::Uuid::new_v4().simple()),
             )
             .await;
@@ -3424,7 +3424,7 @@ async fn test_safety_judgment_pass_with_baseline() {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
             let tenant_id = common::create_test_tenant(
-                &state.pool,
+                state.pool(),
                 &format!("SJPass{}", uuid::Uuid::new_v4().simple()),
             )
             .await;
@@ -3505,7 +3505,7 @@ async fn test_safety_judgment_multiple_failures() {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
         let tenant_id = common::create_test_tenant(
-            &state.pool,
+            state.pool(),
             &format!("SJMulti{}", uuid::Uuid::new_v4().simple()),
         )
         .await;
@@ -3592,7 +3592,7 @@ async fn test_check_overdue_with_overdue_schedule() {
             let state = common::setup_app_state().await;
             let _base_url = common::spawn_test_server(state.clone()).await;
             let tenant_id = common::create_test_tenant(
-                &state.pool,
+                state.pool(),
                 &format!("WHOver{}", uuid::Uuid::new_v4().simple()),
             )
             .await;
@@ -3667,14 +3667,14 @@ async fn test_check_overdue_with_overdue_schedule() {
 
             // check_overdue_schedules (TENKO_OVERDUE_MINUTES デフォルト60分なので2時間前は overdue)
             std::env::set_var("TENKO_OVERDUE_MINUTES", "60");
-            let result = rust_alc_api::webhook::check_overdue_schedules(&state.pool).await;
+            let result = rust_alc_api::webhook::check_overdue_schedules(state.pool()).await;
             assert!(result.is_ok(), "check_overdue failed: {:?}", result.err());
 
             // 少し待つ (deliver_webhook は sync in check_overdue, not spawned)
             tokio::time::sleep(std::time::Duration::from_millis(500)).await;
 
             // overdue_notified_at が更新されたか確認
-            let mut conn = state.pool.acquire().await.unwrap();
+            let mut conn = state.pool().acquire().await.unwrap();
             sqlx::query("SELECT set_config('app.current_tenant_id', $1, true)")
                 .bind(tenant_id.to_string())
                 .execute(&mut *conn)
@@ -3706,7 +3706,7 @@ async fn test_equipment_failure_create_db_error() {
         let _flock = common::db_rename_flock();
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "EqFailErr").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "EqFailErr").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -3717,14 +3717,14 @@ async fn test_equipment_failure_create_db_error() {
                BEGIN RAISE EXCEPTION 'test: equipment_failures insert blocked'; END;
                $$ LANGUAGE plpgsql"#,
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
         sqlx::query(
             "CREATE OR REPLACE TRIGGER fail_eq_insert BEFORE INSERT ON alc_api.equipment_failures \
              FOR EACH ROW EXECUTE FUNCTION alc_api.fail_eq_insert()",
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -3742,11 +3742,11 @@ async fn test_equipment_failure_create_db_error() {
 
         // Cleanup
         sqlx::query("DROP TRIGGER fail_eq_insert ON alc_api.equipment_failures")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
         sqlx::query("DROP FUNCTION alc_api.fail_eq_insert")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
     });
@@ -3767,14 +3767,14 @@ async fn test_equipment_failure_list_db_error() {
         let _flock = common::db_rename_flock();
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "EqListErr").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "EqListErr").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
 
-        ensure_table_exists(&state.pool, "equipment_failures").await;
+        ensure_table_exists(state.pool(), "equipment_failures").await;
         sqlx::query("ALTER TABLE alc_api.equipment_failures RENAME TO equipment_failures_bak")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
 
@@ -3787,7 +3787,7 @@ async fn test_equipment_failure_list_db_error() {
         assert_eq!(res.status(), 500);
 
         sqlx::query("ALTER TABLE alc_api.equipment_failures_bak RENAME TO equipment_failures")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
     });
@@ -3808,7 +3808,7 @@ async fn test_tenko_schedule_create_db_error() {
         let _flock = common::db_rename_flock();
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "SchedCreateErr").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "SchedCreateErr").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -3824,14 +3824,14 @@ async fn test_tenko_schedule_create_db_error() {
                BEGIN RAISE EXCEPTION 'test: tenko_schedules insert blocked'; END;
                $$ LANGUAGE plpgsql"#,
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
         sqlx::query(
             "CREATE OR REPLACE TRIGGER fail_sched_insert BEFORE INSERT ON alc_api.tenko_schedules \
              FOR EACH ROW EXECUTE FUNCTION alc_api.fail_sched_insert()",
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -3852,11 +3852,11 @@ async fn test_tenko_schedule_create_db_error() {
 
         // Cleanup
         sqlx::query("DROP TRIGGER fail_sched_insert ON alc_api.tenko_schedules")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
         sqlx::query("DROP FUNCTION alc_api.fail_sched_insert")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
     });
@@ -3873,13 +3873,13 @@ async fn test_tenko_schedule_list_db_error() {
         let _flock = common::db_rename_flock();
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "SchedListErr").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "SchedListErr").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
 
         sqlx::query("ALTER TABLE alc_api.tenko_schedules RENAME TO tenko_schedules_bak")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
 
@@ -3892,7 +3892,7 @@ async fn test_tenko_schedule_list_db_error() {
         assert_eq!(res.status(), 500);
 
         sqlx::query("ALTER TABLE alc_api.tenko_schedules_bak RENAME TO tenko_schedules")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
     });
@@ -3909,7 +3909,7 @@ async fn test_tenko_schedule_update_db_error() {
         let _flock = common::db_rename_flock();
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "SchedUpdErr").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "SchedUpdErr").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -3941,14 +3941,14 @@ async fn test_tenko_schedule_update_db_error() {
                BEGIN RAISE EXCEPTION 'test: tenko_schedules update blocked'; END;
                $$ LANGUAGE plpgsql"#,
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
         sqlx::query(
             "CREATE OR REPLACE TRIGGER fail_sched_update BEFORE UPDATE ON alc_api.tenko_schedules \
              FOR EACH ROW EXECUTE FUNCTION alc_api.fail_sched_update()",
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -3965,11 +3965,11 @@ async fn test_tenko_schedule_update_db_error() {
 
         // Cleanup
         sqlx::query("DROP TRIGGER fail_sched_update ON alc_api.tenko_schedules")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
         sqlx::query("DROP FUNCTION alc_api.fail_sched_update")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
     });
@@ -3986,7 +3986,7 @@ async fn test_tenko_schedule_delete_db_error() {
         let _flock = common::db_rename_flock();
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
-        let tenant_id = common::create_test_tenant(&state.pool, "SchedDelErr").await;
+        let tenant_id = common::create_test_tenant(state.pool(), "SchedDelErr").await;
         let jwt = common::create_test_jwt(tenant_id, "admin");
         let auth = format!("Bearer {jwt}");
         let client = reqwest::Client::new();
@@ -4018,14 +4018,14 @@ async fn test_tenko_schedule_delete_db_error() {
                BEGIN RAISE EXCEPTION 'test: tenko_schedules delete blocked'; END;
                $$ LANGUAGE plpgsql"#,
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
         sqlx::query(
             "CREATE OR REPLACE TRIGGER fail_sched_delete BEFORE DELETE ON alc_api.tenko_schedules \
              FOR EACH ROW EXECUTE FUNCTION alc_api.fail_sched_delete()",
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -4039,11 +4039,11 @@ async fn test_tenko_schedule_delete_db_error() {
 
         // Cleanup
         sqlx::query("DROP TRIGGER fail_sched_delete ON alc_api.tenko_schedules")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
         sqlx::query("DROP FUNCTION alc_api.fail_sched_delete")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
     });
@@ -4068,7 +4068,7 @@ async fn test_start_session_employee_mismatch() {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
             let tenant_id = common::create_test_tenant(
-                &state.pool,
+                state.pool(),
                 &format!("EmpMismatch{}", uuid::Uuid::new_v4().simple()),
             )
             .await;
@@ -4134,7 +4134,7 @@ async fn test_submit_alcohol_invalid_tenko_type() {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
         let tenant_id = common::create_test_tenant(
-            &state.pool,
+            state.pool(),
             &format!("InvType{}", uuid::Uuid::new_v4().simple()),
         )
         .await;
@@ -4171,18 +4171,18 @@ async fn test_submit_alcohol_invalid_tenko_type() {
         // DROP CHECK → UPDATE tenko_type to invalid → テスト → 行を戻す → ADD CHECK
         let constraint_name: String = sqlx::query_scalar(
             "SELECT conname FROM pg_constraint WHERE conrelid = 'alc_api.tenko_sessions'::regclass AND conname LIKE '%tenko_type%'"
-        ).fetch_one(&state.pool).await.unwrap();
+        ).fetch_one(state.pool()).await.unwrap();
         sqlx::query(&format!(
             "ALTER TABLE alc_api.tenko_sessions DROP CONSTRAINT {constraint_name}"
         ))
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
         sqlx::query(
             "UPDATE alc_api.tenko_sessions SET tenko_type = 'invalid_type' WHERE id = $1::uuid",
         )
         .bind(session_id)
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -4206,11 +4206,11 @@ async fn test_submit_alcohol_invalid_tenko_type() {
             "UPDATE alc_api.tenko_sessions SET tenko_type = 'post_operation' WHERE id = $1::uuid",
         )
         .bind(session_id)
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
         sqlx::query(&format!("ALTER TABLE alc_api.tenko_sessions ADD CONSTRAINT {constraint_name} CHECK (tenko_type IN ('pre_operation', 'post_operation'))"))
-            .execute(&state.pool).await.unwrap();
+            .execute(state.pool()).await.unwrap();
     });
 }
 
@@ -4366,7 +4366,7 @@ async fn test_submit_alcohol_db_error() {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
         let tenant_id = common::create_test_tenant(
-            &state.pool,
+            state.pool(),
             &format!("AlcErr{}", uuid::Uuid::new_v4().simple()),
         )
         .await;
@@ -4396,14 +4396,14 @@ async fn test_submit_alcohol_db_error() {
                BEGIN RAISE EXCEPTION 'test: tenko_sessions alcohol update blocked'; END;
                $$ LANGUAGE plpgsql"#,
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
         sqlx::query(
             "CREATE OR REPLACE TRIGGER fail_ts_alc_update BEFORE UPDATE ON alc_api.tenko_sessions \
              FOR EACH ROW EXECUTE FUNCTION alc_api.fail_ts_alc_update()",
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -4423,11 +4423,11 @@ async fn test_submit_alcohol_db_error() {
 
         // Cleanup
         sqlx::query("DROP TRIGGER fail_ts_alc_update ON alc_api.tenko_sessions")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
         sqlx::query("DROP FUNCTION alc_api.fail_ts_alc_update")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
     });
@@ -4449,7 +4449,7 @@ async fn test_submit_medical_db_error() {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
         let tenant_id = common::create_test_tenant(
-            &state.pool,
+            state.pool(),
             &format!("MedErr{}", uuid::Uuid::new_v4().simple()),
         )
         .await;
@@ -4478,14 +4478,14 @@ async fn test_submit_medical_db_error() {
                BEGIN RAISE EXCEPTION 'test: tenko_sessions medical update blocked'; END;
                $$ LANGUAGE plpgsql"#,
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
         sqlx::query(
             "CREATE OR REPLACE TRIGGER fail_ts_med_update BEFORE UPDATE ON alc_api.tenko_sessions \
              FOR EACH ROW EXECUTE FUNCTION alc_api.fail_ts_med_update()",
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -4502,11 +4502,11 @@ async fn test_submit_medical_db_error() {
 
         // Cleanup
         sqlx::query("DROP TRIGGER fail_ts_med_update ON alc_api.tenko_sessions")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
         sqlx::query("DROP FUNCTION alc_api.fail_ts_med_update")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
     });
@@ -4528,7 +4528,7 @@ async fn test_confirm_instruction_db_error() {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
         let tenant_id = common::create_test_tenant(
-            &state.pool,
+            state.pool(),
             &format!("InstrErr{}", uuid::Uuid::new_v4().simple()),
         )
         .await;
@@ -4585,14 +4585,14 @@ async fn test_confirm_instruction_db_error() {
                BEGIN RAISE EXCEPTION 'test: tenko_sessions instruction update blocked'; END;
                $$ LANGUAGE plpgsql"#,
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
         sqlx::query(
             "CREATE OR REPLACE TRIGGER fail_ts_instr_update BEFORE UPDATE ON alc_api.tenko_sessions \
              FOR EACH ROW EXECUTE FUNCTION alc_api.fail_ts_instr_update()",
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -4608,11 +4608,11 @@ async fn test_confirm_instruction_db_error() {
 
         // Cleanup
         sqlx::query("DROP TRIGGER fail_ts_instr_update ON alc_api.tenko_sessions")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
         sqlx::query("DROP FUNCTION alc_api.fail_ts_instr_update")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
     });
@@ -4903,7 +4903,7 @@ async fn test_resume_session_state_logic() {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
             let tenant_id = common::create_test_tenant(
-                &state.pool,
+                state.pool(),
                 &format!("ResumeState{}", uuid::Uuid::new_v4().simple()),
             )
             .await;
@@ -4990,7 +4990,7 @@ async fn test_resume_session_self_declaration_none() {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
             let tenant_id = common::create_test_tenant(
-                &state.pool,
+                state.pool(),
                 &format!("ResumeSd{}", uuid::Uuid::new_v4().simple()),
             )
             .await;
@@ -5022,7 +5022,7 @@ async fn test_resume_session_self_declaration_none() {
                 WHERE id = $1::uuid"#,
             )
             .bind(session_id)
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
 
@@ -5157,7 +5157,7 @@ async fn test_safety_judgment_diastolic_fail() {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
         let tenant_id = common::create_test_tenant(
-            &state.pool,
+            state.pool(),
             &format!("SJDia{}", uuid::Uuid::new_v4().simple()),
         )
         .await;
@@ -5367,7 +5367,7 @@ async fn test_submit_report_db_error() {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
         let tenant_id = common::create_test_tenant(
-            &state.pool,
+            state.pool(),
             &format!("RptErr{}", uuid::Uuid::new_v4().simple()),
         )
         .await;
@@ -5406,14 +5406,14 @@ async fn test_submit_report_db_error() {
                BEGIN RAISE EXCEPTION 'test: report update blocked'; END;
                $$ LANGUAGE plpgsql"#,
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
         sqlx::query(
             "CREATE OR REPLACE TRIGGER fail_ts_rpt BEFORE UPDATE ON alc_api.tenko_sessions \
              FOR EACH ROW EXECUTE FUNCTION alc_api.fail_ts_rpt()",
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -5430,11 +5430,11 @@ async fn test_submit_report_db_error() {
         assert_eq!(res.status(), 500);
 
         sqlx::query("DROP TRIGGER fail_ts_rpt ON alc_api.tenko_sessions")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
         sqlx::query("DROP FUNCTION alc_api.fail_ts_rpt")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
     });
@@ -5456,7 +5456,7 @@ async fn test_cancel_session_db_error() {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
         let tenant_id = common::create_test_tenant(
-            &state.pool,
+            state.pool(),
             &format!("CnlErr{}", uuid::Uuid::new_v4().simple()),
         )
         .await;
@@ -5482,14 +5482,14 @@ async fn test_cancel_session_db_error() {
                BEGIN RAISE EXCEPTION 'test: cancel update blocked'; END;
                $$ LANGUAGE plpgsql"#,
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
         sqlx::query(
             "CREATE OR REPLACE TRIGGER fail_ts_cnl BEFORE UPDATE ON alc_api.tenko_sessions \
              FOR EACH ROW EXECUTE FUNCTION alc_api.fail_ts_cnl()",
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -5503,11 +5503,11 @@ async fn test_cancel_session_db_error() {
         assert_eq!(res.status(), 500);
 
         sqlx::query("DROP TRIGGER fail_ts_cnl ON alc_api.tenko_sessions")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
         sqlx::query("DROP FUNCTION alc_api.fail_ts_cnl")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
     });
@@ -5529,7 +5529,7 @@ async fn test_create_tenko_record_db_error() {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
         let tenant_id = common::create_test_tenant(
-            &state.pool,
+            state.pool(),
             &format!("RecErr{}", uuid::Uuid::new_v4().simple()),
         )
         .await;
@@ -5575,7 +5575,7 @@ async fn test_create_tenko_record_db_error() {
 
         // RENAME employees before confirm_instruction
         sqlx::query("ALTER TABLE alc_api.employees RENAME TO employees_bak")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
 
@@ -5604,7 +5604,7 @@ async fn test_create_tenko_record_db_error() {
         );
 
         sqlx::query("ALTER TABLE alc_api.employees_bak RENAME TO employees")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
     });
@@ -5626,7 +5626,7 @@ async fn test_submit_self_declaration_db_error() {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
         let tenant_id = common::create_test_tenant(
-            &state.pool,
+            state.pool(),
             &format!("DeclErr{}", uuid::Uuid::new_v4().simple()),
         )
         .await;
@@ -5664,14 +5664,14 @@ async fn test_submit_self_declaration_db_error() {
                BEGIN RAISE EXCEPTION 'test: self_declaration update blocked'; END;
                $$ LANGUAGE plpgsql"#,
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
         sqlx::query(
             "CREATE OR REPLACE TRIGGER fail_ts_decl BEFORE UPDATE ON alc_api.tenko_sessions \
              FOR EACH ROW EXECUTE FUNCTION alc_api.fail_ts_decl()",
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -5691,11 +5691,11 @@ async fn test_submit_self_declaration_db_error() {
         assert_eq!(res.status(), 500);
 
         sqlx::query("DROP TRIGGER fail_ts_decl ON alc_api.tenko_sessions")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
         sqlx::query("DROP FUNCTION alc_api.fail_ts_decl")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
     });
@@ -5717,7 +5717,7 @@ async fn test_perform_safety_judgment_db_error() {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
         let tenant_id = common::create_test_tenant(
-            &state.pool,
+            state.pool(),
             &format!("SJErr{}", uuid::Uuid::new_v4().simple()),
         )
         .await;
@@ -5765,14 +5765,14 @@ async fn test_perform_safety_judgment_db_error() {
                END;
                $$ LANGUAGE plpgsql"#,
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
         sqlx::query(
             "CREATE OR REPLACE TRIGGER fail_ts_sj BEFORE UPDATE ON alc_api.tenko_sessions \
              FOR EACH ROW EXECUTE FUNCTION alc_api.fail_ts_sj()",
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -5792,11 +5792,11 @@ async fn test_perform_safety_judgment_db_error() {
         assert_eq!(res.status(), 500);
 
         sqlx::query("DROP TRIGGER fail_ts_sj ON alc_api.tenko_sessions")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
         sqlx::query("DROP FUNCTION alc_api.fail_ts_sj")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
     });
@@ -5818,7 +5818,7 @@ async fn test_submit_daily_inspection_db_error() {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
         let tenant_id = common::create_test_tenant(
-            &state.pool,
+            state.pool(),
             &format!("DIErr{}", uuid::Uuid::new_v4().simple()),
         )
         .await;
@@ -5874,14 +5874,14 @@ async fn test_submit_daily_inspection_db_error() {
                END;
                $$ LANGUAGE plpgsql"#,
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
         sqlx::query(
             "CREATE OR REPLACE TRIGGER fail_ts_di BEFORE UPDATE ON alc_api.tenko_sessions \
              FOR EACH ROW EXECUTE FUNCTION alc_api.fail_ts_di()",
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -5900,11 +5900,11 @@ async fn test_submit_daily_inspection_db_error() {
         assert_eq!(res.status(), 500);
 
         sqlx::query("DROP TRIGGER fail_ts_di ON alc_api.tenko_sessions")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
         sqlx::query("DROP FUNCTION alc_api.fail_ts_di")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
     });
@@ -5926,7 +5926,7 @@ async fn test_submit_carrying_items_db_error() {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
         let tenant_id = common::create_test_tenant(
-            &state.pool,
+            state.pool(),
             &format!("CIErr{}", uuid::Uuid::new_v4().simple()),
         )
         .await;
@@ -6000,7 +6000,7 @@ async fn test_submit_carrying_items_db_error() {
 
         // RENAME tenko_sessions → the lookup SELECT will fail
         sqlx::query("ALTER TABLE alc_api.tenko_sessions RENAME TO tenko_sessions_bak")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
 
@@ -6018,7 +6018,7 @@ async fn test_submit_carrying_items_db_error() {
         assert_eq!(res.status(), 500);
 
         sqlx::query("ALTER TABLE alc_api.tenko_sessions_bak RENAME TO tenko_sessions")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
     });
@@ -6040,7 +6040,7 @@ async fn test_submit_carrying_items_update_db_error() {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
         let tenant_id = common::create_test_tenant(
-            &state.pool,
+            state.pool(),
             &format!("CIUpd{}", uuid::Uuid::new_v4().simple()),
         )
         .await;
@@ -6123,14 +6123,14 @@ async fn test_submit_carrying_items_update_db_error() {
                END;
                $$ LANGUAGE plpgsql"#,
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
         sqlx::query(
             "CREATE OR REPLACE TRIGGER fail_ts_ci_upd BEFORE UPDATE ON alc_api.tenko_sessions \
              FOR EACH ROW EXECUTE FUNCTION alc_api.fail_ts_ci_upd()",
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -6148,11 +6148,11 @@ async fn test_submit_carrying_items_update_db_error() {
         assert_eq!(res.status(), 500);
 
         sqlx::query("DROP TRIGGER fail_ts_ci_upd ON alc_api.tenko_sessions")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
         sqlx::query("DROP FUNCTION alc_api.fail_ts_ci_upd")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
     });
@@ -6174,7 +6174,7 @@ async fn test_interrupt_session_db_error() {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
         let tenant_id = common::create_test_tenant(
-            &state.pool,
+            state.pool(),
             &format!("IntErr{}", uuid::Uuid::new_v4().simple()),
         )
         .await;
@@ -6200,14 +6200,14 @@ async fn test_interrupt_session_db_error() {
                BEGIN RAISE EXCEPTION 'test: interrupt update blocked'; END;
                $$ LANGUAGE plpgsql"#,
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
         sqlx::query(
             "CREATE OR REPLACE TRIGGER fail_ts_int BEFORE UPDATE ON alc_api.tenko_sessions \
              FOR EACH ROW EXECUTE FUNCTION alc_api.fail_ts_int()",
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -6223,11 +6223,11 @@ async fn test_interrupt_session_db_error() {
         assert_eq!(res.status(), 500);
 
         sqlx::query("DROP TRIGGER fail_ts_int ON alc_api.tenko_sessions")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
         sqlx::query("DROP FUNCTION alc_api.fail_ts_int")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
     });
@@ -6249,7 +6249,7 @@ async fn test_resume_session_db_error() {
         let state = common::setup_app_state().await;
         let base_url = common::spawn_test_server(state.clone()).await;
         let tenant_id = common::create_test_tenant(
-            &state.pool,
+            state.pool(),
             &format!("ResErr{}", uuid::Uuid::new_v4().simple()),
         )
         .await;
@@ -6292,14 +6292,14 @@ async fn test_resume_session_db_error() {
                END;
                $$ LANGUAGE plpgsql"#,
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
         sqlx::query(
             "CREATE OR REPLACE TRIGGER fail_ts_res BEFORE UPDATE ON alc_api.tenko_sessions \
              FOR EACH ROW EXECUTE FUNCTION alc_api.fail_ts_res()",
         )
-        .execute(&state.pool)
+        .execute(state.pool())
         .await
         .unwrap();
 
@@ -6313,11 +6313,11 @@ async fn test_resume_session_db_error() {
         assert_eq!(res.status(), 500);
 
         sqlx::query("DROP TRIGGER fail_ts_res ON alc_api.tenko_sessions")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
         sqlx::query("DROP FUNCTION alc_api.fail_ts_res")
-            .execute(&state.pool)
+            .execute(state.pool())
             .await
             .unwrap();
     });
@@ -6377,7 +6377,7 @@ async fn test_post_operation_report_no_instruction_completes() {
             let state = common::setup_app_state().await;
             let base_url = common::spawn_test_server(state.clone()).await;
             let tenant_id = common::create_test_tenant(
-                &state.pool,
+                state.pool(),
                 &format!("NoInstr{}", uuid::Uuid::new_v4().simple()),
             )
             .await;


### PR DESCRIPTION
## Summary
- `AppState.pool` を `PgPool` → `Option<PgPool>` に変更
- `setup_mock_app_state()` を `async fn` → `fn` に変更、DB 接続を完全除去 (`pool: None`)
- mock テストが **DB 不要** で実行可能に (`cargo test --test 'mock_*'`)
- `tenko_sessions`: webhook firing / safety judgment は pool=None 時にスキップ
- 統合テストは `state.pool()` ヘルパーで従来通り動作

## 変更点
- `src/lib.rs`: `pool: Option<PgPool>` + `AppState::pool()` ヘルパー
- `src/main.rs`: `pool: Some(pool.clone())`
- `src/routes/tenko_sessions.rs`: pool=None 時の webhook/safety_judgment スキップ
- `tests/mock_helpers/app_state.rs`: DB 接続削除、同期関数化
- `tests/mock_*_test.rs`: `create_test_tenant` → `Uuid::new_v4()`、`.await` 削除
- `tests/common/mod.rs` + 統合テスト: `state.pool` → `state.pool()`

## Test plan
- [ ] CI passes (fmt + clippy + unit + integration)
- [ ] `cargo test --test 'mock_*'` passes without DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)