### PR TITLE
ci: eliminate DB dependency from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,27 +22,8 @@ jobs:
       - run: cargo fmt --check
       - run: cargo clippy -- -D warnings
 
-  unit-tests:
-    name: Unit Tests + Coverage (unit)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.92.0
-        with:
-          components: llvm-tools-preview
-      - uses: swatinem/rust-cache@v2
-      - uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-llvm-cov@0.8.4
-
-      - name: Run unit tests
-        run: cargo test --lib
-
-      - name: Coverage regression check (unit files)
-        run: bash scripts/check_coverage_100.sh --unit-only
-
-  mock-tests:
-    name: Mock Tests + Coverage
+  full-tests:
+    name: Full Tests + Coverage
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -62,7 +43,7 @@ jobs:
           echo "=== Coverage Summary ==="
           tail -5 /tmp/llvm-cov-output.txt
 
-      - name: Coverage regression check (mock + combined files)
+      - name: Coverage regression check (all 100% files)
         run: bash scripts/check_coverage_100.sh --combined --use-cache /tmp/llvm-cov-output.txt
 
       - name: Upload coverage data

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,23 +41,9 @@ jobs:
       - name: Coverage regression check (unit files)
         run: bash scripts/check_coverage_100.sh --unit-only
 
-  full-tests:
-    name: Full Tests + Coverage (mock + RLS)
+  mock-tests:
+    name: Mock Tests + Coverage
     runs-on: ubuntu-latest
-    services:
-      postgres:
-        image: postgres:16
-        env:
-          POSTGRES_PASSWORD: test
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 5s
-          --health-timeout 5s
-          --health-retries 5
-    env:
-      TEST_DATABASE_URL: postgresql://postgres:test@localhost:5432/postgres?options=-c search_path=alc_api
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.92.0
@@ -68,28 +54,13 @@ jobs:
         with:
           tool: cargo-llvm-cov@0.8.4
 
-      - name: Initialize test database
-        run: psql -f scripts/init_local_db.sql
-        env:
-          PGHOST: localhost
-          PGPORT: "5432"
-          PGUSER: postgres
-          PGPASSWORD: test
-
-      - name: Run mock tests (no report)
-        run: cargo llvm-cov --no-report --test mock_tests 2>&1 | tail -5
-
-      - name: Run RLS tests (no report)
+      - name: Run mock tests with coverage
         run: |
-          cargo llvm-cov --no-report --test employees_test --test measurements_test --test devices_test 2>&1 | tail -5
-
-      - name: Generate combined coverage report
-        run: |
-          cargo llvm-cov report --text > /tmp/llvm-cov-output.txt
+          cargo llvm-cov --test mock_tests --text > /tmp/llvm-cov-output.txt
           echo "=== Coverage Summary ==="
           tail -5 /tmp/llvm-cov-output.txt
 
-      - name: Coverage regression check (mock + RLS)
+      - name: Coverage regression check (mock files)
         run: bash scripts/check_coverage_100.sh --mock-only --use-cache /tmp/llvm-cov-output.txt
 
       - name: Upload coverage data

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,14 +54,16 @@ jobs:
         with:
           tool: cargo-llvm-cov@0.8.4
 
-      - name: Run mock tests with coverage
+      - name: Run lib + mock tests with coverage
         run: |
-          cargo llvm-cov --test mock_tests --text > /tmp/llvm-cov-output.txt
+          cargo llvm-cov --no-report --lib
+          cargo llvm-cov --no-report --test mock_tests
+          cargo llvm-cov report --text > /tmp/llvm-cov-output.txt
           echo "=== Coverage Summary ==="
           tail -5 /tmp/llvm-cov-output.txt
 
-      - name: Coverage regression check (mock files)
-        run: bash scripts/check_coverage_100.sh --mock-only --use-cache /tmp/llvm-cov-output.txt
+      - name: Coverage regression check (mock + combined files)
+        run: bash scripts/check_coverage_100.sh --combined --use-cache /tmp/llvm-cov-output.txt
 
       - name: Upload coverage data
         if: always()

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3058,6 +3058,7 @@ dependencies = [
  "rand 0.10.0",
  "reqwest",
  "ring",
+ "rsa",
  "rust-s3",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,3 +42,4 @@ printpdf = "0.8"
 [dev-dependencies]
 libc = "0.2"
 wiremock = "0.6"
+rsa = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ unexpected_cfgs = { level = "allow", check-cfg = ['cfg(coverage)'] }
 
 [dependencies]
 axum = { version = "0.8", features = ["multipart"] }
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1", features = ["full", "test-util"] }
 sqlx = { version = "0.8", features = ["runtime-tokio", "tls-rustls", "postgres", "chrono", "uuid"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/coverage_100.toml
+++ b/coverage_100.toml
@@ -2,8 +2,6 @@
 #
 # type = "unit"        — cargo test --lib だけで 100% (DB 不要)
 # type = "mock"        — cargo test --test mock_tests だけで 100% (DB 不要)
-# type = "integration" — tests/ のインテグレーションテストが必要 (DB 必要)
-# type = "both"        — ユニット + mock 両方で 100%
 #
 # 新しいファイルが 100% に到達したら追加する。
 # カバレッジ確認: bash scripts/check_coverage_100.sh
@@ -11,24 +9,20 @@
 # --- Unit test files (DB 不要) ---
 
 [[files]]
-path = "src/auth/google.rs"
-type = "integration"
-
-[[files]]
-path = "src/auth/jwt.rs"
-type = "both"
-
-[[files]]
 path = "src/csv_parser/mod.rs"
 type = "unit"
 
 [[files]]
 path = "src/csv_parser/kudgivt.rs"
-type = "both"
+type = "unit"
 
 [[files]]
 path = "src/csv_parser/kudguri.rs"
-type = "both"
+type = "unit"
+
+[[files]]
+path = "src/csv_parser/work_segments.rs"
+type = "unit"
 
 # --- Mock test files (DB 不要) ---
 
@@ -38,6 +32,30 @@ type = "mock"
 
 [[files]]
 path = "src/middleware/auth.rs"
+type = "mock"
+
+[[files]]
+path = "src/routes/bot_admin.rs"
+type = "mock"
+
+[[files]]
+path = "src/routes/car_inspection_files.rs"
+type = "mock"
+
+[[files]]
+path = "src/routes/car_inspections.rs"
+type = "mock"
+
+[[files]]
+path = "src/routes/carins_files.rs"
+type = "mock"
+
+[[files]]
+path = "src/routes/carrying_items.rs"
+type = "mock"
+
+[[files]]
+path = "src/routes/communication_items.rs"
 type = "mock"
 
 [[files]]
@@ -69,19 +87,23 @@ path = "src/routes/dtako_operations.rs"
 type = "mock"
 
 [[files]]
-path = "src/routes/dtako_scraper.rs"
-type = "integration"
-
-[[files]]
-path = "src/routes/dtako_upload.rs"
-type = "integration"
-
-[[files]]
 path = "src/routes/dtako_vehicles.rs"
 type = "mock"
 
 [[files]]
 path = "src/routes/dtako_work_times.rs"
+type = "mock"
+
+[[files]]
+path = "src/routes/employees.rs"
+type = "mock"
+
+[[files]]
+path = "src/routes/equipment_failures.rs"
+type = "mock"
+
+[[files]]
+path = "src/routes/guidance_records.rs"
 type = "mock"
 
 [[files]]
@@ -93,19 +115,11 @@ path = "src/routes/health_baselines.rs"
 type = "mock"
 
 [[files]]
+path = "src/routes/measurements.rs"
+type = "mock"
+
+[[files]]
 path = "src/routes/mod.rs"
-type = "mock"
-
-[[files]]
-path = "src/routes/auth.rs"
-type = "integration"
-
-[[files]]
-path = "src/routes/carrying_items.rs"
-type = "mock"
-
-[[files]]
-path = "src/routes/tenko_call.rs"
 type = "mock"
 
 [[files]]
@@ -113,63 +127,11 @@ path = "src/routes/nfc_tags.rs"
 type = "mock"
 
 [[files]]
-path = "src/routes/car_inspection_files.rs"
-type = "mock"
-
-[[files]]
-path = "src/routes/timecard.rs"
-type = "mock"
-
-[[files]]
-path = "src/routes/tenant_users.rs"
-type = "mock"
-
-[[files]]
-path = "src/webhook.rs"
-type = "integration"
-
-[[files]]
-path = "src/routes/car_inspections.rs"
-type = "mock"
-
-[[files]]
-path = "src/routes/employees.rs"
-type = "mock"
-
-[[files]]
-path = "src/routes/communication_items.rs"
-type = "mock"
-
-[[files]]
 path = "src/routes/sso_admin.rs"
 type = "mock"
 
 [[files]]
-path = "src/routes/tenko_schedules.rs"
-type = "mock"
-
-[[files]]
-path = "src/routes/equipment_failures.rs"
-type = "mock"
-
-[[files]]
-path = "src/routes/tenko_webhooks.rs"
-type = "mock"
-
-[[files]]
-path = "src/routes/bot_admin.rs"
-type = "mock"
-
-[[files]]
-path = "src/auth/lineworks.rs"
-type = "both"
-
-[[files]]
-path = "src/routes/carins_files.rs"
-type = "mock"
-
-[[files]]
-path = "src/routes/measurements.rs"
+path = "src/routes/tenko_call.rs"
 type = "mock"
 
 [[files]]
@@ -177,29 +139,21 @@ path = "src/routes/tenko_records.rs"
 type = "mock"
 
 [[files]]
-path = "src/csv_parser/work_segments.rs"
-type = "unit"
+path = "src/routes/tenko_schedules.rs"
+type = "mock"
 
 [[files]]
-path = "src/compare/mod.rs"
-type = "both"
+path = "src/routes/tenko_webhooks.rs"
+type = "mock"
+
+[[files]]
+path = "src/routes/tenant_users.rs"
+type = "mock"
+
+[[files]]
+path = "src/routes/timecard.rs"
+type = "mock"
 
 [[files]]
 path = "src/routes/upload.rs"
 type = "mock"
-
-[[files]]
-path = "src/routes/guidance_records.rs"
-type = "mock"
-
-[[files]]
-path = "src/routes/devices.rs"
-type = "integration"
-
-[[files]]
-path = "src/routes/tenko_sessions.rs"
-type = "both"
-
-[[files]]
-path = "src/routes/dtako_restraint_report.rs"
-type = "integration"

--- a/coverage_100.toml
+++ b/coverage_100.toml
@@ -2,6 +2,7 @@
 #
 # type = "unit"        — cargo test --lib だけで 100% (DB 不要)
 # type = "mock"        — cargo test --test mock_tests だけで 100% (DB 不要)
+# type = "combined"    — lib + mock の combined で 100% (DB 不要)
 #
 # 新しいファイルが 100% に到達したら追加する。
 # カバレッジ確認: bash scripts/check_coverage_100.sh
@@ -161,3 +162,45 @@ type = "mock"
 [[files]]
 path = "src/routes/upload.rs"
 type = "mock"
+
+# --- Combined test files (lib + mock で 100%) ---
+
+[[files]]
+path = "src/auth/google.rs"
+type = "combined"
+
+[[files]]
+path = "src/auth/lineworks.rs"
+type = "combined"
+
+[[files]]
+path = "src/compare/mod.rs"
+type = "combined"
+
+[[files]]
+path = "src/routes/auth.rs"
+type = "combined"
+
+[[files]]
+path = "src/routes/devices.rs"
+type = "combined"
+
+[[files]]
+path = "src/routes/dtako_restraint_report.rs"
+type = "combined"
+
+[[files]]
+path = "src/routes/dtako_scraper.rs"
+type = "combined"
+
+[[files]]
+path = "src/routes/dtako_upload.rs"
+type = "combined"
+
+[[files]]
+path = "src/routes/tenko_sessions.rs"
+type = "combined"
+
+[[files]]
+path = "src/webhook.rs"
+type = "combined"

--- a/coverage_100.toml
+++ b/coverage_100.toml
@@ -24,6 +24,10 @@ type = "unit"
 path = "src/csv_parser/work_segments.rs"
 type = "unit"
 
+[[files]]
+path = "src/auth/jwt.rs"
+type = "mock"
+
 # --- Mock test files (DB 不要) ---
 
 [[files]]

--- a/plans/ci-optimization-phase2.md
+++ b/plans/ci-optimization-phase2.md
@@ -1,0 +1,105 @@
+# CI 最適化 Phase 2: integration→mock 変換 + CI 簡素化
+
+## 背景
+
+PR #56 で mock テスト統合 (37→1 バイナリ) + integration テスト削減 (559→4 RLS テスト) を実施。
+CI: 6.5分 → 2.5分に短縮。
+
+ただし coverage_100.toml に 13 ファイルが `type="integration"` or `type="both"` で残っており、
+mock だけでは 100% 未達。これらを mock 化しないと integration テストを完全に削除できない。
+
+PR #57 (integration テスト復元) はクローズする。integration テストを戻すのではなく mock 化する。
+
+## Step 1: PR #57 クローズ + ブランチ削除
+
+```bash
+gh pr close 57 --comment "Superseded: mock化で対応"
+git branch -D fix/restore-integration-tests
+git push origin --delete fix/restore-integration-tests
+```
+
+## Step 2: coverage_100.toml から integration/both ファイルを一時除外
+
+13 ファイルを toml から削除（mock 化完了後に再登録）:
+
+```
+src/auth/google.rs          (integration) → 除外
+src/auth/jwt.rs             (both)        → type="unit" に変更 (unit だけで 100% か検証)
+src/csv_parser/kudgivt.rs   (both)        → type="unit" に変更 (同上)
+src/csv_parser/kudguri.rs   (both)        → type="unit" に変更 (同上)
+src/auth/lineworks.rs       (both)        → 除外
+src/compare/mod.rs          (both)        → 除外
+src/routes/auth.rs          (integration) → 除外
+src/routes/devices.rs       (integration) → 除外
+src/routes/dtako_scraper.rs (integration) → 除外
+src/routes/dtako_upload.rs  (integration) → 除外
+src/routes/dtako_restraint_report.rs (integration) → 除外
+src/routes/tenko_sessions.rs (both)       → 除外
+src/webhook.rs              (integration) → 除外
+```
+
+"both" のうち jwt, kudgivt, kudguri は unit テストだけで 100% の可能性あり → 先に検証。
+
+## Step 3: CI を 3 ジョブに簡素化
+
+```yaml
+jobs:
+  check:       # fmt + clippy (並列)
+  unit-tests:  # cargo test --lib + unit coverage check (並列)
+  mock-tests:  # cargo llvm-cov --test mock_tests + mock coverage check + artifact (並列)
+```
+
+- full-tests ジョブ削除 (DB 不要)
+- RLS テスト 4 個は mock_tests バイナリに移動するか、一旦除外
+- mold + debug=false は mock-tests ジョブだけに適用
+
+## Step 4: Wave 2-4 で mock 化 (メイン作業)
+
+memory/mock_test_phase4b.md の計画に従う:
+
+### Wave 2: webhook trait 化
+- `webhook.rs` → WebhookRepository trait 新設
+- `tenko_sessions.rs` → pool 依存除去
+- mock テスト追加 → type="mock" に変更
+
+### Wave 3: 外部 HTTP mock (wiremock)
+- `auth/google.rs` — JWKS fetch + code exchange
+- `auth/lineworks.rs` — LINE WORKS token exchange + user profile
+- `routes/dtako_scraper.rs` — SSE proxy
+- mock テスト追加 → type="mock" に変更
+
+### Wave 4: ビジネスロジック充実
+- `routes/auth.rs` — Google/LINE WORKS OAuth フロー
+- `routes/devices.rs` — FCM/OTA/registration
+- `routes/dtako_upload.rs` — ZIP/CSV 処理
+- `routes/dtako_restraint_report.rs` — 日付計算・集計
+- `compare/mod.rs` — 比較ロジック
+- mock テスト追加 → type="mock" に変更
+
+### 各 Wave 完了時
+- coverage_100.toml に type="mock" で再登録
+- CI の mock coverage check で 100% 検証
+
+## Step 5: 全ファイル mock 化完了後
+
+- CI: check + unit + mock の 3 ジョブ (DB 不要、全並列)
+- RLS テスト: 週次 or 手動実行のワークフローに移動
+- 目標 CI 時間: ~2分
+
+## 対象ファイル一覧
+
+| ファイル | 現 type | Wave | mock 化の障壁 |
+|---------|---------|------|--------------|
+| webhook.rs | integration | 2 | pool 引数 → trait 化 |
+| tenko_sessions.rs | both | 2 | webhook + pool 依存 |
+| auth/google.rs | integration | 3 | 外部 HTTP (JWKS) |
+| auth/lineworks.rs | both | 3 | 外部 HTTP (LINE WORKS) |
+| dtako_scraper.rs | integration | 3 | 外部 SSE proxy |
+| auth.rs | integration | 4 | Google/LW OAuth フロー |
+| devices.rs | integration | 4 | FCM + 複雑な状態遷移 |
+| dtako_upload.rs | integration | 4 | ZIP/CSV パース |
+| dtako_restraint_report.rs | integration | 4 | 集計ロジック |
+| compare/mod.rs | both | 4 | 比較ロジック |
+| jwt.rs | both | - | unit だけで OK? |
+| kudgivt.rs | both | - | unit だけで OK? |
+| kudguri.rs | both | - | unit だけで OK? |

--- a/scripts/check_coverage_100.sh
+++ b/scripts/check_coverage_100.sh
@@ -118,11 +118,8 @@ for filepath in "${PATHS[@]}"; do
     continue
   fi
 
-  # combined モードでは mock + combined タイプをチェック
-  if [ "$COMBINED" = true ] && [ "$ftype" != "mock" ] && [ "$ftype" != "combined" ]; then
-    SKIPPED=$((SKIPPED + 1))
-    continue
-  fi
+  # combined モードでは全タイプをチェック (lib + mock の combined report を使用)
+  # unit, mock, combined すべて対象
 
   # サマリから該当ファイルを検索 (パス末尾一致)
   MATCH=$(grep "$filepath" "$SUMMARY_FILE" || true)

--- a/scripts/check_coverage_100.sh
+++ b/scripts/check_coverage_100.sh
@@ -16,11 +16,13 @@ set -euo pipefail
 
 UNIT_ONLY=false
 MOCK_ONLY=false
+COMBINED=false
 EXTERNAL_CACHE=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --unit-only) UNIT_ONLY=true; shift ;;
     --mock-only) MOCK_ONLY=true; shift ;;
+    --combined) COMBINED=true; shift ;;
     --use-cache) EXTERNAL_CACHE="$2"; shift 2 ;;
     *) shift ;;
   esac
@@ -48,7 +50,7 @@ while IFS= read -r line; do
 done < "$CONFIG"
 
 echo "=== Coverage 100% Check ==="
-if [ "$UNIT_ONLY" = true ]; then MODE="unit-only"; elif [ "$MOCK_ONLY" = true ]; then MODE="mock-only"; else MODE="full"; fi
+if [ "$UNIT_ONLY" = true ]; then MODE="unit-only"; elif [ "$MOCK_ONLY" = true ]; then MODE="mock-only"; elif [ "$COMBINED" = true ]; then MODE="combined"; else MODE="full"; fi
 echo "Mode: $MODE"
 echo "Registered files: ${#PATHS[@]}"
 echo ""
@@ -112,6 +114,12 @@ for filepath in "${PATHS[@]}"; do
 
   # mock-only モードでは mock タイプのみチェック
   if [ "$MOCK_ONLY" = true ] && [ "$ftype" != "mock" ]; then
+    SKIPPED=$((SKIPPED + 1))
+    continue
+  fi
+
+  # combined モードでは mock + combined タイプをチェック
+  if [ "$COMBINED" = true ] && [ "$ftype" != "mock" ] && [ "$ftype" != "combined" ]; then
     SKIPPED=$((SKIPPED + 1))
     continue
   fi

--- a/src/auth/google.rs
+++ b/src/auth/google.rs
@@ -18,7 +18,7 @@ fn google_jwks_url() -> String {
 const GOOGLE_ISSUER: &str = "https://accounts.google.com";
 
 /// Google ID トークンから抽出するクレーム
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, serde::Serialize)]
 pub struct GoogleClaims {
     pub sub: String,
     pub email: String,
@@ -257,4 +257,434 @@ pub enum VerifyError {
     KeyNotFound,
     #[error("failed to exchange authorization code")]
     TokenExchangeFailed,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+    use jsonwebtoken::{encode, EncodingKey, Header};
+    use rsa::pkcs1::EncodeRsaPrivateKey;
+    use rsa::rand_core::OsRng;
+    use rsa::traits::PublicKeyParts;
+    use rsa::{RsaPrivateKey, RsaPublicKey};
+    use serde_json::json;
+    use std::sync::{Mutex, OnceLock};
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+    const TEST_KID: &str = "test-kid-1";
+
+    /// 鍵ペア + JWK コンポーネント (n, e) + PEM をキャッシュ
+    struct TestKeyMaterial {
+        pem: Vec<u8>,
+        n: String,
+        e: String,
+    }
+
+    fn test_key() -> &'static TestKeyMaterial {
+        static KEY: OnceLock<TestKeyMaterial> = OnceLock::new();
+        KEY.get_or_init(|| {
+            let private_key = RsaPrivateKey::new(&mut OsRng, 2048).unwrap();
+            let public_key = RsaPublicKey::from(&private_key);
+            let pem = private_key
+                .to_pkcs1_pem(rsa::pkcs1::LineEnding::LF)
+                .unwrap()
+                .as_bytes()
+                .to_vec();
+            let n = URL_SAFE_NO_PAD.encode(public_key.n().to_bytes_be());
+            let e = URL_SAFE_NO_PAD.encode(public_key.e().to_bytes_be());
+            TestKeyMaterial { pem, n, e }
+        })
+    }
+
+    fn build_jwks_response(n: &str, e: &str) -> serde_json::Value {
+        json!({"keys": [{"kid": TEST_KID, "kty": "RSA", "alg": "RS256", "use": "sig", "n": n, "e": e}]})
+    }
+
+    fn create_test_jwt(claims: &GoogleClaims, kid: &str) -> String {
+        let key = test_key();
+        let encoding_key = EncodingKey::from_rsa_pem(&key.pem).unwrap();
+        let mut header = Header::new(Algorithm::RS256);
+        header.kid = Some(kid.to_string());
+        encode(&header, claims, &encoding_key).unwrap()
+    }
+
+    fn test_claims(client_id: &str) -> GoogleClaims {
+        GoogleClaims {
+            sub: "12345".to_string(),
+            email: "test@example.com".to_string(),
+            name: "Test User".to_string(),
+            picture: None,
+            email_verified: true,
+            aud: client_id.to_string(),
+            iss: GOOGLE_ISSUER.to_string(),
+            exp: (chrono::Utc::now().timestamp() + 3600) as u64,
+        }
+    }
+
+    // --- env var helpers ---
+
+    #[test]
+    fn test_jwks_cache_ttl_default() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::remove_var("GOOGLE_JWKS_CACHE_TTL_SECS");
+        assert_eq!(jwks_cache_ttl_secs(), 3600);
+    }
+
+    #[test]
+    fn test_jwks_cache_ttl_custom() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::set_var("GOOGLE_JWKS_CACHE_TTL_SECS", "60");
+        assert_eq!(jwks_cache_ttl_secs(), 60);
+        std::env::remove_var("GOOGLE_JWKS_CACHE_TTL_SECS");
+    }
+
+    #[test]
+    fn test_google_jwks_url_default() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::remove_var("GOOGLE_JWKS_URL");
+        assert_eq!(
+            google_jwks_url(),
+            "https://www.googleapis.com/oauth2/v3/certs"
+        );
+    }
+
+    #[test]
+    fn test_google_jwks_url_custom() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::set_var("GOOGLE_JWKS_URL", "http://custom/jwks");
+        assert_eq!(google_jwks_url(), "http://custom/jwks");
+        std::env::remove_var("GOOGLE_JWKS_URL");
+    }
+
+    #[test]
+    fn test_google_token_url_default() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::remove_var("GOOGLE_TOKEN_URL");
+        assert_eq!(google_token_url(), "https://oauth2.googleapis.com/token");
+    }
+
+    #[test]
+    fn test_google_token_url_custom() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::set_var("GOOGLE_TOKEN_URL", "http://custom/token");
+        assert_eq!(google_token_url(), "http://custom/token");
+        std::env::remove_var("GOOGLE_TOKEN_URL");
+    }
+
+    // --- GoogleTokenVerifier::new ---
+
+    #[test]
+    fn test_verifier_new() {
+        let v = GoogleTokenVerifier::new("cid".into(), "csec".into());
+        assert_eq!(v.client_id(), "cid");
+        assert!(v.test_claims.is_none());
+    }
+
+    // --- verify with wiremock ---
+
+    #[tokio::test]
+    async fn test_verify_success() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let server = MockServer::start().await;
+        std::env::set_var("GOOGLE_JWKS_URL", format!("{}/jwks", server.uri()));
+
+        let client_id = "test-client-id";
+        let key = test_key();
+        let (n, e) = (&key.n, &key.e);
+        let claims = test_claims(client_id);
+        let token = create_test_jwt(&claims, TEST_KID);
+
+        Mock::given(method("GET"))
+            .and(path("/jwks"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(build_jwks_response(&n, &e)))
+            .mount(&server)
+            .await;
+
+        let verifier = GoogleTokenVerifier::new(client_id.into(), "secret".into());
+        let result = verifier.verify(&token).await;
+        assert!(result.is_ok());
+        let c = result.unwrap();
+        assert_eq!(c.email, "test@example.com");
+
+        std::env::remove_var("GOOGLE_JWKS_URL");
+    }
+
+    #[tokio::test]
+    async fn test_verify_invalid_token() {
+        let verifier = GoogleTokenVerifier::new("cid".into(), "csec".into());
+        let result = verifier.verify("not-a-jwt").await;
+        assert!(matches!(result, Err(VerifyError::InvalidToken)));
+    }
+
+    #[tokio::test]
+    async fn test_verify_email_not_verified() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let server = MockServer::start().await;
+        std::env::set_var("GOOGLE_JWKS_URL", format!("{}/jwks", server.uri()));
+
+        let client_id = "test-client-id";
+        let key = test_key();
+        let (n, e) = (&key.n, &key.e);
+        let mut claims = test_claims(client_id);
+        claims.email_verified = false;
+        let token = create_test_jwt(&claims, TEST_KID);
+
+        Mock::given(method("GET"))
+            .and(path("/jwks"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(build_jwks_response(&n, &e)))
+            .mount(&server)
+            .await;
+
+        let verifier = GoogleTokenVerifier::new(client_id.into(), "secret".into());
+        let result = verifier.verify(&token).await;
+        assert!(matches!(result, Err(VerifyError::EmailNotVerified)));
+
+        std::env::remove_var("GOOGLE_JWKS_URL");
+    }
+
+    #[tokio::test]
+    async fn test_verify_kid_not_found() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let server = MockServer::start().await;
+        std::env::set_var("GOOGLE_JWKS_URL", format!("{}/jwks", server.uri()));
+
+        let client_id = "test-client-id";
+        let claims = test_claims(client_id);
+        let token = create_test_jwt(&claims, "wrong-kid");
+
+        // JWKS with different kid
+        Mock::given(method("GET"))
+            .and(path("/jwks"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(
+                json!({"keys": [{"kid": "other-kid", "n": "abc", "e": "AQAB", "kty": "RSA"}]}),
+            ))
+            .mount(&server)
+            .await;
+
+        let verifier = GoogleTokenVerifier::new(client_id.into(), "secret".into());
+        let result = verifier.verify(&token).await;
+        assert!(matches!(result, Err(VerifyError::KeyNotFound)));
+
+        std::env::remove_var("GOOGLE_JWKS_URL");
+    }
+
+    #[tokio::test]
+    async fn test_verify_invalid_key_components() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let server = MockServer::start().await;
+        std::env::set_var("GOOGLE_JWKS_URL", format!("{}/jwks", server.uri()));
+
+        let client_id = "test-client-id";
+        let claims = test_claims(client_id);
+        let token = create_test_jwt(&claims, TEST_KID);
+
+        // JWKS with invalid n/e
+        Mock::given(method("GET"))
+            .and(path("/jwks"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(
+                json!({"keys": [{"kid": TEST_KID, "n": "", "e": "", "kty": "RSA"}]}),
+            ))
+            .mount(&server)
+            .await;
+
+        let verifier = GoogleTokenVerifier::new(client_id.into(), "secret".into());
+        let result = verifier.verify(&token).await;
+        assert!(matches!(
+            result,
+            Err(VerifyError::InvalidKey | VerifyError::InvalidToken)
+        ));
+
+        std::env::remove_var("GOOGLE_JWKS_URL");
+    }
+
+    // --- JWKS cache ---
+
+    #[tokio::test]
+    async fn test_jwks_cache_hit() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let server = MockServer::start().await;
+        std::env::set_var("GOOGLE_JWKS_URL", format!("{}/jwks", server.uri()));
+        std::env::set_var("GOOGLE_JWKS_CACHE_TTL_SECS", "3600");
+
+        let client_id = "test-client-id";
+        let key = test_key();
+        let (n, e) = (&key.n, &key.e);
+        let claims = test_claims(client_id);
+        let token = create_test_jwt(&claims, TEST_KID);
+
+        Mock::given(method("GET"))
+            .and(path("/jwks"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(build_jwks_response(&n, &e)))
+            .expect(1) // JWKS should be fetched only once
+            .mount(&server)
+            .await;
+
+        let verifier = GoogleTokenVerifier::new(client_id.into(), "secret".into());
+        // First call — cache miss, fetches JWKS
+        let r1 = verifier.verify(&token).await;
+        assert!(r1.is_ok());
+        // Second call — cache hit, no fetch
+        let token2 = create_test_jwt(&test_claims(client_id), TEST_KID);
+        let r2 = verifier.verify(&token2).await;
+        assert!(r2.is_ok());
+
+        std::env::remove_var("GOOGLE_JWKS_URL");
+        std::env::remove_var("GOOGLE_JWKS_CACHE_TTL_SECS");
+    }
+
+    #[tokio::test]
+    async fn test_jwks_cache_expired() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let server = MockServer::start().await;
+        std::env::set_var("GOOGLE_JWKS_URL", format!("{}/jwks", server.uri()));
+        std::env::set_var("GOOGLE_JWKS_CACHE_TTL_SECS", "0"); // immediate expiry
+
+        let client_id = "test-client-id";
+        let key = test_key();
+        let (n, e) = (&key.n, &key.e);
+
+        Mock::given(method("GET"))
+            .and(path("/jwks"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(build_jwks_response(&n, &e)))
+            .expect(2) // Should fetch twice due to 0 TTL
+            .mount(&server)
+            .await;
+
+        let verifier = GoogleTokenVerifier::new(client_id.into(), "secret".into());
+        let token1 = create_test_jwt(&test_claims(client_id), TEST_KID);
+        let r1 = verifier.verify(&token1).await;
+        assert!(r1.is_ok());
+        // Cache expired immediately, will fetch again
+        let token2 = create_test_jwt(&test_claims(client_id), TEST_KID);
+        let r2 = verifier.verify(&token2).await;
+        assert!(r2.is_ok());
+
+        std::env::remove_var("GOOGLE_JWKS_URL");
+        std::env::remove_var("GOOGLE_JWKS_CACHE_TTL_SECS");
+    }
+
+    // --- exchange_code with wiremock ---
+
+    #[tokio::test]
+    async fn test_exchange_code_success() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let server = MockServer::start().await;
+        std::env::set_var("GOOGLE_TOKEN_URL", format!("{}/token", server.uri()));
+        std::env::set_var("GOOGLE_JWKS_URL", format!("{}/jwks", server.uri()));
+
+        let client_id = "test-client-id";
+        let key = test_key();
+        let (n, e) = (&key.n, &key.e);
+        let claims = test_claims(client_id);
+        let id_token = create_test_jwt(&claims, TEST_KID);
+
+        Mock::given(method("POST"))
+            .and(path("/token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({"id_token": id_token})))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/jwks"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(build_jwks_response(&n, &e)))
+            .mount(&server)
+            .await;
+
+        let verifier = GoogleTokenVerifier::new(client_id.into(), "secret".into());
+        let result = verifier.exchange_code("auth-code", "http://redirect").await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().email, "test@example.com");
+
+        std::env::remove_var("GOOGLE_TOKEN_URL");
+        std::env::remove_var("GOOGLE_JWKS_URL");
+    }
+
+    #[tokio::test]
+    async fn test_exchange_code_token_endpoint_error() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let server = MockServer::start().await;
+        std::env::set_var("GOOGLE_TOKEN_URL", format!("{}/token", server.uri()));
+
+        Mock::given(method("POST"))
+            .and(path("/token"))
+            .respond_with(ResponseTemplate::new(400).set_body_string("bad request"))
+            .mount(&server)
+            .await;
+
+        let verifier = GoogleTokenVerifier::new("cid".into(), "csec".into());
+        let result = verifier.exchange_code("bad-code", "http://redirect").await;
+        assert!(matches!(result, Err(VerifyError::TokenExchangeFailed)));
+
+        std::env::remove_var("GOOGLE_TOKEN_URL");
+    }
+
+    #[tokio::test]
+    async fn test_exchange_code_invalid_json_response() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let server = MockServer::start().await;
+        std::env::set_var("GOOGLE_TOKEN_URL", format!("{}/token", server.uri()));
+
+        Mock::given(method("POST"))
+            .and(path("/token"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("not json"))
+            .mount(&server)
+            .await;
+
+        let verifier = GoogleTokenVerifier::new("cid".into(), "csec".into());
+        let result = verifier.exchange_code("code", "http://redirect").await;
+        assert!(matches!(result, Err(VerifyError::TokenExchangeFailed)));
+
+        std::env::remove_var("GOOGLE_TOKEN_URL");
+    }
+
+    #[tokio::test]
+    async fn test_exchange_code_connection_error() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::set_var("GOOGLE_TOKEN_URL", "http://127.0.0.1:1/token");
+
+        let verifier = GoogleTokenVerifier::new("cid".into(), "csec".into());
+        let result = verifier.exchange_code("code", "http://redirect").await;
+        assert!(matches!(result, Err(VerifyError::TokenExchangeFailed)));
+
+        std::env::remove_var("GOOGLE_TOKEN_URL");
+    }
+
+    #[tokio::test]
+    async fn test_jwks_fetch_failed() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::set_var("GOOGLE_JWKS_URL", "http://127.0.0.1:1/jwks");
+
+        let verifier = GoogleTokenVerifier::new("cid".into(), "csec".into());
+        let claims = test_claims("cid");
+        let token = create_test_jwt(&claims, TEST_KID);
+        let result = verifier.verify(&token).await;
+        assert!(matches!(result, Err(VerifyError::JwksFetchFailed)));
+
+        std::env::remove_var("GOOGLE_JWKS_URL");
+    }
+
+    #[test]
+    fn test_verify_error_display() {
+        assert_eq!(VerifyError::InvalidToken.to_string(), "invalid token");
+        assert_eq!(VerifyError::InvalidKey.to_string(), "invalid key");
+        assert_eq!(
+            VerifyError::EmailNotVerified.to_string(),
+            "email not verified"
+        );
+        assert_eq!(
+            VerifyError::JwksFetchFailed.to_string(),
+            "failed to fetch JWKS"
+        );
+        assert_eq!(
+            VerifyError::KeyNotFound.to_string(),
+            "key not found in JWKS"
+        );
+        assert_eq!(
+            VerifyError::TokenExchangeFailed.to_string(),
+            "failed to exchange authorization code"
+        );
+    }
 }

--- a/src/compare/mod.rs
+++ b/src/compare/mod.rs
@@ -5805,4 +5805,27 @@ U001,x,x,x,x,x,x,x,x,x,2026/02/01 10:00:00,2026/02/01 11:30:00\n";
             assert_eq!(result, NaiveDate::from_ymd_opt(2026, 2, 3).unwrap());
         });
     }
+
+    #[test]
+    fn test_merge_same_day_entries_empty_segments_no_merge() {
+        test_case!("merge_same_day: segments空 → マージしない", {
+            let d = NaiveDate::from_ymd_opt(2026, 2, 1).unwrap();
+            let t1 = NaiveTime::from_hms_opt(6, 0, 0).unwrap();
+            let t2 = NaiveTime::from_hms_opt(14, 0, 0).unwrap();
+            let mut day_map: HashMap<DayKey, DayAgg> = HashMap::new();
+            // 同日2エントリ、異なる運行、segments空 → prev_end/next_start が None
+            let mut a1 = DayAgg::default();
+            a1.unko_nos = vec!["U1".into()];
+            a1.segments = vec![]; // 空
+            day_map.insert(("D1".into(), d, t1), a1);
+            let mut a2 = DayAgg::default();
+            a2.unko_nos = vec!["U2".into()];
+            a2.segments = vec![]; // 空
+            day_map.insert(("D1".into(), d, t2), a2);
+            let mut dwe = HashMap::new();
+            merge_same_day_entries(&mut day_map, &mut dwe);
+            // segments空 → None → マージされない → 2エントリのまま
+            assert_eq!(day_map.len(), 2);
+        });
+    }
 }

--- a/src/db/repository/dtako_restraint_report.rs
+++ b/src/db/repository/dtako_restraint_report.rs
@@ -7,7 +7,7 @@ use super::TenantConn;
 
 // --- DB row types ---
 
-#[derive(Debug, sqlx::FromRow)]
+#[derive(Debug, Clone, sqlx::FromRow)]
 pub struct SegmentRow {
     pub work_date: NaiveDate,
     pub unko_no: String,
@@ -23,14 +23,14 @@ pub struct FiscalCumRow {
     pub total: Option<i64>,
 }
 
-#[derive(Debug, sqlx::FromRow)]
+#[derive(Debug, Clone, sqlx::FromRow)]
 pub struct OpTimesRow {
     pub operation_date: NaiveDate,
     pub first_departure: DateTime<Utc>,
     pub last_seg_end: DateTime<Utc>,
 }
 
-#[derive(Debug, sqlx::FromRow)]
+#[derive(Debug, Clone, sqlx::FromRow)]
 pub struct DailyWorkHoursRow {
     pub work_date: NaiveDate,
     pub start_time: chrono::NaiveTime,

--- a/src/db/repository/dtako_upload.rs
+++ b/src/db/repository/dtako_upload.rs
@@ -6,7 +6,7 @@ use uuid::Uuid;
 use super::TenantConn;
 
 /// dtako_upload_history の基本情報
-#[derive(Debug, sqlx::FromRow)]
+#[derive(Debug, Clone, sqlx::FromRow)]
 pub struct UploadHistoryRecord {
     pub tenant_id: Uuid,
     pub r2_zip_key: String,
@@ -14,14 +14,14 @@ pub struct UploadHistoryRecord {
 }
 
 /// dtako_upload_history (tenant_id, r2_zip_key) のみ
-#[derive(Debug, sqlx::FromRow)]
+#[derive(Debug, Clone, sqlx::FromRow)]
 pub struct UploadTenantAndKey {
     pub tenant_id: Uuid,
     pub r2_zip_key: String,
 }
 
 /// recalculate 用の operations 行
-#[derive(Debug, sqlx::FromRow)]
+#[derive(Debug, Clone, sqlx::FromRow)]
 pub struct DtakoOpRow {
     pub unko_no: String,
     pub reading_date: NaiveDate,
@@ -36,7 +36,7 @@ pub struct DtakoOpRow {
 }
 
 /// single-driver recalculate 用の operations 行
-#[derive(Debug, sqlx::FromRow)]
+#[derive(Debug, Clone, sqlx::FromRow)]
 pub struct DtakoDriverOpRow {
     pub unko_no: String,
     pub reading_date: NaiveDate,

--- a/src/db/repository/mod.rs
+++ b/src/db/repository/mod.rs
@@ -32,6 +32,7 @@ pub mod tenko_schedules;
 pub mod tenko_sessions;
 pub mod tenko_webhooks;
 pub mod timecard;
+pub mod webhook;
 
 pub use auth::{AuthRepository, PgAuthRepository};
 pub use bot_admin::{BotAdminRepository, PgBotAdminRepository};
@@ -73,6 +74,7 @@ pub use tenko_schedules::{PgTenkoSchedulesRepository, TenkoSchedulesRepository};
 pub use tenko_sessions::{PgTenkoSessionRepository, TenkoSessionRepository};
 pub use tenko_webhooks::{PgTenkoWebhooksRepository, TenkoWebhooksRepository};
 pub use timecard::{PgTimecardRepository, TimecardRepository};
+pub use webhook::{PgWebhookRepository, WebhookRepository};
 
 use sqlx::PgPool;
 

--- a/src/db/repository/webhook.rs
+++ b/src/db/repository/webhook.rs
@@ -1,0 +1,151 @@
+use async_trait::async_trait;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use crate::db::models::{TenkoSchedule, WebhookConfig};
+
+use super::TenantConn;
+
+#[async_trait]
+pub trait WebhookRepository: Send + Sync {
+    async fn find_config(
+        &self,
+        tenant_id: Uuid,
+        event_type: &str,
+    ) -> Result<Option<WebhookConfig>, sqlx::Error>;
+
+    async fn record_delivery(
+        &self,
+        tenant_id: Uuid,
+        config_id: Uuid,
+        event_type: &str,
+        payload: &serde_json::Value,
+        status_code: Option<i32>,
+        response_body: Option<&str>,
+        attempt: i32,
+        success: bool,
+    ) -> Result<(), sqlx::Error>;
+
+    async fn find_overdue_configs(&self) -> Result<Vec<WebhookConfig>, sqlx::Error>;
+
+    async fn find_overdue_schedules(
+        &self,
+        tenant_id: Uuid,
+        overdue_minutes: i64,
+    ) -> Result<Vec<TenkoSchedule>, sqlx::Error>;
+
+    async fn get_employee_name(&self, employee_id: Uuid) -> Result<Option<String>, sqlx::Error>;
+
+    async fn mark_overdue_notified(&self, schedule_id: Uuid) -> Result<(), sqlx::Error>;
+}
+
+pub struct PgWebhookRepository {
+    pool: PgPool,
+}
+
+impl PgWebhookRepository {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl WebhookRepository for PgWebhookRepository {
+    async fn find_config(
+        &self,
+        tenant_id: Uuid,
+        event_type: &str,
+    ) -> Result<Option<WebhookConfig>, sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        sqlx::query_as::<_, WebhookConfig>(
+            "SELECT * FROM webhook_configs WHERE tenant_id = $1 AND event_type = $2 AND enabled = TRUE",
+        )
+        .bind(tenant_id)
+        .bind(event_type)
+        .fetch_optional(&mut *tc.conn)
+        .await
+    }
+
+    async fn record_delivery(
+        &self,
+        tenant_id: Uuid,
+        config_id: Uuid,
+        event_type: &str,
+        payload: &serde_json::Value,
+        status_code: Option<i32>,
+        response_body: Option<&str>,
+        attempt: i32,
+        success: bool,
+    ) -> Result<(), sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        sqlx::query(
+            r#"
+            INSERT INTO webhook_deliveries (
+                tenant_id, config_id, event_type, payload,
+                status_code, response_body, attempt, delivered_at, success
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+            "#,
+        )
+        .bind(tenant_id)
+        .bind(config_id)
+        .bind(event_type)
+        .bind(payload)
+        .bind(status_code)
+        .bind(response_body)
+        .bind(attempt)
+        .bind(if success {
+            Some(chrono::Utc::now())
+        } else {
+            None
+        })
+        .bind(success)
+        .execute(&mut *tc.conn)
+        .await?;
+        Ok(())
+    }
+
+    async fn find_overdue_configs(&self) -> Result<Vec<WebhookConfig>, sqlx::Error> {
+        sqlx::query_as::<_, WebhookConfig>(
+            "SELECT * FROM webhook_configs WHERE event_type = 'tenko_overdue' AND enabled = TRUE",
+        )
+        .fetch_all(&self.pool)
+        .await
+    }
+
+    async fn find_overdue_schedules(
+        &self,
+        tenant_id: Uuid,
+        overdue_minutes: i64,
+    ) -> Result<Vec<TenkoSchedule>, sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        sqlx::query_as::<_, TenkoSchedule>(
+            r#"
+            SELECT s.* FROM tenko_schedules s
+            WHERE s.tenant_id = $1
+              AND s.consumed = FALSE
+              AND s.overdue_notified_at IS NULL
+              AND s.scheduled_at + ($2 || ' minutes')::INTERVAL < NOW()
+            "#,
+        )
+        .bind(tenant_id)
+        .bind(overdue_minutes.to_string())
+        .fetch_all(&mut *tc.conn)
+        .await
+    }
+
+    async fn get_employee_name(&self, employee_id: Uuid) -> Result<Option<String>, sqlx::Error> {
+        sqlx::query_scalar("SELECT name FROM employees WHERE id = $1")
+            .bind(employee_id)
+            .fetch_optional(&self.pool)
+            .await
+    }
+
+    async fn mark_overdue_notified(&self, schedule_id: Uuid) -> Result<(), sqlx::Error> {
+        sqlx::query("UPDATE tenko_schedules SET overdue_notified_at = NOW() WHERE id = $1")
+            .bind(schedule_id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+}

--- a/src/db/repository/webhook.rs
+++ b/src/db/repository/webhook.rs
@@ -7,6 +7,7 @@ use crate::db::models::{TenkoSchedule, WebhookConfig};
 use super::TenantConn;
 
 #[async_trait]
+#[allow(clippy::too_many_arguments)]
 pub trait WebhookRepository: Send + Sync {
     async fn find_config(
         &self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,7 @@ pub struct AppState {
     pub carins_storage: Option<Arc<dyn StorageBackend>>,
     pub dtako_storage: Option<Arc<dyn StorageBackend>>,
     pub fcm: Option<Arc<dyn fcm::FcmSenderTrait>>,
+    pub webhook: Option<Arc<dyn webhook::WebhookService>>,
 }
 
 impl AppState {

--- a/src/main.rs
+++ b/src/main.rs
@@ -202,6 +202,9 @@ async fn main() -> anyhow::Result<()> {
         carins_storage,
         dtako_storage,
         fcm,
+        webhook: Some(Arc::new(rust_alc_api::webhook::PgWebhookService::new(
+            pool.clone(),
+        ))),
     };
 
     // 点呼予定超過チェック バックグラウンドタスク

--- a/src/main.rs
+++ b/src/main.rs
@@ -202,18 +202,31 @@ async fn main() -> anyhow::Result<()> {
         carins_storage,
         dtako_storage,
         fcm,
-        webhook: Some(Arc::new(rust_alc_api::webhook::PgWebhookService::new(
-            pool.clone(),
-        ))),
+        webhook: {
+            let wh_repo: Arc<dyn rust_alc_api::db::repository::WebhookRepository> = Arc::new(
+                rust_alc_api::db::repository::PgWebhookRepository::new(pool.clone()),
+            );
+            let wh_http: Arc<dyn rust_alc_api::webhook::WebhookHttpClient> =
+                Arc::new(rust_alc_api::webhook::ReqwestWebhookClient);
+            Some(Arc::new(rust_alc_api::webhook::PgWebhookService::new(
+                wh_repo.clone(),
+                wh_http.clone(),
+            )))
+        },
     };
 
     // 点呼予定超過チェック バックグラウンドタスク
-    let overdue_pool = pool;
+    let overdue_repo: Arc<dyn rust_alc_api::db::repository::WebhookRepository> =
+        Arc::new(rust_alc_api::db::repository::PgWebhookRepository::new(pool));
+    let overdue_http: Arc<dyn rust_alc_api::webhook::WebhookHttpClient> =
+        Arc::new(rust_alc_api::webhook::ReqwestWebhookClient);
     tokio::spawn(async move {
         let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
         loop {
             interval.tick().await;
-            if let Err(e) = rust_alc_api::webhook::check_overdue_schedules(&overdue_pool).await {
+            if let Err(e) =
+                rust_alc_api::webhook::check_overdue_schedules(&*overdue_repo, &*overdue_http).await
+            {
                 tracing::error!("Overdue check failed: {e}");
             }
         }

--- a/src/routes/devices.rs
+++ b/src/routes/devices.rs
@@ -1686,8 +1686,9 @@ async fn generate_unique_code(state: &AppState) -> Result<String, StatusCode> {
             .code_exists(&code_str)
             .await
             .map_err(|e| db_err("generate_unique_code", e))?;
-        if !exists {
-            return Ok(code_str);
+        if exists {
+            continue;
         }
+        return Ok(code_str);
     }
 }

--- a/src/routes/dtako_restraint_report.rs
+++ b/src/routes/dtako_restraint_report.rs
@@ -593,8 +593,7 @@ pub fn report_to_csv_days(report: &RestraintReportResponse) -> Vec<CsvDayRow> {
         .collect()
 }
 
-#[allow(dead_code)]
-fn parse_hhmm(s: &str) -> i32 {
+pub fn parse_hhmm(s: &str) -> i32 {
     let s = s.trim();
     if s.is_empty() {
         return 0;
@@ -618,19 +617,17 @@ async fn compare_csv(
     let filter_driver_cd = query.driver_cd;
 
     // CSVファイルを受け取る
-    let csv_bytes = if let Some(field) = multipart
+    let field = multipart
         .next_field()
         .await
         .map_err(|e| (StatusCode::BAD_REQUEST, format!("multipart error: {e}")))?
-    {
-        field
-            .bytes()
-            .await
-            .map_err(|e| (StatusCode::BAD_REQUEST, format!("field read error: {e}")))?
-            .to_vec()
-    } else {
-        Vec::new()
-    };
+        .ok_or((StatusCode::BAD_REQUEST, "CSVファイルが空です".to_string()))?;
+
+    let csv_bytes = field
+        .bytes()
+        .await
+        .map_err(|e| (StatusCode::BAD_REQUEST, format!("field read error: {e}")))?
+        .to_vec();
 
     if csv_bytes.is_empty() {
         return Err((StatusCode::BAD_REQUEST, "CSVファイルが空です".to_string()));

--- a/src/routes/dtako_upload.rs
+++ b/src/routes/dtako_upload.rs
@@ -690,12 +690,14 @@ async fn calculate_daily_hours(
                 .await?;
         }
 
-        if progress_tx.is_some() && ((i + 1) % 20 == 0 || i + 1 == save_total) {
-            let msg = format!(
-                "data: {}\n\n",
-                serde_json::json!({"event":"progress","current":i+1,"total":save_total,"step":"save"})
-            );
-            let _ = progress_tx.as_ref().unwrap().send(msg).await;
+        if let Some(tx) = &progress_tx {
+            if (i + 1) % 20 == 0 || i + 1 == save_total {
+                let msg = format!(
+                    "data: {}\n\n",
+                    serde_json::json!({"event":"progress","current":i+1,"total":save_total,"step":"save"})
+                );
+                let _ = tx.send(msg).await;
+            }
         }
     }
     Ok(())
@@ -1090,8 +1092,7 @@ pub async fn recalculate_all_core(
     #[rustfmt::skip]
     let send = |msg: String, ptx: &Option<tokio::sync::mpsc::Sender<String>>| {
         let ptx = ptx.clone();
-        #[allow(clippy::manual_map)]
-        async move { let _ = match ptx { Some(tx) => Some(tx.send(msg).await), None => None }; }
+        async move { if let Some(tx) = ptx { let _ = tx.send(msg).await; } }
     };
     let (month_start, month_end) =
         compute_month_range(year, month).ok_or_else(|| anyhow::anyhow!("invalid year/month"))?;

--- a/src/routes/dtako_upload.rs
+++ b/src/routes/dtako_upload.rs
@@ -690,12 +690,12 @@ async fn calculate_daily_hours(
                 .await?;
         }
 
-        if let Some(ref ptx) = progress_tx {
-            if (i + 1) % 20 == 0 || i + 1 == save_total {
-                #[rustfmt::skip]
-                let msg = serde_json::json!({"event":"progress","current":i+1,"total":save_total,"step":"save"});
-                let _ = ptx.send(format!("data: {}\n\n", msg)).await;
-            }
+        if progress_tx.is_some() && ((i + 1) % 20 == 0 || i + 1 == save_total) {
+            let msg = format!(
+                "data: {}\n\n",
+                serde_json::json!({"event":"progress","current":i+1,"total":save_total,"step":"save"})
+            );
+            let _ = progress_tx.as_ref().unwrap().send(msg).await;
         }
     }
     Ok(())
@@ -1087,13 +1087,11 @@ pub async fn recalculate_all_core(
     month: u32,
     progress_tx: Option<tokio::sync::mpsc::Sender<String>>,
 ) -> Result<usize, anyhow::Error> {
+    #[rustfmt::skip]
     let send = |msg: String, ptx: &Option<tokio::sync::mpsc::Sender<String>>| {
         let ptx = ptx.clone();
-        async move {
-            if let Some(tx) = ptx {
-                let _ = tx.send(msg).await;
-            }
-        }
+        #[allow(clippy::manual_map)]
+        async move { let _ = match ptx { Some(tx) => Some(tx.send(msg).await), None => None }; }
     };
     let (month_start, month_end) =
         compute_month_range(year, month).ok_or_else(|| anyhow::anyhow!("invalid year/month"))?;

--- a/src/routes/dtako_upload.rs
+++ b/src/routes/dtako_upload.rs
@@ -832,18 +832,6 @@ pub fn internal_err(e: impl std::fmt::Display) -> (StatusCode, String) {
     )
 }
 
-/// upload 失敗時の status 更新。UPDATE 自体の失敗もログのみで無視。
-/// テストから呼ばれるため pub を維持。内部はリポジトリに委譲。
-pub async fn mark_upload_failed(conn: &mut sqlx::PgConnection, upload_id: Uuid, error_msg: &str) {
-    let _ = sqlx::query(
-        "UPDATE alc_api.dtako_upload_history SET status = 'failed', error_message = $1 WHERE id = $2",
-    )
-    .bind(error_msg)
-    .bind(upload_id)
-    .execute(conn)
-    .await;
-}
-
 /// 年月から月初・月末を計算 (month==12 の年跨ぎ対応)
 pub fn compute_month_range(
     year: i32,

--- a/src/routes/dtako_upload.rs
+++ b/src/routes/dtako_upload.rs
@@ -690,14 +690,15 @@ async fn calculate_daily_hours(
                 .await?;
         }
 
-        if let Some(tx) = &progress_tx {
-            if (i + 1) % 20 == 0 || i + 1 == save_total {
-                let msg = format!(
-                    "data: {}\n\n",
-                    serde_json::json!({"event":"progress","current":i+1,"total":save_total,"step":"save"})
-                );
-                let _ = tx.send(msg).await;
-            }
+        if let Some(tx) = progress_tx
+            .as_ref()
+            .filter(|_| (i + 1) % 20 == 0 || i + 1 == save_total)
+        {
+            let msg = format!(
+                "data: {}\n\n",
+                serde_json::json!({"event":"progress","current":i+1,"total":save_total,"step":"save"})
+            );
+            let _ = tx.send(msg).await;
         }
     }
     Ok(())

--- a/src/routes/dtako_upload.rs
+++ b/src/routes/dtako_upload.rs
@@ -388,21 +388,22 @@ async fn calculate_daily_hours(
         for (unko_no, fd) in ferry_minutes.iter() {
             fi_minutes.insert(unko_no.clone(), fd.total_minutes);
             fi_period_map.insert(unko_no.clone(), fd.periods.clone());
-            if let Some(events) = kudgivt_by_unko.get(unko_no.as_str()) {
-                let mut break_total = 0i32;
-                for ferry_start in &fd.start_times {
-                    let matched_301 = events
-                        .iter()
-                        .filter(|e| classifications.get(&e.event_cd) == Some(&EventClass::Break))
-                        .filter(|e| e.duration_minutes.unwrap_or(0) > 0)
-                        .min_by_key(|e| (e.start_at - *ferry_start).num_seconds().unsigned_abs());
-                    if let Some(evt) = matched_301 {
-                        break_total += evt.duration_minutes.unwrap_or(0);
-                    }
+            let Some(events) = kudgivt_by_unko.get(unko_no.as_str()) else {
+                continue;
+            };
+            let mut break_total = 0i32;
+            for ferry_start in &fd.start_times {
+                let matched_301 = events
+                    .iter()
+                    .filter(|e| classifications.get(&e.event_cd) == Some(&EventClass::Break))
+                    .filter(|e| e.duration_minutes.unwrap_or(0) > 0)
+                    .min_by_key(|e| (e.start_at - *ferry_start).num_seconds().unsigned_abs());
+                if let Some(evt) = matched_301 {
+                    break_total += evt.duration_minutes.unwrap_or(0);
                 }
-                if break_total > 0 {
-                    fi_break_dur.insert(unko_no.clone(), break_total);
-                }
+            }
+            if break_total > 0 {
+                fi_break_dur.insert(unko_no.clone(), break_total);
             }
         }
         FerryInfo {
@@ -691,17 +692,12 @@ async fn calculate_daily_hours(
 
         if let Some(ref ptx) = progress_tx {
             if (i + 1) % 20 == 0 || i + 1 == save_total {
-                let msg = serde_json::json!({
-                    "event": "progress",
-                    "current": i + 1,
-                    "total": save_total,
-                    "step": "save"
-                });
+                #[rustfmt::skip]
+                let msg = serde_json::json!({"event":"progress","current":i+1,"total":save_total,"step":"save"});
                 let _ = ptx.send(format!("data: {}\n\n", msg)).await;
             }
         }
     }
-
     Ok(())
 }
 
@@ -1099,7 +1095,6 @@ pub async fn recalculate_all_core(
             }
         }
     };
-
     let (month_start, month_end) =
         compute_month_range(year, month).ok_or_else(|| anyhow::anyhow!("invalid year/month"))?;
 

--- a/src/routes/tenko_sessions.rs
+++ b/src/routes/tenko_sessions.rs
@@ -1069,4 +1069,51 @@ mod tests {
         check_self_declaration(&Some(decl), &mut failed);
         assert!(failed.is_empty());
     }
+
+    #[test]
+    fn test_check_self_declaration_illness_true() {
+        let decl =
+            serde_json::json!({"illness": true, "fatigue": false, "sleep_deprivation": false});
+        let mut failed = Vec::new();
+        check_self_declaration(&Some(decl), &mut failed);
+        assert_eq!(failed, vec!["illness"]);
+    }
+
+    #[test]
+    fn test_check_self_declaration_fatigue_true() {
+        let decl =
+            serde_json::json!({"illness": false, "fatigue": true, "sleep_deprivation": false});
+        let mut failed = Vec::new();
+        check_self_declaration(&Some(decl), &mut failed);
+        assert_eq!(failed, vec!["fatigue"]);
+    }
+
+    #[test]
+    fn test_check_self_declaration_sleep_deprivation_true() {
+        let decl =
+            serde_json::json!({"illness": false, "fatigue": false, "sleep_deprivation": true});
+        let mut failed = Vec::new();
+        check_self_declaration(&Some(decl), &mut failed);
+        assert_eq!(failed, vec!["sleep_deprivation"]);
+    }
+
+    #[test]
+    fn test_check_self_declaration_all_true() {
+        let decl = serde_json::json!({"illness": true, "fatigue": true, "sleep_deprivation": true});
+        let mut failed = Vec::new();
+        check_self_declaration(&Some(decl), &mut failed);
+        assert_eq!(failed.len(), 3);
+        assert!(failed.contains(&"illness".to_string()));
+        assert!(failed.contains(&"fatigue".to_string()));
+        assert!(failed.contains(&"sleep_deprivation".to_string()));
+    }
+
+    #[test]
+    fn test_check_self_declaration_invalid_json() {
+        let decl = serde_json::json!({"something": "else"});
+        let mut failed = Vec::new();
+        check_self_declaration(&Some(decl), &mut failed);
+        // Deserialization fails, so no items added
+        assert!(failed.is_empty());
+    }
 }

--- a/src/routes/tenko_sessions.rs
+++ b/src/routes/tenko_sessions.rs
@@ -6,6 +6,7 @@ use axum::{
 };
 use chrono::Utc;
 use sha2::{Digest, Sha256};
+use std::sync::Arc;
 use uuid::Uuid;
 
 use crate::db::models::{
@@ -213,12 +214,11 @@ async fn submit_alcohol(
             }
         });
 
-        let pool = match state.pool.clone() {
-            Some(p) => p,
-            None => return Ok(Json(session)),
-        };
-        #[rustfmt::skip]
-        tokio::spawn(async move { let _ = crate::webhook::fire_event(&pool, tenant_id, "alcohol_detected", payload).await; });
+        if let Some(wh) = state.webhook.clone() {
+            tokio::spawn(async move {
+                wh.fire_event(tenant_id, "alcohol_detected", payload).await;
+            });
+        }
     }
 
     Ok(Json(session))
@@ -379,13 +379,11 @@ async fn submit_report(
             }
         });
 
-        let pool = match state.pool.clone() {
-            Some(p) => p,
-            None => return Ok(Json(session)),
-        };
-        tokio::spawn(async move {
-            let _ = crate::webhook::fire_event(&pool, tenant_id, "report_submitted", payload).await;
-        });
+        if let Some(wh) = state.webhook.clone() {
+            tokio::spawn(async move {
+                wh.fire_event(tenant_id, "report_submitted", payload).await;
+            });
+        }
     }
 
     Ok(Json(session))
@@ -571,12 +569,8 @@ async fn submit_self_declaration(
             StatusCode::INTERNAL_SERVER_ERROR
         })?;
 
-    // 安全判定を自動実行 (pool がない場合はスキップ)
-    let session = if let Some(pool) = state.pool.as_ref() {
-        perform_safety_judgment(repo, &session, tenant_id, pool).await?
-    } else {
-        session
-    };
+    // 安全判定を自動実行
+    let session = perform_safety_judgment(repo, &session, tenant_id, state.webhook.clone()).await?;
 
     Ok(Json(session))
 }
@@ -605,7 +599,7 @@ async fn perform_safety_judgment(
     repo: &dyn TenkoSessionRepository,
     session: &TenkoSession,
     tenant_id: Uuid,
-    pool: &sqlx::PgPool,
+    webhook: Option<Arc<dyn crate::webhook::WebhookService>>,
 ) -> Result<TenkoSession, StatusCode> {
     let mut failed_items: Vec<String> = Vec::new();
     let mut medical_diffs = MedicalDiffs {
@@ -750,11 +744,11 @@ async fn perform_safety_judgment(
             }
         });
 
-        let pool = pool.clone();
-        tokio::spawn(async move {
-            let _ =
-                crate::webhook::fire_event(&pool, tenant_id, "tenko_interrupted", payload).await;
-        });
+        if let Some(wh) = webhook {
+            tokio::spawn(async move {
+                wh.fire_event(tenant_id, "tenko_interrupted", payload).await;
+            });
+        }
     }
 
     Ok(session)
@@ -869,12 +863,11 @@ async fn submit_daily_inspection(
             }
         });
 
-        let pool = match state.pool.clone() {
-            Some(p) => p,
-            None => return Ok(Json(session)),
-        };
-        #[rustfmt::skip]
-        tokio::spawn(async move { let _ = crate::webhook::fire_event(&pool, tenant_id, "inspection_ng", payload).await; });
+        if let Some(wh) = state.webhook.clone() {
+            tokio::spawn(async move {
+                wh.fire_event(tenant_id, "inspection_ng", payload).await;
+            });
+        }
     }
 
     Ok(Json(session))
@@ -997,13 +990,11 @@ async fn interrupt_session(
         }
     });
 
-    let pool = match state.pool.clone() {
-        Some(p) => p,
-        None => return Ok(Json(session)),
-    };
-    tokio::spawn(async move {
-        let _ = crate::webhook::fire_event(&pool, tenant_id, "tenko_interrupted", payload).await;
-    });
+    if let Some(wh) = state.webhook.clone() {
+        tokio::spawn(async move {
+            wh.fire_event(tenant_id, "tenko_interrupted", payload).await;
+        });
+    }
 
     Ok(Json(session))
 }

--- a/src/routes/tenko_sessions.rs
+++ b/src/routes/tenko_sessions.rs
@@ -1072,8 +1072,7 @@ mod tests {
 
     #[test]
     fn test_check_self_declaration_illness_true() {
-        let decl =
-            serde_json::json!({"illness": true, "fatigue": false, "sleep_deprivation": false});
+        let decl = serde_json::json!({"illness": true, "fatigue": false, "sleep_deprivation": false, "declared_at": "2026-01-01T00:00:00Z"});
         let mut failed = Vec::new();
         check_self_declaration(&Some(decl), &mut failed);
         assert_eq!(failed, vec!["illness"]);
@@ -1081,8 +1080,7 @@ mod tests {
 
     #[test]
     fn test_check_self_declaration_fatigue_true() {
-        let decl =
-            serde_json::json!({"illness": false, "fatigue": true, "sleep_deprivation": false});
+        let decl = serde_json::json!({"illness": false, "fatigue": true, "sleep_deprivation": false, "declared_at": "2026-01-01T00:00:00Z"});
         let mut failed = Vec::new();
         check_self_declaration(&Some(decl), &mut failed);
         assert_eq!(failed, vec!["fatigue"]);
@@ -1090,8 +1088,7 @@ mod tests {
 
     #[test]
     fn test_check_self_declaration_sleep_deprivation_true() {
-        let decl =
-            serde_json::json!({"illness": false, "fatigue": false, "sleep_deprivation": true});
+        let decl = serde_json::json!({"illness": false, "fatigue": false, "sleep_deprivation": true, "declared_at": "2026-01-01T00:00:00Z"});
         let mut failed = Vec::new();
         check_self_declaration(&Some(decl), &mut failed);
         assert_eq!(failed, vec!["sleep_deprivation"]);
@@ -1099,7 +1096,7 @@ mod tests {
 
     #[test]
     fn test_check_self_declaration_all_true() {
-        let decl = serde_json::json!({"illness": true, "fatigue": true, "sleep_deprivation": true});
+        let decl = serde_json::json!({"illness": true, "fatigue": true, "sleep_deprivation": true, "declared_at": "2026-01-01T00:00:00Z"});
         let mut failed = Vec::new();
         check_self_declaration(&Some(decl), &mut failed);
         assert_eq!(failed.len(), 3);

--- a/src/webhook.rs
+++ b/src/webhook.rs
@@ -2,8 +2,11 @@ use async_trait::async_trait;
 use chrono::Utc;
 use hmac::{Hmac, Mac};
 use sha2::Sha256;
-use sqlx::PgPool;
+use std::sync::Arc;
 use uuid::Uuid;
+
+use crate::db::models::WebhookConfig;
+use crate::db::repository::WebhookRepository;
 
 type HmacSha256 = Hmac<Sha256>;
 
@@ -13,79 +16,43 @@ pub trait WebhookService: Send + Sync {
     async fn fire_event(&self, tenant_id: Uuid, event_type: &str, payload: serde_json::Value);
 }
 
-/// 本番用 WebhookService (PgPool ベース)
-pub struct PgWebhookService {
-    pool: PgPool,
+/// HTTP 配信 trait — テスト時に mock 差し替え可能
+#[async_trait]
+pub trait WebhookHttpClient: Send + Sync {
+    /// Webhook を配信し、(status_code, response_body, success) を返す
+    async fn deliver(
+        &self,
+        url: &str,
+        event_type: &str,
+        payload: &serde_json::Value,
+        secret: Option<&str>,
+    ) -> Result<(Option<i32>, Option<String>, bool), anyhow::Error>;
 }
 
-impl PgWebhookService {
-    pub fn new(pool: PgPool) -> Self {
-        Self { pool }
-    }
-}
+/// 本番用 HTTP クライアント (reqwest)
+pub struct ReqwestWebhookClient;
 
 #[async_trait]
-impl WebhookService for PgWebhookService {
-    async fn fire_event(&self, tenant_id: Uuid, event_type: &str, payload: serde_json::Value) {
-        let _ = fire_event_impl(&self.pool, tenant_id, event_type, payload).await;
-    }
-}
+impl WebhookHttpClient for ReqwestWebhookClient {
+    async fn deliver(
+        &self,
+        url: &str,
+        event_type: &str,
+        payload: &serde_json::Value,
+        secret: Option<&str>,
+    ) -> Result<(Option<i32>, Option<String>, bool), anyhow::Error> {
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(10))
+            .build()?;
 
-/// Webhook イベントを発火 (非同期で配信)
-async fn fire_event_impl(
-    pool: &PgPool,
-    tenant_id: Uuid,
-    event_type: &str,
-    payload: serde_json::Value,
-) -> Result<(), anyhow::Error> {
-    let mut conn = pool.acquire().await?;
-    crate::db::tenant::set_current_tenant(&mut conn, &tenant_id.to_string()).await?;
-
-    let config = sqlx::query_as::<_, crate::db::models::WebhookConfig>(
-        "SELECT * FROM webhook_configs WHERE tenant_id = $1 AND event_type = $2 AND enabled = TRUE",
-    )
-    .bind(tenant_id)
-    .bind(event_type)
-    .fetch_optional(&mut *conn)
-    .await?;
-
-    let config = match config {
-        Some(c) => c,
-        None => return Ok(()), // 設定なし → 何もしない
-    };
-
-    let pool = pool.clone();
-    let event_type = event_type.to_string();
-    tokio::spawn(async move {
-        let _ = deliver_webhook(&pool, &config, &event_type, &payload).await;
-    });
-
-    Ok(())
-}
-
-/// Webhook を配信 (リトライ付き)
-pub async fn deliver_webhook(
-    pool: &PgPool,
-    config: &crate::db::models::WebhookConfig,
-    event_type: &str,
-    payload: &serde_json::Value,
-) -> Result<(), anyhow::Error> {
-    let client = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(10))
-        .build()?;
-
-    let delays = [1u64, 5, 25]; // 指数バックオフ
-
-    for attempt in 1..=3 {
         let body = serde_json::to_string(payload)?;
 
         let mut req = client
-            .post(&config.url)
+            .post(url)
             .header("Content-Type", "application/json")
             .header("X-Webhook-Event", event_type);
 
-        // HMAC-SHA256 署名
-        if let Some(ref secret) = config.secret {
+        if let Some(secret) = secret {
             let mut mac = HmacSha256::new_from_slice(secret.as_bytes()).expect("HMAC key length");
             mac.update(body.as_bytes());
             let signature = hex::encode(mac.finalize().into_bytes());
@@ -94,32 +61,88 @@ pub async fn deliver_webhook(
 
         let resp = req.body(body).send().await;
 
-        let (status_code, response_body, success) = match resp {
+        match resp {
             Ok(r) => {
                 let code = r.status().as_u16() as i32;
                 let body = r.text().await.unwrap_or_default();
                 let ok = (200..300).contains(&(code as u16 as usize));
-                (Some(code), Some(body), ok)
+                Ok((Some(code), Some(body), ok))
             }
             Err(e) => {
-                tracing::warn!("Webhook attempt {attempt} failed: {e}");
-                (None, Some(e.to_string()), false)
+                tracing::warn!("Webhook delivery failed: {e}");
+                Ok((None, Some(e.to_string()), false))
             }
-        };
+        }
+    }
+}
+
+/// 本番用 WebhookService (Repository + HTTP)
+pub struct PgWebhookService {
+    repo: Arc<dyn WebhookRepository>,
+    http: Arc<dyn WebhookHttpClient>,
+}
+
+impl PgWebhookService {
+    pub fn new(repo: Arc<dyn WebhookRepository>, http: Arc<dyn WebhookHttpClient>) -> Self {
+        Self { repo, http }
+    }
+}
+
+#[async_trait]
+impl WebhookService for PgWebhookService {
+    async fn fire_event(&self, tenant_id: Uuid, event_type: &str, payload: serde_json::Value) {
+        let _ = fire_event_impl(&*self.repo, &*self.http, tenant_id, event_type, payload).await;
+    }
+}
+
+/// Webhook イベントを発火 (非同期で配信)
+pub async fn fire_event_impl(
+    repo: &dyn WebhookRepository,
+    http: &dyn WebhookHttpClient,
+    tenant_id: Uuid,
+    event_type: &str,
+    payload: serde_json::Value,
+) -> Result<(), anyhow::Error> {
+    let config = repo.find_config(tenant_id, event_type).await?;
+
+    let config = match config {
+        Some(c) => c,
+        None => return Ok(()), // 設定なし → 何もしない
+    };
+
+    deliver_webhook(repo, http, &config, event_type, &payload).await?;
+
+    Ok(())
+}
+
+/// Webhook を配信 (リトライ付き)
+pub async fn deliver_webhook(
+    repo: &dyn WebhookRepository,
+    http: &dyn WebhookHttpClient,
+    config: &WebhookConfig,
+    event_type: &str,
+    payload: &serde_json::Value,
+) -> Result<(), anyhow::Error> {
+    let delays = [1u64, 5, 25]; // 指数バックオフ
+
+    for attempt in 1..=3 {
+        let (status_code, response_body, success) = http
+            .deliver(&config.url, event_type, payload, config.secret.as_deref())
+            .await?;
 
         // 配信ログ記録
-        let _ = record_delivery(
-            pool,
-            config.tenant_id,
-            config.id,
-            event_type,
-            payload,
-            status_code,
-            response_body.as_deref(),
-            attempt,
-            success,
-        )
-        .await;
+        let _ = repo
+            .record_delivery(
+                config.tenant_id,
+                config.id,
+                event_type,
+                payload,
+                status_code,
+                response_body.as_deref(),
+                attempt,
+                success,
+            )
+            .await;
 
         if success {
             return Ok(());
@@ -133,86 +156,25 @@ pub async fn deliver_webhook(
     Ok(())
 }
 
-#[allow(clippy::too_many_arguments)]
-async fn record_delivery(
-    pool: &PgPool,
-    tenant_id: Uuid,
-    config_id: Uuid,
-    event_type: &str,
-    payload: &serde_json::Value,
-    status_code: Option<i32>,
-    response_body: Option<&str>,
-    attempt: i32,
-    success: bool,
-) -> Result<(), sqlx::Error> {
-    let mut conn = pool.acquire().await?;
-    crate::db::tenant::set_current_tenant(&mut conn, &tenant_id.to_string()).await?;
-
-    sqlx::query(
-        r#"
-        INSERT INTO webhook_deliveries (
-            tenant_id, config_id, event_type, payload,
-            status_code, response_body, attempt, delivered_at, success
-        )
-        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-        "#,
-    )
-    .bind(tenant_id)
-    .bind(config_id)
-    .bind(event_type)
-    .bind(payload)
-    .bind(status_code)
-    .bind(response_body)
-    .bind(attempt)
-    .bind(if success { Some(Utc::now()) } else { None })
-    .bind(success)
-    .execute(&mut *conn)
-    .await?;
-
-    Ok(())
-}
-
 /// 未完了予定の検出 + overdue通知 (バックグラウンドループから呼ばれる)
-pub async fn check_overdue_schedules(pool: &PgPool) -> Result<(), anyhow::Error> {
-    // overdue_minutes 環境変数 (デフォルト60分)
+pub async fn check_overdue_schedules(
+    repo: &dyn WebhookRepository,
+    http: &dyn WebhookHttpClient,
+) -> Result<(), anyhow::Error> {
     let overdue_minutes: i64 = std::env::var("TENKO_OVERDUE_MINUTES")
         .ok()
         .and_then(|v| v.parse().ok())
         .unwrap_or(60);
 
-    // webhook_configs に tenko_overdue が設定されているテナントを取得
-    let configs = sqlx::query_as::<_, crate::db::models::WebhookConfig>(
-        "SELECT * FROM webhook_configs WHERE event_type = 'tenko_overdue' AND enabled = TRUE",
-    )
-    .fetch_all(pool)
-    .await?;
+    let configs = repo.find_overdue_configs().await?;
 
     for config in &configs {
-        let mut conn = pool.acquire().await?;
-        crate::db::tenant::set_current_tenant(&mut conn, &config.tenant_id.to_string()).await?;
-
-        // 予定時刻 + overdue_minutes を過ぎた未消費・未通知の予定を検索
-        let overdue_schedules = sqlx::query_as::<_, crate::db::models::TenkoSchedule>(
-            r#"
-            SELECT s.* FROM tenko_schedules s
-            WHERE s.tenant_id = $1
-              AND s.consumed = FALSE
-              AND s.overdue_notified_at IS NULL
-              AND s.scheduled_at + ($2 || ' minutes')::INTERVAL < NOW()
-            "#,
-        )
-        .bind(config.tenant_id)
-        .bind(overdue_minutes.to_string())
-        .fetch_all(&mut *conn)
-        .await?;
+        let overdue_schedules = repo
+            .find_overdue_schedules(config.tenant_id, overdue_minutes)
+            .await?;
 
         for schedule in &overdue_schedules {
-            // 乗務員名を取得
-            let employee_name: Option<String> =
-                sqlx::query_scalar("SELECT name FROM employees WHERE id = $1")
-                    .bind(schedule.employee_id)
-                    .fetch_optional(&mut *conn)
-                    .await?;
+            let employee_name = repo.get_employee_name(schedule.employee_id).await?;
 
             let minutes = (Utc::now() - schedule.scheduled_at).num_minutes();
 
@@ -231,14 +193,9 @@ pub async fn check_overdue_schedules(pool: &PgPool) -> Result<(), anyhow::Error>
                 }
             });
 
-            // 通知済みマーク
-            sqlx::query("UPDATE tenko_schedules SET overdue_notified_at = NOW() WHERE id = $1")
-                .bind(schedule.id)
-                .execute(&mut *conn)
-                .await?;
+            repo.mark_overdue_notified(schedule.id).await?;
 
-            // Webhook 配信
-            let _ = deliver_webhook(pool, config, "tenko_overdue", &payload).await;
+            let _ = deliver_webhook(repo, http, config, "tenko_overdue", &payload).await;
         }
     }
 

--- a/src/webhook.rs
+++ b/src/webhook.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use chrono::Utc;
 use hmac::{Hmac, Mac};
 use sha2::Sha256;
@@ -6,8 +7,32 @@ use uuid::Uuid;
 
 type HmacSha256 = Hmac<Sha256>;
 
+/// Webhook サービス trait — テスト時に mock 差し替え可能
+#[async_trait]
+pub trait WebhookService: Send + Sync {
+    async fn fire_event(&self, tenant_id: Uuid, event_type: &str, payload: serde_json::Value);
+}
+
+/// 本番用 WebhookService (PgPool ベース)
+pub struct PgWebhookService {
+    pool: PgPool,
+}
+
+impl PgWebhookService {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl WebhookService for PgWebhookService {
+    async fn fire_event(&self, tenant_id: Uuid, event_type: &str, payload: serde_json::Value) {
+        let _ = fire_event_impl(&self.pool, tenant_id, event_type, payload).await;
+    }
+}
+
 /// Webhook イベントを発火 (非同期で配信)
-pub async fn fire_event(
+async fn fire_event_impl(
     pool: &PgPool,
     tenant_id: Uuid,
     event_type: &str,

--- a/src/webhook.rs
+++ b/src/webhook.rs
@@ -201,3 +201,432 @@ pub async fn check_overdue_schedules(
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::models::{TenkoSchedule, WebhookConfig};
+    use crate::db::repository::webhook::WebhookRepository;
+    use chrono::Utc;
+    use std::sync::Mutex;
+
+    // --- Mock Repository ---
+
+    struct MockRepo {
+        config: Option<WebhookConfig>,
+        deliveries: Mutex<Vec<(String, i32, bool)>>,
+        overdue_configs: Vec<WebhookConfig>,
+        overdue_schedules: Vec<TenkoSchedule>,
+        employee_name: Option<String>,
+        notified: Mutex<Vec<Uuid>>,
+    }
+
+    impl MockRepo {
+        fn new() -> Self {
+            Self {
+                config: None,
+                deliveries: Mutex::new(Vec::new()),
+                overdue_configs: Vec::new(),
+                overdue_schedules: Vec::new(),
+                employee_name: None,
+                notified: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn with_config(mut self, config: WebhookConfig) -> Self {
+            self.config = Some(config);
+            self
+        }
+
+        fn with_overdue(
+            mut self,
+            configs: Vec<WebhookConfig>,
+            schedules: Vec<TenkoSchedule>,
+        ) -> Self {
+            self.overdue_configs = configs;
+            self.overdue_schedules = schedules;
+            self
+        }
+
+        fn with_employee_name(mut self, name: Option<String>) -> Self {
+            self.employee_name = name;
+            self
+        }
+    }
+
+    #[async_trait]
+    impl WebhookRepository for MockRepo {
+        async fn find_config(
+            &self,
+            _tenant_id: Uuid,
+            _event_type: &str,
+        ) -> Result<Option<WebhookConfig>, sqlx::Error> {
+            Ok(self.config.clone())
+        }
+
+        async fn record_delivery(
+            &self,
+            _tenant_id: Uuid,
+            _config_id: Uuid,
+            event_type: &str,
+            _payload: &serde_json::Value,
+            _status_code: Option<i32>,
+            _response_body: Option<&str>,
+            attempt: i32,
+            success: bool,
+        ) -> Result<(), sqlx::Error> {
+            self.deliveries
+                .lock()
+                .unwrap()
+                .push((event_type.to_string(), attempt, success));
+            Ok(())
+        }
+
+        async fn find_overdue_configs(&self) -> Result<Vec<WebhookConfig>, sqlx::Error> {
+            Ok(self.overdue_configs.clone())
+        }
+
+        async fn find_overdue_schedules(
+            &self,
+            _tenant_id: Uuid,
+            _overdue_minutes: i64,
+        ) -> Result<Vec<TenkoSchedule>, sqlx::Error> {
+            Ok(self.overdue_schedules.clone())
+        }
+
+        async fn get_employee_name(
+            &self,
+            _employee_id: Uuid,
+        ) -> Result<Option<String>, sqlx::Error> {
+            Ok(self.employee_name.clone())
+        }
+
+        async fn mark_overdue_notified(&self, schedule_id: Uuid) -> Result<(), sqlx::Error> {
+            self.notified.lock().unwrap().push(schedule_id);
+            Ok(())
+        }
+    }
+
+    // --- Mock HTTP Client ---
+
+    struct MockHttp {
+        responses: Mutex<Vec<(Option<i32>, Option<String>, bool)>>,
+    }
+
+    impl MockHttp {
+        fn success() -> Self {
+            Self {
+                responses: Mutex::new(vec![(Some(200), Some("ok".to_string()), true)]),
+            }
+        }
+
+        fn fail_then_succeed() -> Self {
+            Self {
+                responses: Mutex::new(vec![
+                    (Some(500), Some("error".to_string()), false),
+                    (Some(200), Some("ok".to_string()), true),
+                ]),
+            }
+        }
+
+        fn always_fail() -> Self {
+            Self {
+                responses: Mutex::new(vec![
+                    (Some(500), Some("err1".to_string()), false),
+                    (Some(500), Some("err2".to_string()), false),
+                    (Some(500), Some("err3".to_string()), false),
+                ]),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl WebhookHttpClient for MockHttp {
+        async fn deliver(
+            &self,
+            _url: &str,
+            _event_type: &str,
+            _payload: &serde_json::Value,
+            _secret: Option<&str>,
+        ) -> Result<(Option<i32>, Option<String>, bool), anyhow::Error> {
+            let resp = self.responses.lock().unwrap().remove(0);
+            Ok(resp)
+        }
+    }
+
+    // --- Helper ---
+
+    fn make_config(secret: Option<&str>) -> WebhookConfig {
+        WebhookConfig {
+            id: Uuid::new_v4(),
+            tenant_id: Uuid::new_v4(),
+            event_type: "test_event".to_string(),
+            url: "https://example.com/webhook".to_string(),
+            secret: secret.map(|s| s.to_string()),
+            enabled: true,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
+
+    fn make_schedule(tenant_id: Uuid) -> TenkoSchedule {
+        TenkoSchedule {
+            id: Uuid::new_v4(),
+            tenant_id,
+            employee_id: Uuid::new_v4(),
+            tenko_type: "pre_operation".to_string(),
+            responsible_manager_name: "Manager A".to_string(),
+            scheduled_at: Utc::now() - chrono::Duration::hours(2),
+            instruction: None,
+            consumed: false,
+            consumed_by_session_id: None,
+            overdue_notified_at: None,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
+
+    // --- Tests ---
+
+    #[tokio::test(start_paused = true)]
+    async fn test_fire_event_impl_no_config() {
+        let repo = MockRepo::new();
+        let http = MockHttp::success();
+        let tenant_id = Uuid::new_v4();
+
+        let result = fire_event_impl(&repo, &http, tenant_id, "test", serde_json::json!({})).await;
+
+        assert!(result.is_ok());
+        assert!(repo.deliveries.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_fire_event_impl_with_config() {
+        let config = make_config(None);
+        let repo = MockRepo::new().with_config(config);
+        let http = MockHttp::success();
+        let tenant_id = Uuid::new_v4();
+
+        let result = fire_event_impl(&repo, &http, tenant_id, "test", serde_json::json!({})).await;
+
+        assert!(result.is_ok());
+        let deliveries = repo.deliveries.lock().unwrap();
+        assert_eq!(deliveries.len(), 1);
+        assert_eq!(deliveries[0].1, 1);
+        assert!(deliveries[0].2);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_deliver_webhook_success_first_attempt() {
+        let config = make_config(None);
+        let repo = MockRepo::new();
+        let http = MockHttp::success();
+
+        let result =
+            deliver_webhook(&repo, &http, &config, "test_event", &serde_json::json!({})).await;
+
+        assert!(result.is_ok());
+        let deliveries = repo.deliveries.lock().unwrap();
+        assert_eq!(deliveries.len(), 1);
+        assert!(deliveries[0].2);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_deliver_webhook_retry_then_success() {
+        let config = make_config(None);
+        let repo = MockRepo::new();
+        let http = MockHttp::fail_then_succeed();
+
+        let result =
+            deliver_webhook(&repo, &http, &config, "test_event", &serde_json::json!({})).await;
+
+        assert!(result.is_ok());
+        let deliveries = repo.deliveries.lock().unwrap();
+        assert_eq!(deliveries.len(), 2);
+        assert!(!deliveries[0].2);
+        assert!(deliveries[1].2);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_deliver_webhook_all_retries_fail() {
+        let config = make_config(None);
+        let repo = MockRepo::new();
+        let http = MockHttp::always_fail();
+
+        let result =
+            deliver_webhook(&repo, &http, &config, "test_event", &serde_json::json!({})).await;
+
+        assert!(result.is_ok());
+        let deliveries = repo.deliveries.lock().unwrap();
+        assert_eq!(deliveries.len(), 3);
+        assert!(!deliveries[0].2);
+        assert!(!deliveries[1].2);
+        assert!(!deliveries[2].2);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_deliver_webhook_with_secret() {
+        let config = make_config(Some("my-secret-key"));
+        let repo = MockRepo::new();
+        let http = MockHttp::success();
+
+        let result = deliver_webhook(
+            &repo,
+            &http,
+            &config,
+            "test_event",
+            &serde_json::json!({"foo": "bar"}),
+        )
+        .await;
+
+        assert!(result.is_ok());
+        let deliveries = repo.deliveries.lock().unwrap();
+        assert_eq!(deliveries.len(), 1);
+        assert!(deliveries[0].2);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_check_overdue_no_configs() {
+        let repo = MockRepo::new();
+        let http = MockHttp::success();
+
+        let result = check_overdue_schedules(&repo, &http).await;
+
+        assert!(result.is_ok());
+        assert!(repo.notified.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_check_overdue_with_schedules() {
+        let config = make_config(None);
+        let tenant_id = config.tenant_id;
+        let schedule = make_schedule(tenant_id);
+        let schedule_id = schedule.id;
+
+        let repo = MockRepo::new()
+            .with_overdue(vec![config], vec![schedule])
+            .with_employee_name(Some("Taro Yamada".to_string()));
+        let http = MockHttp::success();
+
+        let result = check_overdue_schedules(&repo, &http).await;
+
+        assert!(result.is_ok());
+        let notified = repo.notified.lock().unwrap();
+        assert_eq!(notified.len(), 1);
+        assert_eq!(notified[0], schedule_id);
+        let deliveries = repo.deliveries.lock().unwrap();
+        assert_eq!(deliveries.len(), 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_check_overdue_employee_name_none() {
+        let config = make_config(None);
+        let tenant_id = config.tenant_id;
+        let schedule = make_schedule(tenant_id);
+
+        let repo = MockRepo::new()
+            .with_overdue(vec![config], vec![schedule])
+            .with_employee_name(None);
+        let http = MockHttp::success();
+
+        let result = check_overdue_schedules(&repo, &http).await;
+
+        assert!(result.is_ok());
+        assert_eq!(repo.notified.lock().unwrap().len(), 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_pg_webhook_service_new_and_fire_event() {
+        let config = make_config(None);
+        let repo = Arc::new(MockRepo::new().with_config(config));
+        let http = Arc::new(MockHttp::success());
+
+        let service = PgWebhookService::new(repo.clone(), http);
+
+        service
+            .fire_event(Uuid::new_v4(), "test", serde_json::json!({}))
+            .await;
+
+        let deliveries = repo.deliveries.lock().unwrap();
+        assert_eq!(deliveries.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_reqwest_webhook_client_success() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .respond_with(wiremock::ResponseTemplate::new(200).set_body_string("ok"))
+            .mount(&server)
+            .await;
+
+        let client = ReqwestWebhookClient;
+        let (status, body, success) = client
+            .deliver(
+                &server.uri(),
+                "test_event",
+                &serde_json::json!({"key": "value"}),
+                None,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(status, Some(200));
+        assert_eq!(body.as_deref(), Some("ok"));
+        assert!(success);
+    }
+
+    #[tokio::test]
+    async fn test_reqwest_webhook_client_with_secret() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::header_exists("X-Webhook-Signature"))
+            .respond_with(wiremock::ResponseTemplate::new(200))
+            .mount(&server)
+            .await;
+
+        let client = ReqwestWebhookClient;
+        let (status, _, success) = client
+            .deliver(
+                &server.uri(),
+                "test_event",
+                &serde_json::json!({}),
+                Some("my-secret"),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(status, Some(200));
+        assert!(success);
+    }
+
+    #[tokio::test]
+    async fn test_reqwest_webhook_client_server_error() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .respond_with(wiremock::ResponseTemplate::new(500).set_body_string("error"))
+            .mount(&server)
+            .await;
+
+        let client = ReqwestWebhookClient;
+        let (status, _, success) = client
+            .deliver(&server.uri(), "test", &serde_json::json!({}), None)
+            .await
+            .unwrap();
+
+        assert_eq!(status, Some(500));
+        assert!(!success);
+    }
+
+    #[tokio::test]
+    async fn test_reqwest_webhook_client_connection_error() {
+        let client = ReqwestWebhookClient;
+        let (status, body, success) = client
+            .deliver("http://127.0.0.1:1", "test", &serde_json::json!({}), None)
+            .await
+            .unwrap();
+
+        assert!(status.is_none());
+        assert!(body.is_some());
+        assert!(!success);
+    }
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -312,6 +312,7 @@ fn build_app_state(
         carins_storage: None,
         dtako_storage,
         fcm,
+        webhook: None,
     }
 }
 

--- a/tests/mock_helpers/app_state.rs
+++ b/tests/mock_helpers/app_state.rs
@@ -61,5 +61,6 @@ pub fn setup_mock_app_state() -> AppState {
         carins_storage: None,
         dtako_storage: Some(dtako_storage),
         fcm: None,
+        webhook: None,
     }
 }

--- a/tests/mock_helpers/mod.rs
+++ b/tests/mock_helpers/mod.rs
@@ -11,6 +11,7 @@ mod repos_b;
 #[macro_use]
 mod repos_c;
 pub mod app_state;
+pub mod webhook;
 
 pub use app_state::*;
 pub use repos_a::*;

--- a/tests/mock_helpers/repos_a.rs
+++ b/tests/mock_helpers/repos_a.rs
@@ -74,6 +74,8 @@ pub struct MockAuthRepository {
     pub return_sso_config: std::sync::Mutex<Option<SsoConfigRow>>,
     /// Tenant ID to use for create_tenant_with_domain / create_tenant_by_name
     pub auto_tenant_id: std::sync::Mutex<Option<Uuid>>,
+    /// If Some, find_user_by_lineworks_id returns this user
+    pub return_lineworks_user: std::sync::Mutex<Option<User>>,
 }
 
 impl Default for MockAuthRepository {
@@ -87,6 +89,7 @@ impl Default for MockAuthRepository {
             return_tenant: std::sync::Mutex::new(None),
             return_sso_config: std::sync::Mutex::new(None),
             auto_tenant_id: std::sync::Mutex::new(None),
+            return_lineworks_user: std::sync::Mutex::new(None),
         }
     }
 }
@@ -106,7 +109,7 @@ impl AuthRepository for MockAuthRepository {
         _lineworks_id: &str,
     ) -> Result<Option<User>, sqlx::Error> {
         check_fail!(self);
-        Ok(None)
+        Ok(self.return_lineworks_user.lock().unwrap().clone())
     }
 
     async fn find_user_by_refresh_token_hash(
@@ -732,6 +735,38 @@ impl DailyHealthRepository for MockDailyHealthRepository {
 pub struct MockDeviceRepository {
     pub fail_next: AtomicBool,
     pub return_data: AtomicBool,
+    /// claim で qr_permanent フローを返す
+    pub return_qr_permanent: AtomicBool,
+    /// claim で status="used" を返す
+    pub return_used_status: AtomicBool,
+    /// claim で未知のフロータイプを返す
+    pub return_unknown_flow: AtomicBool,
+    /// check_registration_status で status="approved" (非 pending) を返す
+    pub return_approved_status: AtomicBool,
+    /// check_registration_status で expires_at=None を返す
+    pub return_no_expires: AtomicBool,
+    /// is_expired で true を返す
+    pub return_expired: AtomicBool,
+    /// list_fcm_devices で call_enabled=false のデバイスを返す
+    pub return_call_disabled: AtomicBool,
+    /// list_fcm_devices で call_schedule 付きデバイスを返す (enabled=false)
+    pub return_schedule_disabled: AtomicBool,
+    /// list_fcm_devices で日曜のみ schedule を返す (time-based test に使う)
+    pub return_schedule_with_days: AtomicBool,
+    /// get_fcm_token_bypass_rls で None (token なし) を返す
+    pub return_no_fcm_token: AtomicBool,
+    /// get_device_fcm_token で Some(None) (token null) を返す
+    pub return_null_fcm_token: AtomicBool,
+    /// list_all_callable_devices でデバイスを返す
+    pub return_callable_devices: AtomicBool,
+    /// list_dev_device_tenant_ids でテナント ID を返す
+    pub return_dev_tenants: AtomicBool,
+    /// list_ota_devices で version_code=None のデバイスを返す
+    pub return_ota_no_version: AtomicBool,
+    /// list_devices で DeviceRow を返す (From テスト用)
+    pub return_device_rows: AtomicBool,
+    /// list_pending で RegistrationRequestRow を返す (From テスト用)
+    pub return_pending_rows: AtomicBool,
 }
 
 impl Default for MockDeviceRepository {
@@ -739,6 +774,22 @@ impl Default for MockDeviceRepository {
         Self {
             fail_next: AtomicBool::new(false),
             return_data: AtomicBool::new(false),
+            return_qr_permanent: AtomicBool::new(false),
+            return_used_status: AtomicBool::new(false),
+            return_unknown_flow: AtomicBool::new(false),
+            return_approved_status: AtomicBool::new(false),
+            return_no_expires: AtomicBool::new(false),
+            return_expired: AtomicBool::new(false),
+            return_call_disabled: AtomicBool::new(false),
+            return_schedule_disabled: AtomicBool::new(false),
+            return_schedule_with_days: AtomicBool::new(false),
+            return_no_fcm_token: AtomicBool::new(false),
+            return_null_fcm_token: AtomicBool::new(false),
+            return_callable_devices: AtomicBool::new(false),
+            return_dev_tenants: AtomicBool::new(false),
+            return_ota_no_version: AtomicBool::new(false),
+            return_device_rows: AtomicBool::new(false),
+            return_pending_rows: AtomicBool::new(false),
         }
     }
 }
@@ -770,11 +821,21 @@ impl DeviceRepository for MockDeviceRepository {
     ) -> Result<Option<RegistrationStatusRow>, sqlx::Error> {
         check_fail!(self);
         if self.return_data.load(Ordering::SeqCst) {
+            let status = if self.return_approved_status.load(Ordering::SeqCst) {
+                "approved".to_string()
+            } else {
+                "pending".to_string()
+            };
+            let expires_at = if self.return_no_expires.load(Ordering::SeqCst) {
+                None
+            } else {
+                Some("2099-12-31T23:59:59Z".to_string())
+            };
             Ok(Some(RegistrationStatusRow {
-                status: "pending".to_string(),
+                status,
                 device_id: None,
                 tenant_id: Some(Uuid::nil()),
-                expires_at: Some("2099-12-31T23:59:59Z".to_string()),
+                expires_at,
                 device_name: Some("Test Device".to_string()),
             }))
         } else {
@@ -784,17 +845,29 @@ impl DeviceRepository for MockDeviceRepository {
 
     async fn is_expired(&self, _expires_at: &str) -> Result<bool, sqlx::Error> {
         check_fail!(self);
-        Ok(false)
+        Ok(self.return_expired.load(Ordering::SeqCst))
     }
 
     async fn find_claim_request(&self, _code: &str) -> Result<Option<ClaimLookupRow>, sqlx::Error> {
         check_fail!(self);
         if self.return_data.load(Ordering::SeqCst) {
+            let flow_type = if self.return_qr_permanent.load(Ordering::SeqCst) {
+                "qr_permanent".to_string()
+            } else if self.return_unknown_flow.load(Ordering::SeqCst) {
+                "unknown_flow".to_string()
+            } else {
+                "url".to_string()
+            };
+            let status = if self.return_used_status.load(Ordering::SeqCst) {
+                "used".to_string()
+            } else {
+                "pending".to_string()
+            };
             Ok(Some(ClaimLookupRow {
                 id: Uuid::nil(),
-                flow_type: "url".to_string(),
+                flow_type,
                 tenant_id: Some(Uuid::nil()),
-                status: "pending".to_string(),
+                status,
                 expires_at: Some("2099-12-31T23:59:59Z".to_string()),
                 device_name: Some("Test Device".to_string()),
                 is_device_owner: false,
@@ -882,12 +955,43 @@ impl DeviceRepository for MockDeviceRepository {
     async fn list_fcm_devices(&self) -> Result<Vec<FcmDeviceRow>, sqlx::Error> {
         check_fail!(self);
         if self.return_data.load(Ordering::SeqCst) {
-            Ok(vec![FcmDeviceRow {
-                id: Uuid::nil(),
-                fcm_token: "mock-fcm-token-1".to_string(),
-                call_enabled: true,
-                call_schedule: None,
-            }])
+            if self.return_call_disabled.load(Ordering::SeqCst) {
+                Ok(vec![FcmDeviceRow {
+                    id: Uuid::nil(),
+                    fcm_token: "mock-fcm-token-1".to_string(),
+                    call_enabled: false,
+                    call_schedule: None,
+                }])
+            } else if self.return_schedule_disabled.load(Ordering::SeqCst) {
+                Ok(vec![FcmDeviceRow {
+                    id: Uuid::nil(),
+                    fcm_token: "mock-fcm-token-1".to_string(),
+                    call_enabled: true,
+                    call_schedule: Some(serde_json::json!({"enabled": false})),
+                }])
+            } else if self.return_schedule_with_days.load(Ordering::SeqCst) {
+                // 全曜日 0-6 を含むスケジュール + 0:00-23:59 → 常に通知
+                Ok(vec![FcmDeviceRow {
+                    id: Uuid::nil(),
+                    fcm_token: "mock-fcm-token-1".to_string(),
+                    call_enabled: true,
+                    call_schedule: Some(serde_json::json!({
+                        "enabled": true,
+                        "days": [0, 1, 2, 3, 4, 5, 6],
+                        "startHour": 0,
+                        "startMin": 0,
+                        "endHour": 24,
+                        "endMin": 0
+                    })),
+                }])
+            } else {
+                Ok(vec![FcmDeviceRow {
+                    id: Uuid::nil(),
+                    fcm_token: "mock-fcm-token-1".to_string(),
+                    call_enabled: true,
+                    call_schedule: None,
+                }])
+            }
         } else {
             Ok(vec![])
         }
@@ -918,7 +1022,15 @@ impl DeviceRepository for MockDeviceRepository {
 
     async fn list_all_callable_devices(&self) -> Result<Vec<FcmTestDeviceRow>, sqlx::Error> {
         check_fail!(self);
-        Ok(vec![])
+        if self.return_callable_devices.load(Ordering::SeqCst) {
+            Ok(vec![FcmTestDeviceRow {
+                id: Uuid::nil(),
+                device_name: "Callable Device".to_string(),
+                fcm_token: "mock-callable-token".to_string(),
+            }])
+        } else {
+            Ok(vec![])
+        }
     }
 
     async fn update_watchdog_state(
@@ -946,14 +1058,47 @@ impl DeviceRepository for MockDeviceRepository {
 
     async fn list_dev_device_tenant_ids(&self) -> Result<Vec<String>, sqlx::Error> {
         check_fail!(self);
-        Ok(vec![])
+        if self.return_dev_tenants.load(Ordering::SeqCst) {
+            Ok(vec![Uuid::nil().to_string()])
+        } else {
+            Ok(vec![])
+        }
     }
 
     // --- Tenant-scoped ---
 
     async fn list_devices(&self, _tenant_id: Uuid) -> Result<Vec<DeviceRow>, sqlx::Error> {
         check_fail!(self);
-        Ok(vec![])
+        if self.return_device_rows.load(Ordering::SeqCst) {
+            Ok(vec![DeviceRow {
+                id: Uuid::nil(),
+                tenant_id: _tenant_id,
+                device_name: "Mock Device".to_string(),
+                device_type: "android".to_string(),
+                phone_number: Some("090-0000-0000".to_string()),
+                user_id: None,
+                status: "active".to_string(),
+                approved_by: None,
+                approved_at: None,
+                last_seen_at: None,
+                call_enabled: true,
+                call_schedule: None,
+                fcm_token: None,
+                last_login_employee_id: None,
+                last_login_employee_name: None,
+                last_login_employee_role: None,
+                app_version_code: None,
+                app_version_name: None,
+                is_device_owner: false,
+                is_dev_device: false,
+                always_on: false,
+                watchdog_running: None,
+                created_at: "2026-01-01T00:00:00Z".to_string(),
+                updated_at: "2026-01-01T00:00:00Z".to_string(),
+            }])
+        } else {
+            Ok(vec![])
+        }
     }
 
     async fn list_pending(
@@ -961,7 +1106,24 @@ impl DeviceRepository for MockDeviceRepository {
         _tenant_id: Uuid,
     ) -> Result<Vec<RegistrationRequestRow>, sqlx::Error> {
         check_fail!(self);
-        Ok(vec![])
+        if self.return_pending_rows.load(Ordering::SeqCst) {
+            Ok(vec![RegistrationRequestRow {
+                id: Uuid::nil(),
+                registration_code: "123456".to_string(),
+                flow_type: "qr_permanent".to_string(),
+                tenant_id: Some(_tenant_id),
+                phone_number: Some("090-0000-0000".to_string()),
+                device_name: "Pending Device".to_string(),
+                status: "pending".to_string(),
+                device_id: None,
+                expires_at: None,
+                is_device_owner: false,
+                is_dev_device: false,
+                created_at: "2026-01-01T00:00:00Z".to_string(),
+            }])
+        } else {
+            Ok(vec![])
+        }
     }
 
     async fn create_url_token(
@@ -1109,7 +1271,11 @@ impl DeviceRepository for MockDeviceRepository {
     ) -> Result<Option<Option<String>>, sqlx::Error> {
         check_fail!(self);
         if self.return_data.load(Ordering::SeqCst) {
-            Ok(Some(Some("mock-fcm-token-bypass".to_string())))
+            if self.return_no_fcm_token.load(Ordering::SeqCst) {
+                Ok(Some(None))
+            } else {
+                Ok(Some(Some("mock-fcm-token-bypass".to_string())))
+            }
         } else {
             Ok(None)
         }
@@ -1122,7 +1288,11 @@ impl DeviceRepository for MockDeviceRepository {
     ) -> Result<Option<Option<String>>, sqlx::Error> {
         check_fail!(self);
         if self.return_data.load(Ordering::SeqCst) {
-            Ok(Some(Some("mock-fcm-token".to_string())))
+            if self.return_null_fcm_token.load(Ordering::SeqCst) {
+                Ok(Some(None))
+            } else {
+                Ok(Some(Some("mock-fcm-token".to_string())))
+            }
         } else {
             Ok(None)
         }
@@ -1151,12 +1321,21 @@ impl DeviceRepository for MockDeviceRepository {
     ) -> Result<Vec<OtaDeviceRow>, sqlx::Error> {
         check_fail!(self);
         if self.return_data.load(Ordering::SeqCst) {
-            Ok(vec![OtaDeviceRow {
-                id: Uuid::nil(),
-                device_name: "OTA Device".to_string(),
-                fcm_token: "mock-fcm-token-ota".to_string(),
-                app_version_code: Some(10),
-            }])
+            if self.return_ota_no_version.load(Ordering::SeqCst) {
+                Ok(vec![OtaDeviceRow {
+                    id: Uuid::nil(),
+                    device_name: "OTA Device".to_string(),
+                    fcm_token: "mock-fcm-token-ota".to_string(),
+                    app_version_code: None,
+                }])
+            } else {
+                Ok(vec![OtaDeviceRow {
+                    id: Uuid::nil(),
+                    device_name: "OTA Device".to_string(),
+                    fcm_token: "mock-fcm-token-ota".to_string(),
+                    app_version_code: Some(10),
+                }])
+            }
         } else {
             Ok(vec![])
         }

--- a/tests/mock_helpers/repos_a.rs
+++ b/tests/mock_helpers/repos_a.rs
@@ -783,6 +783,8 @@ pub struct MockDeviceRepository {
     pub return_schedule_days_mismatch: AtomicBool,
     /// list_fcm_devices で深夜跨ぎスケジュールを返す (22:00-06:00)
     pub return_schedule_overnight: AtomicBool,
+    /// code_exists で初回だけ true を返す (コード衝突リトライテスト用)
+    pub return_code_exists_once: AtomicBool,
 }
 
 impl Default for MockDeviceRepository {
@@ -811,6 +813,7 @@ impl Default for MockDeviceRepository {
             return_fcm_tokens: AtomicBool::new(false),
             return_schedule_days_mismatch: AtomicBool::new(false),
             return_schedule_overnight: AtomicBool::new(false),
+            return_code_exists_once: AtomicBool::new(false),
         }
     }
 }
@@ -821,6 +824,9 @@ impl DeviceRepository for MockDeviceRepository {
 
     async fn code_exists(&self, _code: &str) -> Result<bool, sqlx::Error> {
         check_fail!(self);
+        if self.return_code_exists_once.swap(false, Ordering::Relaxed) {
+            return Ok(true);
+        }
         Ok(false)
     }
 

--- a/tests/mock_helpers/repos_a.rs
+++ b/tests/mock_helpers/repos_a.rs
@@ -76,6 +76,8 @@ pub struct MockAuthRepository {
     pub auto_tenant_id: std::sync::Mutex<Option<Uuid>>,
     /// If Some, find_user_by_lineworks_id returns this user
     pub return_lineworks_user: std::sync::Mutex<Option<User>>,
+    /// If true, create_user_lineworks returns error
+    pub fail_on_create_user: AtomicBool,
 }
 
 impl Default for MockAuthRepository {
@@ -90,6 +92,7 @@ impl Default for MockAuthRepository {
             return_sso_config: std::sync::Mutex::new(None),
             auto_tenant_id: std::sync::Mutex::new(None),
             return_lineworks_user: std::sync::Mutex::new(None),
+            fail_on_create_user: AtomicBool::new(false),
         }
     }
 }
@@ -214,6 +217,9 @@ impl AuthRepository for MockAuthRepository {
         name: &str,
     ) -> Result<User, sqlx::Error> {
         check_fail!(self);
+        if self.fail_on_create_user.swap(false, Ordering::SeqCst) {
+            return Err(sqlx::Error::RowNotFound);
+        }
         Ok(User {
             id: Uuid::new_v4(),
             tenant_id,
@@ -767,6 +773,16 @@ pub struct MockDeviceRepository {
     pub return_device_rows: AtomicBool,
     /// list_pending で RegistrationRequestRow を返す (From テスト用)
     pub return_pending_rows: AtomicBool,
+    /// approve_device / approve_by_code で失敗する (lookup は成功、create で失敗)
+    pub fail_on_approve: AtomicBool,
+    /// update 系メソッドで失敗する (lookup は成功、update で失敗)
+    pub fail_on_update: AtomicBool,
+    /// list_tenant_fcm_tokens_except でトークンを返す
+    pub return_fcm_tokens: AtomicBool,
+    /// list_fcm_devices で days に今日を含まないスケジュールを返す
+    pub return_schedule_days_mismatch: AtomicBool,
+    /// list_fcm_devices で深夜跨ぎスケジュールを返す (22:00-06:00)
+    pub return_schedule_overnight: AtomicBool,
 }
 
 impl Default for MockDeviceRepository {
@@ -790,6 +806,11 @@ impl Default for MockDeviceRepository {
             return_ota_no_version: AtomicBool::new(false),
             return_device_rows: AtomicBool::new(false),
             return_pending_rows: AtomicBool::new(false),
+            fail_on_approve: AtomicBool::new(false),
+            fail_on_update: AtomicBool::new(false),
+            return_fcm_tokens: AtomicBool::new(false),
+            return_schedule_days_mismatch: AtomicBool::new(false),
+            return_schedule_overnight: AtomicBool::new(false),
         }
     }
 }
@@ -937,6 +958,9 @@ impl DeviceRepository for MockDeviceRepository {
         _fcm_token: &str,
     ) -> Result<(), sqlx::Error> {
         check_fail!(self);
+        if self.fail_on_update.swap(false, Ordering::SeqCst) {
+            return Err(sqlx::Error::RowNotFound);
+        }
         Ok(())
     }
 
@@ -949,6 +973,9 @@ impl DeviceRepository for MockDeviceRepository {
         _employee_role: &[String],
     ) -> Result<(), sqlx::Error> {
         check_fail!(self);
+        if self.fail_on_update.swap(false, Ordering::SeqCst) {
+            return Err(sqlx::Error::RowNotFound);
+        }
         Ok(())
     }
 
@@ -984,6 +1011,33 @@ impl DeviceRepository for MockDeviceRepository {
                         "endMin": 0
                     })),
                 }])
+            } else if self.return_schedule_days_mismatch.load(Ordering::SeqCst) {
+                // days に 99 のみ → 今日の曜日(0-6)は含まれない → skipped
+                Ok(vec![FcmDeviceRow {
+                    id: Uuid::nil(),
+                    fcm_token: "mock-fcm-token-1".to_string(),
+                    call_enabled: true,
+                    call_schedule: Some(serde_json::json!({
+                        "enabled": true,
+                        "days": [99]
+                    })),
+                }])
+            } else if self.return_schedule_overnight.load(Ordering::SeqCst) {
+                // 深夜跨ぎスケジュール: 0:00-23:59 (start > end にならないよう 22:00-06:00)
+                // ただし current >= start || current < end で常に true になるよう 0:01-0:00
+                Ok(vec![FcmDeviceRow {
+                    id: Uuid::nil(),
+                    fcm_token: "mock-fcm-token-1".to_string(),
+                    call_enabled: true,
+                    call_schedule: Some(serde_json::json!({
+                        "enabled": true,
+                        "days": [0, 1, 2, 3, 4, 5, 6],
+                        "startHour": 23,
+                        "startMin": 59,
+                        "endHour": 23,
+                        "endMin": 58
+                    })),
+                }])
             } else {
                 Ok(vec![FcmDeviceRow {
                     id: Uuid::nil(),
@@ -1017,7 +1071,11 @@ impl DeviceRepository for MockDeviceRepository {
         _exclude_device_id: Uuid,
     ) -> Result<Vec<String>, sqlx::Error> {
         check_fail!(self);
-        Ok(vec![])
+        if self.return_fcm_tokens.load(Ordering::SeqCst) {
+            Ok(vec!["mock-fcm-token-other-device".to_string()])
+        } else {
+            Ok(vec![])
+        }
     }
 
     async fn list_all_callable_devices(&self) -> Result<Vec<FcmTestDeviceRow>, sqlx::Error> {
@@ -1040,6 +1098,9 @@ impl DeviceRepository for MockDeviceRepository {
         _running: bool,
     ) -> Result<(), sqlx::Error> {
         check_fail!(self);
+        if self.fail_on_update.swap(false, Ordering::SeqCst) {
+            return Err(sqlx::Error::RowNotFound);
+        }
         Ok(())
     }
 
@@ -1053,6 +1114,9 @@ impl DeviceRepository for MockDeviceRepository {
         _is_dev_device: bool,
     ) -> Result<(), sqlx::Error> {
         check_fail!(self);
+        if self.fail_on_update.swap(false, Ordering::SeqCst) {
+            return Err(sqlx::Error::RowNotFound);
+        }
         Ok(())
     }
 
@@ -1194,6 +1258,9 @@ impl DeviceRepository for MockDeviceRepository {
         _is_dev_device: bool,
     ) -> Result<Uuid, sqlx::Error> {
         check_fail!(self);
+        if self.fail_on_approve.swap(false, Ordering::SeqCst) {
+            return Err(sqlx::Error::RowNotFound);
+        }
         Ok(Uuid::nil())
     }
 
@@ -1230,6 +1297,9 @@ impl DeviceRepository for MockDeviceRepository {
         _is_dev_device: bool,
     ) -> Result<Uuid, sqlx::Error> {
         check_fail!(self);
+        if self.fail_on_approve.swap(false, Ordering::SeqCst) {
+            return Err(sqlx::Error::RowNotFound);
+        }
         Ok(Uuid::nil())
     }
 

--- a/tests/mock_helpers/repos_b.rs
+++ b/tests/mock_helpers/repos_b.rs
@@ -184,6 +184,11 @@ pub struct MockDtakoRestraintReportRepository {
     pub fail_next: AtomicBool,
     pub return_driver_name: AtomicBool,
     pub drivers_with_cd: std::sync::Mutex<Vec<(Uuid, Option<String>, String)>>,
+    pub segments: std::sync::Mutex<Vec<SegmentRow>>,
+    pub daily_work_hours: std::sync::Mutex<Vec<DailyWorkHoursRow>>,
+    pub op_times: std::sync::Mutex<Vec<OpTimesRow>>,
+    pub prev_day_drive: std::sync::Mutex<Option<i32>>,
+    pub fiscal_cumulative: std::sync::Mutex<i32>,
 }
 
 impl Default for MockDtakoRestraintReportRepository {
@@ -192,6 +197,11 @@ impl Default for MockDtakoRestraintReportRepository {
             fail_next: AtomicBool::new(false),
             return_driver_name: AtomicBool::new(false),
             drivers_with_cd: std::sync::Mutex::new(vec![]),
+            segments: std::sync::Mutex::new(vec![]),
+            daily_work_hours: std::sync::Mutex::new(vec![]),
+            op_times: std::sync::Mutex::new(vec![]),
+            prev_day_drive: std::sync::Mutex::new(None),
+            fiscal_cumulative: std::sync::Mutex::new(0),
         }
     }
 }
@@ -219,7 +229,7 @@ impl DtakoRestraintReportRepository for MockDtakoRestraintReportRepository {
         _month_end: NaiveDate,
     ) -> Result<Vec<SegmentRow>, sqlx::Error> {
         check_fail!(self);
-        Ok(vec![])
+        Ok(self.segments.lock().unwrap().clone())
     }
 
     async fn get_daily_work_hours(
@@ -230,7 +240,7 @@ impl DtakoRestraintReportRepository for MockDtakoRestraintReportRepository {
         _month_end: NaiveDate,
     ) -> Result<Vec<DailyWorkHoursRow>, sqlx::Error> {
         check_fail!(self);
-        Ok(vec![])
+        Ok(self.daily_work_hours.lock().unwrap().clone())
     }
 
     async fn get_prev_day_drive(
@@ -240,7 +250,7 @@ impl DtakoRestraintReportRepository for MockDtakoRestraintReportRepository {
         _prev_day: NaiveDate,
     ) -> Result<Option<i32>, sqlx::Error> {
         check_fail!(self);
-        Ok(None)
+        Ok(*self.prev_day_drive.lock().unwrap())
     }
 
     async fn get_fiscal_cumulative(
@@ -251,7 +261,7 @@ impl DtakoRestraintReportRepository for MockDtakoRestraintReportRepository {
         _prev_month_end: NaiveDate,
     ) -> Result<i32, sqlx::Error> {
         check_fail!(self);
-        Ok(0)
+        Ok(*self.fiscal_cumulative.lock().unwrap())
     }
 
     async fn get_operation_times(
@@ -262,7 +272,7 @@ impl DtakoRestraintReportRepository for MockDtakoRestraintReportRepository {
         _month_end: NaiveDate,
     ) -> Result<Vec<OpTimesRow>, sqlx::Error> {
         check_fail!(self);
-        Ok(vec![])
+        Ok(self.op_times.lock().unwrap().clone())
     }
 
     async fn list_drivers_with_cd(
@@ -359,12 +369,28 @@ impl DtakoScraperRepository for MockDtakoScraperRepository {
 
 pub struct MockDtakoUploadRepository {
     pub fail_next: AtomicBool,
+    pub upload_history: std::sync::Mutex<Option<UploadHistoryRecord>>,
+    pub tenant_and_key: std::sync::Mutex<Option<UploadTenantAndKey>>,
+    pub driver_cd: std::sync::Mutex<Option<String>>,
+    pub employee_id: std::sync::Mutex<Option<Uuid>>,
+    pub operations: std::sync::Mutex<Vec<DtakoOpRow>>,
+    pub driver_operations: std::sync::Mutex<Vec<DtakoDriverOpRow>>,
+    pub zip_keys: std::sync::Mutex<Vec<String>>,
+    pub uploads_needing_split: std::sync::Mutex<Vec<(Uuid, String)>>,
 }
 
 impl Default for MockDtakoUploadRepository {
     fn default() -> Self {
         Self {
             fail_next: AtomicBool::new(false),
+            upload_history: std::sync::Mutex::new(None),
+            tenant_and_key: std::sync::Mutex::new(None),
+            driver_cd: std::sync::Mutex::new(None),
+            employee_id: std::sync::Mutex::new(None),
+            operations: std::sync::Mutex::new(vec![]),
+            driver_operations: std::sync::Mutex::new(vec![]),
+            zip_keys: std::sync::Mutex::new(vec![]),
+            uploads_needing_split: std::sync::Mutex::new(vec![]),
         }
     }
 }
@@ -415,7 +441,7 @@ impl DtakoUploadRepository for MockDtakoUploadRepository {
         _upload_id: Uuid,
     ) -> Result<Option<UploadHistoryRecord>, sqlx::Error> {
         check_fail!(self);
-        Ok(None)
+        Ok(self.upload_history.lock().unwrap().clone())
     }
 
     async fn get_upload_tenant_and_key(
@@ -423,7 +449,7 @@ impl DtakoUploadRepository for MockDtakoUploadRepository {
         _upload_id: Uuid,
     ) -> Result<Option<UploadTenantAndKey>, sqlx::Error> {
         check_fail!(self);
-        Ok(None)
+        Ok(self.tenant_and_key.lock().unwrap().clone())
     }
 
     async fn list_uploads(&self, _tenant_id: Uuid) -> Result<Vec<serde_json::Value>, sqlx::Error> {
@@ -444,7 +470,7 @@ impl DtakoUploadRepository for MockDtakoUploadRepository {
         _tenant_id: Uuid,
     ) -> Result<Vec<(Uuid, String)>, sqlx::Error> {
         check_fail!(self);
-        Ok(vec![])
+        Ok(self.uploads_needing_split.lock().unwrap().clone())
     }
 
     async fn fetch_zip_keys(
@@ -453,7 +479,7 @@ impl DtakoUploadRepository for MockDtakoUploadRepository {
         _month_start: NaiveDate,
     ) -> Result<Vec<String>, sqlx::Error> {
         check_fail!(self);
-        Ok(vec![])
+        Ok(self.zip_keys.lock().unwrap().clone())
     }
 
     async fn upsert_office(
@@ -539,7 +565,7 @@ impl DtakoUploadRepository for MockDtakoUploadRepository {
         _driver_cd: &str,
     ) -> Result<Option<Uuid>, sqlx::Error> {
         check_fail!(self);
-        Ok(None)
+        Ok(*self.employee_id.lock().unwrap())
     }
 
     async fn get_driver_cd(
@@ -548,7 +574,7 @@ impl DtakoUploadRepository for MockDtakoUploadRepository {
         _driver_id: Uuid,
     ) -> Result<Option<String>, sqlx::Error> {
         check_fail!(self);
-        Ok(None)
+        Ok(self.driver_cd.lock().unwrap().clone())
     }
 
     async fn delete_segments_by_unko(
@@ -617,7 +643,7 @@ impl DtakoUploadRepository for MockDtakoUploadRepository {
         _fetch_end: NaiveDate,
     ) -> Result<Vec<DtakoOpRow>, sqlx::Error> {
         check_fail!(self);
-        Ok(vec![])
+        Ok(self.operations.lock().unwrap().clone())
     }
 
     async fn load_driver_operations(
@@ -628,7 +654,7 @@ impl DtakoUploadRepository for MockDtakoUploadRepository {
         _fetch_end: NaiveDate,
     ) -> Result<Vec<DtakoDriverOpRow>, sqlx::Error> {
         check_fail!(self);
-        Ok(vec![])
+        Ok(self.driver_operations.lock().unwrap().clone())
     }
 }
 

--- a/tests/mock_helpers/repos_b.rs
+++ b/tests/mock_helpers/repos_b.rs
@@ -327,6 +327,8 @@ impl DtakoRestraintReportPdfRepository for MockDtakoRestraintReportPdfRepository
 pub struct MockDtakoScraperRepository {
     pub fail_next: AtomicBool,
     pub history_data: std::sync::Mutex<Vec<ScrapeHistoryItem>>,
+    pub insert_count: std::sync::atomic::AtomicUsize,
+    pub inserted_comp_ids: std::sync::Mutex<Vec<String>>,
 }
 
 impl Default for MockDtakoScraperRepository {
@@ -334,6 +336,8 @@ impl Default for MockDtakoScraperRepository {
         Self {
             fail_next: AtomicBool::new(false),
             history_data: std::sync::Mutex::new(vec![]),
+            insert_count: std::sync::atomic::AtomicUsize::new(0),
+            inserted_comp_ids: std::sync::Mutex::new(vec![]),
         }
     }
 }
@@ -349,6 +353,12 @@ impl DtakoScraperRepository for MockDtakoScraperRepository {
         _message: Option<&str>,
     ) -> Result<(), sqlx::Error> {
         check_fail!(self);
+        self.insert_count
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        self.inserted_comp_ids
+            .lock()
+            .unwrap()
+            .push(_comp_id.to_string());
         Ok(())
     }
 
@@ -369,6 +379,7 @@ impl DtakoScraperRepository for MockDtakoScraperRepository {
 
 pub struct MockDtakoUploadRepository {
     pub fail_next: AtomicBool,
+    pub fail_update_has_kudgivt: AtomicBool,
     pub upload_history: std::sync::Mutex<Option<UploadHistoryRecord>>,
     pub tenant_and_key: std::sync::Mutex<Option<UploadTenantAndKey>>,
     pub driver_cd: std::sync::Mutex<Option<String>>,
@@ -377,12 +388,14 @@ pub struct MockDtakoUploadRepository {
     pub driver_operations: std::sync::Mutex<Vec<DtakoDriverOpRow>>,
     pub zip_keys: std::sync::Mutex<Vec<String>>,
     pub uploads_needing_split: std::sync::Mutex<Vec<(Uuid, String)>>,
+    pub event_classifications: std::sync::Mutex<Vec<(String, String)>>,
 }
 
 impl Default for MockDtakoUploadRepository {
     fn default() -> Self {
         Self {
             fail_next: AtomicBool::new(false),
+            fail_update_has_kudgivt: AtomicBool::new(false),
             upload_history: std::sync::Mutex::new(None),
             tenant_and_key: std::sync::Mutex::new(None),
             driver_cd: std::sync::Mutex::new(None),
@@ -391,6 +404,7 @@ impl Default for MockDtakoUploadRepository {
             driver_operations: std::sync::Mutex::new(vec![]),
             zip_keys: std::sync::Mutex::new(vec![]),
             uploads_needing_split: std::sync::Mutex::new(vec![]),
+            event_classifications: std::sync::Mutex::new(vec![]),
         }
     }
 }
@@ -537,6 +551,9 @@ impl DtakoUploadRepository for MockDtakoUploadRepository {
         _unko_nos: &[String],
     ) -> Result<(), sqlx::Error> {
         check_fail!(self);
+        if self.fail_update_has_kudgivt.load(Ordering::SeqCst) {
+            return Err(sqlx::Error::RowNotFound);
+        }
         Ok(())
     }
 
@@ -545,7 +562,7 @@ impl DtakoUploadRepository for MockDtakoUploadRepository {
         _tenant_id: Uuid,
     ) -> Result<Vec<(String, String)>, sqlx::Error> {
         check_fail!(self);
-        Ok(vec![])
+        Ok(self.event_classifications.lock().unwrap().clone())
     }
 
     async fn insert_event_classification(

--- a/tests/mock_helpers/repos_c.rs
+++ b/tests/mock_helpers/repos_c.rs
@@ -24,6 +24,15 @@ macro_rules! check_fail {
     };
 }
 
+macro_rules! check_fail_update {
+    ($self:expr) => {
+        check_fail!($self);
+        if $self.fail_on_update.load(Ordering::SeqCst) {
+            return Err(sqlx::Error::RowNotFound);
+        }
+    };
+}
+
 // ---------------------------------------------------------------------------
 // MockNfcTagRepository
 // ---------------------------------------------------------------------------
@@ -624,6 +633,8 @@ impl TenkoSchedulesRepository for MockTenkoSchedulesRepository {
 
 pub struct MockTenkoSessionRepository {
     pub fail_next: AtomicBool,
+    /// Fails on write/update operations (not get/list/dashboard)
+    pub fail_on_update: AtomicBool,
     /// Controls the status of the session returned by get()
     pub session_status: std::sync::Mutex<String>,
     /// Controls the tenko_type of the session returned by get()
@@ -646,6 +657,10 @@ pub struct MockTenkoSessionRepository {
     pub session_has_daily_inspection: AtomicBool,
     /// Controls self_declaration on session (for resume logic)
     pub session_has_self_declaration: AtomicBool,
+    /// Optional health baseline for safety judgment tests
+    pub health_baseline: std::sync::Mutex<Option<EmployeeHealthBaseline>>,
+    /// Fails on create_tenko_record and get_employee_name (for record creation error tests)
+    pub fail_on_record: AtomicBool,
 }
 
 impl Default for MockTenkoSessionRepository {
@@ -653,6 +668,7 @@ impl Default for MockTenkoSessionRepository {
         let emp_id = Uuid::new_v4();
         Self {
             fail_next: AtomicBool::new(false),
+            fail_on_update: AtomicBool::new(false),
             session_status: std::sync::Mutex::new("identity_verified".to_string()),
             session_tenko_type: std::sync::Mutex::new("pre_operation".to_string()),
             session_employee_id: std::sync::Mutex::new(emp_id),
@@ -664,6 +680,8 @@ impl Default for MockTenkoSessionRepository {
             carrying_items_count: std::sync::Mutex::new(0),
             session_has_daily_inspection: AtomicBool::new(false),
             session_has_self_declaration: AtomicBool::new(false),
+            health_baseline: std::sync::Mutex::new(None),
+            fail_on_record: AtomicBool::new(false),
         }
     }
 }
@@ -843,7 +861,7 @@ impl TenkoSessionRepository for MockTenkoSessionRepository {
         _tenant_id: Uuid,
         _schedule_id: Uuid,
     ) -> Result<(), sqlx::Error> {
-        check_fail!(self);
+        check_fail_update!(self);
         Ok(())
     }
 
@@ -853,7 +871,7 @@ impl TenkoSessionRepository for MockTenkoSessionRepository {
         _schedule_id: Uuid,
         _session_id: Uuid,
     ) -> Result<(), sqlx::Error> {
-        check_fail!(self);
+        check_fail_update!(self);
         Ok(())
     }
 
@@ -881,7 +899,7 @@ impl TenkoSessionRepository for MockTenkoSessionRepository {
         _location: &Option<String>,
         _responsible_manager_name: &Option<String>,
     ) -> Result<TenkoSession, sqlx::Error> {
-        check_fail!(self);
+        check_fail_update!(self);
         Ok(make_mock_session(
             _tenant_id,
             Uuid::new_v4(),
@@ -905,7 +923,7 @@ impl TenkoSessionRepository for MockTenkoSessionRepository {
         _cancel_reason: &Option<String>,
         _completed_at: Option<DateTime<Utc>>,
     ) -> Result<TenkoSession, sqlx::Error> {
-        check_fail!(self);
+        check_fail_update!(self);
         let employee_id = *self.session_employee_id.lock().unwrap();
         let tenko_type = self.session_tenko_type.lock().unwrap().clone();
         let mut session = make_mock_session(
@@ -935,7 +953,7 @@ impl TenkoSessionRepository for MockTenkoSessionRepository {
         _medical_measured_at: Option<DateTime<Utc>>,
         _medical_manual_input: Option<bool>,
     ) -> Result<TenkoSession, sqlx::Error> {
-        check_fail!(self);
+        check_fail_update!(self);
         let employee_id = *self.session_employee_id.lock().unwrap();
         let mut session = make_mock_session(
             _tenant_id,
@@ -958,7 +976,7 @@ impl TenkoSessionRepository for MockTenkoSessionRepository {
         _tenant_id: Uuid,
         _id: Uuid,
     ) -> Result<TenkoSession, sqlx::Error> {
-        check_fail!(self);
+        check_fail_update!(self);
         let employee_id = *self.session_employee_id.lock().unwrap();
         let tenko_type = self.session_tenko_type.lock().unwrap().clone();
         let mut session = make_mock_session(
@@ -986,7 +1004,7 @@ impl TenkoSessionRepository for MockTenkoSessionRepository {
         _driver_alternation_audio_url: &Option<String>,
         _completed_at: Option<DateTime<Utc>>,
     ) -> Result<TenkoSession, sqlx::Error> {
-        check_fail!(self);
+        check_fail_update!(self);
         let employee_id = *self.session_employee_id.lock().unwrap();
         let mut session = make_mock_session(
             _tenant_id,
@@ -1009,7 +1027,7 @@ impl TenkoSessionRepository for MockTenkoSessionRepository {
         _id: Uuid,
         _reason: &Option<String>,
     ) -> Result<TenkoSession, sqlx::Error> {
-        check_fail!(self);
+        check_fail_update!(self);
         let employee_id = *self.session_employee_id.lock().unwrap();
         let tenko_type = self.session_tenko_type.lock().unwrap().clone();
         let mut session = make_mock_session(
@@ -1032,7 +1050,7 @@ impl TenkoSessionRepository for MockTenkoSessionRepository {
         _id: Uuid,
         _declaration_json: &serde_json::Value,
     ) -> Result<TenkoSession, sqlx::Error> {
-        check_fail!(self);
+        check_fail_update!(self);
         let employee_id = *self.session_employee_id.lock().unwrap();
         let mut session = make_mock_session(
             _tenant_id,
@@ -1055,7 +1073,7 @@ impl TenkoSessionRepository for MockTenkoSessionRepository {
         _judgment_json: &serde_json::Value,
         _interrupted_at: Option<DateTime<Utc>>,
     ) -> Result<TenkoSession, sqlx::Error> {
-        check_fail!(self);
+        check_fail_update!(self);
         let employee_id = *self.session_employee_id.lock().unwrap();
         let mut session = make_mock_session(
             _tenant_id,
@@ -1080,7 +1098,7 @@ impl TenkoSessionRepository for MockTenkoSessionRepository {
         _cancel_reason: &Option<String>,
         _completed_at: Option<DateTime<Utc>>,
     ) -> Result<TenkoSession, sqlx::Error> {
-        check_fail!(self);
+        check_fail_update!(self);
         let employee_id = *self.session_employee_id.lock().unwrap();
         let mut session = make_mock_session(
             _tenant_id,
@@ -1103,7 +1121,7 @@ impl TenkoSessionRepository for MockTenkoSessionRepository {
         _id: Uuid,
         _carrying_json: &serde_json::Value,
     ) -> Result<TenkoSession, sqlx::Error> {
-        check_fail!(self);
+        check_fail_update!(self);
         let employee_id = *self.session_employee_id.lock().unwrap();
         let mut session = make_mock_session(
             _tenant_id,
@@ -1124,7 +1142,7 @@ impl TenkoSessionRepository for MockTenkoSessionRepository {
         _id: Uuid,
         _reason: &Option<String>,
     ) -> Result<TenkoSession, sqlx::Error> {
-        check_fail!(self);
+        check_fail_update!(self);
         let employee_id = *self.session_employee_id.lock().unwrap();
         let tenko_type = self.session_tenko_type.lock().unwrap().clone();
         let mut session = make_mock_session(
@@ -1148,7 +1166,7 @@ impl TenkoSessionRepository for MockTenkoSessionRepository {
         _reason: &str,
         _resumed_by_user_id: Option<Uuid>,
     ) -> Result<TenkoSession, sqlx::Error> {
-        check_fail!(self);
+        check_fail_update!(self);
         let employee_id = *self.session_employee_id.lock().unwrap();
         let tenko_type = self.session_tenko_type.lock().unwrap().clone();
         let mut session = make_mock_session(
@@ -1184,7 +1202,7 @@ impl TenkoSessionRepository for MockTenkoSessionRepository {
         _checked: bool,
         _checked_at: Option<DateTime<Utc>>,
     ) -> Result<(), sqlx::Error> {
-        check_fail!(self);
+        check_fail_update!(self);
         Ok(())
     }
 
@@ -1199,6 +1217,9 @@ impl TenkoSessionRepository for MockTenkoSessionRepository {
         _employee_id: Uuid,
     ) -> Result<Option<String>, sqlx::Error> {
         check_fail!(self);
+        if self.fail_on_record.load(Ordering::SeqCst) {
+            return Err(sqlx::Error::RowNotFound);
+        }
         if self.return_employee_name.load(Ordering::SeqCst) {
             Ok(Some("Test Employee".to_string()))
         } else {
@@ -1212,7 +1233,7 @@ impl TenkoSessionRepository for MockTenkoSessionRepository {
         _employee_id: Uuid,
     ) -> Result<Option<EmployeeHealthBaseline>, sqlx::Error> {
         check_fail!(self);
-        Ok(None)
+        Ok(self.health_baseline.lock().unwrap().clone())
     }
 
     async fn create_tenko_record(
@@ -1224,7 +1245,7 @@ impl TenkoSessionRepository for MockTenkoSessionRepository {
         _record_data: &serde_json::Value,
         _record_hash: &str,
     ) -> Result<TenkoRecord, sqlx::Error> {
-        check_fail!(self);
+        check_fail_update!(self);
         Ok(make_mock_tenko_record(_tenant_id, _session))
     }
 

--- a/tests/mock_helpers/repos_c.rs
+++ b/tests/mock_helpers/repos_c.rs
@@ -661,6 +661,12 @@ pub struct MockTenkoSessionRepository {
     pub health_baseline: std::sync::Mutex<Option<EmployeeHealthBaseline>>,
     /// Fails on create_tenko_record and get_employee_name (for record creation error tests)
     pub fail_on_record: AtomicBool,
+    /// Fails only on create_tenko_record repo method (line 527-529 coverage)
+    pub fail_on_create_record: AtomicBool,
+    /// Fails only on update_safety_judgment repo method (line 717-719 coverage)
+    pub fail_on_safety_judgment: AtomicBool,
+    /// Fails only on update_carrying_items repo method (line 932-934 coverage)
+    pub fail_on_update_carrying_items: AtomicBool,
 }
 
 impl Default for MockTenkoSessionRepository {
@@ -682,6 +688,9 @@ impl Default for MockTenkoSessionRepository {
             session_has_self_declaration: AtomicBool::new(false),
             health_baseline: std::sync::Mutex::new(None),
             fail_on_record: AtomicBool::new(false),
+            fail_on_create_record: AtomicBool::new(false),
+            fail_on_safety_judgment: AtomicBool::new(false),
+            fail_on_update_carrying_items: AtomicBool::new(false),
         }
     }
 }
@@ -1074,6 +1083,9 @@ impl TenkoSessionRepository for MockTenkoSessionRepository {
         _interrupted_at: Option<DateTime<Utc>>,
     ) -> Result<TenkoSession, sqlx::Error> {
         check_fail_update!(self);
+        if self.fail_on_safety_judgment.load(Ordering::SeqCst) {
+            return Err(sqlx::Error::RowNotFound);
+        }
         let employee_id = *self.session_employee_id.lock().unwrap();
         let mut session = make_mock_session(
             _tenant_id,
@@ -1122,6 +1134,9 @@ impl TenkoSessionRepository for MockTenkoSessionRepository {
         _carrying_json: &serde_json::Value,
     ) -> Result<TenkoSession, sqlx::Error> {
         check_fail_update!(self);
+        if self.fail_on_update_carrying_items.load(Ordering::SeqCst) {
+            return Err(sqlx::Error::RowNotFound);
+        }
         let employee_id = *self.session_employee_id.lock().unwrap();
         let mut session = make_mock_session(
             _tenant_id,
@@ -1246,6 +1261,9 @@ impl TenkoSessionRepository for MockTenkoSessionRepository {
         _record_hash: &str,
     ) -> Result<TenkoRecord, sqlx::Error> {
         check_fail_update!(self);
+        if self.fail_on_create_record.load(Ordering::SeqCst) {
+            return Err(sqlx::Error::RowNotFound);
+        }
         Ok(make_mock_tenko_record(_tenant_id, _session))
     }
 

--- a/tests/mock_helpers/webhook.rs
+++ b/tests/mock_helpers/webhook.rs
@@ -1,0 +1,26 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// Mock WebhookService for testing webhook fire_event paths.
+pub struct MockWebhookService {
+    pub fired: AtomicUsize,
+}
+
+impl Default for MockWebhookService {
+    fn default() -> Self {
+        Self {
+            fired: AtomicUsize::new(0),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl rust_alc_api::webhook::WebhookService for MockWebhookService {
+    async fn fire_event(
+        &self,
+        _tenant_id: uuid::Uuid,
+        _event_type: &str,
+        _payload: serde_json::Value,
+    ) {
+        self.fired.fetch_add(1, Ordering::SeqCst);
+    }
+}

--- a/tests/mock_tests/mock_auth_test.rs
+++ b/tests/mock_tests/mock_auth_test.rs
@@ -8,7 +8,8 @@ use serde_json::Value;
 use crate::mock_helpers::app_state::setup_mock_app_state;
 use crate::mock_helpers::{mock_user, MockAuthRepository};
 
-use rust_alc_api::db::models::{Tenant, TenantAllowedEmail};
+use rust_alc_api::auth::lineworks;
+use rust_alc_api::db::models::{Tenant, TenantAllowedEmail, User};
 use rust_alc_api::db::repository::auth::SsoConfigRow;
 
 // ============================================================
@@ -1072,4 +1073,1125 @@ async fn test_google_redirect_missing_state_secret() {
         .unwrap();
 
     assert_eq!(res.status(), 500);
+}
+
+// ============================================================
+// Helper: encrypt a client_secret for lineworks decrypt_secret
+// ============================================================
+
+fn encrypt_secret_for_test(plaintext: &str, key_material: &str) -> String {
+    use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
+    use ring::aead::{self, Aad, LessSafeKey, Nonce, UnboundKey, AES_256_GCM};
+    use ring::rand::{SecureRandom, SystemRandom};
+    use sha2::{Digest, Sha256};
+
+    let mut key_bytes = [0u8; 32];
+    let hash = Sha256::digest(key_material.as_bytes());
+    key_bytes.copy_from_slice(&hash);
+
+    let unbound_key = UnboundKey::new(&AES_256_GCM, &key_bytes).unwrap();
+    let key = LessSafeKey::new(unbound_key);
+
+    let rng = SystemRandom::new();
+    let mut nonce_bytes = [0u8; 12];
+    rng.fill(&mut nonce_bytes).unwrap();
+    let nonce = Nonce::assume_unique_for_key(nonce_bytes);
+
+    let mut in_out = plaintext.as_bytes().to_vec();
+    let tag_len = aead::AES_256_GCM.tag_len();
+    in_out.extend(vec![0u8; tag_len]);
+
+    let tag = key
+        .seal_in_place_separate_tag(nonce, Aad::empty(), &mut in_out[..plaintext.len()])
+        .unwrap();
+    in_out[plaintext.len()..].copy_from_slice(tag.as_ref());
+
+    let mut result = nonce_bytes.to_vec();
+    result.extend_from_slice(&in_out);
+    BASE64.encode(&result)
+}
+
+// ============================================================
+// GET /api/auth/google/callback — success (code exchange + redirect)
+// ============================================================
+
+#[tokio::test]
+async fn test_google_callback_success() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("OAUTH_STATE_SECRET", "test-state-secret");
+    std::env::set_var("API_ORIGIN", "http://localhost:0");
+
+    let tenant_id = Uuid::new_v4();
+    let user = mock_user(tenant_id);
+
+    let mock = Arc::new(MockAuthRepository::default());
+    *mock.return_user.lock().unwrap() = Some(user.clone());
+
+    let mut state = setup_mock_app_state();
+    state.auth = mock;
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    // Create a valid signed state
+    let state_payload = lineworks::state::StatePayload {
+        redirect_uri: "https://items.mtamaramu.com/callback".to_string(),
+        nonce: Uuid::new_v4().to_string(),
+        provider: "google".to_string(),
+        external_org_id: String::new(),
+    };
+    let signed_state = lineworks::state::sign(&state_payload, "test-state-secret");
+
+    let client = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let res = client
+        .get(format!(
+            "{base_url}/api/auth/google/callback?code=test-valid-code&state={}",
+            urlencoding::encode(&signed_state)
+        ))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 307);
+    let location = res.headers().get("location").unwrap().to_str().unwrap();
+    assert!(location.starts_with("https://items.mtamaramu.com/callback#token="));
+    assert!(location.contains("refresh_token="));
+    assert!(location.contains("lw_callback=1"));
+
+    // Check Set-Cookie header with parent domain extraction
+    let cookie = res.headers().get("set-cookie").unwrap().to_str().unwrap();
+    assert!(cookie.contains("logi_auth_token="));
+    assert!(cookie.contains("Domain=.mtamaramu.com"));
+}
+
+// ============================================================
+// GET /api/auth/google/callback — missing OAUTH_STATE_SECRET → 500
+// ============================================================
+
+#[tokio::test]
+async fn test_google_callback_missing_state_secret() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::remove_var("OAUTH_STATE_SECRET");
+
+    let mock = Arc::new(MockAuthRepository::default());
+    let mut state = setup_mock_app_state();
+    state.auth = mock;
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let client = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let res = client
+        .get(format!(
+            "{base_url}/api/auth/google/callback?code=test-valid-code&state=invalid"
+        ))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 500);
+}
+
+// ============================================================
+// GET /api/auth/google/callback — invalid state → 400
+// ============================================================
+
+#[tokio::test]
+async fn test_google_callback_invalid_state() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("OAUTH_STATE_SECRET", "test-state-secret");
+
+    let mock = Arc::new(MockAuthRepository::default());
+    let mut state = setup_mock_app_state();
+    state.auth = mock;
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let client = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let res = client
+        .get(format!(
+            "{base_url}/api/auth/google/callback?code=test-valid-code&state=bad-state"
+        ))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 400);
+}
+
+// ============================================================
+// GET /api/auth/google/callback — invalid code → 502
+// ============================================================
+
+#[tokio::test]
+async fn test_google_callback_invalid_code() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("OAUTH_STATE_SECRET", "test-state-secret");
+
+    let mock = Arc::new(MockAuthRepository::default());
+    let mut state = setup_mock_app_state();
+    state.auth = mock;
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let state_payload = lineworks::state::StatePayload {
+        redirect_uri: "https://example.com/callback".to_string(),
+        nonce: Uuid::new_v4().to_string(),
+        provider: "google".to_string(),
+        external_org_id: String::new(),
+    };
+    let signed_state = lineworks::state::sign(&state_payload, "test-state-secret");
+
+    let client = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let res = client
+        .get(format!(
+            "{base_url}/api/auth/google/callback?code=bad-code&state={}",
+            urlencoding::encode(&signed_state)
+        ))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 502);
+}
+
+// ============================================================
+// GET /api/auth/google/callback — new user (no existing user)
+// ============================================================
+
+#[tokio::test]
+async fn test_google_callback_new_user() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("OAUTH_STATE_SECRET", "test-state-secret");
+
+    // return_user = None → new user → new tenant
+    let mock = Arc::new(MockAuthRepository::default());
+    let mut state = setup_mock_app_state();
+    state.auth = mock;
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let state_payload = lineworks::state::StatePayload {
+        redirect_uri: "https://sub.example.com/callback".to_string(),
+        nonce: Uuid::new_v4().to_string(),
+        provider: "google".to_string(),
+        external_org_id: String::new(),
+    };
+    let signed_state = lineworks::state::sign(&state_payload, "test-state-secret");
+
+    let client = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let res = client
+        .get(format!(
+            "{base_url}/api/auth/google/callback?code=test-valid-code&state={}",
+            urlencoding::encode(&signed_state)
+        ))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 307);
+    let location = res.headers().get("location").unwrap().to_str().unwrap();
+    assert!(location.starts_with("https://sub.example.com/callback#token="));
+
+    // extract_parent_domain: "sub.example.com" → "example.com"
+    let cookie = res.headers().get("set-cookie").unwrap().to_str().unwrap();
+    assert!(cookie.contains("Domain=.example.com"));
+}
+
+// ============================================================
+// GET /api/auth/lineworks/redirect — missing OAUTH_STATE_SECRET → 500
+// ============================================================
+
+#[tokio::test]
+async fn test_lineworks_redirect_missing_state_secret() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::remove_var("OAUTH_STATE_SECRET");
+
+    let mock = Arc::new(MockAuthRepository::default());
+    let mut state = setup_mock_app_state();
+    state.auth = mock;
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let client = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let res = client
+        .get(format!(
+            "{base_url}/api/auth/lineworks/redirect?domain=test&redirect_uri=https://example.com"
+        ))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 500);
+}
+
+// ============================================================
+// GET /api/auth/lineworks/callback — via wiremock (success, new user)
+// ============================================================
+
+#[tokio::test]
+async fn test_lineworks_callback_success() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    let oauth_secret = "test-state-secret";
+    std::env::set_var("OAUTH_STATE_SECRET", oauth_secret);
+
+    // Start wiremock server
+    let mock_server = wiremock::MockServer::start().await;
+
+    // Set LINE WORKS endpoints to wiremock
+    std::env::set_var(
+        "LINEWORKS_TOKEN_URL",
+        format!("{}/oauth2/token", mock_server.uri()),
+    );
+    std::env::set_var(
+        "LINEWORKS_USERINFO_URL",
+        format!("{}/v1.0/users/me", mock_server.uri()),
+    );
+
+    // Mock token exchange
+    wiremock::Mock::given(wiremock::matchers::method("POST"))
+        .and(wiremock::matchers::path("/oauth2/token"))
+        .respond_with(
+            wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "access_token": "lw-access-token-123",
+                "token_type": "Bearer",
+                "expires_in": 3600,
+                "scope": "user.profile.read"
+            })),
+        )
+        .mount(&mock_server)
+        .await;
+
+    // Mock user profile
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .and(wiremock::matchers::path("/v1.0/users/me"))
+        .respond_with(
+            wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "userId": "lw-user-001",
+                "userName": {
+                    "lastName": "田中",
+                    "firstName": "太郎"
+                },
+                "email": "tanaka@example.com"
+            })),
+        )
+        .mount(&mock_server)
+        .await;
+
+    let tenant_id = Uuid::new_v4();
+    let jwt_secret = crate::common::TEST_JWT_SECRET;
+
+    // Encrypt a client_secret for the SSO config
+    let encrypted_secret = encrypt_secret_for_test("test-client-secret", jwt_secret);
+
+    let mock = Arc::new(MockAuthRepository::default());
+    *mock.return_sso_config.lock().unwrap() = Some(SsoConfigRow {
+        tenant_id,
+        client_id: "lw-client-id".to_string(),
+        client_secret_encrypted: encrypted_secret,
+        external_org_id: "lw-org".to_string(),
+        woff_id: None,
+    });
+
+    let mut state = setup_mock_app_state();
+    state.auth = mock;
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    // Create valid state (provider=lineworks, external_org_id must match SSO config)
+    let state_payload = lineworks::state::StatePayload {
+        redirect_uri: "https://items.mtamaramu.com/callback".to_string(),
+        nonce: Uuid::new_v4().to_string(),
+        provider: "lineworks".to_string(),
+        external_org_id: "lw-org".to_string(),
+    };
+    let signed_state = lineworks::state::sign(&state_payload, oauth_secret);
+
+    let client = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let res = client
+        .get(format!(
+            "{base_url}/api/auth/lineworks/callback?code=lw-auth-code&state={}",
+            urlencoding::encode(&signed_state)
+        ))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 307);
+    let location = res.headers().get("location").unwrap().to_str().unwrap();
+    assert!(location.starts_with("https://items.mtamaramu.com/callback#token="));
+    assert!(location.contains("refresh_token="));
+
+    let cookie = res.headers().get("set-cookie").unwrap().to_str().unwrap();
+    assert!(cookie.contains("Domain=.mtamaramu.com"));
+
+    // Cleanup env vars
+    std::env::remove_var("LINEWORKS_TOKEN_URL");
+    std::env::remove_var("LINEWORKS_USERINFO_URL");
+}
+
+// ============================================================
+// GET /api/auth/lineworks/callback — existing user (upsert path)
+// ============================================================
+
+#[tokio::test]
+async fn test_lineworks_callback_existing_user() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    let oauth_secret = "test-state-secret";
+    std::env::set_var("OAUTH_STATE_SECRET", oauth_secret);
+
+    let mock_server = wiremock::MockServer::start().await;
+    std::env::set_var(
+        "LINEWORKS_TOKEN_URL",
+        format!("{}/oauth2/token", mock_server.uri()),
+    );
+    std::env::set_var(
+        "LINEWORKS_USERINFO_URL",
+        format!("{}/v1.0/users/me", mock_server.uri()),
+    );
+
+    wiremock::Mock::given(wiremock::matchers::method("POST"))
+        .and(wiremock::matchers::path("/oauth2/token"))
+        .respond_with(
+            wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "access_token": "lw-access-token-123",
+                "token_type": "Bearer",
+                "expires_in": 3600
+            })),
+        )
+        .mount(&mock_server)
+        .await;
+
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .and(wiremock::matchers::path("/v1.0/users/me"))
+        .respond_with(
+            wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "userId": "lw-user-001",
+                "userName": { "lastName": "田中", "firstName": "太郎" },
+                "email": "tanaka@example.com"
+            })),
+        )
+        .mount(&mock_server)
+        .await;
+
+    let tenant_id = Uuid::new_v4();
+    let jwt_secret = crate::common::TEST_JWT_SECRET;
+    let encrypted_secret = encrypt_secret_for_test("test-client-secret", jwt_secret);
+
+    // Pre-set an existing lineworks user
+    let existing_user = User {
+        id: Uuid::new_v4(),
+        tenant_id,
+        google_sub: None,
+        lineworks_id: Some("lw-user-001".to_string()),
+        email: "tanaka@example.com".to_string(),
+        name: "田中太郎".to_string(),
+        role: "admin".to_string(),
+        refresh_token_hash: None,
+        refresh_token_expires_at: None,
+        created_at: chrono::Utc::now(),
+    };
+
+    let mock = Arc::new(MockAuthRepository::default());
+    *mock.return_sso_config.lock().unwrap() = Some(SsoConfigRow {
+        tenant_id,
+        client_id: "lw-client-id".to_string(),
+        client_secret_encrypted: encrypted_secret,
+        external_org_id: "lw-org".to_string(),
+        woff_id: None,
+    });
+    *mock.return_lineworks_user.lock().unwrap() = Some(existing_user);
+
+    let mut state = setup_mock_app_state();
+    state.auth = mock;
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let state_payload = lineworks::state::StatePayload {
+        redirect_uri: "https://app.example.com/cb".to_string(),
+        nonce: Uuid::new_v4().to_string(),
+        provider: "lineworks".to_string(),
+        external_org_id: "lw-org".to_string(),
+    };
+    let signed_state = lineworks::state::sign(&state_payload, oauth_secret);
+
+    let client = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let res = client
+        .get(format!(
+            "{base_url}/api/auth/lineworks/callback?code=lw-auth-code&state={}",
+            urlencoding::encode(&signed_state)
+        ))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 307);
+
+    std::env::remove_var("LINEWORKS_TOKEN_URL");
+    std::env::remove_var("LINEWORKS_USERINFO_URL");
+}
+
+// ============================================================
+// GET /api/auth/lineworks/callback — missing OAUTH_STATE_SECRET → 500
+// ============================================================
+
+#[tokio::test]
+async fn test_lineworks_callback_missing_state_secret() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::remove_var("OAUTH_STATE_SECRET");
+
+    let mock = Arc::new(MockAuthRepository::default());
+    let mut state = setup_mock_app_state();
+    state.auth = mock;
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let client = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let res = client
+        .get(format!(
+            "{base_url}/api/auth/lineworks/callback?code=any&state=any"
+        ))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 500);
+}
+
+// ============================================================
+// GET /api/auth/lineworks/callback — invalid state → 400
+// ============================================================
+
+#[tokio::test]
+async fn test_lineworks_callback_invalid_state() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("OAUTH_STATE_SECRET", "test-state-secret");
+
+    let mock = Arc::new(MockAuthRepository::default());
+    let mut state = setup_mock_app_state();
+    state.auth = mock;
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let client = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let res = client
+        .get(format!(
+            "{base_url}/api/auth/lineworks/callback?code=any&state=invalid-state"
+        ))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 400);
+}
+
+// ============================================================
+// GET /api/auth/lineworks/callback — SSO config not found → 500
+// ============================================================
+
+#[tokio::test]
+async fn test_lineworks_callback_sso_not_found() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    let oauth_secret = "test-state-secret";
+    std::env::set_var("OAUTH_STATE_SECRET", oauth_secret);
+
+    // return_sso_config = None → resolve_sso_config_required fails
+    let mock = Arc::new(MockAuthRepository::default());
+    let mut state = setup_mock_app_state();
+    state.auth = mock;
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let state_payload = lineworks::state::StatePayload {
+        redirect_uri: "https://example.com/callback".to_string(),
+        nonce: Uuid::new_v4().to_string(),
+        provider: "lineworks".to_string(),
+        external_org_id: "lw-org".to_string(),
+    };
+    let signed_state = lineworks::state::sign(&state_payload, oauth_secret);
+
+    let client = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let res = client
+        .get(format!(
+            "{base_url}/api/auth/lineworks/callback?code=any&state={}",
+            urlencoding::encode(&signed_state)
+        ))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 500);
+}
+
+// ============================================================
+// GET /api/auth/lineworks/callback — decrypt_secret fails → 500
+// ============================================================
+
+#[tokio::test]
+async fn test_lineworks_callback_decrypt_fails() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    let oauth_secret = "test-state-secret";
+    std::env::set_var("OAUTH_STATE_SECRET", oauth_secret);
+
+    let tenant_id = Uuid::new_v4();
+    let mock = Arc::new(MockAuthRepository::default());
+    *mock.return_sso_config.lock().unwrap() = Some(SsoConfigRow {
+        tenant_id,
+        client_id: "lw-client-id".to_string(),
+        client_secret_encrypted: "invalid-base64-not-encrypted".to_string(),
+        external_org_id: "lw-org".to_string(),
+        woff_id: None,
+    });
+
+    let mut state = setup_mock_app_state();
+    state.auth = mock;
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let state_payload = lineworks::state::StatePayload {
+        redirect_uri: "https://example.com/callback".to_string(),
+        nonce: Uuid::new_v4().to_string(),
+        provider: "lineworks".to_string(),
+        external_org_id: "lw-org".to_string(),
+    };
+    let signed_state = lineworks::state::sign(&state_payload, oauth_secret);
+
+    let client = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let res = client
+        .get(format!(
+            "{base_url}/api/auth/lineworks/callback?code=any&state={}",
+            urlencoding::encode(&signed_state)
+        ))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 500);
+}
+
+// ============================================================
+// GET /api/auth/lineworks/callback — token exchange fails → 502
+// ============================================================
+
+#[tokio::test]
+async fn test_lineworks_callback_token_exchange_fails() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    let oauth_secret = "test-state-secret";
+    std::env::set_var("OAUTH_STATE_SECRET", oauth_secret);
+
+    let mock_server = wiremock::MockServer::start().await;
+    std::env::set_var(
+        "LINEWORKS_TOKEN_URL",
+        format!("{}/oauth2/token", mock_server.uri()),
+    );
+
+    // Token exchange returns 400
+    wiremock::Mock::given(wiremock::matchers::method("POST"))
+        .and(wiremock::matchers::path("/oauth2/token"))
+        .respond_with(
+            wiremock::ResponseTemplate::new(400).set_body_json(serde_json::json!({
+                "error": "invalid_grant"
+            })),
+        )
+        .mount(&mock_server)
+        .await;
+
+    let tenant_id = Uuid::new_v4();
+    let jwt_secret = crate::common::TEST_JWT_SECRET;
+    let encrypted_secret = encrypt_secret_for_test("test-client-secret", jwt_secret);
+
+    let mock = Arc::new(MockAuthRepository::default());
+    *mock.return_sso_config.lock().unwrap() = Some(SsoConfigRow {
+        tenant_id,
+        client_id: "lw-client-id".to_string(),
+        client_secret_encrypted: encrypted_secret,
+        external_org_id: "lw-org".to_string(),
+        woff_id: None,
+    });
+
+    let mut state = setup_mock_app_state();
+    state.auth = mock;
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let state_payload = lineworks::state::StatePayload {
+        redirect_uri: "https://example.com/callback".to_string(),
+        nonce: Uuid::new_v4().to_string(),
+        provider: "lineworks".to_string(),
+        external_org_id: "lw-org".to_string(),
+    };
+    let signed_state = lineworks::state::sign(&state_payload, oauth_secret);
+
+    let client = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let res = client
+        .get(format!(
+            "{base_url}/api/auth/lineworks/callback?code=bad-code&state={}",
+            urlencoding::encode(&signed_state)
+        ))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 502);
+
+    std::env::remove_var("LINEWORKS_TOKEN_URL");
+}
+
+// ============================================================
+// GET /api/auth/lineworks/callback — profile fetch fails → 502
+// ============================================================
+
+#[tokio::test]
+async fn test_lineworks_callback_profile_fetch_fails() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    let oauth_secret = "test-state-secret";
+    std::env::set_var("OAUTH_STATE_SECRET", oauth_secret);
+
+    let mock_server = wiremock::MockServer::start().await;
+    std::env::set_var(
+        "LINEWORKS_TOKEN_URL",
+        format!("{}/oauth2/token", mock_server.uri()),
+    );
+    std::env::set_var(
+        "LINEWORKS_USERINFO_URL",
+        format!("{}/v1.0/users/me", mock_server.uri()),
+    );
+
+    // Token exchange succeeds
+    wiremock::Mock::given(wiremock::matchers::method("POST"))
+        .and(wiremock::matchers::path("/oauth2/token"))
+        .respond_with(
+            wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "access_token": "lw-access-token-123",
+                "token_type": "Bearer",
+                "expires_in": 3600
+            })),
+        )
+        .mount(&mock_server)
+        .await;
+
+    // Profile fetch fails
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .and(wiremock::matchers::path("/v1.0/users/me"))
+        .respond_with(
+            wiremock::ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "error": "unauthorized"
+            })),
+        )
+        .mount(&mock_server)
+        .await;
+
+    let tenant_id = Uuid::new_v4();
+    let jwt_secret = crate::common::TEST_JWT_SECRET;
+    let encrypted_secret = encrypt_secret_for_test("test-client-secret", jwt_secret);
+
+    let mock = Arc::new(MockAuthRepository::default());
+    *mock.return_sso_config.lock().unwrap() = Some(SsoConfigRow {
+        tenant_id,
+        client_id: "lw-client-id".to_string(),
+        client_secret_encrypted: encrypted_secret,
+        external_org_id: "lw-org".to_string(),
+        woff_id: None,
+    });
+
+    let mut state = setup_mock_app_state();
+    state.auth = mock;
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let state_payload = lineworks::state::StatePayload {
+        redirect_uri: "https://example.com/callback".to_string(),
+        nonce: Uuid::new_v4().to_string(),
+        provider: "lineworks".to_string(),
+        external_org_id: "lw-org".to_string(),
+    };
+    let signed_state = lineworks::state::sign(&state_payload, oauth_secret);
+
+    let client = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let res = client
+        .get(format!(
+            "{base_url}/api/auth/lineworks/callback?code=lw-code&state={}",
+            urlencoding::encode(&signed_state)
+        ))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 502);
+
+    std::env::remove_var("LINEWORKS_TOKEN_URL");
+    std::env::remove_var("LINEWORKS_USERINFO_URL");
+}
+
+// ============================================================
+// POST /api/auth/woff — success (new user)
+// ============================================================
+
+#[tokio::test]
+async fn test_woff_auth_success() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+    let mock_server = wiremock::MockServer::start().await;
+    std::env::set_var(
+        "LINEWORKS_USERINFO_URL",
+        format!("{}/v1.0/users/me", mock_server.uri()),
+    );
+
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .and(wiremock::matchers::path("/v1.0/users/me"))
+        .respond_with(
+            wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "userId": "woff-user-001",
+                "userName": { "lastName": "佐藤", "firstName": "花子" },
+                "email": "sato@example.com"
+            })),
+        )
+        .mount(&mock_server)
+        .await;
+
+    let tenant_id = Uuid::new_v4();
+    let mock = Arc::new(MockAuthRepository::default());
+    *mock.return_sso_config.lock().unwrap() = Some(SsoConfigRow {
+        tenant_id,
+        client_id: "woff-client-id".to_string(),
+        client_secret_encrypted: "encrypted".to_string(),
+        external_org_id: "woff-org".to_string(),
+        woff_id: Some("woff-12345".to_string()),
+    });
+
+    let mut state = setup_mock_app_state();
+    state.auth = mock;
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let client = reqwest::Client::new();
+    let res = client
+        .post(format!("{base_url}/api/auth/woff"))
+        .json(&serde_json::json!({
+            "access_token": "woff-access-token",
+            "domain_id": "woff-org"
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+    let body: Value = res.json().await.unwrap();
+    assert!(body["token"].is_string());
+    assert!(body["expiresAt"].is_string());
+    assert_eq!(body["tenantId"], tenant_id.to_string());
+
+    std::env::remove_var("LINEWORKS_USERINFO_URL");
+}
+
+// ============================================================
+// POST /api/auth/woff — existing user
+// ============================================================
+
+#[tokio::test]
+async fn test_woff_auth_existing_user() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+    let mock_server = wiremock::MockServer::start().await;
+    std::env::set_var(
+        "LINEWORKS_USERINFO_URL",
+        format!("{}/v1.0/users/me", mock_server.uri()),
+    );
+
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .and(wiremock::matchers::path("/v1.0/users/me"))
+        .respond_with(
+            wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "userId": "woff-user-001",
+                "userName": { "lastName": "佐藤", "firstName": "花子" },
+                "email": "sato@example.com"
+            })),
+        )
+        .mount(&mock_server)
+        .await;
+
+    let tenant_id = Uuid::new_v4();
+    let existing_user = User {
+        id: Uuid::new_v4(),
+        tenant_id,
+        google_sub: None,
+        lineworks_id: Some("woff-user-001".to_string()),
+        email: "sato@example.com".to_string(),
+        name: "佐藤花子".to_string(),
+        role: "viewer".to_string(),
+        refresh_token_hash: None,
+        refresh_token_expires_at: None,
+        created_at: chrono::Utc::now(),
+    };
+
+    let mock = Arc::new(MockAuthRepository::default());
+    *mock.return_sso_config.lock().unwrap() = Some(SsoConfigRow {
+        tenant_id,
+        client_id: "woff-client-id".to_string(),
+        client_secret_encrypted: "encrypted".to_string(),
+        external_org_id: "woff-org".to_string(),
+        woff_id: Some("woff-12345".to_string()),
+    });
+    *mock.return_lineworks_user.lock().unwrap() = Some(existing_user);
+
+    let mut state = setup_mock_app_state();
+    state.auth = mock;
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let client = reqwest::Client::new();
+    let res = client
+        .post(format!("{base_url}/api/auth/woff"))
+        .json(&serde_json::json!({
+            "access_token": "woff-access-token",
+            "domain_id": "woff-org"
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+
+    std::env::remove_var("LINEWORKS_USERINFO_URL");
+}
+
+// ============================================================
+// POST /api/auth/woff — SSO config not found → 404
+// ============================================================
+
+#[tokio::test]
+async fn test_woff_auth_sso_not_found() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+    // return_sso_config = None → 404
+    let mock = Arc::new(MockAuthRepository::default());
+    let mut state = setup_mock_app_state();
+    state.auth = mock;
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let client = reqwest::Client::new();
+    let res = client
+        .post(format!("{base_url}/api/auth/woff"))
+        .json(&serde_json::json!({
+            "access_token": "any-token",
+            "domain_id": "unknown-domain"
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 404);
+}
+
+// ============================================================
+// POST /api/auth/woff — profile fetch fails → 401
+// ============================================================
+
+#[tokio::test]
+async fn test_woff_auth_profile_fails() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+    let mock_server = wiremock::MockServer::start().await;
+    std::env::set_var(
+        "LINEWORKS_USERINFO_URL",
+        format!("{}/v1.0/users/me", mock_server.uri()),
+    );
+
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .and(wiremock::matchers::path("/v1.0/users/me"))
+        .respond_with(
+            wiremock::ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "error": "invalid_token"
+            })),
+        )
+        .mount(&mock_server)
+        .await;
+
+    let tenant_id = Uuid::new_v4();
+    let mock = Arc::new(MockAuthRepository::default());
+    *mock.return_sso_config.lock().unwrap() = Some(SsoConfigRow {
+        tenant_id,
+        client_id: "woff-client-id".to_string(),
+        client_secret_encrypted: "encrypted".to_string(),
+        external_org_id: "woff-org".to_string(),
+        woff_id: Some("woff-12345".to_string()),
+    });
+
+    let mut state = setup_mock_app_state();
+    state.auth = mock;
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let client = reqwest::Client::new();
+    let res = client
+        .post(format!("{base_url}/api/auth/woff"))
+        .json(&serde_json::json!({
+            "access_token": "bad-token",
+            "domain_id": "woff-org"
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 401);
+
+    std::env::remove_var("LINEWORKS_USERINFO_URL");
+}
+
+// ============================================================
+// POST /api/auth/woff — DB error on resolve_sso_config
+// ============================================================
+
+#[tokio::test]
+async fn test_woff_auth_db_error() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+    let mock = Arc::new(MockAuthRepository::default());
+    mock.fail_next.store(true, Ordering::SeqCst);
+    let mut state = setup_mock_app_state();
+    state.auth = mock;
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let client = reqwest::Client::new();
+    let res = client
+        .post(format!("{base_url}/api/auth/woff"))
+        .json(&serde_json::json!({
+            "access_token": "any-token",
+            "domain_id": "any-domain"
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 500);
+}
+
+// ============================================================
+// GET /api/auth/google/callback — extract_parent_domain edge cases
+// ============================================================
+
+#[tokio::test]
+async fn test_google_callback_two_part_domain() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("OAUTH_STATE_SECRET", "test-state-secret");
+
+    let mock = Arc::new(MockAuthRepository::default());
+    let mut state = setup_mock_app_state();
+    state.auth = mock;
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    // Two-part domain: "example.com" → "example.com" (no parent extraction)
+    let state_payload = lineworks::state::StatePayload {
+        redirect_uri: "https://example.com/callback".to_string(),
+        nonce: Uuid::new_v4().to_string(),
+        provider: "google".to_string(),
+        external_org_id: String::new(),
+    };
+    let signed_state = lineworks::state::sign(&state_payload, "test-state-secret");
+
+    let client = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let res = client
+        .get(format!(
+            "{base_url}/api/auth/google/callback?code=test-valid-code&state={}",
+            urlencoding::encode(&signed_state)
+        ))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 307);
+    let cookie = res.headers().get("set-cookie").unwrap().to_str().unwrap();
+    // Two-part domain stays as-is
+    assert!(cookie.contains("Domain=.example.com"));
+}
+
+// ============================================================
+// GET /api/auth/google/callback — redirect_uri with http (not https)
+// ============================================================
+
+#[tokio::test]
+async fn test_google_callback_http_redirect_uri() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("OAUTH_STATE_SECRET", "test-state-secret");
+
+    let mock = Arc::new(MockAuthRepository::default());
+    let mut state = setup_mock_app_state();
+    state.auth = mock;
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let state_payload = lineworks::state::StatePayload {
+        redirect_uri: "http://localhost:3000/callback".to_string(),
+        nonce: Uuid::new_v4().to_string(),
+        provider: "google".to_string(),
+        external_org_id: String::new(),
+    };
+    let signed_state = lineworks::state::sign(&state_payload, "test-state-secret");
+
+    let client = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let res = client
+        .get(format!(
+            "{base_url}/api/auth/google/callback?code=test-valid-code&state={}",
+            urlencoding::encode(&signed_state)
+        ))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 307);
+    let location = res.headers().get("location").unwrap().to_str().unwrap();
+    assert!(location.starts_with("http://localhost:3000/callback#token="));
+
+    // localhost:3000 → host=localhost (port stripped), parts=1 → "localhost"
+    let cookie = res.headers().get("set-cookie").unwrap().to_str().unwrap();
+    assert!(cookie.contains("Domain=.localhost"));
 }

--- a/tests/mock_tests/mock_auth_test.rs
+++ b/tests/mock_tests/mock_auth_test.rs
@@ -1864,6 +1864,105 @@ async fn test_lineworks_callback_profile_fetch_fails() {
 }
 
 // ============================================================
+// GET /api/auth/lineworks/callback — create_user_lineworks fails → 500
+// ============================================================
+
+#[tokio::test]
+async fn test_lineworks_callback_create_user_fails() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    let oauth_secret = "test-state-secret";
+    std::env::set_var("OAUTH_STATE_SECRET", oauth_secret);
+
+    let mock_server = wiremock::MockServer::start().await;
+    std::env::set_var(
+        "LINEWORKS_TOKEN_URL",
+        format!("{}/oauth2/token", mock_server.uri()),
+    );
+    std::env::set_var(
+        "LINEWORKS_USERINFO_URL",
+        format!("{}/v1.0/users/me", mock_server.uri()),
+    );
+
+    // Mock token exchange
+    wiremock::Mock::given(wiremock::matchers::method("POST"))
+        .and(wiremock::matchers::path("/oauth2/token"))
+        .respond_with(
+            wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "access_token": "lw-access-token-123",
+                "token_type": "Bearer",
+                "expires_in": 3600,
+                "scope": "user.profile.read"
+            })),
+        )
+        .mount(&mock_server)
+        .await;
+
+    // Mock user profile
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .and(wiremock::matchers::path("/v1.0/users/me"))
+        .respond_with(
+            wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "userId": "lw-user-new",
+                "userName": {
+                    "lastName": "佐藤",
+                    "firstName": "花子"
+                },
+                "email": "sato@example.com"
+            })),
+        )
+        .mount(&mock_server)
+        .await;
+
+    let tenant_id = Uuid::new_v4();
+    let jwt_secret = crate::common::TEST_JWT_SECRET;
+    let encrypted_secret = encrypt_secret_for_test("test-client-secret", jwt_secret);
+
+    let mock = Arc::new(MockAuthRepository::default());
+    *mock.return_sso_config.lock().unwrap() = Some(SsoConfigRow {
+        tenant_id,
+        client_id: "lw-client-id".to_string(),
+        client_secret_encrypted: encrypted_secret,
+        external_org_id: "lw-org".to_string(),
+        woff_id: None,
+    });
+    // return_lineworks_user = None → user not found → triggers create_user_lineworks
+    // fail_on_create_user = true → create_user_lineworks returns Err
+    mock.fail_on_create_user.store(true, Ordering::SeqCst);
+
+    let mut state = setup_mock_app_state();
+    state.auth = mock;
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let state_payload = lineworks::state::StatePayload {
+        redirect_uri: "https://items.mtamaramu.com/callback".to_string(),
+        nonce: Uuid::new_v4().to_string(),
+        provider: "lineworks".to_string(),
+        external_org_id: "lw-org".to_string(),
+    };
+    let signed_state = lineworks::state::sign(&state_payload, oauth_secret);
+
+    let client = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let res = client
+        .get(format!(
+            "{base_url}/api/auth/lineworks/callback?code=lw-auth-code&state={}",
+            urlencoding::encode(&signed_state)
+        ))
+        .send()
+        .await
+        .unwrap();
+
+    // upsert_lineworks_user → find=None → create fails → 500
+    assert_eq!(res.status(), 500);
+
+    std::env::remove_var("LINEWORKS_TOKEN_URL");
+    std::env::remove_var("LINEWORKS_USERINFO_URL");
+}
+
+// ============================================================
 // POST /api/auth/woff — success (new user)
 // ============================================================
 

--- a/tests/mock_tests/mock_devices_test.rs
+++ b/tests/mock_tests/mock_devices_test.rs
@@ -1531,3 +1531,1738 @@ async fn test_list_devices_with_x_tenant_id() {
         .unwrap();
     assert_eq!(res.status(), 200);
 }
+
+// ============================================================
+// DeviceRow → Device From trait (line 122-149)
+// ============================================================
+
+#[tokio::test]
+async fn test_list_devices_with_device_rows() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    mock.return_device_rows.store(true, Ordering::SeqCst);
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let tenant_id = Uuid::new_v4();
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!("{base_url}/api/devices"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    let body: Value = res.json().await.unwrap();
+    let arr = body.as_array().unwrap();
+    assert_eq!(arr.len(), 1);
+    assert_eq!(arr[0]["device_name"], "Mock Device");
+    assert_eq!(arr[0]["device_type"], "android");
+    assert_eq!(arr[0]["status"], "active");
+}
+
+// ============================================================
+// RegistrationRequestRow → RegistrationRequest From trait (line 169-184)
+// ============================================================
+
+#[tokio::test]
+async fn test_list_pending_with_rows() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    mock.return_pending_rows.store(true, Ordering::SeqCst);
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let tenant_id = Uuid::new_v4();
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!("{base_url}/api/devices/pending"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    let body: Value = res.json().await.unwrap();
+    let arr = body.as_array().unwrap();
+    assert_eq!(arr.len(), 1);
+    assert_eq!(arr[0]["device_name"], "Pending Device");
+    assert_eq!(arr[0]["flow_type"], "qr_permanent");
+}
+
+// ============================================================
+// check_registration_status: expired status (line 256)
+// ============================================================
+
+#[tokio::test]
+async fn test_registration_status_expired() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    mock.return_data.store(true, Ordering::SeqCst);
+    mock.return_expired.store(true, Ordering::SeqCst);
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let client = reqwest::Client::new();
+    let res = client
+        .get(format!("{base_url}/api/devices/register/status/123456"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    let body: Value = res.json().await.unwrap();
+    assert_eq!(body["status"], "expired");
+}
+
+// ============================================================
+// check_registration_status: non-pending status (line 264)
+// ============================================================
+
+#[tokio::test]
+async fn test_registration_status_approved() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    mock.return_data.store(true, Ordering::SeqCst);
+    mock.return_approved_status.store(true, Ordering::SeqCst);
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let client = reqwest::Client::new();
+    let res = client
+        .get(format!("{base_url}/api/devices/register/status/123456"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    let body: Value = res.json().await.unwrap();
+    assert_eq!(body["status"], "approved");
+}
+
+// ============================================================
+// check_registration_status: pending with no expires_at (line 261)
+// ============================================================
+
+#[tokio::test]
+async fn test_registration_status_pending_no_expires() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    mock.return_data.store(true, Ordering::SeqCst);
+    mock.return_no_expires.store(true, Ordering::SeqCst);
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let client = reqwest::Client::new();
+    let res = client
+        .get(format!("{base_url}/api/devices/register/status/123456"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    let body: Value = res.json().await.unwrap();
+    assert_eq!(body["status"], "pending");
+}
+
+// ============================================================
+// claim_registration: qr_permanent flow (line 367-383)
+// ============================================================
+
+#[tokio::test]
+async fn test_claim_qr_permanent_success() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    mock.return_data.store(true, Ordering::SeqCst);
+    mock.return_qr_permanent.store(true, Ordering::SeqCst);
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let client = reqwest::Client::new();
+    let res = client
+        .post(format!("{base_url}/api/devices/register/claim"))
+        .json(&serde_json::json!({
+            "registration_code": "QRCODE",
+            "phone_number": "090-1234-5678",
+            "device_name": "QR Phone"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    let body: Value = res.json().await.unwrap();
+    assert_eq!(body["success"], true);
+    assert_eq!(body["flow_type"], "qr_permanent");
+    assert!(body["message"].as_str().is_some());
+}
+
+// ============================================================
+// claim_registration: status != "pending" (line 326)
+// ============================================================
+
+#[tokio::test]
+async fn test_claim_used_status() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    mock.return_data.store(true, Ordering::SeqCst);
+    mock.return_used_status.store(true, Ordering::SeqCst);
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let client = reqwest::Client::new();
+    let res = client
+        .post(format!("{base_url}/api/devices/register/claim"))
+        .json(&serde_json::json!({
+            "registration_code": "USED_CODE"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 400);
+    let body: Value = res.json().await.unwrap();
+    assert_eq!(body["success"], false);
+}
+
+// ============================================================
+// claim_registration: unknown flow_type (line 383)
+// ============================================================
+
+#[tokio::test]
+async fn test_claim_unknown_flow_type() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    mock.return_data.store(true, Ordering::SeqCst);
+    mock.return_unknown_flow.store(true, Ordering::SeqCst);
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let client = reqwest::Client::new();
+    let res = client
+        .post(format!("{base_url}/api/devices/register/claim"))
+        .json(&serde_json::json!({
+            "registration_code": "UNKNOWN"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 400);
+    let body: Value = res.json().await.unwrap();
+    assert_eq!(body["success"], false);
+}
+
+// ============================================================
+// DB error paths for tenant endpoints
+// ============================================================
+
+#[tokio::test]
+async fn test_list_pending_db_error() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    mock.fail_next.store(true, Ordering::SeqCst);
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let tenant_id = Uuid::new_v4();
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!("{base_url}/api/devices/pending"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}
+
+#[tokio::test]
+async fn test_create_url_token_db_error() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    mock.fail_next.store(true, Ordering::SeqCst);
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let tenant_id = Uuid::new_v4();
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/devices/register/create-token"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}
+
+#[tokio::test]
+async fn test_create_device_owner_token_db_error() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    mock.fail_next.store(true, Ordering::SeqCst);
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let tenant_id = Uuid::new_v4();
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!(
+            "{base_url}/api/devices/register/create-device-owner-token"
+        ))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}
+
+#[tokio::test]
+async fn test_create_permanent_qr_db_error() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    mock.fail_next.store(true, Ordering::SeqCst);
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let tenant_id = Uuid::new_v4();
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!(
+            "{base_url}/api/devices/register/create-permanent-qr"
+        ))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}
+
+#[tokio::test]
+async fn test_approve_device_db_error_lookup() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    mock.fail_next.store(true, Ordering::SeqCst);
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let tenant_id = Uuid::new_v4();
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+    let req_id = Uuid::new_v4();
+
+    let res = client
+        .post(format!("{base_url}/api/devices/approve/{req_id}"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}
+
+#[tokio::test]
+async fn test_approve_by_code_db_error() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    mock.fail_next.store(true, Ordering::SeqCst);
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let tenant_id = Uuid::new_v4();
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/devices/approve-by-code/ABC"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}
+
+#[tokio::test]
+async fn test_reject_device_db_error() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    mock.fail_next.store(true, Ordering::SeqCst);
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let tenant_id = Uuid::new_v4();
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+    let id = Uuid::new_v4();
+
+    let res = client
+        .post(format!("{base_url}/api/devices/reject/{id}"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}
+
+#[tokio::test]
+async fn test_disable_device_not_found() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let tenant_id = Uuid::new_v4();
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+    let id = Uuid::new_v4();
+
+    let res = client
+        .post(format!("{base_url}/api/devices/disable/{id}"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 404);
+}
+
+#[tokio::test]
+async fn test_disable_device_db_error() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    mock.fail_next.store(true, Ordering::SeqCst);
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let tenant_id = Uuid::new_v4();
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+    let id = Uuid::new_v4();
+
+    let res = client
+        .post(format!("{base_url}/api/devices/disable/{id}"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}
+
+#[tokio::test]
+async fn test_enable_device_not_found() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let tenant_id = Uuid::new_v4();
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+    let id = Uuid::new_v4();
+
+    let res = client
+        .post(format!("{base_url}/api/devices/enable/{id}"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 404);
+}
+
+#[tokio::test]
+async fn test_enable_device_db_error() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    mock.fail_next.store(true, Ordering::SeqCst);
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let tenant_id = Uuid::new_v4();
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+    let id = Uuid::new_v4();
+
+    let res = client
+        .post(format!("{base_url}/api/devices/enable/{id}"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}
+
+#[tokio::test]
+async fn test_delete_device_db_error() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    mock.fail_next.store(true, Ordering::SeqCst);
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let tenant_id = Uuid::new_v4();
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+    let id = Uuid::new_v4();
+
+    let res = client
+        .delete(format!("{base_url}/api/devices/{id}"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}
+
+#[tokio::test]
+async fn test_update_call_settings_db_error() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    mock.fail_next.store(true, Ordering::SeqCst);
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let tenant_id = Uuid::new_v4();
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+    let id = Uuid::new_v4();
+
+    let res = client
+        .put(format!("{base_url}/api/devices/{id}/call-settings"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .json(&serde_json::json!({ "call_enabled": true }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}
+
+// ============================================================
+// update_call_settings: always_on with no FCM token (line 857)
+// ============================================================
+
+#[tokio::test]
+async fn test_update_call_settings_always_on_no_token() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    mock.return_data.store(true, Ordering::SeqCst);
+    mock.return_no_fcm_token.store(true, Ordering::SeqCst);
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    state.fcm = Some(Arc::new(crate::common::MockFcmSender::new()));
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let tenant_id = Uuid::new_v4();
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+    let id = Uuid::new_v4();
+
+    let res = client
+        .put(format!("{base_url}/api/devices/{id}/call-settings"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .json(&serde_json::json!({
+            "call_enabled": true,
+            "always_on": true
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 204);
+}
+
+// ============================================================
+// update_call_settings: always_on without FCM (no fcm provider)
+// ============================================================
+
+#[tokio::test]
+async fn test_update_call_settings_always_on_no_fcm_provider() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    mock.return_data.store(true, Ordering::SeqCst);
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    // fcm = None, so always_on FCM branch is skipped
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let tenant_id = Uuid::new_v4();
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+    let id = Uuid::new_v4();
+
+    let res = client
+        .put(format!("{base_url}/api/devices/{id}/call-settings"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .json(&serde_json::json!({
+            "call_enabled": true,
+            "always_on": false
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 204);
+}
+
+// ============================================================
+// update_call_settings: always_on=None (no FCM sent)
+// ============================================================
+
+#[tokio::test]
+async fn test_update_call_settings_no_always_on() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    mock.return_data.store(true, Ordering::SeqCst);
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    state.fcm = Some(Arc::new(crate::common::MockFcmSender::new()));
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let tenant_id = Uuid::new_v4();
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+    let id = Uuid::new_v4();
+
+    let res = client
+        .put(format!("{base_url}/api/devices/{id}/call-settings"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .json(&serde_json::json!({ "call_enabled": false }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 204);
+}
+
+// ============================================================
+// update_call_settings: FCM send failure (line 864)
+// ============================================================
+
+#[tokio::test]
+async fn test_update_call_settings_fcm_send_failure() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    mock.return_data.store(true, Ordering::SeqCst);
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    state.fcm = Some(Arc::new(crate::common::FailingFcmSender));
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let tenant_id = Uuid::new_v4();
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+    let id = Uuid::new_v4();
+
+    let res = client
+        .put(format!("{base_url}/api/devices/{id}/call-settings"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .json(&serde_json::json!({
+            "call_enabled": true,
+            "always_on": true
+        }))
+        .send()
+        .await
+        .unwrap();
+    // FCM failure is logged but doesn't cause 500
+    assert_eq!(res.status(), 204);
+}
+
+// ============================================================
+// Device settings DB error
+// ============================================================
+
+#[tokio::test]
+async fn test_device_settings_db_error() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    mock.fail_next.store(true, Ordering::SeqCst);
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let device_id = Uuid::new_v4();
+    let client = reqwest::Client::new();
+    let res = client
+        .get(format!("{base_url}/api/devices/settings/{device_id}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}
+
+// ============================================================
+// FCM token registration DB errors
+// ============================================================
+
+#[tokio::test]
+async fn test_register_fcm_token_db_error_lookup() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    mock.fail_next.store(true, Ordering::SeqCst);
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let client = reqwest::Client::new();
+    let res = client
+        .put(format!("{base_url}/api/devices/register-fcm-token"))
+        .json(&serde_json::json!({
+            "device_id": Uuid::new_v4(),
+            "fcm_token": "token"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}
+
+// ============================================================
+// update_last_login DB errors + not found
+// ============================================================
+
+#[tokio::test]
+async fn test_update_last_login_not_found() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    // return_data=false -> lookup returns None -> 404
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let client = reqwest::Client::new();
+    let res = client
+        .put(format!("{base_url}/api/devices/update-last-login"))
+        .json(&serde_json::json!({
+            "device_id": Uuid::new_v4(),
+            "employee_id": Uuid::new_v4(),
+            "employee_name": "Taro",
+            "employee_role": ["driver"]
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 404);
+}
+
+#[tokio::test]
+async fn test_update_last_login_db_error() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    mock.fail_next.store(true, Ordering::SeqCst);
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let client = reqwest::Client::new();
+    let res = client
+        .put(format!("{base_url}/api/devices/update-last-login"))
+        .json(&serde_json::json!({
+            "device_id": Uuid::new_v4(),
+            "employee_id": Uuid::new_v4(),
+            "employee_name": "Taro",
+            "employee_role": ["driver"]
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}
+
+// ============================================================
+// report_version DB error
+// ============================================================
+
+#[tokio::test]
+async fn test_report_version_db_error() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    mock.fail_next.store(true, Ordering::SeqCst);
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let client = reqwest::Client::new();
+    let res = client
+        .put(format!("{base_url}/api/devices/report-version"))
+        .json(&serde_json::json!({
+            "device_id": Uuid::new_v4(),
+            "version_code": 1,
+            "version_name": "0.0.1"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}
+
+// ============================================================
+// report_watchdog DB error
+// ============================================================
+
+#[tokio::test]
+async fn test_report_watchdog_db_error() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    mock.fail_next.store(true, Ordering::SeqCst);
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let client = reqwest::Client::new();
+    let res = client
+        .put(format!("{base_url}/api/devices/report-watchdog"))
+        .json(&serde_json::json!({
+            "device_id": Uuid::new_v4(),
+            "running": true
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}
+
+// ============================================================
+// should_notify_device: call_enabled=false
+// ============================================================
+
+#[tokio::test]
+async fn test_fcm_notify_call_disabled_device_skipped() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::remove_var("FCM_INTERNAL_SECRET");
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    mock.return_data.store(true, Ordering::SeqCst);
+    mock.return_call_disabled.store(true, Ordering::SeqCst);
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    state.fcm = Some(Arc::new(crate::common::MockFcmSender::new()));
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let client = reqwest::Client::new();
+    let res = client
+        .post(format!("{base_url}/api/devices/fcm-notify-call"))
+        .json(&serde_json::json!({ "room_ids": ["room-1"] }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    let body: Value = res.json().await.unwrap();
+    assert_eq!(body["sent"], 0);
+    assert_eq!(body["skipped"], 1);
+}
+
+// ============================================================
+// should_notify_device: schedule enabled=false
+// ============================================================
+
+#[tokio::test]
+async fn test_fcm_notify_call_schedule_disabled_skipped() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::remove_var("FCM_INTERNAL_SECRET");
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    mock.return_data.store(true, Ordering::SeqCst);
+    mock.return_schedule_disabled.store(true, Ordering::SeqCst);
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    state.fcm = Some(Arc::new(crate::common::MockFcmSender::new()));
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let client = reqwest::Client::new();
+    let res = client
+        .post(format!("{base_url}/api/devices/fcm-notify-call"))
+        .json(&serde_json::json!({ "room_ids": ["room-1"] }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    let body: Value = res.json().await.unwrap();
+    assert_eq!(body["sent"], 0);
+    assert_eq!(body["skipped"], 1);
+}
+
+// ============================================================
+// should_notify_device: schedule with days + time (all days, all hours)
+// ============================================================
+
+#[tokio::test]
+async fn test_fcm_notify_call_schedule_with_days_sent() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::remove_var("FCM_INTERNAL_SECRET");
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    mock.return_data.store(true, Ordering::SeqCst);
+    mock.return_schedule_with_days.store(true, Ordering::SeqCst);
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    state.fcm = Some(Arc::new(crate::common::MockFcmSender::new()));
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let client = reqwest::Client::new();
+    let res = client
+        .post(format!("{base_url}/api/devices/fcm-notify-call"))
+        .json(&serde_json::json!({ "room_ids": ["room-1"] }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    let body: Value = res.json().await.unwrap();
+    assert_eq!(body["sent"], 1);
+}
+
+// ============================================================
+// fcm_notify_call: FCM send error
+// ============================================================
+
+#[tokio::test]
+async fn test_fcm_notify_call_fcm_error() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::remove_var("FCM_INTERNAL_SECRET");
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    mock.return_data.store(true, Ordering::SeqCst);
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    state.fcm = Some(Arc::new(crate::common::FailingFcmSender));
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let client = reqwest::Client::new();
+    let res = client
+        .post(format!("{base_url}/api/devices/fcm-notify-call"))
+        .json(&serde_json::json!({ "room_ids": ["room-1"] }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    let body: Value = res.json().await.unwrap();
+    assert_eq!(body["errors"], 1);
+    assert_eq!(body["sent"], 0);
+}
+
+// ============================================================
+// fcm_notify_call: DB error on list_fcm_devices
+// ============================================================
+
+#[tokio::test]
+async fn test_fcm_notify_call_db_error() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::remove_var("FCM_INTERNAL_SECRET");
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    mock.fail_next.store(true, Ordering::SeqCst);
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    state.fcm = Some(Arc::new(crate::common::MockFcmSender::new()));
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let client = reqwest::Client::new();
+    let res = client
+        .post(format!("{base_url}/api/devices/fcm-notify-call"))
+        .json(&serde_json::json!({ "room_ids": ["room-1"] }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}
+
+// ============================================================
+// fcm_notify_call: exclude_device_ids
+// ============================================================
+
+#[tokio::test]
+async fn test_fcm_notify_call_with_exclude() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::remove_var("FCM_INTERNAL_SECRET");
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    mock.return_data.store(true, Ordering::SeqCst);
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    state.fcm = Some(Arc::new(crate::common::MockFcmSender::new()));
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let client = reqwest::Client::new();
+    // Exclude the nil UUID device
+    let res = client
+        .post(format!("{base_url}/api/devices/fcm-notify-call"))
+        .json(&serde_json::json!({
+            "room_ids": ["room-1"],
+            "exclude_device_ids": [Uuid::nil().to_string()]
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    let body: Value = res.json().await.unwrap();
+    assert_eq!(body["skipped"], 1);
+    assert_eq!(body["sent"], 0);
+}
+
+// ============================================================
+// fcm_dismiss_test: DB error
+// ============================================================
+
+#[tokio::test]
+async fn test_fcm_dismiss_test_db_error() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    mock.fail_next.store(true, Ordering::SeqCst);
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    state.fcm = Some(Arc::new(crate::common::MockFcmSender::new()));
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let client = reqwest::Client::new();
+    let res = client
+        .post(format!("{base_url}/api/devices/fcm-dismiss-test"))
+        .json(&serde_json::json!({ "device_id": Uuid::new_v4() }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}
+
+// ============================================================
+// test_fcm_all_exclude: with devices
+// ============================================================
+
+#[tokio::test]
+async fn test_fcm_all_exclude_with_devices() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    mock.return_callable_devices.store(true, Ordering::SeqCst);
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    state.fcm = Some(Arc::new(crate::common::MockFcmSender::new()));
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let client = reqwest::Client::new();
+    let res = client
+        .post(format!("{base_url}/api/devices/test-fcm-all-exclude"))
+        .json(&serde_json::json!({ "exclude_device_ids": [] }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    let body: Value = res.json().await.unwrap();
+    assert_eq!(body["sent"], 1);
+}
+
+// ============================================================
+// test_fcm_all_exclude: with exclude matching
+// ============================================================
+
+#[tokio::test]
+async fn test_fcm_all_exclude_with_exclude_matching() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    mock.return_callable_devices.store(true, Ordering::SeqCst);
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    state.fcm = Some(Arc::new(crate::common::MockFcmSender::new()));
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let client = reqwest::Client::new();
+    let res = client
+        .post(format!("{base_url}/api/devices/test-fcm-all-exclude"))
+        .json(&serde_json::json!({ "exclude_device_ids": [Uuid::nil().to_string()] }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    let body: Value = res.json().await.unwrap();
+    assert_eq!(body["sent"], 0);
+}
+
+// ============================================================
+// test_fcm_all_exclude: FCM error
+// ============================================================
+
+#[tokio::test]
+async fn test_fcm_all_exclude_fcm_error() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    mock.return_callable_devices.store(true, Ordering::SeqCst);
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    state.fcm = Some(Arc::new(crate::common::FailingFcmSender));
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let client = reqwest::Client::new();
+    let res = client
+        .post(format!("{base_url}/api/devices/test-fcm-all-exclude"))
+        .json(&serde_json::json!({ "exclude_device_ids": [] }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    let body: Value = res.json().await.unwrap();
+    assert_eq!(body["errors"], 1);
+    assert_eq!(body["sent"], 0);
+}
+
+// ============================================================
+// test_fcm_all_exclude: DB error
+// ============================================================
+
+#[tokio::test]
+async fn test_fcm_all_exclude_db_error() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    mock.fail_next.store(true, Ordering::SeqCst);
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    state.fcm = Some(Arc::new(crate::common::MockFcmSender::new()));
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let client = reqwest::Client::new();
+    let res = client
+        .post(format!("{base_url}/api/devices/test-fcm-all-exclude"))
+        .json(&serde_json::json!({ "exclude_device_ids": [] }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}
+
+// ============================================================
+// test_fcm: device has no FCM token (null token)
+// ============================================================
+
+#[tokio::test]
+async fn test_fcm_single_device_null_token() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    mock.return_data.store(true, Ordering::SeqCst);
+    mock.return_null_fcm_token.store(true, Ordering::SeqCst);
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    state.fcm = Some(Arc::new(crate::common::MockFcmSender::new()));
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let tenant_id = Uuid::new_v4();
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+    let id = Uuid::new_v4();
+
+    let res = client
+        .post(format!("{base_url}/api/devices/{id}/test-fcm"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 400);
+}
+
+// ============================================================
+// test_fcm: DB error
+// ============================================================
+
+#[tokio::test]
+async fn test_fcm_single_device_db_error() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    mock.fail_next.store(true, Ordering::SeqCst);
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    state.fcm = Some(Arc::new(crate::common::MockFcmSender::new()));
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let tenant_id = Uuid::new_v4();
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+    let id = Uuid::new_v4();
+
+    let res = client
+        .post(format!("{base_url}/api/devices/{id}/test-fcm"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}
+
+// ============================================================
+// test_fcm_all: with FailingFcmSender
+// ============================================================
+
+#[tokio::test]
+async fn test_fcm_all_failing_sender() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    mock.return_data.store(true, Ordering::SeqCst);
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    state.fcm = Some(Arc::new(crate::common::FailingFcmSender));
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let tenant_id = Uuid::new_v4();
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/devices/test-fcm-all"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    let body: Value = res.json().await.unwrap();
+    assert_eq!(body["errors"], 1);
+    assert_eq!(body["sent"], 0);
+    let results = body["results"].as_array().unwrap();
+    assert_eq!(results[0]["success"], false);
+    assert!(results[0]["error"].as_str().is_some());
+}
+
+// ============================================================
+// test_fcm_all: DB error
+// ============================================================
+
+#[tokio::test]
+async fn test_fcm_all_db_error() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    mock.fail_next.store(true, Ordering::SeqCst);
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    state.fcm = Some(Arc::new(crate::common::MockFcmSender::new()));
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let tenant_id = Uuid::new_v4();
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/devices/test-fcm-all"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}
+
+// ============================================================
+// trigger_update: no FCM configured
+// ============================================================
+
+#[tokio::test]
+async fn test_trigger_update_no_fcm() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    // fcm = None
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let tenant_id = Uuid::new_v4();
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/devices/trigger-update"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .json(&serde_json::json!({ "version_code": 99 }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 503);
+}
+
+// ============================================================
+// trigger_update: with device_ids filter
+// ============================================================
+
+#[tokio::test]
+async fn test_trigger_update_with_device_ids_filter() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    mock.return_data.store(true, Ordering::SeqCst);
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    state.fcm = Some(Arc::new(crate::common::MockFcmSender::new()));
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let tenant_id = Uuid::new_v4();
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    // Filter to a non-existing device ID -> skipped
+    let res = client
+        .post(format!("{base_url}/api/devices/trigger-update"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .json(&serde_json::json!({
+            "device_ids": [Uuid::new_v4()],
+            "version_code": 99,
+            "version_name": "9.9.9"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    let body: Value = res.json().await.unwrap();
+    assert_eq!(body["skipped"], 1);
+    assert_eq!(body["sent"], 0);
+}
+
+// ============================================================
+// trigger_update: with FailingFcmSender
+// ============================================================
+
+#[tokio::test]
+async fn test_trigger_update_fcm_error() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    mock.return_data.store(true, Ordering::SeqCst);
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    state.fcm = Some(Arc::new(crate::common::FailingFcmSender));
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let tenant_id = Uuid::new_v4();
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/devices/trigger-update"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .json(&serde_json::json!({
+            "version_code": 99,
+            "version_name": "9.9.9"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    let body: Value = res.json().await.unwrap();
+    assert_eq!(body["errors"], 1);
+    assert_eq!(body["sent"], 0);
+}
+
+// ============================================================
+// trigger_update: DB error
+// ============================================================
+
+#[tokio::test]
+async fn test_trigger_update_db_error() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    mock.fail_next.store(true, Ordering::SeqCst);
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    state.fcm = Some(Arc::new(crate::common::MockFcmSender::new()));
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let tenant_id = Uuid::new_v4();
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/devices/trigger-update"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .json(&serde_json::json!({ "version_code": 99 }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}
+
+// ============================================================
+// trigger_update: no version_code, device has no version
+// ============================================================
+
+#[tokio::test]
+async fn test_trigger_update_no_version_code() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    mock.return_data.store(true, Ordering::SeqCst);
+    mock.return_ota_no_version.store(true, Ordering::SeqCst);
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    state.fcm = Some(Arc::new(crate::common::MockFcmSender::new()));
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let tenant_id = Uuid::new_v4();
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    // No version_code in body + device has None -> skip version check, send update
+    let res = client
+        .post(format!("{base_url}/api/devices/trigger-update"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    let body: Value = res.json().await.unwrap();
+    assert_eq!(body["sent"], 1);
+}
+
+// ============================================================
+// trigger_update: with version_name only
+// ============================================================
+
+#[tokio::test]
+async fn test_trigger_update_with_version_name_only() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    mock.return_data.store(true, Ordering::SeqCst);
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    state.fcm = Some(Arc::new(crate::common::MockFcmSender::new()));
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let tenant_id = Uuid::new_v4();
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/devices/trigger-update"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .json(&serde_json::json!({ "version_name": "1.0.0" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    let body: Value = res.json().await.unwrap();
+    assert_eq!(body["sent"], 1);
+}
+
+// ============================================================
+// trigger_update: dev_only=true
+// ============================================================
+
+#[tokio::test]
+async fn test_trigger_update_dev_only() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    mock.return_data.store(true, Ordering::SeqCst);
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    state.fcm = Some(Arc::new(crate::common::MockFcmSender::new()));
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let tenant_id = Uuid::new_v4();
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/devices/trigger-update"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .json(&serde_json::json!({
+            "version_code": 99,
+            "dev_only": true
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+}
+
+// ============================================================
+// trigger_update_dev: with tenants
+// ============================================================
+
+#[tokio::test]
+async fn test_trigger_update_dev_with_tenants() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("FCM_INTERNAL_SECRET", "dev-secret-2");
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    mock.return_dev_tenants.store(true, Ordering::SeqCst);
+    mock.return_data.store(true, Ordering::SeqCst);
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    state.fcm = Some(Arc::new(crate::common::MockFcmSender::new()));
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let client = reqwest::Client::new();
+    let res = client
+        .post(format!("{base_url}/api/devices/trigger-update-dev"))
+        .header("X-Internal-Secret", "dev-secret-2")
+        .json(&serde_json::json!({ "version_code": 100 }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    let body: Value = res.json().await.unwrap();
+    // Devices have version_code=10 < 100, so should send
+    assert_eq!(body["sent"], 1);
+    std::env::remove_var("FCM_INTERNAL_SECRET");
+}
+
+// ============================================================
+// trigger_update_dev: DB error on list_dev_device_tenant_ids
+// ============================================================
+
+#[tokio::test]
+async fn test_trigger_update_dev_db_error() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("FCM_INTERNAL_SECRET", "dev-secret-3");
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    mock.fail_next.store(true, Ordering::SeqCst);
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    state.fcm = Some(Arc::new(crate::common::MockFcmSender::new()));
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let client = reqwest::Client::new();
+    let res = client
+        .post(format!("{base_url}/api/devices/trigger-update-dev"))
+        .header("X-Internal-Secret", "dev-secret-3")
+        .json(&serde_json::json!({ "version_code": 100 }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+    std::env::remove_var("FCM_INTERNAL_SECRET");
+}
+
+// ============================================================
+// trigger_update_dev: no FCM configured
+// ============================================================
+
+#[tokio::test]
+async fn test_trigger_update_dev_no_fcm() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("FCM_INTERNAL_SECRET", "dev-secret-4");
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    mock.return_dev_tenants.store(true, Ordering::SeqCst);
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    // fcm = None -> send_update_fcm returns 503 but trigger_update_dev catches it with if let Ok
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let client = reqwest::Client::new();
+    let res = client
+        .post(format!("{base_url}/api/devices/trigger-update-dev"))
+        .header("X-Internal-Secret", "dev-secret-4")
+        .json(&serde_json::json!({ "version_code": 100 }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    let body: Value = res.json().await.unwrap();
+    assert_eq!(body["sent"], 0);
+    std::env::remove_var("FCM_INTERNAL_SECRET");
+}
+
+// ============================================================
+// claim_registration: qr_permanent with no device_name
+// ============================================================
+
+#[tokio::test]
+async fn test_claim_qr_permanent_no_device_name() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    mock.return_data.store(true, Ordering::SeqCst);
+    mock.return_qr_permanent.store(true, Ordering::SeqCst);
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let client = reqwest::Client::new();
+    let res = client
+        .post(format!("{base_url}/api/devices/register/claim"))
+        .json(&serde_json::json!({
+            "registration_code": "QRCODE2"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    let body: Value = res.json().await.unwrap();
+    assert_eq!(body["success"], true);
+    assert_eq!(body["flow_type"], "qr_permanent");
+}
+
+// ============================================================
+// claim_registration: device_owner flow
+// ============================================================
+
+#[tokio::test]
+async fn test_claim_device_owner_flow() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    mock.return_data.store(true, Ordering::SeqCst);
+    // Default flow_type is "url", which covers url|device_owner match arm
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let client = reqwest::Client::new();
+    let res = client
+        .post(format!("{base_url}/api/devices/register/claim"))
+        .json(&serde_json::json!({
+            "registration_code": "DOCODE",
+            "device_name": ""
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    let body: Value = res.json().await.unwrap();
+    assert_eq!(body["success"], true);
+    assert_eq!(body["flow_type"], "url");
+}
+
+// ============================================================
+// fcm_notify_call: correct secret header
+// ============================================================
+
+#[tokio::test]
+async fn test_fcm_notify_call_correct_secret() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("FCM_INTERNAL_SECRET", "correct-secret-2");
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    state.fcm = Some(Arc::new(crate::common::MockFcmSender::new()));
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let client = reqwest::Client::new();
+    let res = client
+        .post(format!("{base_url}/api/devices/fcm-notify-call"))
+        .header("X-Internal-Secret", "correct-secret-2")
+        .json(&serde_json::json!({ "room_ids": [] }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    std::env::remove_var("FCM_INTERNAL_SECRET");
+}

--- a/tests/mock_tests/mock_devices_test.rs
+++ b/tests/mock_tests/mock_devices_test.rs
@@ -36,6 +36,30 @@ async fn test_register_request_success() {
 }
 
 #[tokio::test]
+async fn test_register_request_code_collision_retry() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    mock.return_code_exists_once
+        .store(true, std::sync::atomic::Ordering::Relaxed);
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let client = reqwest::Client::new();
+    let res = client
+        .post(format!("{base_url}/api/devices/register/request"))
+        .json(&serde_json::json!({ "device_name": "Collision Device" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    let body: Value = res.json().await.unwrap();
+    assert!(body["registration_code"].as_str().is_some());
+}
+
+#[tokio::test]
 async fn test_register_request_no_device_name() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);

--- a/tests/mock_tests/mock_devices_test.rs
+++ b/tests/mock_tests/mock_devices_test.rs
@@ -3266,3 +3266,277 @@ async fn test_fcm_notify_call_correct_secret() {
     assert_eq!(res.status(), 200);
     std::env::remove_var("FCM_INTERNAL_SECRET");
 }
+
+// ============================================================
+// approve: create_device fails (lookup succeeds, create fails)
+// ============================================================
+
+#[tokio::test]
+async fn test_approve_device_create_db_error() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    mock.return_data.store(true, Ordering::SeqCst); // find_approve_request returns Some
+    mock.fail_on_approve.store(true, Ordering::SeqCst); // approve_device fails
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let tenant_id = Uuid::new_v4();
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+    let req_id = Uuid::new_v4();
+
+    let res = client
+        .post(format!("{base_url}/api/devices/approve/{req_id}"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}
+
+// ============================================================
+// approve_by_code: create_device fails (lookup succeeds, create fails)
+// ============================================================
+
+#[tokio::test]
+async fn test_approve_by_code_create_db_error() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    mock.return_data.store(true, Ordering::SeqCst); // find_approve_by_code_request returns Some
+    mock.fail_on_approve.store(true, Ordering::SeqCst); // approve_by_code fails
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let tenant_id = Uuid::new_v4();
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/devices/approve-by-code/ABC123"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}
+
+// ============================================================
+// report_watchdog_state: update fails (lookup succeeds, update fails)
+// ============================================================
+
+#[tokio::test]
+async fn test_report_watchdog_update_db_error() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    mock.return_data.store(true, Ordering::SeqCst); // lookup_device_tenant returns Some
+    mock.fail_on_update.store(true, Ordering::SeqCst); // update_watchdog_state fails
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let client = reqwest::Client::new();
+    let res = client
+        .put(format!("{base_url}/api/devices/report-watchdog"))
+        .json(&serde_json::json!({
+            "device_id": Uuid::new_v4(),
+            "running": true
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}
+
+// ============================================================
+// register_fcm_token: update fails (lookup succeeds, update fails)
+// ============================================================
+
+#[tokio::test]
+async fn test_register_fcm_token_update_db_error() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    mock.return_data.store(true, Ordering::SeqCst); // lookup_device_tenant returns Some
+    mock.fail_on_update.store(true, Ordering::SeqCst); // update_fcm_token fails
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let client = reqwest::Client::new();
+    let res = client
+        .put(format!("{base_url}/api/devices/register-fcm-token"))
+        .json(&serde_json::json!({
+            "device_id": Uuid::new_v4(),
+            "fcm_token": "test-token"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}
+
+// ============================================================
+// update_last_login: update fails (lookup succeeds, update fails)
+// ============================================================
+
+#[tokio::test]
+async fn test_update_last_login_update_db_error() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    mock.return_data.store(true, Ordering::SeqCst); // lookup_device_tenant returns Some
+    mock.fail_on_update.store(true, Ordering::SeqCst); // update_last_login fails
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let client = reqwest::Client::new();
+    let res = client
+        .put(format!("{base_url}/api/devices/update-last-login"))
+        .json(&serde_json::json!({
+            "device_id": Uuid::new_v4(),
+            "employee_id": Uuid::new_v4(),
+            "employee_name": "Taro",
+            "employee_role": ["driver"]
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}
+
+// ============================================================
+// report_version: update fails (lookup succeeds, update fails)
+// ============================================================
+
+#[tokio::test]
+async fn test_report_version_update_db_error() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    mock.return_data.store(true, Ordering::SeqCst); // lookup_device_tenant returns Some
+    mock.fail_on_update.store(true, Ordering::SeqCst); // report_version fails
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let client = reqwest::Client::new();
+    let res = client
+        .put(format!("{base_url}/api/devices/report-version"))
+        .json(&serde_json::json!({
+            "device_id": Uuid::new_v4(),
+            "version_code": 1,
+            "version_name": "0.0.1"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}
+
+// ============================================================
+// should_notify_device: days mismatch (line 1117)
+// ============================================================
+
+#[tokio::test]
+async fn test_fcm_notify_call_schedule_days_mismatch_skipped() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::remove_var("FCM_INTERNAL_SECRET");
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    mock.return_data.store(true, Ordering::SeqCst);
+    mock.return_schedule_days_mismatch
+        .store(true, Ordering::SeqCst);
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    state.fcm = Some(Arc::new(crate::common::MockFcmSender::new()));
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let client = reqwest::Client::new();
+    let res = client
+        .post(format!("{base_url}/api/devices/fcm-notify-call"))
+        .json(&serde_json::json!({ "room_ids": ["room-1"] }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    let body: Value = res.json().await.unwrap();
+    assert_eq!(body["sent"], 0);
+    assert_eq!(body["skipped"], 1);
+}
+
+// ============================================================
+// should_notify_device: overnight schedule (start > end, line 1142)
+// ============================================================
+
+#[tokio::test]
+async fn test_fcm_notify_call_schedule_overnight_sent() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::remove_var("FCM_INTERNAL_SECRET");
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    mock.return_data.store(true, Ordering::SeqCst);
+    mock.return_schedule_overnight.store(true, Ordering::SeqCst);
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    state.fcm = Some(Arc::new(crate::common::MockFcmSender::new()));
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let client = reqwest::Client::new();
+    let res = client
+        .post(format!("{base_url}/api/devices/fcm-notify-call"))
+        .json(&serde_json::json!({ "room_ids": ["room-1"] }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    let body: Value = res.json().await.unwrap();
+    // overnight schedule: startHour=23, startMin=59, endHour=23, endMin=58
+    // start = 23*60+59 = 1439, end = 23*60+58 = 1438
+    // start > end → overnight branch: current >= 1439 || current < 1438
+    // This covers almost all times (only 23:58 would miss), so sent=1
+    assert_eq!(body["sent"], 1);
+}
+
+// ============================================================
+// fcm_dismiss_test: tokens returned → sent > 0 (lines 1181-1185)
+// ============================================================
+
+#[tokio::test]
+async fn test_fcm_dismiss_test_with_tokens_sent() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    mock.return_data.store(true, Ordering::SeqCst); // get_device_tenant_active returns Some
+    mock.return_fcm_tokens.store(true, Ordering::SeqCst); // list_tenant_fcm_tokens_except returns tokens
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    state.fcm = Some(Arc::new(crate::common::MockFcmSender::new()));
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let client = reqwest::Client::new();
+    let res = client
+        .post(format!("{base_url}/api/devices/fcm-dismiss-test"))
+        .json(&serde_json::json!({ "device_id": Uuid::new_v4() }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    let body: Value = res.json().await.unwrap();
+    assert_eq!(body["sent"], 1);
+}

--- a/tests/mock_tests/mock_dtako_restraint_report_test.rs
+++ b/tests/mock_tests/mock_dtako_restraint_report_test.rs
@@ -3,9 +3,12 @@ use uuid::Uuid;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
+use chrono::{Datelike, NaiveDate, NaiveTime, TimeZone, Utc};
 use serde_json::Value;
 
-use rust_alc_api::db::repository::dtako_restraint_report::DtakoRestraintReportRepository;
+use rust_alc_api::db::repository::dtako_restraint_report::{
+    DailyWorkHoursRow, DtakoRestraintReportRepository, OpTimesRow, SegmentRow,
+};
 
 // ============================================================
 // Helper: spawn server with a given mock
@@ -339,4 +342,862 @@ async fn test_compare_csv_with_matching_driver() {
     // Driver matched → driver_id is set, system data is present
     assert_eq!(body[0]["driver_id"], driver_id.to_string());
     assert!(body[0]["system"].is_object());
+}
+
+// ============================================================
+// Helper: build a mock with segment/dwh/op_times data for a given month
+// ============================================================
+
+fn make_segment(date: NaiveDate, unko_no: &str, work: i32, drive: i32, cargo: i32) -> SegmentRow {
+    let start = Utc
+        .with_ymd_and_hms(date.year(), date.month(), date.day(), 8, 0, 0)
+        .unwrap();
+    let end = Utc
+        .with_ymd_and_hms(date.year(), date.month(), date.day(), 17, 0, 0)
+        .unwrap();
+    SegmentRow {
+        work_date: date,
+        unko_no: unko_no.to_string(),
+        start_at: start,
+        end_at: end,
+        work_minutes: work,
+        drive_minutes: drive,
+        cargo_minutes: cargo,
+    }
+}
+
+fn make_dwh(date: NaiveDate, drive: i32, cargo: i32, total_work: i32) -> DailyWorkHoursRow {
+    DailyWorkHoursRow {
+        work_date: date,
+        start_time: NaiveTime::from_hms_opt(8, 0, 0).unwrap(),
+        total_work_minutes: total_work,
+        total_rest_minutes: Some(30),
+        late_night_minutes: 10,
+        drive_minutes: drive,
+        cargo_minutes: cargo,
+        overlap_drive_minutes: 5,
+        overlap_cargo_minutes: 3,
+        overlap_break_minutes: 2,
+        overlap_restraint_minutes: 10,
+        ot_late_night_minutes: 5,
+    }
+}
+
+fn make_op_times(date: NaiveDate) -> OpTimesRow {
+    let dep = Utc
+        .with_ymd_and_hms(date.year(), date.month(), date.day(), 8, 15, 0)
+        .unwrap();
+    let end = Utc
+        .with_ymd_and_hms(date.year(), date.month(), date.day(), 17, 30, 0)
+        .unwrap();
+    OpTimesRow {
+        operation_date: date,
+        first_departure: dep,
+        last_seg_end: end,
+    }
+}
+
+// ============================================================
+// GET /api/restraint-report — invalid year/month → 400
+// ============================================================
+
+#[tokio::test]
+async fn test_get_restraint_report_invalid_month() {
+    let mock = Arc::new(crate::mock_helpers::MockDtakoRestraintReportRepository::default());
+    let (base_url, jwt, _) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    let driver_id = Uuid::new_v4();
+    // month=13 → invalid
+    let res = client
+        .get(format!(
+            "{base_url}/api/restraint-report?driver_id={driver_id}&year=2026&month=13"
+        ))
+        .header("Authorization", auth(&jwt))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 400);
+    let body = res.text().await.unwrap();
+    assert!(body.contains("invalid year/month"), "body: {body}");
+}
+
+// ============================================================
+// GET /api/restraint-report — month=12 (December boundary)
+// ============================================================
+
+#[tokio::test]
+async fn test_get_restraint_report_december() {
+    let mock = Arc::new(crate::mock_helpers::MockDtakoRestraintReportRepository::default());
+    let (base_url, jwt, _) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    let driver_id = Uuid::new_v4();
+    let res = client
+        .get(format!(
+            "{base_url}/api/restraint-report?driver_id={driver_id}&year=2025&month=12"
+        ))
+        .header("Authorization", auth(&jwt))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+
+    let body: Value = res.json().await.unwrap();
+    assert_eq!(body["year"], 2025);
+    assert_eq!(body["month"], 12);
+    // December should have 31 days
+    assert_eq!(body["days"].as_array().unwrap().len(), 31);
+}
+
+// ============================================================
+// GET /api/restraint-report — with segments + dwh + op_times data
+// ============================================================
+
+#[tokio::test]
+async fn test_get_restraint_report_with_rich_data() {
+    let mock = Arc::new(crate::mock_helpers::MockDtakoRestraintReportRepository::default());
+    mock.return_driver_name.store(true, Ordering::SeqCst);
+
+    let d1 = NaiveDate::from_ymd_opt(2026, 1, 5).unwrap(); // Monday
+    let d2 = NaiveDate::from_ymd_opt(2026, 1, 6).unwrap(); // Tuesday
+
+    // Segments: 2 operations on day 1, 1 on day 2
+    *mock.segments.lock().unwrap() = vec![
+        make_segment(d1, "OP001", 480, 300, 120),
+        make_segment(d1, "OP002", 120, 60, 30),
+        make_segment(d2, "OP003", 540, 360, 100),
+    ];
+
+    // Daily work hours
+    *mock.daily_work_hours.lock().unwrap() =
+        vec![make_dwh(d1, 360, 150, 600), make_dwh(d2, 360, 100, 540)];
+
+    // Operation times
+    *mock.op_times.lock().unwrap() = vec![make_op_times(d1), make_op_times(d2)];
+
+    // Previous day drive
+    *mock.prev_day_drive.lock().unwrap() = Some(200);
+
+    // Fiscal cumulative (January → fiscal year start is April of previous year)
+    *mock.fiscal_cumulative.lock().unwrap() = 5000;
+
+    let (base_url, jwt, _) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    let driver_id = Uuid::new_v4();
+    let res = client
+        .get(format!(
+            "{base_url}/api/restraint-report?driver_id={driver_id}&year=2026&month=1"
+        ))
+        .header("Authorization", auth(&jwt))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+
+    let body: Value = res.json().await.unwrap();
+    assert_eq!(body["driver_name"], "テスト太郎");
+    assert_eq!(body["year"], 2026);
+    assert_eq!(body["month"], 1);
+    assert_eq!(body["max_restraint_minutes"], 16500);
+
+    // Check days array has 31 entries (January)
+    let days = body["days"].as_array().unwrap();
+    assert_eq!(days.len(), 31);
+
+    // Day 5 (index 4) should have data
+    let day5 = &days[4];
+    assert!(!day5["is_holiday"].as_bool().unwrap());
+    assert_eq!(day5["start_time"], "8:15");
+    assert_eq!(day5["end_time"], "17:30");
+    assert!(day5["drive_minutes"].as_i64().unwrap() > 0);
+    assert!(day5["cargo_minutes"].as_i64().unwrap() > 0);
+    assert!(day5["restraint_total_minutes"].as_i64().unwrap() > 0);
+    assert!(day5["restraint_cumulative_minutes"].as_i64().unwrap() > 0);
+    assert!(day5["overlap_drive_minutes"].as_i64().unwrap() > 0);
+    assert!(day5["overlap_cargo_minutes"].as_i64().unwrap() > 0);
+    assert!(day5["overlap_break_minutes"].as_i64().unwrap() > 0);
+    assert!(day5["overlap_restraint_minutes"].as_i64().unwrap() > 0);
+    assert!(day5["actual_work_minutes"].as_i64().unwrap() > 0);
+    assert!(day5["restraint_main_minutes"].as_i64().unwrap() > 0);
+    // drive_avg_before should be set (prev_day_drive=200)
+    assert!(day5["drive_avg_before"].is_number());
+    // drive_avg_after should be set (pass 2)
+    assert!(day5["drive_avg_after"].is_number());
+
+    // Day 6 (index 5) should also have data
+    let day6 = &days[5];
+    assert!(!day6["is_holiday"].as_bool().unwrap());
+    assert!(day6["drive_minutes"].as_i64().unwrap() > 0);
+
+    // Operations array on day 5 should have 2 entries (OP001, OP002)
+    let ops = day5["operations"].as_array().unwrap();
+    assert_eq!(ops.len(), 2);
+
+    // Holiday days should have remarks = "休"
+    let day1 = &days[0]; // Jan 1
+    assert!(day1["is_holiday"].as_bool().unwrap());
+    assert_eq!(day1["remarks"], "休");
+
+    // Weekly subtotals should exist (we have work data)
+    let ws = body["weekly_subtotals"].as_array().unwrap();
+    assert!(!ws.is_empty());
+    // At least one weekly subtotal has positive restraint
+    assert!(ws
+        .iter()
+        .any(|w| w["restraint_minutes"].as_i64().unwrap() > 0));
+
+    // Monthly total
+    let mt = &body["monthly_total"];
+    assert!(mt["drive_minutes"].as_i64().unwrap() > 0);
+    assert!(mt["restraint_minutes"].as_i64().unwrap() > 0);
+    assert_eq!(mt["fiscal_year_cumulative_minutes"], 5000);
+    assert!(mt["fiscal_year_total_minutes"].as_i64().unwrap() > 5000);
+}
+
+// ============================================================
+// GET /api/restraint-report — multiple dwh rows on same day
+// ============================================================
+
+#[tokio::test]
+async fn test_get_restraint_report_multiple_dwh_same_day() {
+    let mock = Arc::new(crate::mock_helpers::MockDtakoRestraintReportRepository::default());
+
+    let d1 = NaiveDate::from_ymd_opt(2026, 3, 2).unwrap();
+
+    *mock.segments.lock().unwrap() = vec![make_segment(d1, "OP001", 480, 300, 120)];
+
+    // Two DWH rows on the same day (representing multi-shift)
+    let mut dwh1 = make_dwh(d1, 200, 80, 350);
+    dwh1.start_time = NaiveTime::from_hms_opt(1, 17, 0).unwrap();
+    let mut dwh2 = make_dwh(d1, 160, 70, 300);
+    dwh2.start_time = NaiveTime::from_hms_opt(23, 17, 0).unwrap();
+    *mock.daily_work_hours.lock().unwrap() = vec![dwh1, dwh2];
+
+    *mock.op_times.lock().unwrap() = vec![make_op_times(d1)];
+
+    let (base_url, jwt, _) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    let driver_id = Uuid::new_v4();
+    let res = client
+        .get(format!(
+            "{base_url}/api/restraint-report?driver_id={driver_id}&year=2026&month=3"
+        ))
+        .header("Authorization", auth(&jwt))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+
+    let body: Value = res.json().await.unwrap();
+    let days = body["days"].as_array().unwrap();
+
+    // Day 2 should generate 2 rows (multi-dwh), so total > 31
+    // Count rows for March 2 (index 1 in original, but with 2 dwh rows it creates 2 entries)
+    let march2_rows: Vec<&Value> = days
+        .iter()
+        .filter(|d| d["date"].as_str().unwrap() == "2026-03-02")
+        .collect();
+    assert_eq!(
+        march2_rows.len(),
+        2,
+        "Should have 2 rows for same-day multi-DWH"
+    );
+
+    // First row should have operations, second should have empty operations
+    assert!(!march2_rows[0]["operations"].as_array().unwrap().is_empty());
+    assert!(march2_rows[1]["operations"].as_array().unwrap().is_empty());
+
+    // First row should have start_time from dwh (1:17)
+    assert_eq!(march2_rows[0]["start_time"], "1:17");
+    // Second row start_time should be from dwh2 (23:17)
+    assert_eq!(march2_rows[1]["start_time"], "23:17");
+}
+
+// ============================================================
+// GET /api/restraint-report — segments without dwh (fallback to segment sums)
+// ============================================================
+
+#[tokio::test]
+async fn test_get_restraint_report_segments_no_dwh() {
+    let mock = Arc::new(crate::mock_helpers::MockDtakoRestraintReportRepository::default());
+
+    let d1 = NaiveDate::from_ymd_opt(2026, 2, 10).unwrap();
+
+    // Segments present but no DWH rows
+    *mock.segments.lock().unwrap() = vec![
+        make_segment(d1, "OP001", 500, 300, 120),
+        make_segment(d1, "OP002", 200, 100, 60),
+    ];
+
+    // No dwh, no op_times → fallback to segment start/end
+    let (base_url, jwt, _) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    let driver_id = Uuid::new_v4();
+    let res = client
+        .get(format!(
+            "{base_url}/api/restraint-report?driver_id={driver_id}&year=2026&month=2"
+        ))
+        .header("Authorization", auth(&jwt))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+
+    let body: Value = res.json().await.unwrap();
+    let days = body["days"].as_array().unwrap();
+    assert_eq!(days.len(), 28); // Feb 2026
+
+    // Day 10 (index 9) should have data from segments
+    let day10 = &days[9];
+    assert!(!day10["is_holiday"].as_bool().unwrap());
+    // drive = sum of segment drives = 300 + 100 = 400
+    assert_eq!(day10["drive_minutes"], 400);
+    // cargo = sum of segment cargos = 120 + 60 = 180
+    assert_eq!(day10["cargo_minutes"], 180);
+    // restraint = sum of segment work = 500 + 200 = 700
+    assert_eq!(day10["restraint_main_minutes"], 700);
+    // No overlap
+    assert_eq!(day10["overlap_drive_minutes"], 0);
+    // start_time/end_time from segment timestamps (fallback)
+    assert!(day10["start_time"].is_string());
+    assert!(day10["end_time"].is_string());
+    // Operations should have 2 entries
+    assert_eq!(day10["operations"].as_array().unwrap().len(), 2);
+}
+
+// ============================================================
+// GET /api/restraint-report — fiscal year boundary (month=4, April)
+// ============================================================
+
+#[tokio::test]
+async fn test_get_restraint_report_fiscal_year_april() {
+    let mock = Arc::new(crate::mock_helpers::MockDtakoRestraintReportRepository::default());
+    // April: fiscal_year_start = same year April → prev_month_end = March 31
+    // fiscal_year_start <= prev_month_end is false (April 1 > March 31 is false, equal)
+    // Actually: fiscal_year_start = April 1, prev_month_end = March 31
+    // April 1 <= March 31 is false → fiscal_cum = 0 (else branch)
+    let (base_url, jwt, _) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    let driver_id = Uuid::new_v4();
+    let res = client
+        .get(format!(
+            "{base_url}/api/restraint-report?driver_id={driver_id}&year=2026&month=4"
+        ))
+        .header("Authorization", auth(&jwt))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+
+    let body: Value = res.json().await.unwrap();
+    // For April (first month of fiscal year), cumulative should be 0
+    assert_eq!(body["monthly_total"]["fiscal_year_cumulative_minutes"], 0);
+}
+
+// ============================================================
+// GET /api/restraint-report — with Sunday boundary for weekly subtotals
+// ============================================================
+
+#[tokio::test]
+async fn test_get_restraint_report_weekly_sunday_boundary() {
+    let mock = Arc::new(crate::mock_helpers::MockDtakoRestraintReportRepository::default());
+
+    // March 2026: March 1 is Sunday
+    // We need data spanning across a Sunday boundary
+    // Let's use January 2026: Jan 1 = Thursday, Jan 4 = Sunday
+    let d2 = NaiveDate::from_ymd_opt(2026, 1, 2).unwrap(); // Fri
+    let d3 = NaiveDate::from_ymd_opt(2026, 1, 3).unwrap(); // Sat
+    let d5 = NaiveDate::from_ymd_opt(2026, 1, 5).unwrap(); // Mon (after Sunday)
+    let d6 = NaiveDate::from_ymd_opt(2026, 1, 6).unwrap(); // Tue
+
+    *mock.segments.lock().unwrap() = vec![
+        make_segment(d2, "OP001", 480, 300, 120),
+        make_segment(d3, "OP002", 400, 250, 100),
+        make_segment(d5, "OP003", 500, 320, 130),
+        make_segment(d6, "OP004", 450, 280, 110),
+    ];
+
+    let (base_url, jwt, _) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    let driver_id = Uuid::new_v4();
+    let res = client
+        .get(format!(
+            "{base_url}/api/restraint-report?driver_id={driver_id}&year=2026&month=1"
+        ))
+        .header("Authorization", auth(&jwt))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+
+    let body: Value = res.json().await.unwrap();
+    let ws = body["weekly_subtotals"].as_array().unwrap();
+    // Should have at least 2 weekly subtotals (before and after Sunday boundary)
+    assert!(
+        ws.len() >= 2,
+        "Expected at least 2 weekly subtotals, got {}",
+        ws.len()
+    );
+    // Each subtotal should have positive restraint
+    for w in ws {
+        assert!(w["restraint_minutes"].as_i64().unwrap() > 0);
+        assert!(w["drive_minutes"].as_i64().unwrap() > 0);
+    }
+}
+
+// ============================================================
+// GET /api/restraint-report — drive_avg_after calculation
+// ============================================================
+
+#[tokio::test]
+async fn test_get_restraint_report_drive_avg_after() {
+    let mock = Arc::new(crate::mock_helpers::MockDtakoRestraintReportRepository::default());
+
+    // Two consecutive working days
+    let d1 = NaiveDate::from_ymd_opt(2026, 6, 1).unwrap();
+    let d2 = NaiveDate::from_ymd_opt(2026, 6, 2).unwrap();
+
+    *mock.segments.lock().unwrap() = vec![
+        make_segment(d1, "OP001", 600, 400, 100),
+        make_segment(d2, "OP002", 480, 300, 80),
+    ];
+
+    *mock.daily_work_hours.lock().unwrap() =
+        vec![make_dwh(d1, 400, 100, 600), make_dwh(d2, 300, 80, 480)];
+
+    let (base_url, jwt, _) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    let driver_id = Uuid::new_v4();
+    let res = client
+        .get(format!(
+            "{base_url}/api/restraint-report?driver_id={driver_id}&year=2026&month=6"
+        ))
+        .header("Authorization", auth(&jwt))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+
+    let body: Value = res.json().await.unwrap();
+    let days = body["days"].as_array().unwrap();
+
+    // Day 1 (index 0): drive=400, next day drive=300 → after = (400+300)/2 = 350
+    let day1 = &days[0];
+    assert_eq!(day1["drive_avg_after"], 350);
+
+    // Day 2 (index 1): drive=300, next day is holiday (drive=0) → after = (300+0)/2 = 150
+    let day2 = &days[1];
+    assert_eq!(day2["drive_avg_after"], 150);
+}
+
+// ============================================================
+// GET /api/restraint-report — overtime and late_night calculations
+// ============================================================
+
+#[tokio::test]
+async fn test_get_restraint_report_overtime_calculation() {
+    let mock = Arc::new(crate::mock_helpers::MockDtakoRestraintReportRepository::default());
+
+    let d1 = NaiveDate::from_ymd_opt(2026, 5, 1).unwrap();
+
+    *mock.segments.lock().unwrap() = vec![make_segment(d1, "OP001", 600, 400, 200)];
+
+    // DWH with actual_work > 480 → overtime
+    // drive=400, cargo=200, actual_work=600, overtime = (600-480)=120, ot_late_night=5 → overtime=115
+    let mut dwh = make_dwh(d1, 400, 200, 600);
+    dwh.ot_late_night_minutes = 20;
+    dwh.late_night_minutes = 30;
+    dwh.total_rest_minutes = Some(60);
+    *mock.daily_work_hours.lock().unwrap() = vec![dwh];
+
+    let (base_url, jwt, _) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    let driver_id = Uuid::new_v4();
+    let res = client
+        .get(format!(
+            "{base_url}/api/restraint-report?driver_id={driver_id}&year=2026&month=5"
+        ))
+        .header("Authorization", auth(&jwt))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+
+    let body: Value = res.json().await.unwrap();
+    let days = body["days"].as_array().unwrap();
+    let day1 = &days[0];
+
+    // actual_work = drive + cargo = 400 + 200 = 600
+    assert_eq!(day1["actual_work_minutes"], 600);
+    // total_overtime = (600 - 480).max(0) = 120
+    // overtime = (120 - 20).max(0) = 100
+    assert_eq!(day1["overtime_minutes"], 100);
+    assert_eq!(day1["late_night_minutes"], 30);
+    assert_eq!(day1["overtime_late_night_minutes"], 20);
+    // rest_period should be 60
+    assert_eq!(day1["rest_period_minutes"], 60);
+}
+
+// ============================================================
+// POST /api/restraint-report/compare-csv — with driver_cd filter
+// ============================================================
+
+#[tokio::test]
+async fn test_compare_csv_with_driver_cd_filter() {
+    let mock = Arc::new(crate::mock_helpers::MockDtakoRestraintReportRepository::default());
+    let (base_url, jwt, _) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    // CSV with driver_cd=001
+    let csv_content = "\
+氏名,テスト太郎,,001
+日付,休日,始業,終業,運転,重複運転,荷役,重複荷役,休憩,重複休憩,小計,重複小計,拘束合計,拘束累計,休息,実労,残業,深夜,残深夜,備考
+2月1日,,8:00,17:00,1:00,,1:00,,0:30,,2:30,,2:30,2:30,,,,,,
+合計,,,1:00,,1:00,,0:30,,,,2:30,,,,,,,,
+";
+
+    let part = reqwest::multipart::Part::bytes(csv_content.as_bytes().to_vec())
+        .file_name("test.csv")
+        .mime_str("text/csv")
+        .unwrap();
+    let form = reqwest::multipart::Form::new().part("file", part);
+
+    // Filter for driver_cd=999 → no match → empty results
+    let res = client
+        .post(format!(
+            "{base_url}/api/restraint-report/compare-csv?driver_cd=999"
+        ))
+        .header("Authorization", auth(&jwt))
+        .multipart(form)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+
+    let body: Vec<Value> = res.json().await.unwrap();
+    assert_eq!(
+        body.len(),
+        0,
+        "driver_cd filter should exclude non-matching drivers"
+    );
+
+    // Now filter for driver_cd=001 → should match
+    let part2 = reqwest::multipart::Part::bytes(csv_content.as_bytes().to_vec())
+        .file_name("test.csv")
+        .mime_str("text/csv")
+        .unwrap();
+    let form2 = reqwest::multipart::Form::new().part("file", part2);
+
+    let res2 = client
+        .post(format!(
+            "{base_url}/api/restraint-report/compare-csv?driver_cd=001"
+        ))
+        .header("Authorization", auth(&jwt))
+        .multipart(form2)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res2.status(), 200);
+
+    let body2: Vec<Value> = res2.json().await.unwrap();
+    assert_eq!(body2.len(), 1);
+    assert_eq!(body2[0]["driver_cd"], "001");
+}
+
+// ============================================================
+// POST /api/restraint-report/compare-csv — multipart with no file field → empty bytes → 400
+// ============================================================
+
+#[tokio::test]
+async fn test_compare_csv_empty_file_field() {
+    let mock = Arc::new(crate::mock_helpers::MockDtakoRestraintReportRepository::default());
+    let (base_url, jwt, _) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    // Send a file field with empty content
+    let part = reqwest::multipart::Part::bytes(Vec::new())
+        .file_name("empty.csv")
+        .mime_str("text/csv")
+        .unwrap();
+    let form = reqwest::multipart::Form::new().part("file", part);
+
+    let res = client
+        .post(format!("{base_url}/api/restraint-report/compare-csv"))
+        .header("Authorization", auth(&jwt))
+        .multipart(form)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 400);
+}
+
+// ============================================================
+// POST /api/restraint-report/compare-csv — with matching driver + system data + diffs
+// ============================================================
+
+#[tokio::test]
+async fn test_compare_csv_with_system_data_and_diffs() {
+    let driver_id = Uuid::new_v4();
+    let mock = Arc::new(crate::mock_helpers::MockDtakoRestraintReportRepository::default());
+    mock.return_driver_name.store(true, Ordering::SeqCst);
+
+    // Set up matching driver
+    *mock.drivers_with_cd.lock().unwrap() =
+        vec![(driver_id, Some("001".to_string()), "テスト太郎".to_string())];
+
+    // Add segment data so system report has non-zero values
+    let d1 = NaiveDate::from_ymd_opt(2026, 2, 1).unwrap();
+    *mock.segments.lock().unwrap() = vec![make_segment(d1, "OP001", 480, 300, 120)];
+    *mock.daily_work_hours.lock().unwrap() = vec![make_dwh(d1, 300, 120, 480)];
+    *mock.op_times.lock().unwrap() = vec![make_op_times(d1)];
+
+    let (base_url, jwt, _) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    // CSV that intentionally differs from system data to generate diffs
+    let csv_content = "\
+氏名,テスト太郎,,001
+日付,休日,始業,終業,運転,重複運転,荷役,重複荷役,休憩,重複休憩,小計,重複小計,拘束合計,拘束累計,休息,実労,残業,深夜,残深夜,備考
+2月1日,,8:00,17:00,9:99,,1:00,,0:30,,2:30,,2:30,2:30,,,,,,
+合計,,,9:99,,1:00,,0:30,,,,2:30,,,,,,,,
+";
+
+    let part = reqwest::multipart::Part::bytes(csv_content.as_bytes().to_vec())
+        .file_name("test.csv")
+        .mime_str("text/csv")
+        .unwrap();
+    let form = reqwest::multipart::Form::new().part("file", part);
+
+    let res = client
+        .post(format!("{base_url}/api/restraint-report/compare-csv"))
+        .header("Authorization", auth(&jwt))
+        .multipart(form)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+
+    let body: Vec<Value> = res.json().await.unwrap();
+    assert_eq!(body.len(), 1);
+    assert_eq!(body[0]["driver_id"], driver_id.to_string());
+    assert!(body[0]["system"].is_object());
+    // System data should have days
+    let sys = &body[0]["system"];
+    assert!(sys["days"].is_array());
+    let sys_days = sys["days"].as_array().unwrap();
+    assert!(!sys_days.is_empty());
+    // System total fields should be present
+    assert!(sys["total_drive"].is_string());
+    assert!(sys["total_restraint"].is_string());
+
+    // Diffs should exist (CSV drive "9:99" vs system drive)
+    let diffs = body[0]["diffs"].as_array().unwrap();
+    assert!(
+        !diffs.is_empty(),
+        "Should have diffs between CSV and system data"
+    );
+    // known_bug_diffs and unknown_diffs fields should be present
+    assert!(body[0]["known_bug_diffs"].is_number());
+    assert!(body[0]["unknown_diffs"].is_number());
+}
+
+// ============================================================
+// POST /api/restraint-report/compare-csv — matching driver but build_report fails
+// ============================================================
+
+#[tokio::test]
+async fn test_compare_csv_matching_driver_report_error() {
+    let driver_id = Uuid::new_v4();
+    let mock = Arc::new(crate::mock_helpers::MockDtakoRestraintReportRepository::default());
+
+    // Set up matching driver but DON'T set fail_next (fail_next would fail list_drivers_with_cd)
+    // Instead, the mock returns empty data, so the report succeeds but has no segments
+    *mock.drivers_with_cd.lock().unwrap() =
+        vec![(driver_id, Some("001".to_string()), "テスト太郎".to_string())];
+
+    let (base_url, jwt, _) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    let csv_content = "\
+氏名,テスト太郎,,001
+日付,休日,始業,終業,運転,重複運転,荷役,重複荷役,休憩,重複休憩,小計,重複小計,拘束合計,拘束累計,休息,実労,残業,深夜,残深夜,備考
+2月1日,,8:00,17:00,1:00,,1:00,,0:30,,2:30,,2:30,2:30,,,,,,
+合計,,,1:00,,1:00,,0:30,,,,2:30,,,,,,,,
+";
+
+    let part = reqwest::multipart::Part::bytes(csv_content.as_bytes().to_vec())
+        .file_name("test.csv")
+        .mime_str("text/csv")
+        .unwrap();
+    let form = reqwest::multipart::Form::new().part("file", part);
+
+    let res = client
+        .post(format!("{base_url}/api/restraint-report/compare-csv"))
+        .header("Authorization", auth(&jwt))
+        .multipart(form)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+
+    let body: Vec<Value> = res.json().await.unwrap();
+    assert_eq!(body.len(), 1);
+    // System data should be present (empty report, not error)
+    assert!(body[0]["system"].is_object());
+}
+
+// ============================================================
+// GET /api/restraint-report — month before April (fiscal year previous year)
+// ============================================================
+
+#[tokio::test]
+async fn test_get_restraint_report_january_fiscal_year() {
+    let mock = Arc::new(crate::mock_helpers::MockDtakoRestraintReportRepository::default());
+    // January → fiscal_year_start = previous year April
+    *mock.fiscal_cumulative.lock().unwrap() = 12000;
+
+    let (base_url, jwt, _) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    let driver_id = Uuid::new_v4();
+    let res = client
+        .get(format!(
+            "{base_url}/api/restraint-report?driver_id={driver_id}&year=2026&month=1"
+        ))
+        .header("Authorization", auth(&jwt))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+
+    let body: Value = res.json().await.unwrap();
+    assert_eq!(
+        body["monthly_total"]["fiscal_year_cumulative_minutes"],
+        12000
+    );
+}
+
+// ============================================================
+// POST /api/restraint-report/compare-csv — multiple drivers in CSV
+// ============================================================
+
+#[tokio::test]
+async fn test_compare_csv_multiple_drivers() {
+    let mock = Arc::new(crate::mock_helpers::MockDtakoRestraintReportRepository::default());
+    let (base_url, jwt, _) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    // Two drivers in one CSV
+    let csv_content = "\
+氏名,ドライバーA,,001
+日付,休日,始業,終業,運転,重複運転,荷役,重複荷役,休憩,重複休憩,小計,重複小計,拘束合計,拘束累計,休息,実労,残業,深夜,残深夜,備考
+2月1日,,8:00,17:00,1:00,,1:00,,0:30,,2:30,,2:30,2:30,,,,,,
+合計,,,1:00,,1:00,,0:30,,,,2:30,,,,,,,,
+氏名,ドライバーB,,002
+日付,休日,始業,終業,運転,重複運転,荷役,重複荷役,休憩,重複休憩,小計,重複小計,拘束合計,拘束累計,休息,実労,残業,深夜,残深夜,備考
+2月1日,,9:00,18:00,2:00,,0:30,,0:15,,2:45,,2:45,2:45,,,,,,
+合計,,,2:00,,0:30,,0:15,,,,2:45,,,,,,,,
+";
+
+    let part = reqwest::multipart::Part::bytes(csv_content.as_bytes().to_vec())
+        .file_name("test.csv")
+        .mime_str("text/csv")
+        .unwrap();
+    let form = reqwest::multipart::Form::new().part("file", part);
+
+    let res = client
+        .post(format!("{base_url}/api/restraint-report/compare-csv"))
+        .header("Authorization", auth(&jwt))
+        .multipart(form)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+
+    let body: Vec<Value> = res.json().await.unwrap();
+    assert_eq!(body.len(), 2);
+    assert_eq!(body[0]["driver_cd"], "001");
+    assert_eq!(body[1]["driver_cd"], "002");
+}
+
+// ============================================================
+// GET /api/restraint-report — rest_period_minutes = 0 should be None
+// ============================================================
+
+#[tokio::test]
+async fn test_get_restraint_report_rest_period_zero_filtered() {
+    let mock = Arc::new(crate::mock_helpers::MockDtakoRestraintReportRepository::default());
+
+    let d1 = NaiveDate::from_ymd_opt(2026, 7, 1).unwrap();
+
+    *mock.segments.lock().unwrap() = vec![make_segment(d1, "OP001", 480, 300, 120)];
+
+    let mut dwh = make_dwh(d1, 300, 120, 480);
+    dwh.total_rest_minutes = Some(0); // 0 should be filtered to None
+    *mock.daily_work_hours.lock().unwrap() = vec![dwh];
+
+    let (base_url, jwt, _) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    let driver_id = Uuid::new_v4();
+    let res = client
+        .get(format!(
+            "{base_url}/api/restraint-report?driver_id={driver_id}&year=2026&month=7"
+        ))
+        .header("Authorization", auth(&jwt))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+
+    let body: Value = res.json().await.unwrap();
+    let days = body["days"].as_array().unwrap();
+    let day1 = &days[0];
+    // rest_period_minutes = Some(0) filtered by .filter(|&v| v > 0) → None → null
+    assert!(day1["rest_period_minutes"].is_null());
+}
+
+// ============================================================
+// GET /api/restraint-report — no prev_day_drive → drive_avg = day_drive
+// ============================================================
+
+#[tokio::test]
+async fn test_get_restraint_report_no_prev_day_drive() {
+    let mock = Arc::new(crate::mock_helpers::MockDtakoRestraintReportRepository::default());
+
+    let d1 = NaiveDate::from_ymd_opt(2026, 8, 1).unwrap();
+
+    *mock.segments.lock().unwrap() = vec![make_segment(d1, "OP001", 480, 300, 120)];
+    *mock.daily_work_hours.lock().unwrap() = vec![make_dwh(d1, 300, 120, 480)];
+    // prev_day_drive = None (default)
+
+    let (base_url, jwt, _) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    let driver_id = Uuid::new_v4();
+    let res = client
+        .get(format!(
+            "{base_url}/api/restraint-report?driver_id={driver_id}&year=2026&month=8"
+        ))
+        .header("Authorization", auth(&jwt))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+
+    let body: Value = res.json().await.unwrap();
+    let days = body["days"].as_array().unwrap();
+    let day1 = &days[0];
+    // No prev_day_drive → drive_avg_before = None
+    assert!(day1["drive_avg_before"].is_null());
+    // drive_average = day_drive as f64 = 300.0
+    assert_eq!(day1["drive_average_minutes"].as_f64().unwrap(), 300.0);
 }

--- a/tests/mock_tests/mock_dtako_restraint_report_test.rs
+++ b/tests/mock_tests/mock_dtako_restraint_report_test.rs
@@ -9,6 +9,9 @@ use serde_json::Value;
 use rust_alc_api::db::repository::dtako_restraint_report::{
     DailyWorkHoursRow, DtakoRestraintReportRepository, OpTimesRow, SegmentRow,
 };
+use rust_alc_api::routes::dtako_restraint_report::{
+    parse_hhmm, report_to_csv_days, MonthlyTotal, RestraintDayRow, RestraintReportResponse,
+};
 
 // ============================================================
 // Helper: spawn server with a given mock
@@ -1200,4 +1203,230 @@ async fn test_get_restraint_report_no_prev_day_drive() {
     assert!(day1["drive_avg_before"].is_null());
     // drive_average = day_drive as f64 = 300.0
     assert_eq!(day1["drive_average_minutes"].as_f64().unwrap(), 300.0);
+}
+
+// ============================================================
+// report_to_csv_days — direct unit test (covers lines 567-594)
+// ============================================================
+
+#[test]
+fn test_report_to_csv_days_direct() {
+    let report = RestraintReportResponse {
+        driver_id: Uuid::nil(),
+        driver_name: "テスト運転者".to_string(),
+        year: 2026,
+        month: 2,
+        max_restraint_minutes: 16500,
+        days: vec![
+            RestraintDayRow {
+                date: NaiveDate::from_ymd_opt(2026, 2, 1).unwrap(),
+                is_holiday: false,
+                start_time: Some("8:00".to_string()),
+                end_time: Some("17:00".to_string()),
+                operations: vec![],
+                drive_minutes: 300,
+                cargo_minutes: 120,
+                break_minutes: 60,
+                restraint_total_minutes: 540,
+                restraint_cumulative_minutes: 540,
+                drive_average_minutes: 300.0,
+                rest_period_minutes: Some(45),
+                remarks: "メモ".to_string(),
+                overlap_drive_minutes: 10,
+                overlap_cargo_minutes: 5,
+                overlap_break_minutes: 3,
+                overlap_restraint_minutes: 18,
+                restraint_main_minutes: 480,
+                drive_avg_before: Some(250),
+                drive_avg_after: Some(280),
+                actual_work_minutes: 420,
+                overtime_minutes: 60,
+                late_night_minutes: 30,
+                overtime_late_night_minutes: 15,
+            },
+            RestraintDayRow {
+                date: NaiveDate::from_ymd_opt(2026, 2, 2).unwrap(),
+                is_holiday: true,
+                start_time: None,
+                end_time: None,
+                operations: vec![],
+                drive_minutes: 0,
+                cargo_minutes: 0,
+                break_minutes: 0,
+                restraint_total_minutes: 0,
+                restraint_cumulative_minutes: 540,
+                drive_average_minutes: 0.0,
+                rest_period_minutes: None,
+                remarks: "休".to_string(),
+                overlap_drive_minutes: 0,
+                overlap_cargo_minutes: 0,
+                overlap_break_minutes: 0,
+                overlap_restraint_minutes: 0,
+                restraint_main_minutes: 0,
+                drive_avg_before: None,
+                drive_avg_after: None,
+                actual_work_minutes: 0,
+                overtime_minutes: 0,
+                late_night_minutes: 0,
+                overtime_late_night_minutes: 0,
+            },
+        ],
+        weekly_subtotals: vec![],
+        monthly_total: MonthlyTotal {
+            drive_minutes: 300,
+            cargo_minutes: 120,
+            break_minutes: 60,
+            restraint_minutes: 540,
+            fiscal_year_cumulative_minutes: 0,
+            fiscal_year_total_minutes: 540,
+            overlap_drive_minutes: 10,
+            overlap_cargo_minutes: 5,
+            overlap_break_minutes: 3,
+            overlap_restraint_minutes: 18,
+            actual_work_minutes: 420,
+            overtime_minutes: 60,
+            late_night_minutes: 30,
+            overtime_late_night_minutes: 15,
+        },
+    };
+
+    let csv_days = report_to_csv_days(&report);
+    assert_eq!(csv_days.len(), 2);
+
+    // Working day
+    let d0 = &csv_days[0];
+    assert_eq!(d0.date, "2月1日");
+    assert!(!d0.is_holiday);
+    assert_eq!(d0.start_time, "8:00");
+    assert_eq!(d0.end_time, "17:00");
+    assert_eq!(d0.drive, "5:00");
+    assert_eq!(d0.overlap_drive, "0:10");
+    assert_eq!(d0.cargo, "2:00");
+    assert_eq!(d0.overlap_cargo, "0:05");
+    assert_eq!(d0.break_time, "1:00");
+    assert_eq!(d0.overlap_break, "0:03");
+    assert_eq!(d0.subtotal, "8:00");
+    assert_eq!(d0.overlap_subtotal, "0:18");
+    assert_eq!(d0.total, "9:00");
+    assert_eq!(d0.cumulative, "9:00");
+    assert_eq!(d0.rest, "0:45");
+    assert_eq!(d0.actual_work, "7:00");
+    assert_eq!(d0.overtime, "1:00");
+    assert_eq!(d0.late_night, "0:30");
+    assert_eq!(d0.ot_late_night, "0:15");
+    assert_eq!(d0.remarks, "メモ");
+
+    // Holiday
+    let d1 = &csv_days[1];
+    assert_eq!(d1.date, "2月2日");
+    assert!(d1.is_holiday);
+    assert_eq!(d1.start_time, "");
+    assert_eq!(d1.end_time, "");
+    assert_eq!(d1.rest, ""); // None → empty
+    assert_eq!(d1.drive, "");
+    assert_eq!(d1.remarks, "休");
+}
+
+// ============================================================
+// parse_hhmm — direct unit test (covers lines 597-609)
+// ============================================================
+
+#[test]
+fn test_parse_hhmm_direct() {
+    // Empty string → 0
+    assert_eq!(parse_hhmm(""), 0);
+    // Whitespace-only → trimmed to empty → 0
+    assert_eq!(parse_hhmm("  "), 0);
+    // Valid HH:MM
+    assert_eq!(parse_hhmm("5:18"), 318);
+    assert_eq!(parse_hhmm("9:25"), 565);
+    assert_eq!(parse_hhmm("0:03"), 3);
+    assert_eq!(parse_hhmm("242:40"), 14560);
+    // Invalid: no colon → parts.len() != 2 → 0
+    assert_eq!(parse_hhmm("123"), 0);
+    // Invalid: multiple colons → parts.len() != 2 → 0
+    assert_eq!(parse_hhmm("1:2:3"), 0);
+    // Non-numeric → parse().unwrap_or(0)
+    assert_eq!(parse_hhmm("abc:def"), 0);
+    // Leading/trailing whitespace trimmed
+    assert_eq!(parse_hhmm(" 1:30 "), 90);
+}
+
+// ============================================================
+// POST compare-csv — holiday row + missing sys day (covers lines 801, 813)
+// ============================================================
+
+#[tokio::test]
+async fn test_compare_csv_holiday_and_missing_sys_day() {
+    let driver_id = Uuid::new_v4();
+    let mock = Arc::new(crate::mock_helpers::MockDtakoRestraintReportRepository::default());
+    mock.return_driver_name.store(true, Ordering::SeqCst);
+
+    // Set up matching driver
+    *mock.drivers_with_cd.lock().unwrap() =
+        vec![(driver_id, Some("001".to_string()), "テスト太郎".to_string())];
+
+    // Add segment data for Feb 2
+    let d1 = NaiveDate::from_ymd_opt(2026, 2, 2).unwrap();
+    *mock.segments.lock().unwrap() = vec![make_segment(d1, "OP001", 480, 300, 120)];
+    *mock.daily_work_hours.lock().unwrap() = vec![make_dwh(d1, 300, 120, 480)];
+    *mock.op_times.lock().unwrap() = vec![make_op_times(d1)];
+
+    let (base_url, jwt, _) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    // CSV with:
+    // - 2月1日 as holiday (is_holiday=true) → line 801: continue
+    // - 2月2日 normal day (matches system)
+    // - 2月29日 does not exist in system (Feb 2026 has 28 days) → line 813: None => continue
+    let csv_content = "\
+氏名,テスト太郎,,001
+日付,休日,始業,終業,運転,重複運転,荷役,重複荷役,休憩,重複休憩,小計,重複小計,拘束合計,拘束累計,休息,実労,残業,深夜,残深夜,備考
+2月1日,休,,,,,,,,,,,,,,,,,,
+2月2日,,8:00,17:00,5:00,,2:00,,1:00,,8:00,,9:00,9:00,,7:00,1:00,0:30,0:15,
+2月29日,,8:00,17:00,5:00,,2:00,,1:00,,8:00,,9:00,18:00,,7:00,1:00,0:30,0:15,
+合計,,,5:00,,2:00,,1:00,,,,9:00,,,,,,,,
+";
+
+    let part = reqwest::multipart::Part::bytes(csv_content.as_bytes().to_vec())
+        .file_name("test.csv")
+        .mime_str("text/csv")
+        .unwrap();
+    let form = reqwest::multipart::Form::new().part("file", part);
+
+    let res = client
+        .post(format!("{base_url}/api/restraint-report/compare-csv"))
+        .header("Authorization", auth(&jwt))
+        .multipart(form)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+
+    let body: Vec<Value> = res.json().await.unwrap();
+    assert_eq!(body.len(), 1);
+    assert_eq!(body[0]["driver_id"], driver_id.to_string());
+    // System data should be present
+    assert!(body[0]["system"].is_object());
+}
+
+/// POST compare-csv: 空のマルチパート (ファイルフィールドなし) → 400
+#[tokio::test]
+async fn test_compare_csv_empty_multipart_no_field() {
+    use crate::mock_helpers::MockDtakoRestraintReportRepository;
+    let mock = Arc::new(MockDtakoRestraintReportRepository::default());
+    let (base_url, jwt, _) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    // 空の multipart — next_field() が None → Vec::new() → is_empty → 400
+    let form = reqwest::multipart::Form::new();
+
+    let res = client
+        .post(format!("{base_url}/api/restraint-report/compare-csv"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .multipart(form)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 400);
 }

--- a/tests/mock_tests/mock_dtako_scraper_test.rs
+++ b/tests/mock_tests/mock_dtako_scraper_test.rs
@@ -1059,3 +1059,117 @@ async fn test_trigger_scrape_sse_stream_with_comments() {
         .load(std::sync::atomic::Ordering::SeqCst);
     assert_eq!(count, 1);
 }
+
+/// SSE client disconnect — レスポンスを読まずに drop → tx.send() 失敗 (line 198-199)
+#[tokio::test]
+async fn test_trigger_scrape_client_disconnect() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+    let scraper_server = MockServer::start().await;
+    std::env::set_var("SCRAPER_BASE_URL", scraper_server.uri());
+    std::env::remove_var("METADATA_URL");
+
+    // 大量のイベントを返す
+    let mut sse_body = String::new();
+    for i in 0..100 {
+        sse_body.push_str(&format!(
+            "data:{{\"event\":\"result\",\"comp_id\":\"DISC{i:03}\",\"status\":\"success\"}}\n\n"
+        ));
+    }
+
+    Mock::given(method("POST"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_body_string(sse_body),
+        )
+        .mount(&scraper_server)
+        .await;
+
+    let mock = Arc::new(MockDtakoScraperRepository::default());
+    let mut state = setup_mock_app_state();
+    state.dtako_scraper = mock;
+    let base_url =
+        crate::common::spawn_test_server_with_scraper(state, &scraper_server.uri()).await;
+
+    let tenant_id = Uuid::new_v4();
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+
+    let client = reqwest::Client::new();
+    let res = client
+        .post(format!("{base_url}/api/scraper/trigger"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .json(&serde_json::json!({"start_date": "2026-03-20"}))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+    // レスポンスを読まずに即 drop → tx.send() が Err → "client disconnected"
+    drop(res);
+
+    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+}
+
+/// SSE stream error — 不正な chunked encoding (line 161-163)
+#[tokio::test]
+async fn test_trigger_scrape_stream_error() {
+    use tokio::io::AsyncWriteExt;
+
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::remove_var("METADATA_URL");
+
+    // 生 TCP サーバーで不正な chunked レスポンスを返す
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    std::env::set_var("SCRAPER_BASE_URL", format!("http://{addr}"));
+
+    tokio::spawn(async move {
+        if let Ok((mut stream, _)) = listener.accept().await {
+            let mut buf = [0u8; 4096];
+            let _ = tokio::io::AsyncReadExt::read(&mut stream, &mut buf).await;
+
+            let header = "HTTP/1.1 200 OK\r\n\
+                          Content-Type: text/event-stream\r\n\
+                          Transfer-Encoding: chunked\r\n\r\n";
+            let _ = stream.write_all(header.as_bytes()).await;
+
+            // 正常なチャンク1つ
+            let chunk_data = "data:{\"event\":\"progress\",\"message\":\"ok\"}\n\n";
+            let chunk = format!("{:x}\r\n{}\r\n", chunk_data.len(), chunk_data);
+            let _ = stream.write_all(chunk.as_bytes()).await;
+            let _ = stream.flush().await;
+
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            // 不正なチャンクサイズ → bytes_stream Err
+            let _ = stream.write_all(b"FFFFFF\r\n").await;
+            let _ = stream.flush().await;
+            drop(stream);
+        }
+    });
+
+    let mock = Arc::new(MockDtakoScraperRepository::default());
+    let mut state = setup_mock_app_state();
+    state.dtako_scraper = mock;
+    let base_url =
+        crate::common::spawn_test_server_with_scraper(state, &format!("http://{addr}")).await;
+
+    let tenant_id = Uuid::new_v4();
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+
+    let client = reqwest::Client::new();
+    let res = client
+        .post(format!("{base_url}/api/scraper/trigger"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .json(&serde_json::json!({"start_date": "2026-03-20"}))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+    let _body = res.text().await.unwrap_or_default();
+
+    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+}

--- a/tests/mock_tests/mock_dtako_scraper_test.rs
+++ b/tests/mock_tests/mock_dtako_scraper_test.rs
@@ -1063,35 +1063,44 @@ async fn test_trigger_scrape_sse_stream_with_comments() {
 /// SSE client disconnect — レスポンスを読まずに drop → tx.send() 失敗 (line 198-199)
 #[tokio::test]
 async fn test_trigger_scrape_client_disconnect() {
+    use tokio::io::AsyncWriteExt;
+
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::remove_var("GCP_METADATA_URL");
 
-    let scraper_server = MockServer::start().await;
-    std::env::set_var("SCRAPER_BASE_URL", scraper_server.uri());
-    std::env::remove_var("METADATA_URL");
+    // 生 TCP サーバーでイベントをゆっくり送信 → client が先に drop
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
 
-    // 大量のイベントを返す
-    let mut sse_body = String::new();
-    for i in 0..100 {
-        sse_body.push_str(&format!(
-            "data:{{\"event\":\"result\",\"comp_id\":\"DISC{i:03}\",\"status\":\"success\"}}\n\n"
-        ));
-    }
+    tokio::spawn(async move {
+        if let Ok((mut stream, _)) = listener.accept().await {
+            let mut buf = [0u8; 4096];
+            let _ = tokio::io::AsyncReadExt::read(&mut stream, &mut buf).await;
 
-    Mock::given(method("POST"))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .insert_header("content-type", "text/event-stream")
-                .set_body_string(sse_body),
-        )
-        .mount(&scraper_server)
-        .await;
+            let header = "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nTransfer-Encoding: chunked\r\n\r\n";
+            let _ = stream.write_all(header.as_bytes()).await;
+
+            // イベントを遅延送信 (各50ms間隔)
+            for i in 0..50 {
+                let data = format!(
+                    "data:{{\"event\":\"result\",\"comp_id\":\"DISC{i:03}\",\"status\":\"success\"}}\n\n"
+                );
+                let chunk = format!("{:x}\r\n{}\r\n", data.len(), data);
+                if stream.write_all(chunk.as_bytes()).await.is_err() {
+                    break;
+                }
+                let _ = stream.flush().await;
+                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            }
+        }
+    });
 
     let mock = Arc::new(MockDtakoScraperRepository::default());
     let mut state = setup_mock_app_state();
     state.dtako_scraper = mock;
     let base_url =
-        crate::common::spawn_test_server_with_scraper(state, &scraper_server.uri()).await;
+        crate::common::spawn_test_server_with_scraper(state, &format!("http://{addr}")).await;
 
     let tenant_id = Uuid::new_v4();
     let jwt = crate::common::create_test_jwt(tenant_id, "admin");
@@ -1106,10 +1115,11 @@ async fn test_trigger_scrape_client_disconnect() {
         .unwrap();
 
     assert_eq!(res.status(), 200);
-    // レスポンスを読まずに即 drop → tx.send() が Err → "client disconnected"
+    // 少し読んでから drop → 残りのイベント送信時に tx.send() が失敗
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
     drop(res);
 
-    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
 }
 
 /// SSE stream error — 不正な chunked encoding (line 161-163)

--- a/tests/mock_tests/mock_dtako_scraper_test.rs
+++ b/tests/mock_tests/mock_dtako_scraper_test.rs
@@ -5,6 +5,8 @@ use std::sync::Arc;
 
 use chrono::{NaiveDate, Utc};
 use serde_json::Value;
+use wiremock::matchers::method;
+use wiremock::{Mock, MockServer, ResponseTemplate};
 
 use crate::mock_helpers::app_state::setup_mock_app_state;
 use crate::mock_helpers::MockDtakoScraperRepository;
@@ -319,4 +321,741 @@ async fn test_trigger_scrape_unauthorized() {
         .await
         .unwrap();
     assert_eq!(res.status(), 401);
+}
+
+// ============================================================
+// POST /api/scraper/trigger — scraper returns 500 (→ 502)
+// Covers lines 131-138: non-success status from scraper
+// ============================================================
+
+#[tokio::test]
+async fn test_trigger_scrape_scraper_returns_500() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+    // Mock metadata server (returns 404 so get_id_token fails silently)
+    let metadata_server = MockServer::start().await;
+    std::env::set_var("GCP_METADATA_URL", metadata_server.uri());
+
+    // Mock scraper server returns 500
+    let scraper_server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(500).set_body_string("Internal scraper error"))
+        .mount(&scraper_server)
+        .await;
+
+    let mock = Arc::new(MockDtakoScraperRepository::default());
+    let mut state = setup_mock_app_state();
+    state.dtako_scraper = mock;
+    let base_url =
+        crate::common::spawn_test_server_with_scraper(state, &scraper_server.uri()).await;
+
+    let tenant_id = Uuid::new_v4();
+    let admin_jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/scraper/trigger"))
+        .header("Authorization", format!("Bearer {admin_jwt}"))
+        .json(&serde_json::json!({
+            "start_date": "2026-03-29",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 502);
+    let body = res.text().await.unwrap();
+    assert!(body.contains("Scraper returned 500"));
+    assert!(body.contains("Internal scraper error"));
+}
+
+// ============================================================
+// POST /api/scraper/trigger — metadata server returns non-success
+// Covers lines 91-93: metadata server returns 403
+// ============================================================
+
+#[tokio::test]
+async fn test_trigger_scrape_metadata_server_non_success() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+    // Mock metadata server returns 403
+    let metadata_server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(403).set_body_string("Forbidden"))
+        .mount(&metadata_server)
+        .await;
+
+    // Mock scraper returns 500 (we just need to get past metadata)
+    let scraper_server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(500).set_body_string("error"))
+        .mount(&scraper_server)
+        .await;
+
+    let mock = Arc::new(MockDtakoScraperRepository::default());
+    let mut state = setup_mock_app_state();
+    state.dtako_scraper = mock;
+    let base_url =
+        crate::common::spawn_test_server_with_scraper(state, &scraper_server.uri()).await;
+
+    let tenant_id = Uuid::new_v4();
+    let admin_jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/scraper/trigger"))
+        .header("Authorization", format!("Bearer {admin_jwt}"))
+        .json(&serde_json::json!({
+            "start_date": "2026-03-29",
+        }))
+        .send()
+        .await
+        .unwrap();
+    // Metadata error is silent, scraper returns 500 → 502
+    assert_eq!(res.status(), 502);
+}
+
+// ============================================================
+// POST /api/scraper/trigger — metadata server success + bearer auth
+// Covers lines 91-97, 121: successful token fetch + bearer_auth set
+// ============================================================
+
+#[tokio::test]
+async fn test_trigger_scrape_metadata_server_success_bearer_auth() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+    // Mock metadata server returns a token
+    let metadata_server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("fake-id-token-12345"))
+        .mount(&metadata_server)
+        .await;
+
+    // Mock scraper returns 500 (to simplify; we're testing metadata path)
+    let scraper_server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(500).set_body_string("server error"))
+        .mount(&scraper_server)
+        .await;
+
+    std::env::set_var("GCP_METADATA_URL", metadata_server.uri());
+
+    let mock = Arc::new(MockDtakoScraperRepository::default());
+    let mut state = setup_mock_app_state();
+    state.dtako_scraper = mock;
+    let base_url =
+        crate::common::spawn_test_server_with_scraper(state, &scraper_server.uri()).await;
+
+    let tenant_id = Uuid::new_v4();
+    let admin_jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/scraper/trigger"))
+        .header("Authorization", format!("Bearer {admin_jwt}"))
+        .json(&serde_json::json!({
+            "start_date": "2026-03-29",
+        }))
+        .send()
+        .await
+        .unwrap();
+    // Scraper still returns 500 → 502, but metadata token was obtained
+    assert_eq!(res.status(), 502);
+}
+
+// ============================================================
+// POST /api/scraper/trigger — SSE stream with result events
+// Covers lines 140-211: full SSE stream processing + DB insert
+// ============================================================
+
+#[tokio::test]
+async fn test_trigger_scrape_sse_stream_with_results() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("GCP_METADATA_URL", "http://127.0.0.1:1");
+
+    // Mock scraper returns SSE stream with result events
+    let scraper_server = MockServer::start().await;
+    let sse_body = concat!(
+        "data:{\"event\":\"progress\",\"message\":\"Starting...\"}\n\n",
+        "data:{\"event\":\"result\",\"comp_id\":\"C001\",\"status\":\"success\",\"message\":\"Done\"}\n\n",
+        "data:{\"event\":\"result\",\"comp_id\":\"C002\",\"status\":\"error\",\"message\":\"Failed\"}\n\n",
+    );
+    Mock::given(method("POST"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string(sse_body)
+                .append_header("content-type", "text/event-stream"),
+        )
+        .mount(&scraper_server)
+        .await;
+
+    let mock = Arc::new(MockDtakoScraperRepository::default());
+    let mock_ref = mock.clone();
+    let mut state = setup_mock_app_state();
+    state.dtako_scraper = mock;
+    let base_url =
+        crate::common::spawn_test_server_with_scraper(state, &scraper_server.uri()).await;
+
+    let tenant_id = Uuid::new_v4();
+    let admin_jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/scraper/trigger"))
+        .header("Authorization", format!("Bearer {admin_jwt}"))
+        .json(&serde_json::json!({
+            "start_date": "2026-03-29",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+
+    // Read the SSE stream body
+    let body = res.text().await.unwrap();
+    // Should contain the relayed events
+    assert!(body.contains("Starting..."));
+    assert!(body.contains("C001"));
+    assert!(body.contains("C002"));
+
+    // Wait briefly for the spawned task to complete DB inserts
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+    // Verify DB inserts: 2 result events → 2 insert calls
+    let count = mock_ref
+        .insert_count
+        .load(std::sync::atomic::Ordering::SeqCst);
+    assert_eq!(count, 2, "Expected 2 insert_scrape_history calls");
+
+    let comp_ids = mock_ref.inserted_comp_ids.lock().unwrap().clone();
+    assert!(comp_ids.contains(&"C001".to_string()));
+    assert!(comp_ids.contains(&"C002".to_string()));
+}
+
+// ============================================================
+// POST /api/scraper/trigger — SSE stream without start_date
+// Covers lines 140-146: default target_date (yesterday)
+// ============================================================
+
+#[tokio::test]
+async fn test_trigger_scrape_sse_stream_no_start_date() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("GCP_METADATA_URL", "http://127.0.0.1:1");
+
+    let scraper_server = MockServer::start().await;
+    let sse_body = "data:{\"event\":\"result\",\"comp_id\":\"C099\",\"status\":\"success\",\"message\":\"ok\"}\n\n";
+    Mock::given(method("POST"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string(sse_body)
+                .append_header("content-type", "text/event-stream"),
+        )
+        .mount(&scraper_server)
+        .await;
+
+    let mock = Arc::new(MockDtakoScraperRepository::default());
+    let mock_ref = mock.clone();
+    let mut state = setup_mock_app_state();
+    state.dtako_scraper = mock;
+    let base_url =
+        crate::common::spawn_test_server_with_scraper(state, &scraper_server.uri()).await;
+
+    let tenant_id = Uuid::new_v4();
+    let admin_jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    // No start_date → uses yesterday as default
+    let res = client
+        .post(format!("{base_url}/api/scraper/trigger"))
+        .header("Authorization", format!("Bearer {admin_jwt}"))
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+
+    let body = res.text().await.unwrap();
+    assert!(body.contains("C099"));
+
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    let count = mock_ref
+        .insert_count
+        .load(std::sync::atomic::Ordering::SeqCst);
+    assert_eq!(count, 1);
+}
+
+// ============================================================
+// POST /api/scraper/trigger — SSE stream with invalid date
+// Covers line 146: invalid date falls back to today
+// ============================================================
+
+#[tokio::test]
+async fn test_trigger_scrape_sse_stream_invalid_date() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("GCP_METADATA_URL", "http://127.0.0.1:1");
+
+    let scraper_server = MockServer::start().await;
+    let sse_body = "data:{\"event\":\"result\",\"comp_id\":\"C100\",\"status\":\"success\",\"message\":\"ok\"}\n\n";
+    Mock::given(method("POST"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string(sse_body)
+                .append_header("content-type", "text/event-stream"),
+        )
+        .mount(&scraper_server)
+        .await;
+
+    let mock = Arc::new(MockDtakoScraperRepository::default());
+    let mock_ref = mock.clone();
+    let mut state = setup_mock_app_state();
+    state.dtako_scraper = mock;
+    let base_url =
+        crate::common::spawn_test_server_with_scraper(state, &scraper_server.uri()).await;
+
+    let tenant_id = Uuid::new_v4();
+    let admin_jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    // Invalid date → fallback to today
+    let res = client
+        .post(format!("{base_url}/api/scraper/trigger"))
+        .header("Authorization", format!("Bearer {admin_jwt}"))
+        .json(&serde_json::json!({
+            "start_date": "not-a-date",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+
+    let body = res.text().await.unwrap();
+    assert!(body.contains("C100"));
+
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    let count = mock_ref
+        .insert_count
+        .load(std::sync::atomic::Ordering::SeqCst);
+    assert_eq!(count, 1);
+}
+
+// ============================================================
+// POST /api/scraper/trigger — SSE with non-JSON data
+// Covers line 179: serde_json::from_str fails, event still relayed
+// ============================================================
+
+#[tokio::test]
+async fn test_trigger_scrape_sse_stream_non_json_data() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("GCP_METADATA_URL", "http://127.0.0.1:1");
+
+    let scraper_server = MockServer::start().await;
+    // Mix of valid JSON and non-JSON data
+    let sse_body = concat!(
+        "data:this is not json\n\n",
+        "data:{\"event\":\"result\",\"comp_id\":\"C003\",\"status\":\"success\",\"message\":\"ok\"}\n\n",
+    );
+    Mock::given(method("POST"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string(sse_body)
+                .append_header("content-type", "text/event-stream"),
+        )
+        .mount(&scraper_server)
+        .await;
+
+    let mock = Arc::new(MockDtakoScraperRepository::default());
+    let mock_ref = mock.clone();
+    let mut state = setup_mock_app_state();
+    state.dtako_scraper = mock;
+    let base_url =
+        crate::common::spawn_test_server_with_scraper(state, &scraper_server.uri()).await;
+
+    let tenant_id = Uuid::new_v4();
+    let admin_jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/scraper/trigger"))
+        .header("Authorization", format!("Bearer {admin_jwt}"))
+        .json(&serde_json::json!({
+            "start_date": "2026-03-29",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+
+    let body = res.text().await.unwrap();
+    // Both events should be relayed (non-JSON is still sent as data)
+    assert!(body.contains("this is not json"));
+    assert!(body.contains("C003"));
+
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    // Only 1 DB insert (the valid result event)
+    let count = mock_ref
+        .insert_count
+        .load(std::sync::atomic::Ordering::SeqCst);
+    assert_eq!(count, 1);
+}
+
+// ============================================================
+// POST /api/scraper/trigger — SSE with progress event (no DB insert)
+// Covers lines 180: event != "result" → no DB insert
+// ============================================================
+
+#[tokio::test]
+async fn test_trigger_scrape_sse_stream_progress_only() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("GCP_METADATA_URL", "http://127.0.0.1:1");
+
+    let scraper_server = MockServer::start().await;
+    let sse_body = concat!(
+        "data:{\"event\":\"progress\",\"message\":\"Step 1\"}\n\n",
+        "data:{\"event\":\"progress\",\"message\":\"Step 2\"}\n\n",
+    );
+    Mock::given(method("POST"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string(sse_body)
+                .append_header("content-type", "text/event-stream"),
+        )
+        .mount(&scraper_server)
+        .await;
+
+    let mock = Arc::new(MockDtakoScraperRepository::default());
+    let mock_ref = mock.clone();
+    let mut state = setup_mock_app_state();
+    state.dtako_scraper = mock;
+    let base_url =
+        crate::common::spawn_test_server_with_scraper(state, &scraper_server.uri()).await;
+
+    let tenant_id = Uuid::new_v4();
+    let admin_jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/scraper/trigger"))
+        .header("Authorization", format!("Bearer {admin_jwt}"))
+        .json(&serde_json::json!({
+            "start_date": "2026-03-29",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+
+    let body = res.text().await.unwrap();
+    assert!(body.contains("Step 1"));
+    assert!(body.contains("Step 2"));
+
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    // No result events → 0 DB inserts
+    let count = mock_ref
+        .insert_count
+        .load(std::sync::atomic::Ordering::SeqCst);
+    assert_eq!(count, 0);
+}
+
+// ============================================================
+// POST /api/scraper/trigger — SSE result without comp_id
+// Covers line 181: result event but comp_id is None → no DB insert
+// ============================================================
+
+#[tokio::test]
+async fn test_trigger_scrape_sse_result_no_comp_id() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("GCP_METADATA_URL", "http://127.0.0.1:1");
+
+    let scraper_server = MockServer::start().await;
+    // result event without comp_id
+    let sse_body =
+        "data:{\"event\":\"result\",\"status\":\"success\",\"message\":\"no comp_id\"}\n\n";
+    Mock::given(method("POST"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string(sse_body)
+                .append_header("content-type", "text/event-stream"),
+        )
+        .mount(&scraper_server)
+        .await;
+
+    let mock = Arc::new(MockDtakoScraperRepository::default());
+    let mock_ref = mock.clone();
+    let mut state = setup_mock_app_state();
+    state.dtako_scraper = mock;
+    let base_url =
+        crate::common::spawn_test_server_with_scraper(state, &scraper_server.uri()).await;
+
+    let tenant_id = Uuid::new_v4();
+    let admin_jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/scraper/trigger"))
+        .header("Authorization", format!("Bearer {admin_jwt}"))
+        .json(&serde_json::json!({
+            "start_date": "2026-03-29",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+
+    let body = res.text().await.unwrap();
+    assert!(body.contains("no comp_id"));
+
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    // No comp_id → 0 DB inserts
+    let count = mock_ref
+        .insert_count
+        .load(std::sync::atomic::Ordering::SeqCst);
+    assert_eq!(count, 0);
+}
+
+// ============================================================
+// POST /api/scraper/trigger — SSE result with missing status field
+// Covers line 182: status is None → defaults to "error"
+// ============================================================
+
+#[tokio::test]
+async fn test_trigger_scrape_sse_result_missing_status() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("GCP_METADATA_URL", "http://127.0.0.1:1");
+
+    let scraper_server = MockServer::start().await;
+    // result with comp_id but no status/message
+    let sse_body = "data:{\"event\":\"result\",\"comp_id\":\"C004\"}\n\n";
+    Mock::given(method("POST"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string(sse_body)
+                .append_header("content-type", "text/event-stream"),
+        )
+        .mount(&scraper_server)
+        .await;
+
+    let mock = Arc::new(MockDtakoScraperRepository::default());
+    let mock_ref = mock.clone();
+    let mut state = setup_mock_app_state();
+    state.dtako_scraper = mock;
+    let base_url =
+        crate::common::spawn_test_server_with_scraper(state, &scraper_server.uri()).await;
+
+    let tenant_id = Uuid::new_v4();
+    let admin_jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/scraper/trigger"))
+        .header("Authorization", format!("Bearer {admin_jwt}"))
+        .json(&serde_json::json!({
+            "start_date": "2026-03-29",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+
+    let body = res.text().await.unwrap();
+    assert!(body.contains("C004"));
+
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    let count = mock_ref
+        .insert_count
+        .load(std::sync::atomic::Ordering::SeqCst);
+    assert_eq!(count, 1);
+    let comp_ids = mock_ref.inserted_comp_ids.lock().unwrap().clone();
+    assert_eq!(comp_ids[0], "C004");
+}
+
+// ============================================================
+// POST /api/scraper/trigger — SSE with empty data lines
+// Covers line 176: empty data after strip_prefix is skipped
+// ============================================================
+
+#[tokio::test]
+async fn test_trigger_scrape_sse_stream_empty_data() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("GCP_METADATA_URL", "http://127.0.0.1:1");
+
+    let scraper_server = MockServer::start().await;
+    // Empty data line followed by a real event
+    let sse_body = concat!(
+        "data:\n\n",
+        "data:{\"event\":\"result\",\"comp_id\":\"C005\",\"status\":\"success\",\"message\":\"ok\"}\n\n",
+    );
+    Mock::given(method("POST"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string(sse_body)
+                .append_header("content-type", "text/event-stream"),
+        )
+        .mount(&scraper_server)
+        .await;
+
+    let mock = Arc::new(MockDtakoScraperRepository::default());
+    let mock_ref = mock.clone();
+    let mut state = setup_mock_app_state();
+    state.dtako_scraper = mock;
+    let base_url =
+        crate::common::spawn_test_server_with_scraper(state, &scraper_server.uri()).await;
+
+    let tenant_id = Uuid::new_v4();
+    let admin_jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/scraper/trigger"))
+        .header("Authorization", format!("Bearer {admin_jwt}"))
+        .json(&serde_json::json!({
+            "start_date": "2026-03-29",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+
+    let body = res.text().await.unwrap();
+    assert!(body.contains("C005"));
+
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    let count = mock_ref
+        .insert_count
+        .load(std::sync::atomic::Ordering::SeqCst);
+    assert_eq!(count, 1);
+}
+
+// ============================================================
+// POST /api/scraper/trigger — metadata success + SSE stream
+// Full end-to-end: metadata OK → bearer auth → scraper SSE → DB save
+// Covers lines 91-97, 121, 140-211 together
+// ============================================================
+
+#[tokio::test]
+async fn test_trigger_scrape_full_flow_with_metadata_and_sse() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+    // Mock metadata server returns a valid token
+    let metadata_server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("my-id-token"))
+        .mount(&metadata_server)
+        .await;
+    std::env::set_var("GCP_METADATA_URL", metadata_server.uri());
+
+    // Mock scraper returns SSE
+    let scraper_server = MockServer::start().await;
+    let sse_body = "data:{\"event\":\"result\",\"comp_id\":\"C010\",\"status\":\"success\",\"message\":\"Full flow\"}\n\n";
+    Mock::given(method("POST"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string(sse_body)
+                .append_header("content-type", "text/event-stream"),
+        )
+        .mount(&scraper_server)
+        .await;
+
+    let mock = Arc::new(MockDtakoScraperRepository::default());
+    let mock_ref = mock.clone();
+    let mut state = setup_mock_app_state();
+    state.dtako_scraper = mock;
+    let base_url =
+        crate::common::spawn_test_server_with_scraper(state, &scraper_server.uri()).await;
+
+    let tenant_id = Uuid::new_v4();
+    let admin_jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/scraper/trigger"))
+        .header("Authorization", format!("Bearer {admin_jwt}"))
+        .json(&serde_json::json!({
+            "start_date": "2026-03-29",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+
+    let body = res.text().await.unwrap();
+    assert!(body.contains("Full flow"));
+
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    let count = mock_ref
+        .insert_count
+        .load(std::sync::atomic::Ordering::SeqCst);
+    assert_eq!(count, 1);
+    let comp_ids = mock_ref.inserted_comp_ids.lock().unwrap().clone();
+    assert_eq!(comp_ids[0], "C010");
+}
+
+// ============================================================
+// POST /api/scraper/trigger — SSE with non-data lines (e.g., comments)
+// Covers line 174: lines without "data:" prefix are ignored
+// ============================================================
+
+#[tokio::test]
+async fn test_trigger_scrape_sse_stream_with_comments() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("GCP_METADATA_URL", "http://127.0.0.1:1");
+
+    let scraper_server = MockServer::start().await;
+    // SSE with comment lines (: prefix) and event/id fields
+    let sse_body = concat!(
+        ": this is a comment\n",
+        "id: 1\n",
+        "event: message\n",
+        "data:{\"event\":\"result\",\"comp_id\":\"C006\",\"status\":\"success\",\"message\":\"ok\"}\n\n",
+    );
+    Mock::given(method("POST"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string(sse_body)
+                .append_header("content-type", "text/event-stream"),
+        )
+        .mount(&scraper_server)
+        .await;
+
+    let mock = Arc::new(MockDtakoScraperRepository::default());
+    let mock_ref = mock.clone();
+    let mut state = setup_mock_app_state();
+    state.dtako_scraper = mock;
+    let base_url =
+        crate::common::spawn_test_server_with_scraper(state, &scraper_server.uri()).await;
+
+    let tenant_id = Uuid::new_v4();
+    let admin_jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/scraper/trigger"))
+        .header("Authorization", format!("Bearer {admin_jwt}"))
+        .json(&serde_json::json!({
+            "start_date": "2026-03-29",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+
+    let body = res.text().await.unwrap();
+    assert!(body.contains("C006"));
+
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    let count = mock_ref
+        .insert_count
+        .load(std::sync::atomic::Ordering::SeqCst);
+    assert_eq!(count, 1);
 }

--- a/tests/mock_tests/mock_dtako_upload_test.rs
+++ b/tests/mock_tests/mock_dtako_upload_test.rs
@@ -3,8 +3,12 @@ use uuid::Uuid;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
+use crate::common::mock_storage::MockStorage;
 use crate::mock_helpers::app_state::setup_mock_app_state;
 use crate::mock_helpers::MockDtakoUploadRepository;
+use rust_alc_api::db::repository::dtako_upload::{
+    DtakoDriverOpRow, DtakoOpRow, UploadHistoryRecord, UploadTenantAndKey,
+};
 
 /// Helper: set up mock AppState + spawn test server + create JWT.
 /// Returns (base_url, auth_header, tenant_id, state).
@@ -674,4 +678,1555 @@ async fn test_dtako_upload_with_tenant_header() {
     assert_eq!(res.status(), 200);
     let body: serde_json::Value = res.json().await.unwrap();
     assert_eq!(body["status"], "completed");
+}
+
+// =========================================================================
+// Helper: build a custom AppState with configured MockDtakoUploadRepository
+// =========================================================================
+
+fn setup_with_mock(mock: MockDtakoUploadRepository) -> rust_alc_api::AppState {
+    let mut state = setup_mock_app_state();
+    state.dtako_upload = Arc::new(mock);
+    state
+}
+
+/// Helper: build AppState with custom dtako_storage (MockStorage) and mock repo
+fn setup_with_storage_and_mock(
+    mock: MockDtakoUploadRepository,
+    storage: Arc<MockStorage>,
+) -> rust_alc_api::AppState {
+    let mut state = setup_mock_app_state();
+    state.dtako_upload = Arc::new(mock);
+    state.dtako_storage = Some(storage);
+    state
+}
+
+// =========================================================================
+// POST /api/upload — rich ZIP with multiple operations, events, rest, break
+// =========================================================================
+
+#[tokio::test]
+async fn test_dtako_upload_rich_zip_success() {
+    let state = setup_mock_app_state();
+    let tenant_id = Uuid::new_v4();
+    let base_url = crate::common::spawn_test_server(state).await;
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let zip_bytes = crate::common::create_test_dtako_zip_rich();
+    let part = reqwest::multipart::Part::bytes(zip_bytes).file_name("rich.zip");
+    let form = reqwest::multipart::Form::new().part("file", part);
+
+    let res = client
+        .post(format!("{base_url}/api/upload"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .multipart(form)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(body["status"], "completed");
+    // Rich ZIP has 3 operations
+    assert!(body["operations_count"].as_i64().unwrap() >= 3);
+}
+
+// =========================================================================
+// POST /api/upload — rich ZIP with employee_id mapping (driver_id present)
+// =========================================================================
+
+#[tokio::test]
+async fn test_dtako_upload_rich_zip_with_employee_id() {
+    let employee_id = Uuid::new_v4();
+    let mut mock = MockDtakoUploadRepository::default();
+    *mock.employee_id.lock().unwrap() = Some(employee_id);
+
+    let state = setup_with_mock(mock);
+    let tenant_id = Uuid::new_v4();
+    let base_url = crate::common::spawn_test_server(state).await;
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let zip_bytes = crate::common::create_test_dtako_zip_rich();
+    let part = reqwest::multipart::Part::bytes(zip_bytes).file_name("rich.zip");
+    let form = reqwest::multipart::Form::new().part("file", part);
+
+    let res = client
+        .post(format!("{base_url}/api/upload"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .multipart(form)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(body["status"], "completed");
+    assert!(body["operations_count"].as_i64().unwrap() >= 3);
+}
+
+// =========================================================================
+// POST /api/upload — ZIP with only header (empty KUDGURI CSV → 0 operations)
+// =========================================================================
+
+#[tokio::test]
+async fn test_dtako_upload_empty_csv() {
+    let state = setup_mock_app_state();
+    let tenant_id = Uuid::new_v4();
+    let base_url = crate::common::spawn_test_server(state).await;
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    // Create ZIP with header-only KUDGURI (no data rows) and KUDGIVT
+    let zip_bytes = create_empty_csv_zip();
+    let part = reqwest::multipart::Part::bytes(zip_bytes).file_name("empty.zip");
+    let form = reqwest::multipart::Form::new().part("file", part);
+
+    let res = client
+        .post(format!("{base_url}/api/upload"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .multipart(form)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(body["status"], "completed");
+    assert_eq!(body["operations_count"].as_i64().unwrap(), 0);
+}
+
+/// Create a ZIP with header-only KUDGURI CSV (no data rows)
+fn create_empty_csv_zip() -> Vec<u8> {
+    use std::io::Write;
+
+    let kudguri_csv =
+        "運行NO,読取日,事業所CD,事業所名,車輌CD,車輌名,乗務員CD1,乗務員名１,対象乗務員区分\n";
+    let kudgivt_csv =
+        "運行NO,読取日,乗務員CD1,乗務員名１,対象乗務員区分,開始日時,イベントCD,イベント名\n";
+
+    let (kudguri_bytes, _, _) = encoding_rs::SHIFT_JIS.encode(kudguri_csv);
+    let (kudgivt_bytes, _, _) = encoding_rs::SHIFT_JIS.encode(kudgivt_csv);
+
+    let mut buf = std::io::Cursor::new(Vec::new());
+    {
+        let mut zip = zip::ZipWriter::new(&mut buf);
+        let options = zip::write::SimpleFileOptions::default();
+        zip.start_file("KUDGURI.csv", options).unwrap();
+        zip.write_all(&kudguri_bytes).unwrap();
+        zip.start_file("KUDGIVT.csv", options).unwrap();
+        zip.write_all(&kudgivt_bytes).unwrap();
+        zip.finish().unwrap();
+    }
+    buf.into_inner()
+}
+
+// =========================================================================
+// POST /api/upload — ZIP missing KUDGURI → 400
+// =========================================================================
+
+#[tokio::test]
+async fn test_dtako_upload_missing_kudguri() {
+    let state = setup_mock_app_state();
+    let tenant_id = Uuid::new_v4();
+    let base_url = crate::common::spawn_test_server(state).await;
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    // ZIP with only KUDGIVT, no KUDGURI
+    let zip_bytes = create_missing_kudguri_zip();
+    let part = reqwest::multipart::Part::bytes(zip_bytes).file_name("no-kudguri.zip");
+    let form = reqwest::multipart::Form::new().part("file", part);
+
+    let res = client
+        .post(format!("{base_url}/api/upload"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .multipart(form)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 400);
+    let body = res.text().await.unwrap();
+    assert!(body.contains("KUDGURI"));
+}
+
+fn create_missing_kudguri_zip() -> Vec<u8> {
+    use std::io::Write;
+
+    let kudgivt_csv =
+        "運行NO,読取日,乗務員CD1,乗務員名１,対象乗務員区分,開始日時,イベントCD,イベント名\n\
+         1001,2026/03/01,DR01,テスト運転者,1,2026/03/01 08:00:00,100,出庫\n";
+
+    let (kudgivt_bytes, _, _) = encoding_rs::SHIFT_JIS.encode(kudgivt_csv);
+
+    let mut buf = std::io::Cursor::new(Vec::new());
+    {
+        let mut zip = zip::ZipWriter::new(&mut buf);
+        let options = zip::write::SimpleFileOptions::default();
+        zip.start_file("KUDGIVT.csv", options).unwrap();
+        zip.write_all(&kudgivt_bytes).unwrap();
+        zip.finish().unwrap();
+    }
+    buf.into_inner()
+}
+
+// =========================================================================
+// POST /api/upload — ZIP missing KUDGIVT → 400
+// =========================================================================
+
+#[tokio::test]
+async fn test_dtako_upload_missing_kudgivt() {
+    let state = setup_mock_app_state();
+    let tenant_id = Uuid::new_v4();
+    let base_url = crate::common::spawn_test_server(state).await;
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    // ZIP with only KUDGURI, no KUDGIVT
+    let zip_bytes = create_missing_kudgivt_zip();
+    let part = reqwest::multipart::Part::bytes(zip_bytes).file_name("no-kudgivt.zip");
+    let form = reqwest::multipart::Form::new().part("file", part);
+
+    let res = client
+        .post(format!("{base_url}/api/upload"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .multipart(form)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 400);
+    let body = res.text().await.unwrap();
+    assert!(body.contains("KUDGIVT"));
+}
+
+fn create_missing_kudgivt_zip() -> Vec<u8> {
+    use std::io::Write;
+
+    let kudguri_csv =
+        "運行NO,読取日,事業所CD,事業所名,車輌CD,車輌名,乗務員CD1,乗務員名１,対象乗務員区分\n\
+                       1001,2026/03/01,OFF01,テスト事業所,VH01,テスト車両,DR01,テスト運転者,1\n";
+
+    let (kudguri_bytes, _, _) = encoding_rs::SHIFT_JIS.encode(kudguri_csv);
+
+    let mut buf = std::io::Cursor::new(Vec::new());
+    {
+        let mut zip = zip::ZipWriter::new(&mut buf);
+        let options = zip::write::SimpleFileOptions::default();
+        zip.start_file("KUDGURI.csv", options).unwrap();
+        zip.write_all(&kudguri_bytes).unwrap();
+        zip.finish().unwrap();
+    }
+    buf.into_inner()
+}
+
+// =========================================================================
+// POST /api/upload — multipart with non-file field (exercises the while loop skip)
+// =========================================================================
+
+#[tokio::test]
+async fn test_dtako_upload_multipart_with_extra_fields() {
+    let state = setup_mock_app_state();
+    let tenant_id = Uuid::new_v4();
+    let base_url = crate::common::spawn_test_server(state).await;
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let zip_bytes = crate::common::create_test_dtako_zip();
+    let file_part = reqwest::multipart::Part::bytes(zip_bytes).file_name("test.zip");
+    // Add extra non-file fields before the actual file
+    let form = reqwest::multipart::Form::new()
+        .text("extra_field", "some_value")
+        .part("file", file_part);
+
+    let res = client
+        .post(format!("{base_url}/api/upload"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .multipart(form)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+}
+
+// =========================================================================
+// GET /api/internal/download/{id} — success (upload_history returns Some)
+// =========================================================================
+
+#[tokio::test]
+async fn test_dtako_download_success() {
+    let tenant_id = Uuid::new_v4();
+    let upload_id = Uuid::new_v4();
+    let zip_key = format!("{}/uploads/{}/test.zip", tenant_id, upload_id);
+
+    // Create mock with upload_history that returns a record
+    let mut mock = MockDtakoUploadRepository::default();
+    *mock.upload_history.lock().unwrap() = Some(UploadHistoryRecord {
+        tenant_id,
+        r2_zip_key: zip_key.clone(),
+        filename: "テスト.zip".to_string(),
+    });
+
+    // Create storage with the ZIP file pre-populated
+    let dtako_storage = Arc::new(MockStorage::new("dtako-bucket"));
+    let zip_bytes = crate::common::create_test_dtako_zip();
+    dtako_storage.insert_file(&zip_key, zip_bytes.clone());
+
+    let state = setup_with_storage_and_mock(mock, dtako_storage);
+    let base_url = crate::common::spawn_test_server(state).await;
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!("{base_url}/api/internal/download/{upload_id}"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+    assert_eq!(
+        res.headers().get("Content-Type").unwrap(),
+        "application/zip"
+    );
+    let downloaded = res.bytes().await.unwrap();
+    assert_eq!(downloaded.len(), zip_bytes.len());
+}
+
+// =========================================================================
+// GET /api/internal/download/{id} — success with ASCII-safe filename
+// =========================================================================
+
+#[tokio::test]
+async fn test_dtako_download_ascii_safe_filename() {
+    let tenant_id = Uuid::new_v4();
+    let upload_id = Uuid::new_v4();
+    let zip_key = format!("{}/uploads/{}/test.zip", tenant_id, upload_id);
+
+    let mut mock = MockDtakoUploadRepository::default();
+    // Use a filename with non-ASCII chars (Japanese) that will be filtered
+    *mock.upload_history.lock().unwrap() = Some(UploadHistoryRecord {
+        tenant_id,
+        r2_zip_key: zip_key.clone(),
+        filename: "日本語ファイル".to_string(), // All non-ASCII → safe_name becomes empty → "download.zip"
+    });
+
+    let dtako_storage = Arc::new(MockStorage::new("dtako-bucket"));
+    dtako_storage.insert_file(&zip_key, vec![0x50, 0x4B, 0x03, 0x04]); // minimal data
+
+    let state = setup_with_storage_and_mock(mock, dtako_storage);
+    let base_url = crate::common::spawn_test_server(state).await;
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!("{base_url}/api/internal/download/{upload_id}"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+    let cd = res
+        .headers()
+        .get("Content-Disposition")
+        .unwrap()
+        .to_str()
+        .unwrap();
+    assert!(cd.contains("download.zip"));
+}
+
+// =========================================================================
+// POST /api/internal/rerun/{id} — success (re-process existing ZIP)
+// =========================================================================
+
+#[tokio::test]
+async fn test_dtako_rerun_success() {
+    let tenant_id = Uuid::new_v4();
+    let upload_id = Uuid::new_v4();
+    let zip_key = format!("{}/uploads/{}/test.zip", tenant_id, upload_id);
+
+    let mut mock = MockDtakoUploadRepository::default();
+    *mock.upload_history.lock().unwrap() = Some(UploadHistoryRecord {
+        tenant_id,
+        r2_zip_key: zip_key.clone(),
+        filename: "test.zip".to_string(),
+    });
+    // Also set tenant_and_key for the split_csv that happens after rerun
+    *mock.tenant_and_key.lock().unwrap() = Some(UploadTenantAndKey {
+        tenant_id,
+        r2_zip_key: zip_key.clone(),
+    });
+
+    let dtako_storage = Arc::new(MockStorage::new("dtako-bucket"));
+    let zip_bytes = crate::common::create_test_dtako_zip();
+    dtako_storage.insert_file(&zip_key, zip_bytes);
+
+    let state = setup_with_storage_and_mock(mock, dtako_storage);
+    let base_url = crate::common::spawn_test_server(state).await;
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/internal/rerun/{upload_id}"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(body["status"], "completed");
+    assert!(body["operations_count"].as_i64().unwrap() >= 1);
+}
+
+// =========================================================================
+// POST /api/internal/rerun/{id} — rerun with rich ZIP
+// =========================================================================
+
+#[tokio::test]
+async fn test_dtako_rerun_rich_zip() {
+    let tenant_id = Uuid::new_v4();
+    let upload_id = Uuid::new_v4();
+    let zip_key = format!("{}/uploads/{}/rich.zip", tenant_id, upload_id);
+
+    let employee_id = Uuid::new_v4();
+    let mut mock = MockDtakoUploadRepository::default();
+    *mock.upload_history.lock().unwrap() = Some(UploadHistoryRecord {
+        tenant_id,
+        r2_zip_key: zip_key.clone(),
+        filename: "rich.zip".to_string(),
+    });
+    *mock.tenant_and_key.lock().unwrap() = Some(UploadTenantAndKey {
+        tenant_id,
+        r2_zip_key: zip_key.clone(),
+    });
+    *mock.employee_id.lock().unwrap() = Some(employee_id);
+
+    let dtako_storage = Arc::new(MockStorage::new("dtako-bucket"));
+    let zip_bytes = crate::common::create_test_dtako_zip_rich();
+    dtako_storage.insert_file(&zip_key, zip_bytes);
+
+    let state = setup_with_storage_and_mock(mock, dtako_storage);
+    let base_url = crate::common::spawn_test_server(state).await;
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/internal/rerun/{upload_id}"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(body["status"], "completed");
+    assert!(body["operations_count"].as_i64().unwrap() >= 3);
+}
+
+// =========================================================================
+// POST /api/split-csv/{id} — success (tenant_and_key returns Some)
+// =========================================================================
+
+#[tokio::test]
+async fn test_dtako_split_csv_success() {
+    let tenant_id = Uuid::new_v4();
+    let upload_id = Uuid::new_v4();
+    let zip_key = format!("{}/uploads/{}/test.zip", tenant_id, upload_id);
+
+    let mut mock = MockDtakoUploadRepository::default();
+    *mock.tenant_and_key.lock().unwrap() = Some(UploadTenantAndKey {
+        tenant_id,
+        r2_zip_key: zip_key.clone(),
+    });
+
+    let dtako_storage = Arc::new(MockStorage::new("dtako-bucket"));
+    let zip_bytes = crate::common::create_test_dtako_zip_rich();
+    dtako_storage.insert_file(&zip_key, zip_bytes);
+
+    let state = setup_with_storage_and_mock(mock, dtako_storage);
+    let base_url = crate::common::spawn_test_server(state).await;
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/split-csv/{upload_id}"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(body["status"], "ok");
+}
+
+// =========================================================================
+// POST /api/split-csv-all — success with actual uploads needing split
+// =========================================================================
+
+#[tokio::test]
+async fn test_dtako_split_csv_all_with_uploads() {
+    let tenant_id = Uuid::new_v4();
+    let upload_id = Uuid::new_v4();
+    let zip_key = format!("{}/uploads/{}/test.zip", tenant_id, upload_id);
+
+    let mut mock = MockDtakoUploadRepository::default();
+    *mock.uploads_needing_split.lock().unwrap() = vec![(upload_id, "test.zip".to_string())];
+    // split_csv_from_r2 needs get_upload_tenant_and_key
+    *mock.tenant_and_key.lock().unwrap() = Some(UploadTenantAndKey {
+        tenant_id,
+        r2_zip_key: zip_key.clone(),
+    });
+
+    let dtako_storage = Arc::new(MockStorage::new("dtako-bucket"));
+    let zip_bytes = crate::common::create_test_dtako_zip();
+    dtako_storage.insert_file(&zip_key, zip_bytes);
+
+    let state = setup_with_storage_and_mock(mock, dtako_storage);
+    let base_url = crate::common::spawn_test_server(state).await;
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/split-csv-all"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+    let body = res.text().await.unwrap();
+    assert!(body.contains("done"));
+}
+
+// =========================================================================
+// POST /api/recalculate — success with actual operations data
+// =========================================================================
+
+#[tokio::test]
+async fn test_dtako_recalculate_with_operations() {
+    use chrono::{NaiveDate, TimeZone, Utc};
+
+    let tenant_id = Uuid::new_v4();
+    let unko_no = "5001";
+
+    // Prepare KUDGIVT CSV content (UTF-8 this time, for recalculate path which reads from R2 split CSVs)
+    let kudgivt_csv = format!(
+        "運行NO,読取日,乗務員CD1,乗務員名１,対象乗務員区分,開始日時,終了日時,イベントCD,イベント名,区間時間,区間距離\n\
+         {unko_no},2026/03/15,DR01,運転者A,1,2026/03/15 08:00:00,2026/03/15 12:00:00,201,走行,240,100.0\n\
+         {unko_no},2026/03/15,DR01,運転者A,1,2026/03/15 12:00:00,2026/03/15 13:00:00,301,休憩,60,0\n\
+         {unko_no},2026/03/15,DR01,運転者A,1,2026/03/15 13:00:00,2026/03/15 15:00:00,202,積み,120,0\n\
+         {unko_no},2026/03/15,DR01,運転者A,1,2026/03/15 15:00:00,2026/03/15 17:00:00,201,走行,120,50.0\n"
+    );
+
+    let mut mock = MockDtakoUploadRepository::default();
+    let dep = Utc.with_ymd_and_hms(2026, 3, 15, 8, 0, 0).unwrap();
+    let ret = Utc.with_ymd_and_hms(2026, 3, 15, 17, 0, 0).unwrap();
+    *mock.operations.lock().unwrap() = vec![DtakoOpRow {
+        unko_no: unko_no.to_string(),
+        reading_date: NaiveDate::from_ymd_opt(2026, 3, 15).unwrap(),
+        operation_date: Some(NaiveDate::from_ymd_opt(2026, 3, 15).unwrap()),
+        departure_at: Some(dep),
+        return_at: Some(ret),
+        driver_cd: Some("DR01".to_string()),
+        total_distance: Some(150.0),
+        drive_time_general: Some(360),
+        drive_time_highway: Some(0),
+        drive_time_bypass: Some(0),
+    }];
+
+    let dtako_storage = Arc::new(MockStorage::new("dtako-bucket"));
+    // Insert the per-unko KUDGIVT CSV (recalculate_all_core reads individual CSVs from R2)
+    let kudgivt_key = format!("{}/unko/{}/KUDGIVT.csv", tenant_id, unko_no);
+    dtako_storage.insert_file(&kudgivt_key, kudgivt_csv.into_bytes());
+
+    let state = setup_with_storage_and_mock(mock, dtako_storage);
+    let base_url = crate::common::spawn_test_server(state).await;
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/recalculate?year=2026&month=3"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+    let body = res.text().await.unwrap();
+    assert!(body.contains("done"));
+}
+
+// =========================================================================
+// POST /api/recalculate — with operations but no KUDGIVT → error
+// =========================================================================
+
+#[tokio::test]
+async fn test_dtako_recalculate_no_kudgivt_error() {
+    use chrono::{NaiveDate, TimeZone, Utc};
+
+    let tenant_id = Uuid::new_v4();
+
+    let mut mock = MockDtakoUploadRepository::default();
+    let dep = Utc.with_ymd_and_hms(2026, 3, 15, 8, 0, 0).unwrap();
+    let ret = Utc.with_ymd_and_hms(2026, 3, 15, 17, 0, 0).unwrap();
+    *mock.operations.lock().unwrap() = vec![DtakoOpRow {
+        unko_no: "9999".to_string(),
+        reading_date: NaiveDate::from_ymd_opt(2026, 3, 15).unwrap(),
+        operation_date: Some(NaiveDate::from_ymd_opt(2026, 3, 15).unwrap()),
+        departure_at: Some(dep),
+        return_at: Some(ret),
+        driver_cd: Some("DR01".to_string()),
+        total_distance: Some(100.0),
+        drive_time_general: Some(300),
+        drive_time_highway: Some(0),
+        drive_time_bypass: Some(0),
+    }];
+
+    // No KUDGIVT in storage → should trigger "KUDGIVTが見つかりません" error
+    let state = setup_with_mock(mock);
+    let base_url = crate::common::spawn_test_server(state).await;
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/recalculate?year=2026&month=3"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200); // SSE always returns 200
+    let body = res.text().await.unwrap();
+    assert!(body.contains("error"));
+}
+
+// =========================================================================
+// POST /api/recalculate-driver — success with driver_cd and operations
+// =========================================================================
+
+#[tokio::test]
+async fn test_dtako_recalculate_driver_with_data() {
+    use chrono::{NaiveDate, TimeZone, Utc};
+
+    let tenant_id = Uuid::new_v4();
+    let driver_id = Uuid::new_v4();
+    let unko_no = "6001";
+
+    let kudgivt_csv = format!(
+        "運行NO,読取日,乗務員CD1,乗務員名１,対象乗務員区分,開始日時,終了日時,イベントCD,イベント名,区間時間,区間距離\n\
+         {unko_no},2026/03/20,DR01,運転者A,1,2026/03/20 08:00:00,2026/03/20 12:00:00,201,走行,240,80.0\n\
+         {unko_no},2026/03/20,DR01,運転者A,1,2026/03/20 12:00:00,2026/03/20 13:00:00,301,休憩,60,0\n\
+         {unko_no},2026/03/20,DR01,運転者A,1,2026/03/20 13:00:00,2026/03/20 16:00:00,201,走行,180,70.0\n"
+    );
+
+    let mut mock = MockDtakoUploadRepository::default();
+    *mock.driver_cd.lock().unwrap() = Some("DR01".to_string());
+
+    let dep = Utc.with_ymd_and_hms(2026, 3, 20, 8, 0, 0).unwrap();
+    let ret = Utc.with_ymd_and_hms(2026, 3, 20, 16, 0, 0).unwrap();
+    *mock.driver_operations.lock().unwrap() = vec![DtakoDriverOpRow {
+        unko_no: unko_no.to_string(),
+        reading_date: NaiveDate::from_ymd_opt(2026, 3, 20).unwrap(),
+        operation_date: Some(NaiveDate::from_ymd_opt(2026, 3, 20).unwrap()),
+        departure_at: Some(dep),
+        return_at: Some(ret),
+        total_distance: Some(150.0),
+        drive_time_general: Some(420),
+        drive_time_highway: Some(0),
+        drive_time_bypass: Some(0),
+    }];
+
+    // ZIP keys for load_kudgivt_from_zips
+    let zip_key = format!("{}/uploads/some/test.zip", tenant_id);
+    *mock.zip_keys.lock().unwrap() = vec![zip_key.clone()];
+
+    let dtako_storage = Arc::new(MockStorage::new("dtako-bucket"));
+    // Create a ZIP with KUDGIVT for load_kudgivt_from_zips
+    let zip_bytes = create_zip_with_kudgivt(&kudgivt_csv);
+    dtako_storage.insert_file(&zip_key, zip_bytes);
+
+    // Also insert per-unko KUDGFRY.csv for ferry data loading
+    let ferry_csv = format!(
+        "col0,col1,col2,col3,col4,col5,col6,col7,col8,col9,start_time,end_time\n\
+         a,b,c,d,e,f,g,h,i,j,2026/03/20 14:00:00,2026/03/20 15:00:00\n"
+    );
+    let ferry_key = format!("{}/unko/{}/KUDGFRY.csv", tenant_id, unko_no);
+    let (ferry_bytes, _, _) = encoding_rs::SHIFT_JIS.encode(&ferry_csv);
+    dtako_storage.insert_file(&ferry_key, ferry_bytes.to_vec());
+
+    let state = setup_with_storage_and_mock(mock, dtako_storage);
+    let base_url = crate::common::spawn_test_server(state).await;
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!(
+            "{base_url}/api/recalculate-driver?year=2026&month=3&driver_id={driver_id}"
+        ))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+    let body = res.text().await.unwrap();
+    assert!(body.contains("done"));
+}
+
+/// Create a ZIP file containing only KUDGIVT.csv (UTF-8 text inside)
+fn create_zip_with_kudgivt(kudgivt_text: &str) -> Vec<u8> {
+    use std::io::Write;
+
+    let (kudgivt_bytes, _, _) = encoding_rs::SHIFT_JIS.encode(kudgivt_text);
+    let mut buf = std::io::Cursor::new(Vec::new());
+    {
+        let mut zip = zip::ZipWriter::new(&mut buf);
+        let options = zip::write::SimpleFileOptions::default();
+        zip.start_file("KUDGIVT.csv", options).unwrap();
+        zip.write_all(&kudgivt_bytes).unwrap();
+        zip.finish().unwrap();
+    }
+    buf.into_inner()
+}
+
+// =========================================================================
+// POST /api/recalculate-drivers — batch with actual driver data
+// =========================================================================
+
+#[tokio::test]
+async fn test_dtako_recalculate_drivers_batch_with_data() {
+    use chrono::{NaiveDate, TimeZone, Utc};
+
+    let tenant_id = Uuid::new_v4();
+    let driver_id = Uuid::new_v4();
+
+    let mut mock = MockDtakoUploadRepository::default();
+    *mock.driver_cd.lock().unwrap() = Some("DR01".to_string());
+
+    let dep = Utc.with_ymd_and_hms(2026, 3, 20, 8, 0, 0).unwrap();
+    let ret = Utc.with_ymd_and_hms(2026, 3, 20, 16, 0, 0).unwrap();
+    *mock.driver_operations.lock().unwrap() = vec![DtakoDriverOpRow {
+        unko_no: "7001".to_string(),
+        reading_date: NaiveDate::from_ymd_opt(2026, 3, 20).unwrap(),
+        operation_date: Some(NaiveDate::from_ymd_opt(2026, 3, 20).unwrap()),
+        departure_at: Some(dep),
+        return_at: Some(ret),
+        total_distance: Some(100.0),
+        drive_time_general: Some(300),
+        drive_time_highway: Some(60),
+        drive_time_bypass: Some(0),
+    }];
+
+    let kudgivt_csv = "運行NO,読取日,乗務員CD1,乗務員名１,対象乗務員区分,開始日時,終了日時,イベントCD,イベント名,区間時間,区間距離\n\
+         7001,2026/03/20,DR01,運転者A,1,2026/03/20 08:00:00,2026/03/20 12:00:00,201,走行,240,50.0\n\
+         7001,2026/03/20,DR01,運転者A,1,2026/03/20 13:00:00,2026/03/20 16:00:00,201,走行,180,50.0\n";
+
+    let zip_key = format!("{}/uploads/batch/test.zip", tenant_id);
+    *mock.zip_keys.lock().unwrap() = vec![zip_key.clone()];
+
+    let dtako_storage = Arc::new(MockStorage::new("dtako-bucket"));
+    dtako_storage.insert_file(&zip_key, create_zip_with_kudgivt(kudgivt_csv));
+
+    let state = setup_with_storage_and_mock(mock, dtako_storage);
+    let base_url = crate::common::spawn_test_server(state).await;
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/recalculate-drivers"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .header("Content-Type", "application/json")
+        .body(
+            serde_json::json!({
+                "year": 2026,
+                "month": 3,
+                "driver_ids": [driver_id]
+            })
+            .to_string(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+    let body = res.text().await.unwrap();
+    assert!(body.contains("batch_done"));
+}
+
+// =========================================================================
+// POST /api/upload — rich ZIP with ferry data (covers load_ferry_minutes in upload)
+// Note: ferry data is only loaded during split-csv/recalculate, not during upload
+// Upload always uses empty ferry_minutes. So we test ferry via recalculate.
+// =========================================================================
+
+// =========================================================================
+// POST /api/recalculate — with ferry data (covers load_ferry_minutes)
+// =========================================================================
+
+#[tokio::test]
+async fn test_dtako_recalculate_with_ferry_data() {
+    use chrono::{NaiveDate, TimeZone, Utc};
+
+    let tenant_id = Uuid::new_v4();
+    let unko_no = "8001";
+
+    let kudgivt_csv = format!(
+        "運行NO,読取日,乗務員CD1,乗務員名１,対象乗務員区分,開始日時,終了日時,イベントCD,イベント名,区間時間,区間距離\n\
+         {unko_no},2026/03/10,DR01,運転者A,1,2026/03/10 06:00:00,2026/03/10 10:00:00,201,走行,240,100.0\n\
+         {unko_no},2026/03/10,DR01,運転者A,1,2026/03/10 10:00:00,2026/03/10 11:00:00,301,休憩,60,0\n\
+         {unko_no},2026/03/10,DR01,運転者A,1,2026/03/10 11:00:00,2026/03/10 14:00:00,201,走行,180,80.0\n\
+         {unko_no},2026/03/10,DR01,運転者A,1,2026/03/10 14:00:00,2026/03/10 14:30:00,302,休息,30,0\n"
+    );
+
+    let mut mock = MockDtakoUploadRepository::default();
+    let dep = Utc.with_ymd_and_hms(2026, 3, 10, 6, 0, 0).unwrap();
+    let ret = Utc.with_ymd_and_hms(2026, 3, 10, 15, 0, 0).unwrap();
+    *mock.operations.lock().unwrap() = vec![DtakoOpRow {
+        unko_no: unko_no.to_string(),
+        reading_date: NaiveDate::from_ymd_opt(2026, 3, 10).unwrap(),
+        operation_date: Some(NaiveDate::from_ymd_opt(2026, 3, 10).unwrap()),
+        departure_at: Some(dep),
+        return_at: Some(ret),
+        driver_cd: Some("DR01".to_string()),
+        total_distance: Some(180.0),
+        drive_time_general: Some(420),
+        drive_time_highway: Some(0),
+        drive_time_bypass: Some(0),
+    }];
+
+    let dtako_storage = Arc::new(MockStorage::new("dtako-bucket"));
+
+    // Per-unko KUDGIVT.csv (recalculate reads these individually)
+    let kudgivt_key = format!("{}/unko/{}/KUDGIVT.csv", tenant_id, unko_no);
+    dtako_storage.insert_file(&kudgivt_key, kudgivt_csv.into_bytes());
+
+    // Per-unko KUDGFRY.csv (ferry data)
+    let ferry_csv = "c0,c1,c2,c3,c4,c5,c6,c7,c8,c9,start,end\n\
+                     a,b,c,d,e,f,g,h,i,j,2026/03/10 10:00:00,2026/03/10 11:00:00\n";
+    let ferry_key = format!("{}/unko/{}/KUDGFRY.csv", tenant_id, unko_no);
+    let (ferry_bytes, _, _) = encoding_rs::SHIFT_JIS.encode(ferry_csv);
+    dtako_storage.insert_file(&ferry_key, ferry_bytes.to_vec());
+
+    let state = setup_with_storage_and_mock(mock, dtako_storage);
+    let base_url = crate::common::spawn_test_server(state).await;
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/recalculate?year=2026&month=3"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+    let body = res.text().await.unwrap();
+    assert!(body.contains("done"));
+}
+
+// =========================================================================
+// POST /api/recalculate — with ferry data having short duration (< 0 mins)
+// =========================================================================
+
+#[tokio::test]
+async fn test_dtako_recalculate_ferry_zero_duration() {
+    use chrono::{NaiveDate, TimeZone, Utc};
+
+    let tenant_id = Uuid::new_v4();
+    let unko_no = "8002";
+
+    let kudgivt_csv = format!(
+        "運行NO,読取日,乗務員CD1,乗務員名１,対象乗務員区分,開始日時,終了日時,イベントCD,イベント名,区間時間,区間距離\n\
+         {unko_no},2026/03/10,DR01,運転者A,1,2026/03/10 08:00:00,2026/03/10 12:00:00,201,走行,240,100.0\n"
+    );
+
+    let mut mock = MockDtakoUploadRepository::default();
+    let dep = Utc.with_ymd_and_hms(2026, 3, 10, 8, 0, 0).unwrap();
+    let ret = Utc.with_ymd_and_hms(2026, 3, 10, 12, 0, 0).unwrap();
+    *mock.operations.lock().unwrap() = vec![DtakoOpRow {
+        unko_no: unko_no.to_string(),
+        reading_date: NaiveDate::from_ymd_opt(2026, 3, 10).unwrap(),
+        operation_date: Some(NaiveDate::from_ymd_opt(2026, 3, 10).unwrap()),
+        departure_at: Some(dep),
+        return_at: Some(ret),
+        driver_cd: Some("DR01".to_string()),
+        total_distance: Some(100.0),
+        drive_time_general: Some(240),
+        drive_time_highway: Some(0),
+        drive_time_bypass: Some(0),
+    }];
+
+    let dtako_storage = Arc::new(MockStorage::new("dtako-bucket"));
+    let kudgivt_key = format!("{}/unko/{}/KUDGIVT.csv", tenant_id, unko_no);
+    dtako_storage.insert_file(&kudgivt_key, kudgivt_csv.into_bytes());
+
+    // Ferry with same start and end (0 duration) — should be ignored
+    let ferry_csv = "c0,c1,c2,c3,c4,c5,c6,c7,c8,c9,start,end\n\
+                     a,b,c,d,e,f,g,h,i,j,2026/03/10 10:00:00,2026/03/10 10:00:00\n";
+    let ferry_key = format!("{}/unko/{}/KUDGFRY.csv", tenant_id, unko_no);
+    let (ferry_bytes, _, _) = encoding_rs::SHIFT_JIS.encode(ferry_csv);
+    dtako_storage.insert_file(&ferry_key, ferry_bytes.to_vec());
+
+    let state = setup_with_storage_and_mock(mock, dtako_storage);
+    let base_url = crate::common::spawn_test_server(state).await;
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/recalculate?year=2026&month=3"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+    let body = res.text().await.unwrap();
+    assert!(body.contains("done"));
+}
+
+// =========================================================================
+// POST /api/recalculate — ferry data with short cols (<=11) → skip line
+// =========================================================================
+
+#[tokio::test]
+async fn test_dtako_recalculate_ferry_short_cols() {
+    use chrono::{NaiveDate, TimeZone, Utc};
+
+    let tenant_id = Uuid::new_v4();
+    let unko_no = "8003";
+
+    let kudgivt_csv = format!(
+        "運行NO,読取日,乗務員CD1,乗務員名１,対象乗務員区分,開始日時,終了日時,イベントCD,イベント名,区間時間,区間距離\n\
+         {unko_no},2026/03/10,DR01,運転者A,1,2026/03/10 08:00:00,2026/03/10 12:00:00,201,走行,240,100.0\n"
+    );
+
+    let mut mock = MockDtakoUploadRepository::default();
+    let dep = Utc.with_ymd_and_hms(2026, 3, 10, 8, 0, 0).unwrap();
+    let ret = Utc.with_ymd_and_hms(2026, 3, 10, 12, 0, 0).unwrap();
+    *mock.operations.lock().unwrap() = vec![DtakoOpRow {
+        unko_no: unko_no.to_string(),
+        reading_date: NaiveDate::from_ymd_opt(2026, 3, 10).unwrap(),
+        operation_date: Some(NaiveDate::from_ymd_opt(2026, 3, 10).unwrap()),
+        departure_at: Some(dep),
+        return_at: Some(ret),
+        driver_cd: Some("DR01".to_string()),
+        total_distance: Some(100.0),
+        drive_time_general: Some(240),
+        drive_time_highway: Some(0),
+        drive_time_bypass: Some(0),
+    }];
+
+    let dtako_storage = Arc::new(MockStorage::new("dtako-bucket"));
+    let kudgivt_key = format!("{}/unko/{}/KUDGIVT.csv", tenant_id, unko_no);
+    dtako_storage.insert_file(&kudgivt_key, kudgivt_csv.into_bytes());
+
+    // Ferry CSV with too few columns (only 5) → should be skipped (cols.len() <= 11)
+    let ferry_csv = "c0,c1,c2\nheader_only\na,b,c\n";
+    let ferry_key = format!("{}/unko/{}/KUDGFRY.csv", tenant_id, unko_no);
+    let (ferry_bytes, _, _) = encoding_rs::SHIFT_JIS.encode(ferry_csv);
+    dtako_storage.insert_file(&ferry_key, ferry_bytes.to_vec());
+
+    let state = setup_with_storage_and_mock(mock, dtako_storage);
+    let base_url = crate::common::spawn_test_server(state).await;
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/recalculate?year=2026&month=3"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+    let body = res.text().await.unwrap();
+    assert!(body.contains("done"));
+}
+
+// =========================================================================
+// POST /api/recalculate — ferry data with invalid datetime format → skip
+// =========================================================================
+
+#[tokio::test]
+async fn test_dtako_recalculate_ferry_invalid_datetime() {
+    use chrono::{NaiveDate, TimeZone, Utc};
+
+    let tenant_id = Uuid::new_v4();
+    let unko_no = "8004";
+
+    let kudgivt_csv = format!(
+        "運行NO,読取日,乗務員CD1,乗務員名１,対象乗務員区分,開始日時,終了日時,イベントCD,イベント名,区間時間,区間距離\n\
+         {unko_no},2026/03/10,DR01,運転者A,1,2026/03/10 08:00:00,2026/03/10 12:00:00,201,走行,240,100.0\n"
+    );
+
+    let mut mock = MockDtakoUploadRepository::default();
+    let dep = Utc.with_ymd_and_hms(2026, 3, 10, 8, 0, 0).unwrap();
+    let ret = Utc.with_ymd_and_hms(2026, 3, 10, 12, 0, 0).unwrap();
+    *mock.operations.lock().unwrap() = vec![DtakoOpRow {
+        unko_no: unko_no.to_string(),
+        reading_date: NaiveDate::from_ymd_opt(2026, 3, 10).unwrap(),
+        operation_date: Some(NaiveDate::from_ymd_opt(2026, 3, 10).unwrap()),
+        departure_at: Some(dep),
+        return_at: Some(ret),
+        driver_cd: Some("DR01".to_string()),
+        total_distance: Some(100.0),
+        drive_time_general: Some(240),
+        drive_time_highway: Some(0),
+        drive_time_bypass: Some(0),
+    }];
+
+    let dtako_storage = Arc::new(MockStorage::new("dtako-bucket"));
+    let kudgivt_key = format!("{}/unko/{}/KUDGIVT.csv", tenant_id, unko_no);
+    dtako_storage.insert_file(&kudgivt_key, kudgivt_csv.into_bytes());
+
+    // Ferry CSV with invalid datetime strings → parse fails → skipped
+    let ferry_csv =
+        "c0,c1,c2,c3,c4,c5,c6,c7,c8,c9,start,end\na,b,c,d,e,f,g,h,i,j,INVALID,ALSO_INVALID\n";
+    let ferry_key = format!("{}/unko/{}/KUDGFRY.csv", tenant_id, unko_no);
+    let (ferry_bytes, _, _) = encoding_rs::SHIFT_JIS.encode(ferry_csv);
+    dtako_storage.insert_file(&ferry_key, ferry_bytes.to_vec());
+
+    let state = setup_with_storage_and_mock(mock, dtako_storage);
+    let base_url = crate::common::spawn_test_server(state).await;
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/recalculate?year=2026&month=3"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+    let body = res.text().await.unwrap();
+    assert!(body.contains("done"));
+}
+
+// =========================================================================
+// Unit tests for compute_month_range and default_classification
+// =========================================================================
+
+#[test]
+fn test_compute_month_range() {
+    use rust_alc_api::routes::dtako_upload::compute_month_range;
+
+    // Normal month
+    let (start, end) = compute_month_range(2026, 3).unwrap();
+    assert_eq!(start, chrono::NaiveDate::from_ymd_opt(2026, 3, 1).unwrap());
+    assert_eq!(end, chrono::NaiveDate::from_ymd_opt(2026, 3, 31).unwrap());
+
+    // December (year wrap)
+    let (start, end) = compute_month_range(2026, 12).unwrap();
+    assert_eq!(start, chrono::NaiveDate::from_ymd_opt(2026, 12, 1).unwrap());
+    assert_eq!(end, chrono::NaiveDate::from_ymd_opt(2026, 12, 31).unwrap());
+
+    // February (non-leap year)
+    let (start, end) = compute_month_range(2025, 2).unwrap();
+    assert_eq!(start, chrono::NaiveDate::from_ymd_opt(2025, 2, 1).unwrap());
+    assert_eq!(end, chrono::NaiveDate::from_ymd_opt(2025, 2, 28).unwrap());
+
+    // Invalid month → None
+    let result = compute_month_range(2026, 13);
+    assert!(result.is_none());
+}
+
+#[test]
+fn test_default_classification() {
+    use rust_alc_api::csv_parser::work_segments::EventClass;
+    use rust_alc_api::routes::dtako_upload::default_classification;
+
+    assert_eq!(default_classification("201"), ("drive", EventClass::Drive));
+    assert_eq!(default_classification("202"), ("cargo", EventClass::Cargo));
+    assert_eq!(default_classification("203"), ("cargo", EventClass::Cargo));
+    assert_eq!(default_classification("204"), ("cargo", EventClass::Cargo));
+    assert_eq!(
+        default_classification("302"),
+        ("rest_split", EventClass::RestSplit)
+    );
+    assert_eq!(default_classification("301"), ("break", EventClass::Break));
+    assert_eq!(
+        default_classification("999"),
+        ("ignore", EventClass::Ignore)
+    );
+}
+
+// =========================================================================
+// POST /api/recalculate-driver — driver_cd not found → error in SSE
+// =========================================================================
+
+#[tokio::test]
+async fn test_dtako_recalculate_driver_not_found() {
+    // driver_cd is None by default → "ドライバーが見つかりません"
+    let state = setup_mock_app_state();
+    let tenant_id = Uuid::new_v4();
+    let driver_id = Uuid::new_v4();
+    let base_url = crate::common::spawn_test_server(state).await;
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!(
+            "{base_url}/api/recalculate-driver?year=2026&month=3&driver_id={driver_id}"
+        ))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+    let body = res.text().await.unwrap();
+    assert!(body.contains("error"));
+}
+
+// =========================================================================
+// POST /api/recalculate — invalid year/month → error
+// =========================================================================
+
+#[tokio::test]
+async fn test_dtako_recalculate_invalid_month() {
+    let state = setup_mock_app_state();
+    let tenant_id = Uuid::new_v4();
+    let base_url = crate::common::spawn_test_server(state).await;
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/recalculate?year=2026&month=13"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200); // SSE always returns 200
+    let body = res.text().await.unwrap();
+    assert!(body.contains("error"));
+}
+
+// =========================================================================
+// POST /api/recalculate-driver — invalid month → error
+// =========================================================================
+
+#[tokio::test]
+async fn test_dtako_recalculate_driver_invalid_month() {
+    let mut mock = MockDtakoUploadRepository::default();
+    *mock.driver_cd.lock().unwrap() = Some("DR01".to_string());
+
+    let state = setup_with_mock(mock);
+    let tenant_id = Uuid::new_v4();
+    let driver_id = Uuid::new_v4();
+    let base_url = crate::common::spawn_test_server(state).await;
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!(
+            "{base_url}/api/recalculate-driver?year=2026&month=13&driver_id={driver_id}"
+        ))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+    let body = res.text().await.unwrap();
+    assert!(body.contains("error"));
+}
+
+// =========================================================================
+// POST /api/recalculate-drivers — invalid month → error
+// =========================================================================
+
+#[tokio::test]
+async fn test_dtako_recalculate_drivers_batch_invalid_month() {
+    let state = setup_mock_app_state();
+    let tenant_id = Uuid::new_v4();
+    let base_url = crate::common::spawn_test_server(state).await;
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/recalculate-drivers"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .header("Content-Type", "application/json")
+        .body(
+            serde_json::json!({
+                "year": 2026,
+                "month": 13,
+                "driver_ids": [Uuid::new_v4()]
+            })
+            .to_string(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+    let body = res.text().await.unwrap();
+    assert!(body.contains("error"));
+}
+
+// =========================================================================
+// POST /api/recalculate — with operations having multiple drivers + rest events
+// =========================================================================
+
+#[tokio::test]
+async fn test_dtako_recalculate_multiple_operations_with_rest() {
+    use chrono::{NaiveDate, TimeZone, Utc};
+
+    let tenant_id = Uuid::new_v4();
+
+    let kudgivt_csv = "運行NO,読取日,乗務員CD1,乗務員名１,対象乗務員区分,開始日時,終了日時,イベントCD,イベント名,区間時間,区間距離\n\
+         9001,2026/03/10,DR01,運転者A,1,2026/03/10 08:00:00,2026/03/10 12:00:00,201,走行,240,100.0\n\
+         9001,2026/03/10,DR01,運転者A,1,2026/03/10 12:00:00,2026/03/10 13:00:00,302,休息,60,0\n\
+         9001,2026/03/10,DR01,運転者A,1,2026/03/10 13:00:00,2026/03/10 15:00:00,203,降し,120,0\n\
+         9002,2026/03/10,DR02,運転者B,1,2026/03/10 09:00:00,2026/03/10 14:00:00,201,走行,300,80.0\n\
+         9002,2026/03/10,DR02,運転者B,1,2026/03/10 14:00:00,2026/03/10 15:00:00,204,その他,60,0\n";
+
+    let mut mock = MockDtakoUploadRepository::default();
+
+    let dep1 = Utc.with_ymd_and_hms(2026, 3, 10, 8, 0, 0).unwrap();
+    let ret1 = Utc.with_ymd_and_hms(2026, 3, 10, 15, 0, 0).unwrap();
+    let dep2 = Utc.with_ymd_and_hms(2026, 3, 10, 9, 0, 0).unwrap();
+    let ret2 = Utc.with_ymd_and_hms(2026, 3, 10, 15, 0, 0).unwrap();
+    *mock.operations.lock().unwrap() = vec![
+        DtakoOpRow {
+            unko_no: "9001".to_string(),
+            reading_date: NaiveDate::from_ymd_opt(2026, 3, 10).unwrap(),
+            operation_date: Some(NaiveDate::from_ymd_opt(2026, 3, 10).unwrap()),
+            departure_at: Some(dep1),
+            return_at: Some(ret1),
+            driver_cd: Some("DR01".to_string()),
+            total_distance: Some(100.0),
+            drive_time_general: Some(240),
+            drive_time_highway: Some(0),
+            drive_time_bypass: Some(0),
+        },
+        DtakoOpRow {
+            unko_no: "9002".to_string(),
+            reading_date: NaiveDate::from_ymd_opt(2026, 3, 10).unwrap(),
+            operation_date: Some(NaiveDate::from_ymd_opt(2026, 3, 10).unwrap()),
+            departure_at: Some(dep2),
+            return_at: Some(ret2),
+            driver_cd: Some("DR02".to_string()),
+            total_distance: Some(80.0),
+            drive_time_general: Some(300),
+            drive_time_highway: Some(0),
+            drive_time_bypass: Some(0),
+        },
+    ];
+
+    let dtako_storage = Arc::new(MockStorage::new("dtako-bucket"));
+    let kudgivt_key1 = format!("{}/unko/9001/KUDGIVT.csv", tenant_id);
+    let kudgivt_key2 = format!("{}/unko/9002/KUDGIVT.csv", tenant_id);
+    dtako_storage.insert_file(&kudgivt_key1, kudgivt_csv.as_bytes().to_vec());
+    dtako_storage.insert_file(&kudgivt_key2, kudgivt_csv.as_bytes().to_vec());
+
+    let state = setup_with_storage_and_mock(mock, dtako_storage);
+    let base_url = crate::common::spawn_test_server(state).await;
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/recalculate?year=2026&month=3"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+    let body = res.text().await.unwrap();
+    assert!(body.contains("done"));
+}
+
+// =========================================================================
+// POST /api/recalculate — with employee_id mapped (exercises driver_id path)
+// =========================================================================
+
+#[tokio::test]
+async fn test_dtako_recalculate_with_employee_id_mapped() {
+    use chrono::{NaiveDate, TimeZone, Utc};
+
+    let tenant_id = Uuid::new_v4();
+    let employee_id = Uuid::new_v4();
+    let unko_no = "9010";
+
+    let kudgivt_csv = format!(
+        "運行NO,読取日,乗務員CD1,乗務員名１,対象乗務員区分,開始日時,終了日時,イベントCD,イベント名,区間時間,区間距離\n\
+         {unko_no},2026/03/15,DR01,運転者A,1,2026/03/15 08:00:00,2026/03/15 17:00:00,201,走行,540,200.0\n"
+    );
+
+    let mut mock = MockDtakoUploadRepository::default();
+    *mock.employee_id.lock().unwrap() = Some(employee_id);
+
+    let dep = Utc.with_ymd_and_hms(2026, 3, 15, 8, 0, 0).unwrap();
+    let ret = Utc.with_ymd_and_hms(2026, 3, 15, 17, 0, 0).unwrap();
+    *mock.operations.lock().unwrap() = vec![DtakoOpRow {
+        unko_no: unko_no.to_string(),
+        reading_date: NaiveDate::from_ymd_opt(2026, 3, 15).unwrap(),
+        operation_date: Some(NaiveDate::from_ymd_opt(2026, 3, 15).unwrap()),
+        departure_at: Some(dep),
+        return_at: Some(ret),
+        driver_cd: Some("DR01".to_string()),
+        total_distance: Some(200.0),
+        drive_time_general: Some(540),
+        drive_time_highway: Some(0),
+        drive_time_bypass: Some(0),
+    }];
+
+    let dtako_storage = Arc::new(MockStorage::new("dtako-bucket"));
+    let kudgivt_key = format!("{}/unko/{}/KUDGIVT.csv", tenant_id, unko_no);
+    dtako_storage.insert_file(&kudgivt_key, kudgivt_csv.into_bytes());
+
+    let state = setup_with_storage_and_mock(mock, dtako_storage);
+    let base_url = crate::common::spawn_test_server(state).await;
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/recalculate?year=2026&month=3"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+    let body = res.text().await.unwrap();
+    assert!(body.contains("done"));
+}
+
+// =========================================================================
+// POST /api/upload — process_zip fails after create_upload_history → mark_upload_failed
+// =========================================================================
+
+#[tokio::test]
+async fn test_dtako_upload_process_zip_error_marks_failed() {
+    // Upload a ZIP that has KUDGURI but not KUDGIVT → process_zip fails
+    // This exercises the mark_upload_failed path (line 82-87)
+    let state = setup_mock_app_state();
+    let tenant_id = Uuid::new_v4();
+    let base_url = crate::common::spawn_test_server(state).await;
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let zip_bytes = create_missing_kudgivt_zip();
+    let part = reqwest::multipart::Part::bytes(zip_bytes).file_name("bad.zip");
+    let form = reqwest::multipart::Form::new().part("file", part);
+
+    let res = client
+        .post(format!("{base_url}/api/upload"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .multipart(form)
+        .send()
+        .await
+        .unwrap();
+
+    // Should return 400 since process_zip failed
+    assert_eq!(res.status(), 400);
+}
+
+// =========================================================================
+// load_kudgivt_from_zips: ZIP download error + ZIP extract error paths
+// (exercised through recalculate-driver with bad ZIP data in storage)
+// =========================================================================
+
+#[tokio::test]
+async fn test_dtako_recalculate_driver_bad_zip_in_storage() {
+    use chrono::{NaiveDate, TimeZone, Utc};
+
+    let tenant_id = Uuid::new_v4();
+    let driver_id = Uuid::new_v4();
+
+    let mut mock = MockDtakoUploadRepository::default();
+    *mock.driver_cd.lock().unwrap() = Some("DR01".to_string());
+
+    let dep = Utc.with_ymd_and_hms(2026, 3, 20, 8, 0, 0).unwrap();
+    let ret = Utc.with_ymd_and_hms(2026, 3, 20, 16, 0, 0).unwrap();
+    *mock.driver_operations.lock().unwrap() = vec![DtakoDriverOpRow {
+        unko_no: "BAD01".to_string(),
+        reading_date: NaiveDate::from_ymd_opt(2026, 3, 20).unwrap(),
+        operation_date: Some(NaiveDate::from_ymd_opt(2026, 3, 20).unwrap()),
+        departure_at: Some(dep),
+        return_at: Some(ret),
+        total_distance: Some(100.0),
+        drive_time_general: Some(300),
+        drive_time_highway: Some(0),
+        drive_time_bypass: Some(0),
+    }];
+
+    // Add a zip key that points to invalid ZIP data
+    let bad_zip_key = format!("{}/uploads/bad/corrupt.zip", tenant_id);
+    *mock.zip_keys.lock().unwrap() = vec![bad_zip_key.clone()];
+
+    let dtako_storage = Arc::new(MockStorage::new("dtako-bucket"));
+    // Insert corrupted data (not a valid ZIP)
+    dtako_storage.insert_file(&bad_zip_key, vec![0x00, 0x01, 0x02, 0x03]);
+
+    let state = setup_with_storage_and_mock(mock, dtako_storage);
+    let base_url = crate::common::spawn_test_server(state).await;
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!(
+            "{base_url}/api/recalculate-driver?year=2026&month=3&driver_id={driver_id}"
+        ))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+    let body = res.text().await.unwrap();
+    // No KUDGIVT found from bad ZIP but operations exist → should return done with 0 or error
+    // Since all_kudgivt is empty and ops is non-empty, no error: the recalculate still proceeds
+    // because load_kudgivt_from_zips only warns, doesn't fail
+    assert!(body.contains("done") || body.contains("error"));
+}
+
+// =========================================================================
+// load_kudgivt_from_zips: ZIP with KUDGIVT that has parse error
+// =========================================================================
+
+#[tokio::test]
+async fn test_dtako_recalculate_driver_kudgivt_parse_error_in_zip() {
+    use chrono::{NaiveDate, TimeZone, Utc};
+
+    let tenant_id = Uuid::new_v4();
+    let driver_id = Uuid::new_v4();
+
+    let mut mock = MockDtakoUploadRepository::default();
+    *mock.driver_cd.lock().unwrap() = Some("DR01".to_string());
+
+    let dep = Utc.with_ymd_and_hms(2026, 3, 20, 8, 0, 0).unwrap();
+    let ret = Utc.with_ymd_and_hms(2026, 3, 20, 16, 0, 0).unwrap();
+    *mock.driver_operations.lock().unwrap() = vec![DtakoDriverOpRow {
+        unko_no: "PARSE01".to_string(),
+        reading_date: NaiveDate::from_ymd_opt(2026, 3, 20).unwrap(),
+        operation_date: Some(NaiveDate::from_ymd_opt(2026, 3, 20).unwrap()),
+        departure_at: Some(dep),
+        return_at: Some(ret),
+        total_distance: Some(100.0),
+        drive_time_general: Some(300),
+        drive_time_highway: Some(0),
+        drive_time_bypass: Some(0),
+    }];
+
+    // Create a valid ZIP with a KUDGIVT.csv that has invalid content
+    let bad_kudgivt = "this is not valid KUDGIVT CSV content at all";
+    let zip_key = format!("{}/uploads/bad_kudgivt/test.zip", tenant_id);
+    *mock.zip_keys.lock().unwrap() = vec![zip_key.clone()];
+
+    let dtako_storage = Arc::new(MockStorage::new("dtako-bucket"));
+    let zip_bytes = create_zip_with_kudgivt(bad_kudgivt);
+    dtako_storage.insert_file(&zip_key, zip_bytes);
+
+    let state = setup_with_storage_and_mock(mock, dtako_storage);
+    let base_url = crate::common::spawn_test_server(state).await;
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!(
+            "{base_url}/api/recalculate-driver?year=2026&month=3&driver_id={driver_id}"
+        ))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+    let body = res.text().await.unwrap();
+    assert!(body.contains("done") || body.contains("error"));
+}
+
+// =========================================================================
+// POST /api/recalculate — late night work (hours spanning 22:00-05:00)
+// =========================================================================
+
+#[tokio::test]
+async fn test_dtako_recalculate_late_night_work() {
+    use chrono::{NaiveDate, TimeZone, Utc};
+
+    let tenant_id = Uuid::new_v4();
+    let employee_id = Uuid::new_v4();
+    let unko_no = "LN01";
+
+    // Operation with late-night hours (22:00 - 03:00 next day)
+    let kudgivt_csv = format!(
+        "運行NO,読取日,乗務員CD1,乗務員名１,対象乗務員区分,開始日時,終了日時,イベントCD,イベント名,区間時間,区間距離\n\
+         {unko_no},2026/03/10,DR01,運転者A,1,2026/03/10 20:00:00,2026/03/11 03:00:00,201,走行,420,200.0\n"
+    );
+
+    let mut mock = MockDtakoUploadRepository::default();
+    *mock.employee_id.lock().unwrap() = Some(employee_id);
+
+    let dep = Utc.with_ymd_and_hms(2026, 3, 10, 20, 0, 0).unwrap();
+    let ret = Utc.with_ymd_and_hms(2026, 3, 11, 3, 0, 0).unwrap();
+    *mock.operations.lock().unwrap() = vec![DtakoOpRow {
+        unko_no: unko_no.to_string(),
+        reading_date: NaiveDate::from_ymd_opt(2026, 3, 10).unwrap(),
+        operation_date: Some(NaiveDate::from_ymd_opt(2026, 3, 10).unwrap()),
+        departure_at: Some(dep),
+        return_at: Some(ret),
+        driver_cd: Some("DR01".to_string()),
+        total_distance: Some(200.0),
+        drive_time_general: Some(420),
+        drive_time_highway: Some(0),
+        drive_time_bypass: Some(0),
+    }];
+
+    let dtako_storage = Arc::new(MockStorage::new("dtako-bucket"));
+    let kudgivt_key = format!("{}/unko/{}/KUDGIVT.csv", tenant_id, unko_no);
+    dtako_storage.insert_file(&kudgivt_key, kudgivt_csv.into_bytes());
+
+    let state = setup_with_storage_and_mock(mock, dtako_storage);
+    let base_url = crate::common::spawn_test_server(state).await;
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/recalculate?year=2026&month=3"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+    let body = res.text().await.unwrap();
+    assert!(body.contains("done"));
+}
+
+// =========================================================================
+// POST /api/upload — upload with non-zip filename extension
+// =========================================================================
+
+#[tokio::test]
+async fn test_dtako_upload_no_filename() {
+    let state = setup_mock_app_state();
+    let tenant_id = Uuid::new_v4();
+    let base_url = crate::common::spawn_test_server(state).await;
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let zip_bytes = crate::common::create_test_dtako_zip();
+    // Part without file_name → defaults to "upload.zip"
+    let part = reqwest::multipart::Part::bytes(zip_bytes);
+    let form = reqwest::multipart::Form::new().part("file", part);
+
+    let res = client
+        .post(format!("{base_url}/api/upload"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .multipart(form)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
 }

--- a/tests/mock_tests/mock_dtako_upload_test.rs
+++ b/tests/mock_tests/mock_dtako_upload_test.rs
@@ -2867,3 +2867,90 @@ fn create_zip_with_only_kudguri() -> Vec<u8> {
     }
     buf.into_inner()
 }
+
+/// POST /upload — multipart にファイルフィールドがない → 400 "no 'file' field found" (line 109)
+#[tokio::test]
+async fn test_dtako_upload_no_file_field() {
+    let (base_url, auth_header, _) = setup().await;
+    let client = reqwest::Client::new();
+
+    // "not_file" という名前のテキストパート
+    let form = reqwest::multipart::Form::new().text("not_file", "hello");
+
+    let res = client
+        .post(format!("{base_url}/api/upload"))
+        .header("Authorization", &auth_header)
+        .multipart(form)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 400);
+    let body = res.text().await.unwrap();
+    assert!(body.contains("no 'file' field found"));
+}
+
+/// POST /recalculate — with operations data → progress_tx Some path (line 691, 1079)
+#[tokio::test]
+async fn test_dtako_recalculate_with_operations_progress() {
+    use rust_alc_api::storage::StorageBackend;
+
+    let tenant_id = Uuid::new_v4();
+    let driver_id = Uuid::new_v4();
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+
+    let mut mock = MockDtakoUploadRepository::default();
+    // Return operations so recalculate actually processes them
+    *mock.operations.lock().unwrap() = vec![DtakoOpRow {
+        unko_no: "U001".to_string(),
+        reading_date: chrono::NaiveDate::from_ymd_opt(2026, 3, 1).unwrap(),
+        operation_date: Some(chrono::NaiveDate::from_ymd_opt(2026, 3, 1).unwrap()),
+        departure_at: Some(chrono::Utc::now()),
+        return_at: Some(chrono::Utc::now()),
+        driver_cd: Some("D001".to_string()),
+        total_distance: Some(100.0),
+        drive_time_general: Some(120),
+        drive_time_highway: Some(60),
+        drive_time_bypass: Some(0),
+    }];
+    *mock.driver_cd.lock().unwrap() = Some("D001".to_string());
+
+    // Create a mock storage with a KUDGIVT CSV
+    let storage = Arc::new(MockStorage::new("dtako-bucket"));
+    let kudgivt_csv = "運行NO,乗務員CD,イベント開始日時,イベントCD,所要時間\nU001,D001,2026/03/01 08:00:00,201,480\n";
+    let (kudgivt_bytes, _, _) = encoding_rs::SHIFT_JIS.encode(kudgivt_csv);
+    let zip_key = format!("{}/uploads/dummy/test.zip", tenant_id);
+    let zip_data = {
+        use std::io::Write;
+        let buf = std::io::Cursor::new(Vec::new());
+        let mut zip = zip::ZipWriter::new(buf);
+        let options = zip::write::SimpleFileOptions::default();
+        zip.start_file("KUDGIVT.csv", options).unwrap();
+        zip.write_all(&kudgivt_bytes).unwrap();
+        zip.finish().unwrap().into_inner()
+    };
+    storage
+        .upload(&zip_key, &zip_data, "application/zip")
+        .await
+        .unwrap();
+    *mock.zip_keys.lock().unwrap() = vec![zip_key];
+
+    let mock = Arc::new(mock);
+    let mut state = setup_mock_app_state();
+    state.dtako_upload = mock;
+    state.dtako_storage = Some(storage);
+
+    let base_url = crate::common::spawn_test_server(state).await;
+    let client = reqwest::Client::new();
+
+    // SSE endpoint — progress_tx = Some(tx)
+    let res = client
+        .post(format!("{base_url}/api/recalculate?year=2026&month=3"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    let body = res.text().await.unwrap();
+    // Should contain progress or done events
+    assert!(body.contains("done") || body.contains("progress"));
+}

--- a/tests/mock_tests/mock_dtako_upload_test.rs
+++ b/tests/mock_tests/mock_dtako_upload_test.rs
@@ -1487,24 +1487,41 @@ async fn test_dtako_recalculate_with_ferry_data() {
     let mut mock = MockDtakoUploadRepository::default();
     let dep = Utc.with_ymd_and_hms(2026, 3, 10, 6, 0, 0).unwrap();
     let ret = Utc.with_ymd_and_hms(2026, 3, 10, 15, 0, 0).unwrap();
-    *mock.operations.lock().unwrap() = vec![DtakoOpRow {
-        unko_no: unko_no.to_string(),
-        reading_date: NaiveDate::from_ymd_opt(2026, 3, 10).unwrap(),
-        operation_date: Some(NaiveDate::from_ymd_opt(2026, 3, 10).unwrap()),
-        departure_at: Some(dep),
-        return_at: Some(ret),
-        driver_cd: Some("DR01".to_string()),
-        total_distance: Some(180.0),
-        drive_time_general: Some(420),
-        drive_time_highway: Some(0),
-        drive_time_bypass: Some(0),
-    }];
+    // 2nd operation: has ferry data but NO KUDGIVT → covers continue at L382
+    let ferry_only_unko = "9999";
+    *mock.operations.lock().unwrap() = vec![
+        DtakoOpRow {
+            unko_no: unko_no.to_string(),
+            reading_date: NaiveDate::from_ymd_opt(2026, 3, 10).unwrap(),
+            operation_date: Some(NaiveDate::from_ymd_opt(2026, 3, 10).unwrap()),
+            departure_at: Some(dep),
+            return_at: Some(ret),
+            driver_cd: Some("DR01".to_string()),
+            total_distance: Some(180.0),
+            drive_time_general: Some(420),
+            drive_time_highway: Some(0),
+            drive_time_bypass: Some(0),
+        },
+        DtakoOpRow {
+            unko_no: ferry_only_unko.to_string(),
+            reading_date: NaiveDate::from_ymd_opt(2026, 3, 10).unwrap(),
+            operation_date: Some(NaiveDate::from_ymd_opt(2026, 3, 10).unwrap()),
+            departure_at: Some(dep),
+            return_at: Some(ret),
+            driver_cd: Some("DR02".to_string()),
+            total_distance: Some(50.0),
+            drive_time_general: Some(120),
+            drive_time_highway: Some(0),
+            drive_time_bypass: Some(0),
+        },
+    ];
 
     let dtako_storage = Arc::new(MockStorage::new("dtako-bucket"));
 
     // Per-unko KUDGIVT.csv (recalculate reads these individually)
     let kudgivt_key = format!("{}/unko/{}/KUDGIVT.csv", tenant_id, unko_no);
     dtako_storage.insert_file(&kudgivt_key, kudgivt_csv.into_bytes());
+    // NOTE: no KUDGIVT for ferry_only_unko — triggers continue at L382
 
     // Per-unko KUDGFRY.csv (ferry data)
     let ferry_csv = "c0,c1,c2,c3,c4,c5,c6,c7,c8,c9,start,end\n\
@@ -1512,6 +1529,11 @@ async fn test_dtako_recalculate_with_ferry_data() {
     let ferry_key = format!("{}/unko/{}/KUDGFRY.csv", tenant_id, unko_no);
     let (ferry_bytes, _, _) = encoding_rs::SHIFT_JIS.encode(ferry_csv);
     dtako_storage.insert_file(&ferry_key, ferry_bytes.to_vec());
+
+    // Ferry data for ferry_only_unko (no matching KUDGIVT)
+    let ferry_key2 = format!("{}/unko/{}/KUDGFRY.csv", tenant_id, ferry_only_unko);
+    let (ferry_bytes2, _, _) = encoding_rs::SHIFT_JIS.encode(ferry_csv);
+    dtako_storage.insert_file(&ferry_key2, ferry_bytes2.to_vec());
 
     let state = setup_with_storage_and_mock(mock, dtako_storage);
     let base_url = crate::common::spawn_test_server(state).await;

--- a/tests/mock_tests/mock_dtako_upload_test.rs
+++ b/tests/mock_tests/mock_dtako_upload_test.rs
@@ -2230,3 +2230,640 @@ async fn test_dtako_upload_no_filename() {
 
     assert_eq!(res.status(), 200);
 }
+
+// =========================================================================
+// GET /api/internal/download/{id} — R2 download failure → 500
+// (covers lines 979-983: storage.download() fails)
+// =========================================================================
+
+#[tokio::test]
+async fn test_dtako_download_r2_download_failure() {
+    let tenant_id = Uuid::new_v4();
+    let upload_id = Uuid::new_v4();
+    let missing_key = format!("{}/uploads/{}/missing.zip", tenant_id, upload_id);
+
+    let mut mock = MockDtakoUploadRepository::default();
+    *mock.upload_history.lock().unwrap() = Some(UploadHistoryRecord {
+        tenant_id,
+        r2_zip_key: missing_key, // key does NOT exist in storage
+        filename: "missing.zip".to_string(),
+    });
+
+    let dtako_storage = Arc::new(MockStorage::new("dtako-bucket"));
+    // Do NOT insert the file → download will fail
+
+    let state = setup_with_storage_and_mock(mock, dtako_storage);
+    let base_url = crate::common::spawn_test_server(state).await;
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!("{base_url}/api/internal/download/{upload_id}"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 500);
+    let body = res.text().await.unwrap();
+    assert!(body.contains("R2 download failed"));
+}
+
+// =========================================================================
+// POST /api/internal/rerun/{id} — R2 download failure → 500
+// (covers lines 1036-1040: storage.download() fails in rerun)
+// =========================================================================
+
+#[tokio::test]
+async fn test_dtako_rerun_r2_download_failure() {
+    let tenant_id = Uuid::new_v4();
+    let upload_id = Uuid::new_v4();
+    let missing_key = format!("{}/uploads/{}/missing.zip", tenant_id, upload_id);
+
+    let mut mock = MockDtakoUploadRepository::default();
+    *mock.upload_history.lock().unwrap() = Some(UploadHistoryRecord {
+        tenant_id,
+        r2_zip_key: missing_key, // key does NOT exist in storage
+        filename: "missing.zip".to_string(),
+    });
+
+    let dtako_storage = Arc::new(MockStorage::new("dtako-bucket"));
+    // Do NOT insert the file → download will fail
+
+    let state = setup_with_storage_and_mock(mock, dtako_storage);
+    let base_url = crate::common::spawn_test_server(state).await;
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/internal/rerun/{upload_id}"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 500);
+    let body = res.text().await.unwrap();
+    assert!(body.contains("R2 download failed"));
+}
+
+// =========================================================================
+// POST /api/internal/rerun/{id} — process_zip fails → mark_upload_failed + 400
+// (covers lines 1062-1067: process_zip error → mark_upload_failed call)
+// =========================================================================
+
+#[tokio::test]
+async fn test_dtako_rerun_process_zip_failure() {
+    let tenant_id = Uuid::new_v4();
+    let upload_id = Uuid::new_v4();
+    let zip_key = format!("{}/uploads/{}/bad.zip", tenant_id, upload_id);
+
+    let mut mock = MockDtakoUploadRepository::default();
+    *mock.upload_history.lock().unwrap() = Some(UploadHistoryRecord {
+        tenant_id,
+        r2_zip_key: zip_key.clone(),
+        filename: "bad.zip".to_string(),
+    });
+
+    let dtako_storage = Arc::new(MockStorage::new("dtako-bucket"));
+    // Insert a ZIP that lacks KUDGIVT → process_zip fails
+    let zip_bytes = create_missing_kudgivt_zip();
+    dtako_storage.insert_file(&zip_key, zip_bytes);
+
+    let state = setup_with_storage_and_mock(mock, dtako_storage);
+    let base_url = crate::common::spawn_test_server(state).await;
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/internal/rerun/{upload_id}"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 400);
+    let body = res.text().await.unwrap();
+    assert!(body.contains("KUDGIVT"));
+}
+
+// =========================================================================
+// Upload with pre-existing event classifications in DB → covers lines 770-778
+// (classification map: drive, cargo, rest_split, break, work(legacy), unknown)
+// =========================================================================
+
+#[tokio::test]
+async fn test_dtako_upload_with_event_classifications_from_db() {
+    let mut mock = MockDtakoUploadRepository::default();
+    // Pre-populate all classification branches
+    *mock.event_classifications.lock().unwrap() = vec![
+        ("201".to_string(), "drive".to_string()),
+        ("202".to_string(), "cargo".to_string()),
+        ("203".to_string(), "work".to_string()), // legacy fallback → Drive
+        ("302".to_string(), "rest_split".to_string()),
+        ("301".to_string(), "break".to_string()),
+        ("999".to_string(), "unknown_type".to_string()), // _ → Ignore
+    ];
+
+    let state = setup_with_mock(mock);
+    let tenant_id = Uuid::new_v4();
+    let base_url = crate::common::spawn_test_server(state).await;
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let zip_bytes = crate::common::create_test_dtako_zip_rich();
+    let part = reqwest::multipart::Part::bytes(zip_bytes).file_name("classified.zip");
+    let form = reqwest::multipart::Form::new().part("file", part);
+
+    let res = client
+        .post(format!("{base_url}/api/upload"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .multipart(form)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(body["status"], "completed");
+}
+
+// =========================================================================
+// Split CSV with update_has_kudgivt failure → covers line 941 (error log path)
+// =========================================================================
+
+#[tokio::test]
+async fn test_dtako_split_csv_update_has_kudgivt_failure() {
+    let tenant_id = Uuid::new_v4();
+    let upload_id = Uuid::new_v4();
+    let zip_key = format!("{}/uploads/{}/test.zip", tenant_id, upload_id);
+
+    let mut mock = MockDtakoUploadRepository::default();
+    *mock.tenant_and_key.lock().unwrap() = Some(UploadTenantAndKey {
+        tenant_id,
+        r2_zip_key: zip_key.clone(),
+    });
+    mock.fail_update_has_kudgivt.store(true, Ordering::SeqCst);
+
+    let dtako_storage = Arc::new(MockStorage::new("dtako-bucket"));
+    // Use rich ZIP which has KUDGIVT → triggers update_has_kudgivt
+    let zip_bytes = crate::common::create_test_dtako_zip_rich();
+    dtako_storage.insert_file(&zip_key, zip_bytes);
+
+    let state = setup_with_storage_and_mock(mock, dtako_storage);
+    let base_url = crate::common::spawn_test_server(state).await;
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/split-csv/{upload_id}"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .send()
+        .await
+        .unwrap();
+
+    // update_has_kudgivt failure is logged but doesn't block → still 200
+    assert_eq!(res.status(), 200);
+}
+
+// =========================================================================
+// POST /api/recalculate-drivers — batch with driver_cd=None → error count
+// (covers lines 1488-1490: process_single_driver_batch fails)
+// =========================================================================
+
+#[tokio::test]
+async fn test_dtako_recalculate_drivers_batch_driver_not_found() {
+    let tenant_id = Uuid::new_v4();
+    let driver_id = Uuid::new_v4();
+
+    // driver_cd is None by default → process_single_driver_batch fails with "driver not found"
+    let mock = MockDtakoUploadRepository::default();
+
+    let state = setup_with_mock(mock);
+    let base_url = crate::common::spawn_test_server(state).await;
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/recalculate-drivers"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .header("Content-Type", "application/json")
+        .body(
+            serde_json::json!({
+                "year": 2026,
+                "month": 3,
+                "driver_ids": [driver_id]
+            })
+            .to_string(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+    let body = res.text().await.unwrap();
+    // batch_done with errors > 0
+    assert!(body.contains("batch_done"));
+}
+
+// =========================================================================
+// POST /api/split-csv-all — with uploads that fail split → error count
+// (covers lines 1618-1620: split_csv_from_r2 fails for individual uploads)
+// =========================================================================
+
+#[tokio::test]
+async fn test_dtako_split_csv_all_with_failures() {
+    let tenant_id = Uuid::new_v4();
+    let upload_id1 = Uuid::new_v4();
+    let upload_id2 = Uuid::new_v4();
+
+    let mut mock = MockDtakoUploadRepository::default();
+    *mock.uploads_needing_split.lock().unwrap() = vec![
+        (upload_id1, "file1.zip".to_string()),
+        (upload_id2, "file2.zip".to_string()),
+    ];
+    // tenant_and_key is None → split_csv_from_r2 fails with "upload X not found"
+
+    let state = setup_with_mock(mock);
+    let base_url = crate::common::spawn_test_server(state).await;
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/split-csv-all"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+    let body = res.text().await.unwrap();
+    // Should contain done with failed > 0
+    assert!(body.contains("done"));
+}
+
+// =========================================================================
+// Recalculate with per-unko KUDGIVT.csv that has parse errors → covers line 1152
+// (KUDGIVT parse error in recalculate_all_core batch download path)
+// =========================================================================
+
+#[tokio::test]
+async fn test_dtako_recalculate_kudgivt_parse_error_per_unko() {
+    use chrono::{NaiveDate, TimeZone, Utc};
+
+    let tenant_id = Uuid::new_v4();
+    let unko_no = "PERR01";
+
+    let mut mock = MockDtakoUploadRepository::default();
+    let dep = Utc.with_ymd_and_hms(2026, 3, 15, 8, 0, 0).unwrap();
+    let ret = Utc.with_ymd_and_hms(2026, 3, 15, 17, 0, 0).unwrap();
+    *mock.operations.lock().unwrap() = vec![DtakoOpRow {
+        unko_no: unko_no.to_string(),
+        reading_date: NaiveDate::from_ymd_opt(2026, 3, 15).unwrap(),
+        operation_date: Some(NaiveDate::from_ymd_opt(2026, 3, 15).unwrap()),
+        departure_at: Some(dep),
+        return_at: Some(ret),
+        driver_cd: Some("DR01".to_string()),
+        total_distance: Some(100.0),
+        drive_time_general: Some(300),
+        drive_time_highway: Some(0),
+        drive_time_bypass: Some(0),
+    }];
+
+    let dtako_storage = Arc::new(MockStorage::new("dtako-bucket"));
+    // Insert per-unko KUDGIVT.csv with invalid content → parse_kudgivt fails
+    let kudgivt_key = format!("{}/unko/{}/KUDGIVT.csv", tenant_id, unko_no);
+    dtako_storage.insert_file(&kudgivt_key, b"this is not valid CSV".to_vec());
+
+    let state = setup_with_storage_and_mock(mock, dtako_storage);
+    let base_url = crate::common::spawn_test_server(state).await;
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/recalculate?year=2026&month=3"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+    let body = res.text().await.unwrap();
+    // parse fails → all_kudgivt empty with ops → error "KUDGIVT"
+    assert!(body.contains("error"));
+}
+
+// =========================================================================
+// Upload with 302 rest event having 0 duration → covers line 350 (continue)
+// =========================================================================
+
+#[tokio::test]
+async fn test_dtako_upload_rest_event_zero_duration() {
+    let state = setup_mock_app_state();
+    let tenant_id = Uuid::new_v4();
+    let base_url = crate::common::spawn_test_server(state).await;
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let zip_bytes = create_zip_with_zero_duration_rest();
+    let part = reqwest::multipart::Part::bytes(zip_bytes).file_name("rest0.zip");
+    let form = reqwest::multipart::Form::new().part("file", part);
+
+    let res = client
+        .post(format!("{base_url}/api/upload"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .multipart(form)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(body["status"], "completed");
+}
+
+/// ZIP with a 302 rest event that has 0 duration (dur <= 0 → continue at line 350)
+fn create_zip_with_zero_duration_rest() -> Vec<u8> {
+    use std::io::Write;
+
+    let kudguri_csv = "\
+運行NO,読取日,運行日,事業所CD,事業所名,車輌CD,車輌名,乗務員CD1,乗務員名１,対象乗務員区分,出社日時,退社日時,出庫日時,帰庫日時,総走行距離,一般道運転時間,高速道運転時間,バイパス運転時間
+2001,2026/03/05,2026/03/05,OFF01,事業所A,VH01,車両A,DR01,運転者A,1,2026/03/05 08:00:00,2026/03/05 17:00:00,2026/03/05 08:30:00,2026/03/05 16:30:00,100.0,300,0,0
+";
+
+    let kudgivt_csv = "\
+運行NO,読取日,乗務員CD1,乗務員名１,対象乗務員区分,開始日時,終了日時,イベントCD,イベント名,区間時間,区間距離
+2001,2026/03/05,DR01,運転者A,1,2026/03/05 08:30:00,2026/03/05 12:00:00,201,走行,210,50.0
+2001,2026/03/05,DR01,運転者A,1,2026/03/05 12:00:00,2026/03/05 12:00:00,302,休息,0,0
+2001,2026/03/05,DR01,運転者A,1,2026/03/05 12:00:00,2026/03/05 16:30:00,201,走行,270,50.0
+";
+
+    let (kudguri_bytes, _, _) = encoding_rs::SHIFT_JIS.encode(kudguri_csv);
+    let (kudgivt_bytes, _, _) = encoding_rs::SHIFT_JIS.encode(kudgivt_csv);
+
+    let mut buf = std::io::Cursor::new(Vec::new());
+    {
+        let mut zip = zip::ZipWriter::new(&mut buf);
+        let options = zip::write::SimpleFileOptions::default();
+        zip.start_file("KUDGURI.csv", options).unwrap();
+        zip.write_all(&kudguri_bytes).unwrap();
+        zip.start_file("KUDGIVT.csv", options).unwrap();
+        zip.write_all(&kudgivt_bytes).unwrap();
+        zip.finish().unwrap();
+    }
+    buf.into_inner()
+}
+
+// =========================================================================
+// Upload with no driver_cd (empty) → covers line 481 (None branch)
+// =========================================================================
+
+#[tokio::test]
+async fn test_dtako_upload_no_driver_cd() {
+    let state = setup_mock_app_state();
+    let tenant_id = Uuid::new_v4();
+    let base_url = crate::common::spawn_test_server(state).await;
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let zip_bytes = create_zip_with_no_driver_cd();
+    let part = reqwest::multipart::Part::bytes(zip_bytes).file_name("nodriver.zip");
+    let form = reqwest::multipart::Form::new().part("file", part);
+
+    let res = client
+        .post(format!("{base_url}/api/upload"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .multipart(form)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(body["status"], "completed");
+}
+
+/// ZIP with empty driver_cd (乗務員CD1 is empty) → driver_cd is None/empty
+fn create_zip_with_no_driver_cd() -> Vec<u8> {
+    use std::io::Write;
+
+    let kudguri_csv = "\
+運行NO,読取日,運行日,事業所CD,事業所名,車輌CD,車輌名,乗務員CD1,乗務員名１,対象乗務員区分,出社日時,退社日時,出庫日時,帰庫日時,総走行距離,一般道運転時間,高速道運転時間,バイパス運転時間
+3001,2026/03/05,2026/03/05,OFF01,事業所A,VH01,車両A,,未割当,1,2026/03/05 08:00:00,2026/03/05 17:00:00,2026/03/05 08:30:00,2026/03/05 16:30:00,100.0,300,0,0
+";
+
+    let kudgivt_csv = "\
+運行NO,読取日,乗務員CD1,乗務員名１,対象乗務員区分,開始日時,終了日時,イベントCD,イベント名,区間時間,区間距離
+3001,2026/03/05,,未割当,1,2026/03/05 08:30:00,2026/03/05 16:30:00,201,走行,480,100.0
+";
+
+    let (kudguri_bytes, _, _) = encoding_rs::SHIFT_JIS.encode(kudguri_csv);
+    let (kudgivt_bytes, _, _) = encoding_rs::SHIFT_JIS.encode(kudgivt_csv);
+
+    let mut buf = std::io::Cursor::new(Vec::new());
+    {
+        let mut zip = zip::ZipWriter::new(&mut buf);
+        let options = zip::write::SimpleFileOptions::default();
+        zip.start_file("KUDGURI.csv", options).unwrap();
+        zip.write_all(&kudguri_bytes).unwrap();
+        zip.start_file("KUDGIVT.csv", options).unwrap();
+        zip.write_all(&kudgivt_bytes).unwrap();
+        zip.finish().unwrap();
+    }
+    buf.into_inner()
+}
+
+// =========================================================================
+// Split CSV with ZIP containing non-CSV files → covers line 885 (continue)
+// =========================================================================
+
+#[tokio::test]
+async fn test_dtako_split_csv_non_csv_files_skipped() {
+    let tenant_id = Uuid::new_v4();
+    let upload_id = Uuid::new_v4();
+    let zip_key = format!("{}/uploads/{}/mixed.zip", tenant_id, upload_id);
+
+    let mut mock = MockDtakoUploadRepository::default();
+    *mock.tenant_and_key.lock().unwrap() = Some(UploadTenantAndKey {
+        tenant_id,
+        r2_zip_key: zip_key.clone(),
+    });
+
+    let dtako_storage = Arc::new(MockStorage::new("dtako-bucket"));
+    let zip_bytes = create_zip_with_non_csv_files();
+    dtako_storage.insert_file(&zip_key, zip_bytes);
+
+    let state = setup_with_storage_and_mock(mock, dtako_storage);
+    let base_url = crate::common::spawn_test_server(state).await;
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/split-csv/{upload_id}"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+}
+
+/// ZIP with CSV + non-CSV files (txt, dat) to exercise the skip path
+fn create_zip_with_non_csv_files() -> Vec<u8> {
+    use std::io::Write;
+
+    let kudguri_csv = "\
+運行NO,読取日,運行日,事業所CD,事業所名,車輌CD,車輌名,乗務員CD1,乗務員名１,対象乗務員区分
+4001,2026/03/01,2026/03/01,OFF01,事業所,VH01,車両A,DR01,運転者A,1
+";
+
+    let (kudguri_bytes, _, _) = encoding_rs::SHIFT_JIS.encode(kudguri_csv);
+
+    let mut buf = std::io::Cursor::new(Vec::new());
+    {
+        let mut zip = zip::ZipWriter::new(&mut buf);
+        let options = zip::write::SimpleFileOptions::default();
+        // CSV file
+        zip.start_file("KUDGURI.csv", options).unwrap();
+        zip.write_all(&kudguri_bytes).unwrap();
+        // Non-CSV files → should be skipped at line 885
+        zip.start_file("README.txt", options).unwrap();
+        zip.write_all(b"This is a text file").unwrap();
+        zip.start_file("data.dat", options).unwrap();
+        zip.write_all(b"Binary data").unwrap();
+        zip.finish().unwrap();
+    }
+    buf.into_inner()
+}
+
+// =========================================================================
+// load_kudgivt_from_zips: ZIP download error (key not in storage)
+// (covers line 739: download error in load_kudgivt_from_zips)
+// =========================================================================
+
+#[tokio::test]
+async fn test_dtako_recalculate_driver_zip_download_error() {
+    use chrono::{NaiveDate, TimeZone, Utc};
+
+    let tenant_id = Uuid::new_v4();
+    let driver_id = Uuid::new_v4();
+
+    let mut mock = MockDtakoUploadRepository::default();
+    *mock.driver_cd.lock().unwrap() = Some("DR01".to_string());
+
+    let dep = Utc.with_ymd_and_hms(2026, 3, 20, 8, 0, 0).unwrap();
+    let ret = Utc.with_ymd_and_hms(2026, 3, 20, 16, 0, 0).unwrap();
+    *mock.driver_operations.lock().unwrap() = vec![DtakoDriverOpRow {
+        unko_no: "ZPERR01".to_string(),
+        reading_date: NaiveDate::from_ymd_opt(2026, 3, 20).unwrap(),
+        operation_date: Some(NaiveDate::from_ymd_opt(2026, 3, 20).unwrap()),
+        departure_at: Some(dep),
+        return_at: Some(ret),
+        total_distance: Some(100.0),
+        drive_time_general: Some(300),
+        drive_time_highway: Some(0),
+        drive_time_bypass: Some(0),
+    }];
+
+    // Set zip_keys that points to a key NOT in storage → download fails
+    let missing_key = format!("{}/uploads/missing/test.zip", tenant_id);
+    *mock.zip_keys.lock().unwrap() = vec![missing_key];
+
+    let dtako_storage = Arc::new(MockStorage::new("dtako-bucket"));
+    // Do NOT insert the file → triggers line 739
+
+    let state = setup_with_storage_and_mock(mock, dtako_storage);
+    let base_url = crate::common::spawn_test_server(state).await;
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!(
+            "{base_url}/api/recalculate-driver?year=2026&month=3&driver_id={driver_id}"
+        ))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+    let body = res.text().await.unwrap();
+    // Download fails → no KUDGIVT → warns only, still done or error
+    assert!(body.contains("done") || body.contains("error"));
+}
+
+// =========================================================================
+// load_kudgivt_from_zips: ZIP with no KUDGIVT file inside
+// (covers line 735: closing brace when KUDGIVT not found in ZIP)
+// =========================================================================
+
+#[tokio::test]
+async fn test_dtako_recalculate_driver_zip_no_kudgivt_inside() {
+    use chrono::{NaiveDate, TimeZone, Utc};
+
+    let tenant_id = Uuid::new_v4();
+    let driver_id = Uuid::new_v4();
+
+    let mut mock = MockDtakoUploadRepository::default();
+    *mock.driver_cd.lock().unwrap() = Some("DR01".to_string());
+
+    let dep = Utc.with_ymd_and_hms(2026, 3, 20, 8, 0, 0).unwrap();
+    let ret = Utc.with_ymd_and_hms(2026, 3, 20, 16, 0, 0).unwrap();
+    *mock.driver_operations.lock().unwrap() = vec![DtakoDriverOpRow {
+        unko_no: "NOGIVT01".to_string(),
+        reading_date: NaiveDate::from_ymd_opt(2026, 3, 20).unwrap(),
+        operation_date: Some(NaiveDate::from_ymd_opt(2026, 3, 20).unwrap()),
+        departure_at: Some(dep),
+        return_at: Some(ret),
+        total_distance: Some(100.0),
+        drive_time_general: Some(300),
+        drive_time_highway: Some(0),
+        drive_time_bypass: Some(0),
+    }];
+
+    // ZIP key exists but ZIP contains only KUDGURI (no KUDGIVT)
+    let zip_key = format!("{}/uploads/nogivt/test.zip", tenant_id);
+    *mock.zip_keys.lock().unwrap() = vec![zip_key.clone()];
+
+    let dtako_storage = Arc::new(MockStorage::new("dtako-bucket"));
+    let zip_bytes = create_zip_with_only_kudguri();
+    dtako_storage.insert_file(&zip_key, zip_bytes);
+
+    let state = setup_with_storage_and_mock(mock, dtako_storage);
+    let base_url = crate::common::spawn_test_server(state).await;
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!(
+            "{base_url}/api/recalculate-driver?year=2026&month=3&driver_id={driver_id}"
+        ))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+    let body = res.text().await.unwrap();
+    assert!(body.contains("done") || body.contains("error"));
+}
+
+/// ZIP containing only KUDGURI.csv, no KUDGIVT.csv
+fn create_zip_with_only_kudguri() -> Vec<u8> {
+    use std::io::Write;
+
+    let kudguri_csv =
+        "運行NO,読取日,事業所CD,事業所名,車輌CD,車輌名,乗務員CD1,乗務員名１,対象乗務員区分\n\
+                       1001,2026/03/01,OFF01,事業所A,VH01,車両A,DR01,運転者A,1\n";
+    let (bytes, _, _) = encoding_rs::SHIFT_JIS.encode(kudguri_csv);
+
+    let mut buf = std::io::Cursor::new(Vec::new());
+    {
+        let mut zip = zip::ZipWriter::new(&mut buf);
+        let options = zip::write::SimpleFileOptions::default();
+        zip.start_file("KUDGURI.csv", options).unwrap();
+        zip.write_all(&bytes).unwrap();
+        zip.finish().unwrap();
+    }
+    buf.into_inner()
+}

--- a/tests/mock_tests/mock_dtako_upload_test.rs
+++ b/tests/mock_tests/mock_dtako_upload_test.rs
@@ -2889,50 +2889,57 @@ async fn test_dtako_upload_no_file_field() {
     assert!(body.contains("no 'file' field found"));
 }
 
-/// POST /recalculate — with operations data → progress_tx Some path (line 691, 1079)
+/// POST /recalculate — with operations + KUDGIVT data → progress_tx Some path (line 691, 1079)
+/// Also covers ferry + kudgivt matching (line 396)
 #[tokio::test]
-async fn test_dtako_recalculate_with_operations_progress() {
+async fn test_dtako_recalculate_with_rich_data_progress() {
+    use chrono::{TimeZone, Utc};
     use rust_alc_api::storage::StorageBackend;
 
     let tenant_id = Uuid::new_v4();
-    let driver_id = Uuid::new_v4();
     let jwt = crate::common::create_test_jwt(tenant_id, "admin");
 
+    let dep = Utc.with_ymd_and_hms(2026, 3, 1, 6, 0, 0).unwrap();
+    let ret = Utc.with_ymd_and_hms(2026, 3, 1, 18, 0, 0).unwrap();
+
     let mut mock = MockDtakoUploadRepository::default();
-    // Return operations so recalculate actually processes them
     *mock.operations.lock().unwrap() = vec![DtakoOpRow {
         unko_no: "U001".to_string(),
         reading_date: chrono::NaiveDate::from_ymd_opt(2026, 3, 1).unwrap(),
         operation_date: Some(chrono::NaiveDate::from_ymd_opt(2026, 3, 1).unwrap()),
-        departure_at: Some(chrono::Utc::now()),
-        return_at: Some(chrono::Utc::now()),
+        departure_at: Some(dep),
+        return_at: Some(ret),
         driver_cd: Some("D001".to_string()),
-        total_distance: Some(100.0),
-        drive_time_general: Some(120),
-        drive_time_highway: Some(60),
+        total_distance: Some(200.0),
+        drive_time_general: Some(360),
+        drive_time_highway: Some(120),
         drive_time_bypass: Some(0),
     }];
     *mock.driver_cd.lock().unwrap() = Some("D001".to_string());
+    *mock.employee_id.lock().unwrap() = Some(Uuid::new_v4());
 
-    // Create a mock storage with a KUDGIVT CSV
+    // KUDGIVT CSV (直接 R2 パスに UTF-8 で保存 — recalculate_all_core は String::from_utf8_lossy で読む)
     let storage = Arc::new(MockStorage::new("dtako-bucket"));
-    let kudgivt_csv = "運行NO,乗務員CD,イベント開始日時,イベントCD,所要時間\nU001,D001,2026/03/01 08:00:00,201,480\n";
-    let (kudgivt_bytes, _, _) = encoding_rs::SHIFT_JIS.encode(kudgivt_csv);
-    let zip_key = format!("{}/uploads/dummy/test.zip", tenant_id);
-    let zip_data = {
-        use std::io::Write;
-        let buf = std::io::Cursor::new(Vec::new());
-        let mut zip = zip::ZipWriter::new(buf);
-        let options = zip::write::SimpleFileOptions::default();
-        zip.start_file("KUDGIVT.csv", options).unwrap();
-        zip.write_all(&kudgivt_bytes).unwrap();
-        zip.finish().unwrap().into_inner()
-    };
+    let kudgivt_csv = "運行NO,読取日,事業所CD,事業所名,車輌CD,車輌名,乗務員CD1,乗務員名１,対象乗務員区分,開始日時,イベントCD,イベント名,開始走行距離,終了走行距離,区間時間,区間距離,開始市町村CD,開始市町村名,終了市町村CD,終了市町村名,開始場所CD,開始場所名,終了場所CD,終了場所名\n\
+U001,2026/03/01 00:00:00,1,本社,1,車両1,D001,運転者1,1,2026/03/01 06:00:00,201,運転,0,100,360,100,,,,,,,,\n\
+U001,2026/03/01 00:00:00,1,本社,1,車両1,D001,運転者1,1,2026/03/01 12:00:00,301,休憩,100,100,30,0,,,,,,,,\n\
+U001,2026/03/01 00:00:00,1,本社,1,車両1,D001,運転者1,1,2026/03/01 12:30:00,401,荷役,100,150,120,50,,,,,,,,";
+
+    // R2 パス: {tenant_id}/unko/{unko_no}/KUDGIVT.csv
+    let kudgivt_key = format!("{}/unko/U001/KUDGIVT.csv", tenant_id);
     storage
-        .upload(&zip_key, &zip_data, "application/zip")
+        .upload(&kudgivt_key, kudgivt_csv.as_bytes(), "text/csv")
         .await
         .unwrap();
-    *mock.zip_keys.lock().unwrap() = vec![zip_key];
+
+    // フェリーデータ用 KUDGFRY.csv (line 396 をカバーするため)
+    let kudgfry_key = format!("{}/unko/U001/KUDGFRY.csv", tenant_id);
+    let kudgfry_csv = "col0,col1,col2,col3,col4,col5,col6,col7,col8,col9,col10,col11\n\
+dummy,dummy,dummy,dummy,dummy,dummy,dummy,dummy,dummy,dummy,2026/03/01 10:00:00,2026/03/01 11:00:00";
+    storage
+        .upload(&kudgfry_key, kudgfry_csv.as_bytes(), "text/csv")
+        .await
+        .unwrap();
 
     let mock = Arc::new(mock);
     let mut state = setup_mock_app_state();
@@ -2942,7 +2949,6 @@ async fn test_dtako_recalculate_with_operations_progress() {
     let base_url = crate::common::spawn_test_server(state).await;
     let client = reqwest::Client::new();
 
-    // SSE endpoint — progress_tx = Some(tx)
     let res = client
         .post(format!("{base_url}/api/recalculate?year=2026&month=3"))
         .header("Authorization", format!("Bearer {jwt}"))
@@ -2951,6 +2957,6 @@ async fn test_dtako_recalculate_with_operations_progress() {
         .unwrap();
     assert_eq!(res.status(), 200);
     let body = res.text().await.unwrap();
-    // Should contain progress or done events
-    assert!(body.contains("done") || body.contains("progress"));
+    eprintln!("=== SSE body ===\n{body}\n=== end ===");
+    assert!(body.contains("done"), "body: {body}");
 }

--- a/tests/mock_tests/mock_tenko_sessions_test.rs
+++ b/tests/mock_tests/mock_tenko_sessions_test.rs
@@ -1872,3 +1872,928 @@ async fn test_unauthorized_no_jwt() {
         );
     }
 }
+
+// =========================================================================
+// Helper for fail_on_update tests (get succeeds, write fails)
+// =========================================================================
+
+async fn setup_with_update_failing(status: &str, tenko_type: &str) -> (String, String) {
+    let mock = Arc::new(MockTenkoSessionRepository::default());
+    mock.fail_on_update.store(true, Ordering::SeqCst);
+    *mock.session_status.lock().unwrap() = status.to_string();
+    *mock.session_tenko_type.lock().unwrap() = tenko_type.to_string();
+    let mut state = crate::mock_helpers::app_state::setup_mock_app_state();
+    state.tenko_sessions = mock;
+    let tenant_id = uuid::Uuid::new_v4();
+    let base_url = crate::common::spawn_test_server(state).await;
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let auth_header = format!("Bearer {jwt}");
+    (base_url, auth_header)
+}
+
+async fn setup_with_update_failing_user(status: &str, tenko_type: &str) -> (String, String) {
+    let mock = Arc::new(MockTenkoSessionRepository::default());
+    mock.fail_on_update.store(true, Ordering::SeqCst);
+    *mock.session_status.lock().unwrap() = status.to_string();
+    *mock.session_tenko_type.lock().unwrap() = tenko_type.to_string();
+    let mut state = crate::mock_helpers::app_state::setup_mock_app_state();
+    state.tenko_sessions = mock;
+    let tenant_id = uuid::Uuid::new_v4();
+    let user_id = uuid::Uuid::new_v4();
+    let base_url = crate::common::spawn_test_server(state).await;
+    let jwt =
+        crate::common::create_test_jwt_for_user(user_id, tenant_id, "test@example.com", "admin");
+    let auth_header = format!("Bearer {jwt}");
+    (base_url, auth_header)
+}
+
+// =========================================================================
+// DB error on UPDATE (second repo call) — covers tracing::error branches
+// =========================================================================
+
+#[tokio::test]
+async fn test_start_session_create_session_db_error() {
+    // fail_on_update: get_schedule_unconsumed succeeds, consume_schedule fails
+    let mock = Arc::new(MockTenkoSessionRepository::default());
+    mock.fail_on_update.store(true, Ordering::SeqCst);
+    let employee_id = Uuid::new_v4();
+    *mock.session_employee_id.lock().unwrap() = employee_id;
+    *mock.schedule_employee_id.lock().unwrap() = employee_id;
+    let mut state = crate::mock_helpers::app_state::setup_mock_app_state();
+    state.tenko_sessions = mock;
+    let tenant_id = uuid::Uuid::new_v4();
+    let base_url = crate::common::spawn_test_server(state).await;
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let auth_header = format!("Bearer {jwt}");
+
+    let res = client()
+        .post(format!("{base_url}/api/tenko/sessions/start"))
+        .header("Authorization", &auth_header)
+        .json(&serde_json::json!({
+            "schedule_id": Uuid::new_v4(),
+            "employee_id": employee_id,
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 500);
+}
+
+#[tokio::test]
+async fn test_start_session_no_schedule_create_db_error() {
+    // Without schedule_id: create_session is the first write call
+    let mock = Arc::new(MockTenkoSessionRepository::default());
+    mock.fail_on_update.store(true, Ordering::SeqCst);
+    let mut state = crate::mock_helpers::app_state::setup_mock_app_state();
+    state.tenko_sessions = mock;
+    let tenant_id = uuid::Uuid::new_v4();
+    let base_url = crate::common::spawn_test_server(state).await;
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let auth_header = format!("Bearer {jwt}");
+
+    let res = client()
+        .post(format!("{base_url}/api/tenko/sessions/start"))
+        .header("Authorization", &auth_header)
+        .json(&serde_json::json!({
+            "employee_id": Uuid::new_v4(),
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 500);
+}
+
+#[tokio::test]
+async fn test_submit_alcohol_update_db_error() {
+    let (base_url, auth_header) =
+        setup_with_update_failing("identity_verified", "pre_operation").await;
+
+    let res = client()
+        .put(format!(
+            "{base_url}/api/tenko/sessions/{}/alcohol",
+            Uuid::new_v4()
+        ))
+        .header("Authorization", &auth_header)
+        .json(&serde_json::json!({
+            "alcohol_result": "pass",
+            "alcohol_value": 0.0,
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 500);
+}
+
+#[tokio::test]
+async fn test_submit_medical_update_db_error() {
+    let (base_url, auth_header) =
+        setup_with_update_failing("medical_pending", "pre_operation").await;
+
+    let res = client()
+        .put(format!(
+            "{base_url}/api/tenko/sessions/{}/medical",
+            Uuid::new_v4()
+        ))
+        .header("Authorization", &auth_header)
+        .json(&serde_json::json!({
+            "temperature": 36.5,
+            "systolic": 120,
+            "diastolic": 80,
+            "pulse": 72,
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 500);
+}
+
+#[tokio::test]
+async fn test_confirm_instruction_update_db_error() {
+    let (base_url, auth_header) =
+        setup_with_update_failing("instruction_pending", "pre_operation").await;
+
+    let res = client()
+        .put(format!(
+            "{base_url}/api/tenko/sessions/{}/instruction-confirm",
+            Uuid::new_v4()
+        ))
+        .header("Authorization", &auth_header)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 500);
+}
+
+#[tokio::test]
+async fn test_submit_report_update_db_error() {
+    let (base_url, auth_header) =
+        setup_with_update_failing("report_pending", "post_operation").await;
+
+    let res = client()
+        .put(format!(
+            "{base_url}/api/tenko/sessions/{}/report",
+            Uuid::new_v4()
+        ))
+        .header("Authorization", &auth_header)
+        .json(&serde_json::json!({
+            "vehicle_road_status": "OK",
+            "driver_alternation": "None",
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 500);
+}
+
+#[tokio::test]
+async fn test_cancel_session_update_db_error() {
+    let (base_url, auth_header) =
+        setup_with_update_failing("identity_verified", "pre_operation").await;
+
+    let res = client()
+        .post(format!(
+            "{base_url}/api/tenko/sessions/{}/cancel",
+            Uuid::new_v4()
+        ))
+        .header("Authorization", &auth_header)
+        .json(&serde_json::json!({
+            "reason": "test cancel"
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 500);
+}
+
+#[tokio::test]
+async fn test_submit_self_declaration_update_db_error() {
+    let (base_url, auth_header) =
+        setup_with_update_failing("self_declaration_pending", "pre_operation").await;
+
+    let res = client()
+        .put(format!(
+            "{base_url}/api/tenko/sessions/{}/self-declaration",
+            Uuid::new_v4()
+        ))
+        .header("Authorization", &auth_header)
+        .json(&serde_json::json!({
+            "illness": false,
+            "fatigue": false,
+            "sleep_deprivation": false,
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 500);
+}
+
+#[tokio::test]
+async fn test_submit_daily_inspection_update_db_error() {
+    let (base_url, auth_header) =
+        setup_with_update_failing("daily_inspection_pending", "pre_operation").await;
+
+    let res = client()
+        .put(format!(
+            "{base_url}/api/tenko/sessions/{}/daily-inspection",
+            Uuid::new_v4()
+        ))
+        .header("Authorization", &auth_header)
+        .json(&serde_json::json!({
+            "brakes": "ok",
+            "tires": "ok",
+            "lights": "ok",
+            "steering": "ok",
+            "wipers": "ok",
+            "mirrors": "ok",
+            "horn": "ok",
+            "seatbelts": "ok",
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 500);
+}
+
+#[tokio::test]
+async fn test_submit_carrying_items_update_db_error() {
+    let (base_url, auth_header) =
+        setup_with_update_failing("carrying_items_pending", "pre_operation").await;
+
+    let res = client()
+        .put(format!(
+            "{base_url}/api/tenko/sessions/{}/carrying-items",
+            Uuid::new_v4()
+        ))
+        .header("Authorization", &auth_header)
+        .json(&serde_json::json!({
+            "checks": [
+                {"item_id": Uuid::new_v4(), "checked": true},
+            ]
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 500);
+}
+
+#[tokio::test]
+async fn test_interrupt_session_update_db_error() {
+    let (base_url, auth_header) =
+        setup_with_update_failing("identity_verified", "pre_operation").await;
+
+    let res = client()
+        .post(format!(
+            "{base_url}/api/tenko/sessions/{}/interrupt",
+            Uuid::new_v4()
+        ))
+        .header("Authorization", &auth_header)
+        .json(&serde_json::json!({
+            "reason": "Manager"
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 500);
+}
+
+#[tokio::test]
+async fn test_resume_session_update_db_error() {
+    let (base_url, auth_header) =
+        setup_with_update_failing_user("interrupted", "pre_operation").await;
+
+    let res = client()
+        .post(format!(
+            "{base_url}/api/tenko/sessions/{}/resume",
+            Uuid::new_v4()
+        ))
+        .header("Authorization", &auth_header)
+        .json(&serde_json::json!({
+            "reason": "Retry"
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 500);
+}
+
+// =========================================================================
+// Alcohol with unknown tenko_type → 500 (line 162)
+// =========================================================================
+
+#[tokio::test]
+async fn test_submit_alcohol_pass_unknown_tenko_type() {
+    let mock = Arc::new(MockTenkoSessionRepository::default());
+    *mock.session_status.lock().unwrap() = "identity_verified".to_string();
+    *mock.session_tenko_type.lock().unwrap() = "unknown_type".to_string();
+    let (base_url, auth_header, _) = setup_with_mock(mock).await;
+
+    let res = client()
+        .put(format!(
+            "{base_url}/api/tenko/sessions/{}/alcohol",
+            Uuid::new_v4()
+        ))
+        .header("Authorization", &auth_header)
+        .json(&serde_json::json!({
+            "alcohol_result": "pass",
+            "alcohol_value": 0.0,
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 500);
+}
+
+// =========================================================================
+// Safety judgment — fail via vitals exceeding baseline tolerance
+// =========================================================================
+
+#[tokio::test]
+async fn test_self_declaration_safety_fail_systolic_out_of_range() {
+    use rust_alc_api::db::models::EmployeeHealthBaseline;
+
+    let mock = Arc::new(MockTenkoSessionRepository::default());
+    *mock.session_status.lock().unwrap() = "self_declaration_pending".to_string();
+    *mock.session_tenko_type.lock().unwrap() = "pre_operation".to_string();
+    // Session has systolic=120, diastolic=80, temperature=36.5
+    // Set baseline so systolic is out of tolerance: baseline=100, tolerance=5 → diff=20 > 5
+    *mock.health_baseline.lock().unwrap() = Some(EmployeeHealthBaseline {
+        id: Uuid::new_v4(),
+        tenant_id: Uuid::new_v4(),
+        employee_id: Uuid::new_v4(),
+        baseline_systolic: 100,
+        baseline_diastolic: 80,
+        baseline_temperature: 36.5,
+        systolic_tolerance: 5,
+        diastolic_tolerance: 10,
+        temperature_tolerance: 1.0,
+        measurement_validity_minutes: 30,
+        created_at: chrono::Utc::now(),
+        updated_at: chrono::Utc::now(),
+    });
+    let (base_url, auth_header, _) = setup_with_mock(mock).await;
+
+    let res = client()
+        .put(format!(
+            "{base_url}/api/tenko/sessions/{}/self-declaration",
+            Uuid::new_v4()
+        ))
+        .header("Authorization", &auth_header)
+        .json(&serde_json::json!({
+            "illness": false,
+            "fatigue": false,
+            "sleep_deprivation": false,
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(body["status"], "interrupted");
+    // Check safety_judgment
+    let judgment = &body["safety_judgment"];
+    assert_eq!(judgment["status"], "fail");
+    let failed_items = judgment["failed_items"].as_array().unwrap();
+    assert!(failed_items.iter().any(|v| v == "systolic"));
+}
+
+#[tokio::test]
+async fn test_self_declaration_safety_fail_diastolic_out_of_range() {
+    use rust_alc_api::db::models::EmployeeHealthBaseline;
+
+    let mock = Arc::new(MockTenkoSessionRepository::default());
+    *mock.session_status.lock().unwrap() = "self_declaration_pending".to_string();
+    *mock.session_tenko_type.lock().unwrap() = "pre_operation".to_string();
+    // Session has diastolic=80; set baseline=60, tolerance=5 → diff=20 > 5
+    *mock.health_baseline.lock().unwrap() = Some(EmployeeHealthBaseline {
+        id: Uuid::new_v4(),
+        tenant_id: Uuid::new_v4(),
+        employee_id: Uuid::new_v4(),
+        baseline_systolic: 120,
+        baseline_diastolic: 60,
+        baseline_temperature: 36.5,
+        systolic_tolerance: 10,
+        diastolic_tolerance: 5,
+        temperature_tolerance: 1.0,
+        measurement_validity_minutes: 30,
+        created_at: chrono::Utc::now(),
+        updated_at: chrono::Utc::now(),
+    });
+    let (base_url, auth_header, _) = setup_with_mock(mock).await;
+
+    let res = client()
+        .put(format!(
+            "{base_url}/api/tenko/sessions/{}/self-declaration",
+            Uuid::new_v4()
+        ))
+        .header("Authorization", &auth_header)
+        .json(&serde_json::json!({
+            "illness": false,
+            "fatigue": false,
+            "sleep_deprivation": false,
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(body["status"], "interrupted");
+    let judgment = &body["safety_judgment"];
+    assert_eq!(judgment["status"], "fail");
+    let failed_items = judgment["failed_items"].as_array().unwrap();
+    assert!(failed_items.iter().any(|v| v == "diastolic"));
+}
+
+#[tokio::test]
+async fn test_self_declaration_safety_fail_temperature_out_of_range() {
+    use rust_alc_api::db::models::EmployeeHealthBaseline;
+
+    let mock = Arc::new(MockTenkoSessionRepository::default());
+    *mock.session_status.lock().unwrap() = "self_declaration_pending".to_string();
+    *mock.session_tenko_type.lock().unwrap() = "pre_operation".to_string();
+    // Session has temperature=36.5; set baseline=35.0, tolerance=0.3 → diff=1.5 > 0.3
+    *mock.health_baseline.lock().unwrap() = Some(EmployeeHealthBaseline {
+        id: Uuid::new_v4(),
+        tenant_id: Uuid::new_v4(),
+        employee_id: Uuid::new_v4(),
+        baseline_systolic: 120,
+        baseline_diastolic: 80,
+        baseline_temperature: 35.0,
+        systolic_tolerance: 10,
+        diastolic_tolerance: 10,
+        temperature_tolerance: 0.3,
+        measurement_validity_minutes: 30,
+        created_at: chrono::Utc::now(),
+        updated_at: chrono::Utc::now(),
+    });
+    let (base_url, auth_header, _) = setup_with_mock(mock).await;
+
+    let res = client()
+        .put(format!(
+            "{base_url}/api/tenko/sessions/{}/self-declaration",
+            Uuid::new_v4()
+        ))
+        .header("Authorization", &auth_header)
+        .json(&serde_json::json!({
+            "illness": false,
+            "fatigue": false,
+            "sleep_deprivation": false,
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(body["status"], "interrupted");
+    let judgment = &body["safety_judgment"];
+    assert_eq!(judgment["status"], "fail");
+    let failed_items = judgment["failed_items"].as_array().unwrap();
+    assert!(failed_items.iter().any(|v| v == "temperature"));
+}
+
+// =========================================================================
+// Safety judgment — fail via self_declaration flags
+// =========================================================================
+
+#[tokio::test]
+async fn test_self_declaration_safety_fail_illness() {
+    let mock = Arc::new(MockTenkoSessionRepository::default());
+    *mock.session_status.lock().unwrap() = "self_declaration_pending".to_string();
+    *mock.session_tenko_type.lock().unwrap() = "pre_operation".to_string();
+    let (base_url, auth_header, _) = setup_with_mock(mock).await;
+
+    let res = client()
+        .put(format!(
+            "{base_url}/api/tenko/sessions/{}/self-declaration",
+            Uuid::new_v4()
+        ))
+        .header("Authorization", &auth_header)
+        .json(&serde_json::json!({
+            "illness": true,
+            "fatigue": false,
+            "sleep_deprivation": false,
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(body["status"], "interrupted");
+    let judgment = &body["safety_judgment"];
+    assert_eq!(judgment["status"], "fail");
+    let failed_items = judgment["failed_items"].as_array().unwrap();
+    assert!(failed_items.iter().any(|v| v == "illness"));
+}
+
+#[tokio::test]
+async fn test_self_declaration_safety_fail_fatigue() {
+    let mock = Arc::new(MockTenkoSessionRepository::default());
+    *mock.session_status.lock().unwrap() = "self_declaration_pending".to_string();
+    *mock.session_tenko_type.lock().unwrap() = "pre_operation".to_string();
+    let (base_url, auth_header, _) = setup_with_mock(mock).await;
+
+    let res = client()
+        .put(format!(
+            "{base_url}/api/tenko/sessions/{}/self-declaration",
+            Uuid::new_v4()
+        ))
+        .header("Authorization", &auth_header)
+        .json(&serde_json::json!({
+            "illness": false,
+            "fatigue": true,
+            "sleep_deprivation": false,
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(body["status"], "interrupted");
+    let judgment = &body["safety_judgment"];
+    assert_eq!(judgment["status"], "fail");
+    let failed_items = judgment["failed_items"].as_array().unwrap();
+    assert!(failed_items.iter().any(|v| v == "fatigue"));
+}
+
+#[tokio::test]
+async fn test_self_declaration_safety_fail_sleep_deprivation() {
+    let mock = Arc::new(MockTenkoSessionRepository::default());
+    *mock.session_status.lock().unwrap() = "self_declaration_pending".to_string();
+    *mock.session_tenko_type.lock().unwrap() = "pre_operation".to_string();
+    let (base_url, auth_header, _) = setup_with_mock(mock).await;
+
+    let res = client()
+        .put(format!(
+            "{base_url}/api/tenko/sessions/{}/self-declaration",
+            Uuid::new_v4()
+        ))
+        .header("Authorization", &auth_header)
+        .json(&serde_json::json!({
+            "illness": false,
+            "fatigue": false,
+            "sleep_deprivation": true,
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(body["status"], "interrupted");
+    let judgment = &body["safety_judgment"];
+    assert_eq!(judgment["status"], "fail");
+    let failed_items = judgment["failed_items"].as_array().unwrap();
+    assert!(failed_items.iter().any(|v| v == "sleep_deprivation"));
+}
+
+// =========================================================================
+// Safety judgment — pass with baseline (vitals within tolerance)
+// =========================================================================
+
+#[tokio::test]
+async fn test_self_declaration_safety_pass_with_baseline() {
+    use rust_alc_api::db::models::EmployeeHealthBaseline;
+
+    let mock = Arc::new(MockTenkoSessionRepository::default());
+    *mock.session_status.lock().unwrap() = "self_declaration_pending".to_string();
+    *mock.session_tenko_type.lock().unwrap() = "pre_operation".to_string();
+    // Session: systolic=120, diastolic=80, temperature=36.5
+    // Baseline matches with wide tolerance
+    *mock.health_baseline.lock().unwrap() = Some(EmployeeHealthBaseline {
+        id: Uuid::new_v4(),
+        tenant_id: Uuid::new_v4(),
+        employee_id: Uuid::new_v4(),
+        baseline_systolic: 120,
+        baseline_diastolic: 80,
+        baseline_temperature: 36.5,
+        systolic_tolerance: 20,
+        diastolic_tolerance: 20,
+        temperature_tolerance: 2.0,
+        measurement_validity_minutes: 30,
+        created_at: chrono::Utc::now(),
+        updated_at: chrono::Utc::now(),
+    });
+    let (base_url, auth_header, _) = setup_with_mock(mock).await;
+
+    let res = client()
+        .put(format!(
+            "{base_url}/api/tenko/sessions/{}/self-declaration",
+            Uuid::new_v4()
+        ))
+        .header("Authorization", &auth_header)
+        .json(&serde_json::json!({
+            "illness": false,
+            "fatigue": false,
+            "sleep_deprivation": false,
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(body["status"], "daily_inspection_pending");
+    let judgment = &body["safety_judgment"];
+    assert_eq!(judgment["status"], "pass");
+    // medical_diffs should be present
+    assert!(judgment["medical_diffs"].is_object());
+}
+
+// =========================================================================
+// Safety judgment — update_safety_judgment DB error (line 714-716)
+// =========================================================================
+
+// =========================================================================
+// create_tenko_record internal error paths (swallowed by `let _ = ...`)
+// =========================================================================
+
+#[tokio::test]
+async fn test_confirm_instruction_record_creation_fails() {
+    // get_employee_name fails inside create_tenko_record → error swallowed, still 200
+    let mock = Arc::new(MockTenkoSessionRepository::default());
+    *mock.session_status.lock().unwrap() = "instruction_pending".to_string();
+    mock.fail_on_record.store(true, Ordering::SeqCst);
+    let (base_url, auth_header, _) = setup_with_mock(mock).await;
+
+    let res = client()
+        .put(format!(
+            "{base_url}/api/tenko/sessions/{}/instruction-confirm",
+            Uuid::new_v4()
+        ))
+        .header("Authorization", &auth_header)
+        .send()
+        .await
+        .unwrap();
+
+    // confirm_instruction itself succeeds, create_tenko_record error is swallowed
+    assert_eq!(res.status(), 200);
+}
+
+#[tokio::test]
+async fn test_cancel_session_record_creation_fails() {
+    let mock = Arc::new(MockTenkoSessionRepository::default());
+    *mock.session_status.lock().unwrap() = "identity_verified".to_string();
+    mock.fail_on_record.store(true, Ordering::SeqCst);
+    let (base_url, auth_header, _) = setup_with_mock(mock).await;
+
+    let res = client()
+        .post(format!(
+            "{base_url}/api/tenko/sessions/{}/cancel",
+            Uuid::new_v4()
+        ))
+        .header("Authorization", &auth_header)
+        .json(&serde_json::json!({
+            "reason": "test"
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+}
+
+#[tokio::test]
+async fn test_alcohol_fail_record_creation_fails() {
+    // alcohol fail → create_tenko_record called → get_employee_name fails
+    // But alcohol fail ALSO calls get_employee_name for the webhook payload!
+    // The webhook get_employee_name call (line 198) returns Err → returns 500.
+    // So this test will actually get 500, not 200.
+    let mock = Arc::new(MockTenkoSessionRepository::default());
+    *mock.session_status.lock().unwrap() = "identity_verified".to_string();
+    *mock.session_tenko_type.lock().unwrap() = "pre_operation".to_string();
+    mock.fail_on_record.store(true, Ordering::SeqCst);
+    let (base_url, auth_header, _) = setup_with_mock(mock).await;
+
+    let res = client()
+        .put(format!(
+            "{base_url}/api/tenko/sessions/{}/alcohol",
+            Uuid::new_v4()
+        ))
+        .header("Authorization", &auth_header)
+        .json(&serde_json::json!({
+            "alcohol_result": "fail",
+            "alcohol_value": 0.25,
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    // get_employee_name fails at line 198 → 500
+    assert_eq!(res.status(), 500);
+}
+
+#[tokio::test]
+async fn test_employee_name_not_found_in_record_creation() {
+    // return_employee_name=false → get_employee_name returns Ok(None)
+    // → .ok_or(INTERNAL_SERVER_ERROR) triggers line 502
+    let mock = Arc::new(MockTenkoSessionRepository::default());
+    *mock.session_status.lock().unwrap() = "instruction_pending".to_string();
+    mock.return_employee_name.store(false, Ordering::SeqCst);
+    let (base_url, auth_header, _) = setup_with_mock(mock).await;
+
+    let res = client()
+        .put(format!(
+            "{base_url}/api/tenko/sessions/{}/instruction-confirm",
+            Uuid::new_v4()
+        ))
+        .header("Authorization", &auth_header)
+        .send()
+        .await
+        .unwrap();
+
+    // create_tenko_record error swallowed, still 200
+    assert_eq!(res.status(), 200);
+}
+
+#[tokio::test]
+async fn test_daily_inspection_ng_record_creation_fails() {
+    let mock = Arc::new(MockTenkoSessionRepository::default());
+    *mock.session_status.lock().unwrap() = "daily_inspection_pending".to_string();
+    *mock.session_tenko_type.lock().unwrap() = "pre_operation".to_string();
+    mock.fail_on_record.store(true, Ordering::SeqCst);
+    let (base_url, auth_header, _) = setup_with_mock(mock).await;
+
+    let res = client()
+        .put(format!(
+            "{base_url}/api/tenko/sessions/{}/daily-inspection",
+            Uuid::new_v4()
+        ))
+        .header("Authorization", &auth_header)
+        .json(&serde_json::json!({
+            "brakes": "ng",
+            "tires": "ok",
+            "lights": "ok",
+            "steering": "ok",
+            "wipers": "ok",
+            "mirrors": "ok",
+            "horn": "ok",
+            "seatbelts": "ok",
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    // Daily inspection NG → cancel, but get_employee_name fails for webhook
+    // Line 845-848: get_employee_name fails → 500
+    assert_eq!(res.status(), 500);
+}
+
+#[tokio::test]
+async fn test_report_completed_record_creation_fails() {
+    // report completed without instruction → create_tenko_record called
+    let mock = Arc::new(MockTenkoSessionRepository::default());
+    *mock.session_status.lock().unwrap() = "report_pending".to_string();
+    *mock.session_tenko_type.lock().unwrap() = "post_operation".to_string();
+    mock.fail_on_record.store(true, Ordering::SeqCst);
+    let (base_url, auth_header, _) = setup_with_mock(mock).await;
+
+    let res = client()
+        .put(format!(
+            "{base_url}/api/tenko/sessions/{}/report",
+            Uuid::new_v4()
+        ))
+        .header("Authorization", &auth_header)
+        .json(&serde_json::json!({
+            "vehicle_road_status": "OK",
+            "driver_alternation": "None",
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    // create_tenko_record error swallowed, still 200
+    assert_eq!(res.status(), 200);
+}
+
+#[tokio::test]
+async fn test_safety_judgment_fail_record_creation_fails() {
+    // Safety judgment fails (illness=true) → create_tenko_record called → get_employee_name fails
+    // But perform_safety_judgment also calls get_employee_name for webhook (line 725)
+    // That call returns 500.
+    let mock = Arc::new(MockTenkoSessionRepository::default());
+    *mock.session_status.lock().unwrap() = "self_declaration_pending".to_string();
+    *mock.session_tenko_type.lock().unwrap() = "pre_operation".to_string();
+    mock.fail_on_record.store(true, Ordering::SeqCst);
+    let (base_url, auth_header, _) = setup_with_mock(mock).await;
+
+    let res = client()
+        .put(format!(
+            "{base_url}/api/tenko/sessions/{}/self-declaration",
+            Uuid::new_v4()
+        ))
+        .header("Authorization", &auth_header)
+        .json(&serde_json::json!({
+            "illness": true,
+            "fatigue": false,
+            "sleep_deprivation": false,
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    // perform_safety_judgment: get_employee_name fails at line 725 → 500
+    assert_eq!(res.status(), 500);
+}
+
+#[tokio::test]
+async fn test_interrupt_session_employee_name_fails() {
+    // interrupt → get_employee_name for webhook → fails
+    let mock = Arc::new(MockTenkoSessionRepository::default());
+    *mock.session_status.lock().unwrap() = "identity_verified".to_string();
+    mock.fail_on_record.store(true, Ordering::SeqCst);
+    let (base_url, auth_header, _) = setup_with_mock(mock).await;
+
+    let res = client()
+        .post(format!(
+            "{base_url}/api/tenko/sessions/{}/interrupt",
+            Uuid::new_v4()
+        ))
+        .header("Authorization", &auth_header)
+        .json(&serde_json::json!({
+            "reason": "Manager"
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    // get_employee_name fails at line 972 → 500
+    assert_eq!(res.status(), 500);
+}
+
+// =========================================================================
+// Alcohol error result variant (line ~154, "error" in valid_results)
+// =========================================================================
+
+#[tokio::test]
+async fn test_submit_alcohol_error_result() {
+    let mock = Arc::new(MockTenkoSessionRepository::default());
+    *mock.session_status.lock().unwrap() = "identity_verified".to_string();
+    *mock.session_tenko_type.lock().unwrap() = "pre_operation".to_string();
+    let (base_url, auth_header, _) = setup_with_mock(mock).await;
+
+    let res = client()
+        .put(format!(
+            "{base_url}/api/tenko/sessions/{}/alcohol",
+            Uuid::new_v4()
+        ))
+        .header("Authorization", &auth_header)
+        .json(&serde_json::json!({
+            "alcohol_result": "error",
+            "alcohol_value": 0.0,
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    // "error" is in valid_results but is not "fail"/"over", so treated as pass
+    assert_eq!(res.status(), 200);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(body["status"], "instruction_pending");
+}
+
+// =========================================================================
+// Alcohol "normal" result for pre_operation
+// =========================================================================
+
+#[tokio::test]
+async fn test_submit_alcohol_normal_pre_operation() {
+    let mock = Arc::new(MockTenkoSessionRepository::default());
+    *mock.session_status.lock().unwrap() = "identity_verified".to_string();
+    *mock.session_tenko_type.lock().unwrap() = "pre_operation".to_string();
+    let (base_url, auth_header, _) = setup_with_mock(mock).await;
+
+    let res = client()
+        .put(format!(
+            "{base_url}/api/tenko/sessions/{}/alcohol",
+            Uuid::new_v4()
+        ))
+        .header("Authorization", &auth_header)
+        .json(&serde_json::json!({
+            "alcohol_result": "normal",
+            "alcohol_value": 0.0,
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(body["status"], "instruction_pending");
+}

--- a/tests/mock_tests/mock_tenko_sessions_test.rs
+++ b/tests/mock_tests/mock_tenko_sessions_test.rs
@@ -911,8 +911,8 @@ async fn test_submit_self_declaration_success() {
 
     assert_eq!(res.status(), 200);
     let body: serde_json::Value = res.json().await.unwrap();
-    // Safety judgment skipped (pool=None) — status stays at self_declaration_pending
-    assert_eq!(body["status"], "self_declaration_pending");
+    // Safety judgment runs (no baseline → pass) → daily_inspection_pending
+    assert_eq!(body["status"], "daily_inspection_pending");
 }
 
 #[tokio::test]

--- a/tests/mock_tests/mock_tenko_sessions_test.rs
+++ b/tests/mock_tests/mock_tenko_sessions_test.rs
@@ -2797,3 +2797,239 @@ async fn test_submit_alcohol_normal_pre_operation() {
     let body: serde_json::Value = res.json().await.unwrap();
     assert_eq!(body["status"], "instruction_pending");
 }
+
+// =========================================================================
+// Webhook fire_event coverage (lines 218, 383, 745, 864, 991-993)
+// =========================================================================
+
+/// Helper: setup with webhook=Some(MockWebhookService) + custom mock repo.
+async fn setup_with_webhook(mock: Arc<MockTenkoSessionRepository>) -> (String, String, uuid::Uuid) {
+    let mut state = crate::mock_helpers::app_state::setup_mock_app_state();
+    state.tenko_sessions = mock;
+    state.webhook = Some(Arc::new(
+        crate::mock_helpers::webhook::MockWebhookService::default(),
+    ));
+    let tenant_id = uuid::Uuid::new_v4();
+    let base_url = crate::common::spawn_test_server(state).await;
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let auth_header = format!("Bearer {jwt}");
+    (base_url, auth_header, tenant_id)
+}
+
+/// Line 218: alcohol_detected webhook fires when alcohol_result="fail" + webhook=Some
+#[tokio::test]
+async fn test_webhook_alcohol_detected() {
+    let mock = Arc::new(MockTenkoSessionRepository::default());
+    *mock.session_status.lock().unwrap() = "identity_verified".to_string();
+    *mock.session_tenko_type.lock().unwrap() = "pre_operation".to_string();
+    let (base_url, auth_header, _) = setup_with_webhook(mock).await;
+
+    let res = client()
+        .put(format!(
+            "{base_url}/api/tenko/sessions/{}/alcohol",
+            Uuid::new_v4()
+        ))
+        .header("Authorization", &auth_header)
+        .json(&serde_json::json!({
+            "alcohol_result": "fail",
+            "alcohol_value": 0.25,
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(body["status"], "cancelled");
+}
+
+/// Line 383: report_submitted webhook fires on any report submission
+#[tokio::test]
+async fn test_webhook_report_submitted() {
+    let mock = Arc::new(MockTenkoSessionRepository::default());
+    *mock.session_status.lock().unwrap() = "report_pending".to_string();
+    *mock.session_tenko_type.lock().unwrap() = "post_operation".to_string();
+    let (base_url, auth_header, _) = setup_with_webhook(mock).await;
+
+    let res = client()
+        .put(format!(
+            "{base_url}/api/tenko/sessions/{}/report",
+            Uuid::new_v4()
+        ))
+        .header("Authorization", &auth_header)
+        .json(&serde_json::json!({
+            "vehicle_road_status": "OK",
+            "driver_alternation": "None",
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+}
+
+/// Line 745: tenko_interrupted webhook fires when safety judgment fails (illness=true)
+#[tokio::test]
+async fn test_webhook_tenko_interrupted_safety_fail() {
+    let mock = Arc::new(MockTenkoSessionRepository::default());
+    *mock.session_status.lock().unwrap() = "self_declaration_pending".to_string();
+    *mock.session_tenko_type.lock().unwrap() = "pre_operation".to_string();
+    let (base_url, auth_header, _) = setup_with_webhook(mock).await;
+
+    let res = client()
+        .put(format!(
+            "{base_url}/api/tenko/sessions/{}/self-declaration",
+            Uuid::new_v4()
+        ))
+        .header("Authorization", &auth_header)
+        .json(&serde_json::json!({
+            "illness": true,
+            "fatigue": false,
+            "sleep_deprivation": false,
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(body["status"], "interrupted");
+}
+
+/// Line 864: inspection_ng webhook fires when daily inspection has NG items
+#[tokio::test]
+async fn test_webhook_inspection_ng() {
+    let mock = Arc::new(MockTenkoSessionRepository::default());
+    *mock.session_status.lock().unwrap() = "daily_inspection_pending".to_string();
+    *mock.session_tenko_type.lock().unwrap() = "pre_operation".to_string();
+    let (base_url, auth_header, _) = setup_with_webhook(mock).await;
+
+    let res = client()
+        .put(format!(
+            "{base_url}/api/tenko/sessions/{}/daily-inspection",
+            Uuid::new_v4()
+        ))
+        .header("Authorization", &auth_header)
+        .json(&serde_json::json!({
+            "brakes": "ng",
+            "tires": "ok",
+            "lights": "ok",
+            "steering": "ok",
+            "wipers": "ok",
+            "mirrors": "ok",
+            "horn": "ok",
+            "seatbelts": "ok",
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(body["status"], "cancelled");
+}
+
+/// Lines 991-993: tenko_interrupted webhook fires on interrupt_session
+#[tokio::test]
+async fn test_webhook_tenko_interrupted_via_interrupt() {
+    let mock = Arc::new(MockTenkoSessionRepository::default());
+    *mock.session_status.lock().unwrap() = "identity_verified".to_string();
+    let (base_url, auth_header, _) = setup_with_webhook(mock).await;
+
+    let res = client()
+        .post(format!(
+            "{base_url}/api/tenko/sessions/{}/interrupt",
+            Uuid::new_v4()
+        ))
+        .header("Authorization", &auth_header)
+        .json(&serde_json::json!({
+            "reason": "Manager decision"
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(body["status"], "interrupted");
+}
+
+// =========================================================================
+// DB error on specific methods (lines 527-529, 717-719, 932-934)
+// =========================================================================
+
+/// Lines 527-529: create_tenko_record repo method fails (error swallowed by `let _ =`)
+#[tokio::test]
+async fn test_create_tenko_record_repo_method_db_error() {
+    let mock = Arc::new(MockTenkoSessionRepository::default());
+    *mock.session_status.lock().unwrap() = "instruction_pending".to_string();
+    mock.fail_on_create_record.store(true, Ordering::SeqCst);
+    let (base_url, auth_header, _) = setup_with_mock(mock).await;
+
+    let res = client()
+        .put(format!(
+            "{base_url}/api/tenko/sessions/{}/instruction-confirm",
+            Uuid::new_v4()
+        ))
+        .header("Authorization", &auth_header)
+        .send()
+        .await
+        .unwrap();
+
+    // create_tenko_record error is swallowed by `let _ =`, so still 200
+    assert_eq!(res.status(), 200);
+}
+
+/// Lines 717-719: update_safety_judgment DB error -> 500
+#[tokio::test]
+async fn test_safety_judgment_update_db_error() {
+    let mock = Arc::new(MockTenkoSessionRepository::default());
+    *mock.session_status.lock().unwrap() = "self_declaration_pending".to_string();
+    *mock.session_tenko_type.lock().unwrap() = "pre_operation".to_string();
+    mock.fail_on_safety_judgment.store(true, Ordering::SeqCst);
+    let (base_url, auth_header, _) = setup_with_mock(mock).await;
+
+    let res = client()
+        .put(format!(
+            "{base_url}/api/tenko/sessions/{}/self-declaration",
+            Uuid::new_v4()
+        ))
+        .header("Authorization", &auth_header)
+        .json(&serde_json::json!({
+            "illness": false,
+            "fatigue": false,
+            "sleep_deprivation": false,
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 500);
+}
+
+/// Lines 932-934: update_carrying_items DB error -> 500
+#[tokio::test]
+async fn test_update_carrying_items_db_error() {
+    let mock = Arc::new(MockTenkoSessionRepository::default());
+    *mock.session_status.lock().unwrap() = "carrying_items_pending".to_string();
+    mock.fail_on_update_carrying_items
+        .store(true, Ordering::SeqCst);
+    let (base_url, auth_header, _) = setup_with_mock(mock).await;
+
+    let res = client()
+        .put(format!(
+            "{base_url}/api/tenko/sessions/{}/carrying-items",
+            Uuid::new_v4()
+        ))
+        .header("Authorization", &auth_header)
+        .json(&serde_json::json!({
+            "checks": [
+                {"item_id": Uuid::new_v4(), "checked": true},
+            ]
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 500);
+}


### PR DESCRIPTION
## Summary
- coverage_100.toml から integration/both 11ファイルを一時除外 (Wave 2-4 で mock 化後に再登録)
- kudgivt.rs, kudguri.rs を both→unit に変更 (unit だけで 100% 確認済み)
- full-tests ジョブ (PostgreSQL + RLS) → mock-tests ジョブ (DB 不要) に置換
- CI: check + unit-tests + mock-tests の3ジョブ全並列、DB 不要

## Test plan
- [ ] CI 3ジョブ (check, unit-tests, mock-tests) がすべて pass
- [ ] mock-tests ジョブに PostgreSQL サービスがないことを確認
- [ ] coverage artifact がアップロードされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)