### PR TITLE
chore: Wave 1 - 7 files type=integration → type=mock

### DIFF
--- a/coverage_100.toml
+++ b/coverage_100.toml
@@ -38,7 +38,7 @@ type = "mock"
 
 [[files]]
 path = "src/middleware/auth.rs"
-type = "integration"
+type = "mock"
 test_file = "tests/coverage_100_test.rs"
 
 [[files]]
@@ -156,7 +156,7 @@ test_file = "tests/coverage/main.rs"
 
 [[files]]
 path = "src/routes/employees.rs"
-type = "integration"
+type = "mock"
 test_file = "tests/coverage/main.rs"
 
 [[files]]
@@ -166,7 +166,7 @@ test_file = "tests/coverage/main.rs"
 
 [[files]]
 path = "src/routes/sso_admin.rs"
-type = "integration"
+type = "mock"
 test_file = "tests/coverage/main.rs"
 
 [[files]]
@@ -186,7 +186,7 @@ test_file = "tests/coverage/main.rs"
 
 [[files]]
 path = "src/routes/bot_admin.rs"
-type = "integration"
+type = "mock"
 test_file = "tests/coverage/main.rs"
 
 [[files]]
@@ -200,12 +200,12 @@ test_file = "tests/coverage/main.rs"
 
 [[files]]
 path = "src/routes/measurements.rs"
-type = "integration"
+type = "mock"
 test_file = "tests/coverage/main.rs"
 
 [[files]]
 path = "src/routes/tenko_records.rs"
-type = "integration"
+type = "mock"
 test_file = "tests/coverage/main.rs"
 
 [[files]]
@@ -223,7 +223,7 @@ test_file = "tests/coverage/main.rs"
 
 [[files]]
 path = "src/routes/guidance_records.rs"
-type = "integration"
+type = "mock"
 test_file = "tests/coverage/main.rs"
 
 [[files]]

--- a/tests/mock_auth_test.rs
+++ b/tests/mock_auth_test.rs
@@ -16,6 +16,33 @@ use rust_alc_api::db::models::{Tenant, TenantAllowedEmail};
 use rust_alc_api::db::repository::auth::SsoConfigRow;
 
 // ============================================================
+// require_jwt — invalid/malformed JWT returns 401
+// ============================================================
+
+#[tokio::test]
+async fn test_require_jwt_invalid_token_returns_401() {
+    let _guard = common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
+
+    let mock = Arc::new(MockAuthRepository::default());
+    let mut state = setup_mock_app_state();
+    state.auth = mock;
+    let base_url = common::spawn_test_server(state).await;
+
+    let client = reqwest::Client::new();
+    // Send a malformed JWT token to a require_jwt protected endpoint (auth::protected_router)
+    let res = client
+        .get(format!("{base_url}/api/auth/me"))
+        .header("Authorization", "Bearer invalid-token-here")
+        .send()
+        .await
+        .unwrap();
+
+    // verify_access_token fails → 401
+    assert_eq!(res.status(), 401);
+}
+
+// ============================================================
 // POST /api/auth/google — google_login (existing user)
 // ============================================================
 

--- a/tests/mock_employees_test.rs
+++ b/tests/mock_employees_test.rs
@@ -340,6 +340,28 @@ async fn update_face_db_error_returns_500() {
 }
 
 #[tokio::test]
+async fn update_face_without_embedding_success() {
+    let mock = Arc::new(MockEmployeeRepository::default());
+    mock.return_some.store(true, Ordering::SeqCst);
+    let (base, auth) = setup_with_mock(mock).await;
+    let id = uuid::Uuid::new_v4();
+    // Send without face_embedding field (None) to skip the embedding length check
+    let res = client()
+        .put(format!("{base}/api/employees/{id}/face"))
+        .header("Authorization", &auth)
+        .json(&serde_json::json!({
+            "face_photo_url": "https://example.com/photo.jpg",
+            "face_model_version": "v1"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(body["name"], "Test Employee");
+}
+
+#[tokio::test]
 async fn update_face_bad_embedding_length_returns_400() {
     let (base, auth) = setup().await;
     let id = uuid::Uuid::new_v4();

--- a/tests/mock_guidance_records_test.rs
+++ b/tests/mock_guidance_records_test.rs
@@ -250,16 +250,18 @@ async fn list_records_db_error_count() {
 
 #[tokio::test]
 async fn list_records_db_error_list_tree() {
-    // We need count to succeed but list_tree to fail.
-    // fail_next is consumed by count_top_level, so we need a second fail.
-    // Since check_fail! swaps false, we manually set fail after count.
-    // Actually, check_fail! only fires once. We need 2 calls to fail on the second.
-    // Workaround: use a mock that fails on the second call.
-    // But our mock only has one AtomicBool. Let's just test with fail_next on
-    // the first call (count) which is already tested above.
-    // For list_tree error, we'd need a more complex mock. Skip this edge case
-    // as it's covered by the count error test above (same 500 path).
-    // Instead, test the no-auth case.
+    // count_top_level succeeds, but list_tree fails via dedicated flag
+    let mock = Arc::new(MockGuidanceRecordsRepository::default());
+    mock.fail_on_list_tree.store(true, Ordering::SeqCst);
+    let (base, auth, _) = setup_with_mock(mock).await;
+
+    let res = client()
+        .get(format!("{base}/api/guidance-records"))
+        .header("Authorization", &auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
 }
 
 // ===========================================================================

--- a/tests/mock_helpers/repos_b.rs
+++ b/tests/mock_helpers/repos_b.rs
@@ -985,6 +985,7 @@ impl EquipmentFailuresRepository for MockEquipmentFailuresRepository {
 
 pub struct MockGuidanceRecordsRepository {
     pub fail_next: AtomicBool,
+    pub fail_on_list_tree: AtomicBool,
     pub return_record: std::sync::Mutex<Option<GuidanceRecord>>,
     pub return_attachment: std::sync::Mutex<Option<GuidanceRecordAttachment>>,
     pub parent_depth: std::sync::Mutex<Option<i32>>,
@@ -998,6 +999,7 @@ impl Default for MockGuidanceRecordsRepository {
     fn default() -> Self {
         Self {
             fail_next: AtomicBool::new(false),
+            fail_on_list_tree: AtomicBool::new(false),
             return_record: std::sync::Mutex::new(None),
             return_attachment: std::sync::Mutex::new(None),
             parent_depth: std::sync::Mutex::new(None),
@@ -1033,6 +1035,9 @@ impl GuidanceRecordsRepository for MockGuidanceRecordsRepository {
         _limit: i64,
         _offset: i64,
     ) -> Result<Vec<GuidanceRecordWithName>, sqlx::Error> {
+        if self.fail_on_list_tree.swap(false, Ordering::SeqCst) {
+            return Err(sqlx::Error::RowNotFound);
+        }
         check_fail!(self);
         Ok(self.list_tree_result.lock().unwrap().clone())
     }

--- a/tests/mock_helpers/repos_c.rs
+++ b/tests/mock_helpers/repos_c.rs
@@ -346,6 +346,7 @@ pub struct MockTenkoRecordsRepository {
     pub fail_next: AtomicBool,
     pub return_some: AtomicBool,
     pub return_data: AtomicBool,
+    pub return_ng_data: AtomicBool,
 }
 
 impl Default for MockTenkoRecordsRepository {
@@ -354,6 +355,7 @@ impl Default for MockTenkoRecordsRepository {
             fail_next: AtomicBool::new(false),
             return_some: AtomicBool::new(false),
             return_data: AtomicBool::new(false),
+            return_ng_data: AtomicBool::new(false),
         }
     }
 }
@@ -410,7 +412,7 @@ impl TenkoRecordsRepository for MockTenkoRecordsRepository {
         _filter: &TenkoRecordFilter,
     ) -> Result<i64, sqlx::Error> {
         check_fail!(self);
-        if self.return_data.load(Ordering::SeqCst) {
+        if self.return_data.load(Ordering::SeqCst) || self.return_ng_data.load(Ordering::SeqCst) {
             return Ok(1);
         }
         Ok(0)
@@ -424,6 +426,13 @@ impl TenkoRecordsRepository for MockTenkoRecordsRepository {
         _offset: i64,
     ) -> Result<Vec<TenkoRecord>, sqlx::Error> {
         check_fail!(self);
+        if self.return_ng_data.load(Ordering::SeqCst) {
+            let mut record = make_mock_tenko_record_for_list(_tenant_id, Uuid::new_v4());
+            record.daily_inspection = Some(
+                serde_json::json!({"brakes": "ng", "tires": "ok", "lights": "ok", "steering": "ok", "wipers": "ok", "mirrors": "ok", "horn": "ok", "seatbelts": "ok"}),
+            );
+            return Ok(vec![record]);
+        }
         if self.return_data.load(Ordering::SeqCst) {
             return Ok(vec![make_mock_tenko_record_for_list(
                 _tenant_id,
@@ -447,6 +456,13 @@ impl TenkoRecordsRepository for MockTenkoRecordsRepository {
         _filter: &TenkoRecordFilter,
     ) -> Result<Vec<TenkoRecord>, sqlx::Error> {
         check_fail!(self);
+        if self.return_ng_data.load(Ordering::SeqCst) {
+            let mut record = make_mock_tenko_record_for_list(_tenant_id, Uuid::new_v4());
+            record.daily_inspection = Some(
+                serde_json::json!({"brakes": "ng", "tires": "ok", "lights": "ok", "steering": "ok", "wipers": "ok", "mirrors": "ok", "horn": "ok", "seatbelts": "ok"}),
+            );
+            return Ok(vec![record]);
+        }
         if self.return_data.load(Ordering::SeqCst) {
             return Ok(vec![make_mock_tenko_record_for_list(
                 _tenant_id,

--- a/tests/mock_measurements_test.rs
+++ b/tests/mock_measurements_test.rs
@@ -398,6 +398,45 @@ async fn test_update_measurement_success() {
 }
 
 // =========================================================================
+// PUT /api/measurements/{id} — success without status field (200)
+// =========================================================================
+
+#[tokio::test]
+async fn test_update_measurement_without_status_success() {
+    let _guard = common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", common::TEST_JWT_SECRET);
+
+    let mock = Arc::new(MockMeasurementsRepository::default());
+    mock.return_some.store(true, Ordering::SeqCst);
+
+    let mut state = mock_helpers::app_state::setup_mock_app_state();
+    state.measurements = mock;
+
+    let tenant_id = Uuid::new_v4();
+    let base_url = common::spawn_test_server(state).await;
+    let jwt = common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let id = Uuid::new_v4();
+    // Send without status field to skip the status validation branch
+    let body = serde_json::json!({
+        "alcohol_value": 0.15,
+    });
+
+    let res = client
+        .put(format!("{base_url}/api/measurements/{id}"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+    let json: Value = res.json().await.unwrap();
+    assert!(json["id"].is_string());
+}
+
+// =========================================================================
 // PUT /api/measurements/{id} — not found (404)
 // =========================================================================
 

--- a/tests/mock_tenko_records_test.rs
+++ b/tests/mock_tenko_records_test.rs
@@ -450,7 +450,7 @@ async fn test_export_csv_db_error() {
 async fn test_export_csv_with_ng_daily_inspection() {
     // Test that daily_inspection with an "ng" item produces "ng" in CSV
     let mock = Arc::new(MockTenkoRecordsRepository::default());
-    mock.return_data.store(true, Ordering::SeqCst);
+    mock.return_ng_data.store(true, Ordering::SeqCst);
     let mut state = mock_helpers::app_state::setup_mock_app_state();
     state.tenko_records = mock;
     let tenant_id = uuid::Uuid::new_v4();
@@ -466,11 +466,14 @@ async fn test_export_csv_with_ng_daily_inspection() {
         .unwrap();
     assert_eq!(res.status(), 200);
 
-    // The default mock data has all "ok" items, so inspection_status = "ok"
+    // The ng mock data has brakes="ng", so daily_inspection_status = "ng"
     let bytes = res.bytes().await.unwrap();
     let csv_str = std::str::from_utf8(&bytes[3..]).unwrap();
-    // Verify the daily inspection column has "ok"
-    assert!(csv_str.contains(",ok,"));
+    // Verify the daily inspection column has "ng" (not "ok")
+    assert!(
+        csv_str.contains(",ng,"),
+        "Expected 'ng' in CSV but got: {csv_str}"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- `bot_admin.rs`, `sso_admin.rs` の coverage_100.toml type を `integration` → `mock` に変更
- `employees.rs`, `measurements.rs`, `tenko_records.rs`, `guidance_records.rs`, `middleware/auth.rs` に mock テスト追加 + type を `mock` に変更
- mock-only カバレッジで全 7 ファイル 100% 達成

## Test plan
- [x] ローカル mock-only カバレッジ 100% 確認 (`check_coverage_100.sh --mock-only`)
- [ ] CI `Mock Tests + Coverage (no DB)` pass
- [ ] CI `Integration Tests + Coverage (full)` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)