### PR TITLE
ci: add Docker layer cache (GHA)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,12 +73,17 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build and push (sha tag)
         uses: docker/build-push-action@v6
         with:
           context: .
           push: true
           tags: ghcr.io/${{ github.repository }}:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
   docker-latest:
     name: Tag latest


### PR DESCRIPTION
## Summary
- `docker/setup-buildx-action` + `cache-from/cache-to: type=gha` 追加
- PR でビルドしたレイヤーが main で再利用され、main の Docker build が数秒に

## Test plan
- [ ] PR CI の docker-push が成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)