### PR TITLE
feat: add mock-tests CI job + coverage check (DB-free)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,28 @@ jobs:
       - name: Coverage regression check (unit files)
         run: bash scripts/check_coverage_100.sh --unit-only
 
+  mock-tests:
+    name: Mock Tests + Coverage (no DB)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@1.92.0
+        with:
+          components: llvm-tools-preview
+      - uses: swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov@0.8.4
+
+      - name: Run mock tests + coverage
+        run: |
+          cargo llvm-cov --test 'mock_*' --text > /tmp/mock-cov.txt 2>/tmp/mock-cov-stderr.txt || { echo "Mock tests failed:"; tail -30 /tmp/mock-cov-stderr.txt; exit 1; }
+          echo "=== Test results ==="
+          grep "test result:" /tmp/mock-cov-stderr.txt || true
+
+      - name: Coverage regression check (mock files)
+        run: bash scripts/check_coverage_100.sh --mock-only --use-cache /tmp/mock-cov.txt
+
   integration-tests:
     name: Integration Tests + Coverage (full)
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,17 @@ cov-check:
 cov-check-unit:
 	bash scripts/check_coverage_100.sh --unit-only
 
+cov-check-mock:
+	bash scripts/check_coverage_100.sh --mock-only
+
+# --- Mock テスト (DB 不要) ---
+
+mock-test:
+	cargo test --test 'mock_*'
+
+mock-cov:
+	cargo llvm-cov --test 'mock_*' --summary-only
+
 # --- CI カバレッジ取得 (artifact からダウンロード) ---
 
 COV_CACHE := /tmp/llvm-cov-cache/ci-latest.txt

--- a/coverage_100.toml
+++ b/coverage_100.toml
@@ -1,6 +1,7 @@
 # 100% カバレッジ達成済みファイルの登録簿
 #
 # type = "unit"        — cargo test --lib だけで 100% (DB 不要)
+# type = "mock"        — cargo test --test 'mock_*' だけで 100% (DB 不要)
 # type = "integration" — tests/ のインテグレーションテストが必要 (DB 必要)
 # type = "both"        — ユニット + インテグレーション両方で 100%
 #
@@ -33,7 +34,7 @@ type = "both"
 
 [[files]]
 path = "src/db/models.rs"
-type = "integration"
+type = "mock"
 
 [[files]]
 path = "src/middleware/auth.rs"
@@ -42,37 +43,37 @@ test_file = "tests/coverage_100_test.rs"
 
 [[files]]
 path = "src/routes/daily_health.rs"
-type = "integration"
+type = "mock"
 test_file = "tests/coverage_100_test.rs"
 
 [[files]]
 path = "src/routes/driver_info.rs"
-type = "integration"
+type = "mock"
 test_file = "tests/misc_routes_test.rs"
 
 [[files]]
 path = "src/routes/dtako_csv_proxy.rs"
-type = "integration"
+type = "mock"
 test_file = "tests/dtako_test.rs"
 
 [[files]]
 path = "src/routes/dtako_daily_hours.rs"
-type = "integration"
+type = "mock"
 test_file = "tests/dtako_test.rs"
 
 [[files]]
 path = "src/routes/dtako_drivers.rs"
-type = "integration"
+type = "mock"
 test_file = "tests/dtako_test.rs"
 
 [[files]]
 path = "src/routes/dtako_event_classifications.rs"
-type = "integration"
+type = "mock"
 test_file = "tests/dtako_test.rs"
 
 [[files]]
 path = "src/routes/dtako_operations.rs"
-type = "integration"
+type = "mock"
 test_file = "tests/coverage_100_test.rs"
 
 [[files]]
@@ -86,27 +87,27 @@ test_file = "tests/dtako_test.rs"
 
 [[files]]
 path = "src/routes/dtako_vehicles.rs"
-type = "integration"
+type = "mock"
 test_file = "tests/dtako_test.rs"
 
 [[files]]
 path = "src/routes/dtako_work_times.rs"
-type = "integration"
+type = "mock"
 test_file = "tests/dtako_test.rs"
 
 [[files]]
 path = "src/routes/health.rs"
-type = "integration"
+type = "mock"
 test_file = "tests/health_test.rs"
 
 [[files]]
 path = "src/routes/health_baselines.rs"
-type = "integration"
+type = "mock"
 test_file = "tests/coverage_100_test.rs"
 
 [[files]]
 path = "src/routes/mod.rs"
-type = "integration"
+type = "mock"
 
 [[files]]
 path = "src/routes/auth.rs"
@@ -115,32 +116,32 @@ test_file = "tests/auth_test.rs"
 
 [[files]]
 path = "src/routes/carrying_items.rs"
-type = "integration"
+type = "mock"
 test_file = "tests/misc_routes_test.rs"
 
 [[files]]
 path = "src/routes/tenko_call.rs"
-type = "integration"
+type = "mock"
 test_file = "tests/coverage/main.rs"
 
 [[files]]
 path = "src/routes/nfc_tags.rs"
-type = "integration"
+type = "mock"
 test_file = "tests/coverage_100_test.rs"
 
 [[files]]
 path = "src/routes/car_inspection_files.rs"
-type = "integration"
+type = "mock"
 test_file = "tests/carins_test.rs"
 
 [[files]]
 path = "src/routes/timecard.rs"
-type = "integration"
+type = "mock"
 test_file = "tests/coverage/main.rs"
 
 [[files]]
 path = "src/routes/tenant_users.rs"
-type = "integration"
+type = "mock"
 test_file = "tests/coverage/main.rs"
 
 [[files]]
@@ -150,7 +151,7 @@ test_file = "tests/tenko_webhooks_test.rs"
 
 [[files]]
 path = "src/routes/car_inspections.rs"
-type = "integration"
+type = "mock"
 test_file = "tests/coverage/main.rs"
 
 [[files]]
@@ -160,7 +161,7 @@ test_file = "tests/coverage/main.rs"
 
 [[files]]
 path = "src/routes/communication_items.rs"
-type = "integration"
+type = "mock"
 test_file = "tests/coverage/main.rs"
 
 [[files]]
@@ -170,17 +171,17 @@ test_file = "tests/coverage/main.rs"
 
 [[files]]
 path = "src/routes/tenko_schedules.rs"
-type = "integration"
+type = "mock"
 test_file = "tests/coverage/main.rs"
 
 [[files]]
 path = "src/routes/equipment_failures.rs"
-type = "integration"
+type = "mock"
 test_file = "tests/coverage/main.rs"
 
 [[files]]
 path = "src/routes/tenko_webhooks.rs"
-type = "integration"
+type = "mock"
 test_file = "tests/coverage/main.rs"
 
 [[files]]
@@ -194,7 +195,7 @@ type = "both"
 
 [[files]]
 path = "src/routes/carins_files.rs"
-type = "integration"
+type = "mock"
 test_file = "tests/coverage/main.rs"
 
 [[files]]
@@ -217,7 +218,7 @@ type = "both"
 
 [[files]]
 path = "src/routes/upload.rs"
-type = "integration"
+type = "mock"
 test_file = "tests/coverage/main.rs"
 
 [[files]]

--- a/scripts/check_coverage_100.sh
+++ b/scripts/check_coverage_100.sh
@@ -2,8 +2,9 @@
 # coverage_100.toml に登録されたファイルが 100% カバレッジを維持しているか検証する
 #
 # Usage:
-#   bash scripts/check_coverage_100.sh              # 全ファイル (unit + integration)
+#   bash scripts/check_coverage_100.sh              # 全ファイル (unit + mock + integration)
 #   bash scripts/check_coverage_100.sh --unit-only   # unit タイプのファイルのみ
+#   bash scripts/check_coverage_100.sh --mock-only   # mock タイプのファイルのみ (DB 不要)
 #
 # 前提: cargo-llvm-cov がインストール済み
 # integration モードでは TEST_DATABASE_URL が設定済みであること
@@ -14,10 +15,12 @@
 set -euo pipefail
 
 UNIT_ONLY=false
+MOCK_ONLY=false
 EXTERNAL_CACHE=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --unit-only) UNIT_ONLY=true; shift ;;
+    --mock-only) MOCK_ONLY=true; shift ;;
     --use-cache) EXTERNAL_CACHE="$2"; shift 2 ;;
     *) shift ;;
   esac
@@ -45,7 +48,8 @@ while IFS= read -r line; do
 done < "$CONFIG"
 
 echo "=== Coverage 100% Check ==="
-echo "Mode: $([ "$UNIT_ONLY" = true ] && echo 'unit-only' || echo 'full')"
+if [ "$UNIT_ONLY" = true ]; then MODE="unit-only"; elif [ "$MOCK_ONLY" = true ]; then MODE="mock-only"; else MODE="full"; fi
+echo "Mode: $MODE"
 echo "Registered files: ${#PATHS[@]}"
 echo ""
 
@@ -62,6 +66,8 @@ else
   echo "Running cargo llvm-cov --text..."
   if [ "$UNIT_ONLY" = true ]; then
     cargo llvm-cov --lib --text > "$CACHE_FILE" 2>&1 || { echo "cargo llvm-cov failed:"; tail -50 "$CACHE_FILE"; exit 101; }
+  elif [ "$MOCK_ONLY" = true ]; then
+    cargo llvm-cov --test 'mock_*' --text > "$CACHE_FILE" 2>&1 || { echo "cargo llvm-cov failed:"; tail -50 "$CACHE_FILE"; exit 101; }
   else
     [[ -f .test-config ]] && source .test-config
     cargo llvm-cov --text > "$CACHE_FILE" 2>&1 || { echo "cargo llvm-cov failed:"; tail -50 "$CACHE_FILE"; exit 101; }
@@ -100,6 +106,12 @@ for filepath in "${PATHS[@]}"; do
 
   # unit-only モードでは unit タイプのみチェック
   if [ "$UNIT_ONLY" = true ] && [ "$ftype" != "unit" ]; then
+    SKIPPED=$((SKIPPED + 1))
+    continue
+  fi
+
+  # mock-only モードでは mock タイプのみチェック
+  if [ "$MOCK_ONLY" = true ] && [ "$ftype" != "mock" ]; then
     SKIPPED=$((SKIPPED + 1))
     continue
   fi


### PR DESCRIPTION
## Summary
- CI に `mock-tests` ジョブ追加 (DB 不要、並列実行)
- `coverage_100.toml` に `type = "mock"` 追加 (26ファイル)
- `check_coverage_100.sh --mock-only` でDB不要の100%検証
- Makefile: `mock-test`, `mock-cov`, `cov-check-mock`

## CI ジョブ構成 (4ジョブ並列)
| Job | DB | 内容 |
|-----|-----|------|
| check | 不要 | fmt + clippy |
| unit-tests | 不要 | cargo test --lib + 100%検証(unit) |
| **mock-tests** | **不要** | **cargo test --test 'mock_*' + 100%検証(mock)** |
| integration-tests | 必要 | 全テスト + 100%検証(全ファイル) |

## Test plan
- [ ] CI 4ジョブ全パス
- [ ] mock-tests ジョブが DB なしで 100% 検証パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)