### PR TITLE
feat: export-ts-bindings.sh for frontend type sync

### DIFF
--- a/scripts/export-ts-bindings.sh
+++ b/scripts/export-ts-bindings.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# rust-alc-api の TypeScript 型定義を CI artifact から取得し、指定ディレクトリに出力
+#
+# Usage:
+#   ./scripts/export-ts-bindings.sh <output-dir>              # latest main
+#   ./scripts/export-ts-bindings.sh <output-dir> <sha>        # 特定 SHA
+#
+# Examples:
+#   # auth-worker
+#   ./scripts/export-ts-bindings.sh ../auth-worker/src/types
+#   # alc-app
+#   ./scripts/export-ts-bindings.sh ../alc-app/web/app/types
+#   # nuxt-dtako-admin
+#   ./scripts/export-ts-bindings.sh ../nuxt-dtako-admin/app/types
+#
+# 前提: gh CLI、rust-alc-api リポジトリへのアクセス権
+
+set -euo pipefail
+
+REPO="yhonda-ohishi-alc/rust-alc-api"
+
+if [ $# -lt 1 ]; then
+  echo "Usage: $0 <output-dir> [sha]" >&2
+  exit 1
+fi
+
+DEST="$1"
+SHA="${2:-}"
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+if [ -z "$SHA" ]; then
+  SHA=$(gh run list -R "$REPO" --branch main --status success --json headSha --jq '.[0].headSha' 2>/dev/null)
+  if [ -z "$SHA" ]; then
+    echo "ERROR: Could not find successful run on main" >&2
+    exit 1
+  fi
+fi
+
+ARTIFACT_NAME="ts-bindings-${SHA}"
+echo "Downloading: $ARTIFACT_NAME"
+
+RUN_ID=$(gh api "repos/$REPO/actions/artifacts?name=$ARTIFACT_NAME" --jq '.artifacts[0].workflow_run.id' 2>/dev/null)
+if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
+  echo "ERROR: Artifact '$ARTIFACT_NAME' not found" >&2
+  exit 1
+fi
+
+gh run download "$RUN_ID" -R "$REPO" -n "$ARTIFACT_NAME" -D "$TMPDIR/bindings"
+
+# 出力ファイル生成
+mkdir -p "$DEST"
+OUTPUT="$DEST/alc-api.ts"
+
+cat > "$OUTPUT" << HEADER
+// Auto-generated from rust-alc-api (ts-rs)
+// Source SHA: $SHA
+// Do not edit. Regenerate: scripts/export-ts-bindings.sh $DEST
+HEADER
+
+echo "" >> "$OUTPUT"
+
+find "$TMPDIR/bindings" -name "*.ts" -print0 | sort -z | while IFS= read -r -d '' f; do
+  grep "^export type" "$f" >> "$OUTPUT"
+done
+
+echo "" >> "$OUTPUT"
+cat >> "$OUTPUT" << 'WRAPPERS'
+// List response wrappers
+export type SsoConfigListResponse = { configs: SsoConfigRow[] };
+export type BotConfigListResponse = { configs: BotConfigResponse[] };
+export type UsersListResponse = { users: UserResponse[] };
+export type InvitationsListResponse = { invitations: TenantAllowedEmail[] };
+WRAPPERS
+
+echo "✅ $OUTPUT (SHA: ${SHA:0:12})"


### PR DESCRIPTION
## Summary
- `scripts/export-ts-bindings.sh <output-dir> [sha]` — CI artifact から TypeScript 型定義を取得
- auth-worker, alc-app, nuxt-dtako-admin 等の全 frontend で共用

## Test plan
- [x] `./scripts/export-ts-bindings.sh /home/yhonda/js/auth-worker/src/types` で動作確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)