### PR TITLE
fix: staging API_ORIGIN placeholder replacement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,8 +263,11 @@ jobs:
           APP_IMAGE="${AR_PREFIX}/ghcr.io/${{ github.repository }}-staging:${{ github.sha }}"
           DB_IMAGE="${AR_PREFIX}/ghcr.io/${{ github.repository }}-staging-db:latest"
 
+          STAGING_URL="${{ vars.STAGING_API_URL }}"
+
           sed -e "s|PLACEHOLDER_APP_IMAGE|${APP_IMAGE}|" \
               -e "s|PLACEHOLDER_DB_IMAGE|${DB_IMAGE}|" \
+              -e "s|PLACEHOLDER_STAGING_URL|${STAGING_URL}|" \
               staging/cloudrun-staging.yaml > /tmp/staging-deploy.yaml
 
           gcloud run services replace /tmp/staging-deploy.yaml \


### PR DESCRIPTION
## Summary
- `PLACEHOLDER_STAGING_URL` を `vars.STAGING_API_URL` で sed 置換
- staging の Google OAuth redirect_uri が壊れていた問題を修正

## Test plan
- [ ] CI pass
- [ ] staging deploy 後に Google OAuth ログインが動くこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)