### PR TITLE
feat: R2_ENDPOINT + R2_PATH_STYLE for MinIO

### DIFF
--- a/crates/alc-storage/src/r2.rs
+++ b/crates/alc-storage/src/r2.rs
@@ -17,16 +17,21 @@ impl R2Backend {
         secret_key: String,
         public_url_base: Option<String>,
     ) -> Result<Self, StorageError> {
+        let endpoint = std::env::var("R2_ENDPOINT")
+            .unwrap_or_else(|_| format!("https://{}.r2.cloudflarestorage.com", account_id));
         let region = Region::Custom {
             region: "auto".to_string(),
-            endpoint: format!("https://{}.r2.cloudflarestorage.com", account_id),
+            endpoint,
         };
 
         let credentials = Credentials::new(Some(&access_key), Some(&secret_key), None, None, None)
             .map_err(|e| StorageError::Config(format!("R2 credentials: {e}")))?;
 
-        let bucket = Bucket::new(&bucket_name, region, credentials)
+        let mut bucket = Bucket::new(&bucket_name, region, credentials)
             .map_err(|e| StorageError::Config(format!("R2 bucket: {e}")))?;
+        if std::env::var("R2_PATH_STYLE").is_ok() {
+            bucket = bucket.with_path_style();
+        }
 
         let public_url_base = public_url_base
             .unwrap_or_else(|| format!("https://{}.r2.dev/{}", account_id, bucket_name));


### PR DESCRIPTION
## Summary
- `R2_ENDPOINT` 環境変数で S3 エンドポイントを上書き可能に (デフォルト: Cloudflare R2)
- `R2_PATH_STYLE` 環境変数で path-style アクセスを有効化 (MinIO 用)
- alc-app の integration test で MinIO をストレージとして使用するための前提

## Test plan
- [ ] CI pass (既存テストに影響なし — 環境変数未設定時は従来動作)

🤖 Generated with [Claude Code](https://claude.com/claude-code)