### PR TITLE
ci: latest tag only on main, sha on all

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,9 +73,30 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push
+      - name: Build and push (sha tag)
         uses: docker/build-push-action@v6
         with:
           context: .
           push: true
           tags: ghcr.io/${{ github.repository }}:${{ github.sha }}
+
+  docker-latest:
+    name: Tag latest
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    needs: [check, full-tests, docker-push]
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Copy sha tag to latest
+        run: |
+          docker pull ghcr.io/${{ github.repository }}:${{ github.sha }}
+          docker tag ghcr.io/${{ github.repository }}:${{ github.sha }} ghcr.io/${{ github.repository }}:latest
+          docker push ghcr.io/${{ github.repository }}:latest


### PR DESCRIPTION
## Summary
- PR: `ghcr.io/.../rust-alc-api:<sha>` のみ push
- main merge: `<sha>` + `latest` を push
- CI fail した PR で latest が上書きされるのを防止

## Test plan
- [ ] PR CI で docker-push が sha タグのみで成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)