### PR TITLE
feat: staging environment with Cloud Run multi-container

### DIFF
--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -1,0 +1,47 @@
+name: Cache Cleanup
+
+on:
+  pull_request:
+    types: [closed]
+  schedule:
+    - cron: '0 3 * * 0' # 毎週日曜 03:00 UTC
+
+jobs:
+  cleanup-branch-cache:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Delete caches for closed branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH="refs/pull/${{ github.event.pull_request.number }}/merge"
+          echo "Deleting caches for: $BRANCH"
+          gh cache list --ref "$BRANCH" --json id -q '.[].id' | while read id; do
+            gh cache delete "$id" || true
+          done
+          HEAD_REF="refs/heads/${{ github.event.pull_request.head.ref }}"
+          echo "Deleting caches for: $HEAD_REF"
+          gh cache list --ref "$HEAD_REF" --json id -q '.[].id' | while read id; do
+            gh cache delete "$id" || true
+          done
+
+  cleanup-stale-cache:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Keep only 50 newest caches
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh cache list --json id --sort last_accessed_at --order desc --limit 1000 -q '.[].id' \
+            | tail -n +51 | while read id; do
+            echo "Deleting cache: $id"
+            gh cache delete "$id" || true
+          done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.92.0
+      - uses: swatinem/rust-cache@v2
       - uses: mozilla-actions/sccache-action@v0.0.9
       - name: Generate TypeScript bindings
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,8 +195,8 @@ jobs:
 
       - name: Deploy to Cloud Run (multi-container)
         run: |
-          sed -e "s|PLACEHOLDER_APP_IMAGE|ghcr.io/${{ github.repository }}-staging:${{ github.sha }}|" \
-              -e "s|PLACEHOLDER_DB_IMAGE|ghcr.io/${{ github.repository }}-staging-db:latest|" \
+          sed -e "s|PLACEHOLDER_APP_IMAGE|asia-northeast1-docker.pkg.dev/cloudsql-sv/ghcr/${{ github.repository }}-staging:${{ github.sha }}|" \
+              -e "s|PLACEHOLDER_DB_IMAGE|asia-northeast1-docker.pkg.dev/cloudsql-sv/ghcr/${{ github.repository }}-staging-db:latest|" \
               staging/cloudrun-staging.yaml > /tmp/staging-deploy.yaml
 
           gcloud run services replace /tmp/staging-deploy.yaml \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,3 +143,74 @@ jobs:
           docker pull ghcr.io/${{ github.repository }}:${{ github.sha }}
           docker tag ghcr.io/${{ github.repository }}:${{ github.sha }} ghcr.io/${{ github.repository }}:latest
           docker push ghcr.io/${{ github.repository }}:latest
+
+  deploy-staging:
+    name: Deploy Staging
+    if: github.event_name == 'pull_request'
+    needs: [check, full-tests, docker-push]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Staging PostgreSQL イメージ build & push
+      - name: Build staging-db image
+        run: |
+          docker build -f staging/Dockerfile.postgres \
+            -t ghcr.io/${{ github.repository }}-staging-db:latest .
+          docker push ghcr.io/${{ github.repository }}-staging-db:latest
+
+      # Staging app イメージ (entrypoint 差し替え版) build & push
+      - name: Build staging app image
+        run: |
+          mkdir -p staging-context/staging
+          docker create --name extract ghcr.io/${{ github.repository }}:${{ github.sha }}
+          docker cp extract:/usr/local/bin/rust-alc-api staging-context/
+          docker cp extract:/usr/local/bin/migrate staging-context/
+          docker cp extract:/app/migrations staging-context/
+          docker rm extract
+          cp staging/Dockerfile.app staging-context/Dockerfile
+          cp staging/entrypoint.sh staging-context/staging/
+          docker build -t ghcr.io/${{ github.repository }}-staging:${{ github.sha }} staging-context/
+          docker push ghcr.io/${{ github.repository }}-staging:${{ github.sha }}
+
+      # GCP 認証 & Cloud Run デプロイ
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Deploy to Cloud Run (multi-container)
+        run: |
+          sed -e "s|PLACEHOLDER_APP_IMAGE|ghcr.io/${{ github.repository }}-staging:${{ github.sha }}|" \
+              -e "s|PLACEHOLDER_DB_IMAGE|ghcr.io/${{ github.repository }}-staging-db:latest|" \
+              staging/cloudrun-staging.yaml > /tmp/staging-deploy.yaml
+
+          gcloud run services replace /tmp/staging-deploy.yaml \
+            --region asia-northeast1 \
+            --project cloudsql-sv
+
+          gcloud run services add-iam-policy-binding rust-alc-api-staging \
+            --region asia-northeast1 \
+            --member="allUsers" \
+            --role="roles/run.invoker" \
+            --project cloudsql-sv
+
+      - name: Print staging URL
+        run: |
+          URL=$(gcloud run services describe rust-alc-api-staging \
+            --region asia-northeast1 --project cloudsql-sv \
+            --format 'value(status.url)')
+          echo "::notice ::Staging URL: $URL"

--- a/scripts/export-ts-bindings.sh
+++ b/scripts/export-ts-bindings.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# rust-alc-api の TypeScript 型定義を CI artifact から取得し、指定ディレクトリに出力
+#
+# Usage:
+#   ./scripts/export-ts-bindings.sh <output-dir>              # latest main
+#   ./scripts/export-ts-bindings.sh <output-dir> <sha>        # 特定 SHA
+#
+# Examples:
+#   # auth-worker
+#   ./scripts/export-ts-bindings.sh ../auth-worker/src/types
+#   # alc-app
+#   ./scripts/export-ts-bindings.sh ../alc-app/web/app/types
+#   # nuxt-dtako-admin
+#   ./scripts/export-ts-bindings.sh ../nuxt-dtako-admin/app/types
+#
+# 前提: gh CLI、rust-alc-api リポジトリへのアクセス権
+
+set -euo pipefail
+
+REPO="yhonda-ohishi-alc/rust-alc-api"
+
+if [ $# -lt 1 ]; then
+  echo "Usage: $0 <output-dir> [sha]" >&2
+  exit 1
+fi
+
+DEST="$1"
+SHA="${2:-}"
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+if [ -z "$SHA" ]; then
+  SHA=$(gh run list -R "$REPO" --branch main --status success --json headSha --jq '.[0].headSha' 2>/dev/null)
+  if [ -z "$SHA" ]; then
+    echo "ERROR: Could not find successful run on main" >&2
+    exit 1
+  fi
+fi
+
+ARTIFACT_NAME="ts-bindings-${SHA}"
+echo "Downloading: $ARTIFACT_NAME"
+
+RUN_ID=$(gh api "repos/$REPO/actions/artifacts?name=$ARTIFACT_NAME" --jq '.artifacts[0].workflow_run.id' 2>/dev/null)
+if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
+  echo "ERROR: Artifact '$ARTIFACT_NAME' not found" >&2
+  exit 1
+fi
+
+gh run download "$RUN_ID" -R "$REPO" -n "$ARTIFACT_NAME" -D "$TMPDIR/bindings"
+
+# 出力ファイル生成
+mkdir -p "$DEST"
+OUTPUT="$DEST/alc-api.ts"
+
+cat > "$OUTPUT" << HEADER
+// Auto-generated from rust-alc-api (ts-rs)
+// Source SHA: $SHA
+// Do not edit. Regenerate: scripts/export-ts-bindings.sh $DEST
+HEADER
+
+echo "" >> "$OUTPUT"
+
+find "$TMPDIR/bindings" -name "*.ts" -print0 | sort -z | while IFS= read -r -d '' f; do
+  grep "^export type" "$f" >> "$OUTPUT"
+done
+
+echo "" >> "$OUTPUT"
+cat >> "$OUTPUT" << 'WRAPPERS'
+// List response wrappers
+export type SsoConfigListResponse = { configs: SsoConfigRow[] };
+export type BotConfigListResponse = { configs: BotConfigResponse[] };
+export type UsersListResponse = { users: UserResponse[] };
+export type InvitationsListResponse = { invitations: TenantAllowedEmail[] };
+WRAPPERS
+
+echo "✅ $OUTPUT (SHA: ${SHA:0:12})"

--- a/src/main.rs
+++ b/src/main.rs
@@ -243,6 +243,7 @@ async fn main() -> anyhow::Result<()> {
     tracing::info!("Scraper URL: {}", scraper_url);
 
     let app = Router::new()
+        .route("/health", axum::routing::get(|| async { "ok" }))
         .nest("/api", rust_alc_api::routes::router())
         .layer(Extension(google_verifier))
         .layer(Extension(jwt_secret))

--- a/staging/Dockerfile.app
+++ b/staging/Dockerfile.app
@@ -1,0 +1,15 @@
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y ca-certificates postgresql-client && rm -rf /var/lib/apt/lists/*
+
+COPY rust-alc-api /usr/local/bin/
+COPY migrate /usr/local/bin/
+COPY migrations /app/migrations
+COPY staging/entrypoint.sh /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
+
+WORKDIR /app
+ENV PORT=8080
+EXPOSE 8080
+
+CMD ["/app/entrypoint.sh"]

--- a/staging/Dockerfile.postgres
+++ b/staging/Dockerfile.postgres
@@ -1,0 +1,4 @@
+FROM postgres:16
+COPY scripts/init_local_db.sql /docker-entrypoint-initdb.d/01-init.sql
+ENV POSTGRES_PASSWORD=staging
+ENV POSTGRES_HOST_AUTH_METHOD=trust

--- a/staging/cloudrun-staging.yaml
+++ b/staging/cloudrun-staging.yaml
@@ -38,8 +38,6 @@ spec:
               value: "ohishi-dtako-staging"
             - name: FCM_PROJECT_ID
               value: "alc-fcm"
-            - name: PORT
-              value: "8080"
             - name: RUST_LOG
               value: "info"
             # Secrets — secretKeyRef で Secret Manager から注入

--- a/staging/cloudrun-staging.yaml
+++ b/staging/cloudrun-staging.yaml
@@ -1,0 +1,130 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: rust-alc-api-staging
+  labels:
+    cloud.googleapis.com/location: asia-northeast1
+  annotations:
+    run.googleapis.com/launch-stage: BETA
+spec:
+  template:
+    metadata:
+      annotations:
+        run.googleapis.com/container-dependencies: '{"app":["postgres"]}'
+        autoscaling.knative.dev/maxScale: "1"
+        autoscaling.knative.dev/minScale: "0"
+    spec:
+      containerConcurrency: 80
+      timeoutSeconds: 300
+      containers:
+        - name: app
+          image: PLACEHOLDER_APP_IMAGE
+          ports:
+            - containerPort: 8080
+          env:
+            - name: DATABASE_URL
+              value: "postgresql://postgres:staging@localhost:5432/postgres?options=-c search_path=alc_api"
+            - name: STORAGE_BACKEND
+              value: "r2"
+            - name: R2_BUCKET
+              value: "alc-face-photos-staging"
+            - name: R2_ACCOUNT_ID
+              value: "24b45709d060d957340180e995f0d373"
+            - name: API_ORIGIN
+              value: "PLACEHOLDER_STAGING_URL"
+            - name: CARINS_R2_BUCKET
+              value: "carins-files-staging"
+            - name: DTAKO_R2_BUCKET
+              value: "ohishi-dtako-staging"
+            - name: FCM_PROJECT_ID
+              value: "alc-fcm"
+            - name: PORT
+              value: "8080"
+            - name: RUST_LOG
+              value: "info"
+            # Secrets — secretKeyRef で Secret Manager から注入
+            - name: JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: latest
+                  name: alc-api-staging-jwt-secret
+            - name: GOOGLE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  key: latest
+                  name: GOOGLE_CLIENT_ID
+            - name: GOOGLE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: latest
+                  name: GOOGLE_CLIENT_SECRET
+            - name: R2_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: latest
+                  name: alc-r2-access-key
+            - name: R2_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: latest
+                  name: alc-r2-secret-key
+            - name: OAUTH_STATE_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: latest
+                  name: alc-oauth-state-secret
+            - name: CARINS_R2_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: latest
+                  name: carins-r2-access-key
+            - name: CARINS_R2_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: latest
+                  name: carins-r2-secret-key
+            - name: DTAKO_R2_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: latest
+                  name: dtako-r2-access-key
+            - name: DTAKO_R2_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: latest
+                  name: dtako-r2-secret-key
+          resources:
+            limits:
+              memory: 512Mi
+              cpu: "1"
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 3
+            failureThreshold: 20
+        - name: postgres
+          image: PLACEHOLDER_DB_IMAGE
+          env:
+            - name: POSTGRES_PASSWORD
+              value: "staging"
+            - name: POSTGRES_HOST_AUTH_METHOD
+              value: "trust"
+          resources:
+            limits:
+              memory: 512Mi
+              cpu: "1"
+          startupProbe:
+            tcpSocket:
+              port: 5432
+            initialDelaySeconds: 2
+            periodSeconds: 2
+            failureThreshold: 15
+          volumeMounts:
+            - name: pg-data
+              mountPath: /var/lib/postgresql/data
+      volumes:
+        - name: pg-data
+          emptyDir:
+            sizeLimit: 1Gi

--- a/staging/entrypoint.sh
+++ b/staging/entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+
+# Wait for postgres sidecar to be ready
+echo "Waiting for PostgreSQL..."
+until pg_isready -h localhost -p 5432 -U postgres 2>/dev/null; do
+  sleep 1
+done
+echo "PostgreSQL is ready"
+
+# Run migrations
+echo "Running migrations..."
+DATABASE_URL="postgresql://postgres:staging@localhost:5432/postgres?options=-c search_path=alc_api" \
+  /usr/local/bin/migrate
+
+echo "Migrations completed, starting app..."
+
+# Start the app with DATABASE_URL pointing to local postgres
+export DATABASE_URL="postgresql://postgres:staging@localhost:5432/postgres?options=-c search_path=alc_api"
+exec /usr/local/bin/rust-alc-api


### PR DESCRIPTION
## Summary
- Cloud Run マルチコンテナ (app + PostgreSQL sidecar) で staging 環境を構築
- PR 時に CI から自動デプロイ、毎回 DB がリセットされる
- /health エンドポイント追加 (startupProbe 用)

## Test plan
- [ ] CI の deploy-staging ジョブが正常に完了する
- [ ] staging URL にアクセスして /health が "ok" を返す
- [ ] staging URL 確定後、フロントエンドの wrangler 設定を更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)