### PR TITLE
ci: add dev tag for PR Docker images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,27 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+  docker-dev:
+    name: Tag dev
+    if: github.event_name == 'pull_request'
+    needs: [docker-push]
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Copy sha tag to dev
+        run: |
+          docker pull ghcr.io/${{ github.repository }}:${{ github.sha }}
+          docker tag ghcr.io/${{ github.repository }}:${{ github.sha }} ghcr.io/${{ github.repository }}:dev
+          docker push ghcr.io/${{ github.repository }}:dev
+
   docker-latest:
     name: Tag latest
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'


### PR DESCRIPTION
## Summary
- PR ビルド時に `ghcr.io/ippoan/rust-alc-api:dev` タグを push
- alc-app の integration-test が `dev` タグを参照するために必要

## Test plan
- [ ] PR の CI で `docker-dev` ジョブが実行され `dev` タグが push されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)