### PR TITLE
feat: add ts-rs bindings for carins types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,6 +41,7 @@ dependencies = [
  "serde_json",
  "sqlx",
  "tracing",
+ "ts-rs",
  "uuid",
 ]
 
@@ -4526,6 +4527,7 @@ checksum = "e640d9b0964e9d39df633548591090ab92f7a4567bc31d3891af23471a3365c6"
 dependencies = [
  "chrono",
  "lazy_static",
+ "serde_json",
  "thiserror 2.0.18",
  "ts-rs-macros",
  "uuid",

--- a/crates/alc-carins/Cargo.toml
+++ b/crates/alc-carins/Cargo.toml
@@ -13,4 +13,5 @@ chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"
+ts-rs = { version = "10", features = ["chrono-impl", "uuid-impl", "serde-json-impl"] }
 uuid = { version = "1", features = ["v4", "serde"] }

--- a/crates/alc-carins/src/car_inspections.rs
+++ b/crates/alc-carins/src/car_inspections.rs
@@ -21,7 +21,8 @@ pub fn tenant_router() -> Router<AppState> {
         .route("/car-inspections/{id}", get(get_by_id))
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ts_rs::TS)]
+#[ts(export, rename = "CarInspectionListResponse")]
 struct ListResponse {
     #[serde(rename = "carInspections")]
     car_inspections: Vec<serde_json::Value>,

--- a/crates/alc-carins/src/carins_files.rs
+++ b/crates/alc-carins/src/carins_files.rs
@@ -23,7 +23,8 @@ pub fn tenant_router() -> Router<AppState> {
         .route("/files/{uuid}/restore", post(restore_file))
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ts_rs::TS)]
+#[ts(export, rename = "FileListResponse")]
 struct ListResponse {
     files: Vec<FileRow>,
 }

--- a/crates/alc-carins/src/nfc_tags.rs
+++ b/crates/alc-carins/src/nfc_tags.rs
@@ -26,7 +26,8 @@ struct SearchQuery {
     uuid: String,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ts_rs::TS)]
+#[ts(export, rename = "NfcTagSearchResponse")]
 struct SearchResponse {
     nfc_tag: NfcTag,
     car_inspection: Option<serde_json::Value>,

--- a/crates/alc-core/src/models.rs
+++ b/crates/alc-core/src/models.rs
@@ -907,7 +907,8 @@ pub struct DtakoSegmentsResponse {
 
 // --- NFC Tag ---
 
-#[derive(Debug, Clone, sqlx::FromRow, serde::Serialize)]
+#[derive(Debug, Clone, sqlx::FromRow, serde::Serialize, ts_rs::TS)]
+#[ts(export)]
 #[serde(rename_all = "camelCase")]
 pub struct NfcTag {
     pub id: i32,

--- a/crates/alc-core/src/repository/carins_files.rs
+++ b/crates/alc-core/src/repository/carins_files.rs
@@ -3,7 +3,8 @@ use chrono::{DateTime, Utc};
 use serde::Serialize;
 use uuid::Uuid;
 
-#[derive(Debug, Clone, sqlx::FromRow, Serialize)]
+#[derive(Debug, Clone, sqlx::FromRow, Serialize, ts_rs::TS)]
+#[ts(export)]
 #[serde(rename_all = "camelCase")]
 pub struct FileRow {
     pub uuid: String,


### PR DESCRIPTION
## Summary
- NfcTag, FileRow に `#[derive(TS)]` 追加 (alc-core)
- CarInspectionListResponse, FileListResponse, NfcTagSearchResponse に `#[derive(TS)]` 追加 (alc-carins)
- alc-carins に ts-rs 依存追加

nuxt-pwa-carins の型安全化に必要。

## Test plan
- [ ] CI pass
- [ ] `cargo test -p alc-core --lib` + `cargo test -p alc-carins --lib` で bindings 生成確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)