### PR TITLE
ci: add GHCR docker push on main merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ghcr.io/${{ github.repository }}
 
 jobs:
   check:
@@ -56,3 +58,30 @@ jobs:
           name: llvm-cov-text
           path: /tmp/llvm-cov-output.txt
           retention-days: 30
+
+  docker-push:
+    name: Push Docker Image to GHCR
+    needs: [check, full-tests]
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:latest
+            ${{ env.IMAGE_NAME }}:${{ github.sha }}


### PR DESCRIPTION
## Summary
- main merge 時に CI (check + full-tests) 通過後、`ghcr.io/yhonda-ohishi-alc/rust-alc-api:latest` に Docker image を push
- alc-app の integration test が GHCR から API image を pull するための前提

## Test plan
- [ ] CI の check + full-tests が通ること
- [ ] main merge 後に GHCR に image が push されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)