### PR TITLE
fix: deduplicate types in export-ts-bindings.sh

### DIFF
--- a/scripts/export-ts-bindings.sh
+++ b/scripts/export-ts-bindings.sh
@@ -60,9 +60,13 @@ HEADER
 
 echo "" >> "$OUTPUT"
 
+# serde_json::Value equivalent (needed by some generated types)
+echo "export type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue };" >> "$OUTPUT"
+
+# Collect all export type lines, deduplicate by type name
 find "$TMPDIR/bindings" -name "*.ts" -print0 | sort -z | while IFS= read -r -d '' f; do
-  grep "^export type" "$f" >> "$OUTPUT"
-done
+  grep "^export type" "$f"
+done | awk -F'[ =]' '!seen[$3]++' >> "$OUTPUT"
 
 echo "" >> "$OUTPUT"
 cat >> "$OUTPUT" << 'WRAPPERS'


### PR DESCRIPTION
## Summary
- 重複する export type を型名で deduplicate (awk)
- JsonValue 型定義を追加 (serde_json::Value 用)
- auth-worker CI で FileRow/NfcTag 重複 + JsonValue 未定義エラーを修正

## Test plan
- [ ] CI pass
- [ ] auth-worker CI rerun で型エラー解消

🤖 Generated with [Claude Code](https://claude.com/claude-code)