### PR TITLE
refactor: remove #[rustfmt::skip] from tenko_sessions + guidance_records

### DIFF
--- a/src/routes/guidance_records.rs
+++ b/src/routes/guidance_records.rs
@@ -337,9 +337,11 @@ async fn download_attachment(
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
         .ok_or(StatusCode::NOT_FOUND)?;
 
-    #[rustfmt::skip]
     let key = state.storage.extract_key(&att.storage_url).ok_or_else(|| {
-        tracing::error!("Failed to extract key from storage_url: {}", att.storage_url);
+        tracing::error!(
+            "Failed to extract key from storage_url: {}",
+            att.storage_url
+        );
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
 

--- a/src/routes/guidance_records.rs
+++ b/src/routes/guidance_records.rs
@@ -338,10 +338,11 @@ async fn download_attachment(
         .ok_or(StatusCode::NOT_FOUND)?;
 
     let key = state.storage.extract_key(&att.storage_url).ok_or_else(|| {
-        tracing::error!(
+        let msg = format!(
             "Failed to extract key from storage_url: {}",
             att.storage_url
         );
+        tracing::error!("{msg}");
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
 

--- a/src/routes/tenko_sessions.rs
+++ b/src/routes/tenko_sessions.rs
@@ -676,8 +676,11 @@ async fn perform_safety_judgment(
             &mut failed_items,
         );
     } else {
-        #[rustfmt::skip]
-        tracing::warn!("No health baseline for employee {}, defaulting to pass", session.employee_id);
+        let msg = format!(
+            "No health baseline for employee {}, defaulting to pass",
+            session.employee_id
+        );
+        tracing::warn!("{msg}");
     }
 
     // 自己申告チェック


### PR DESCRIPTION
## Summary
- Remove 2 `#[rustfmt::skip]` annotations (tenko_sessions.rs, guidance_records.rs)
- Convert tracing::warn to `format!` pre-computation pattern for llvm-cov compatibility
- Remove unnecessary rustfmt skip on let binding

## Test plan
- [ ] CI single-test passes (coverage 100% maintained)

🤖 Generated with [Claude Code](https://claude.com/claude-code)