### PR TITLE
feat: auto-parse car inspection JSON on file upload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "adobe-cmap-parser"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae8abfa9a4688de8fc9f42b3f013b6fffec18ed8a554f5f113577e0b9b3212a3"
+dependencies = [
+ "pom",
+]
+
+[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -37,6 +46,8 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "chrono",
+ "pdf-extract",
+ "regex",
  "serde",
  "serde_json",
  "sqlx",
@@ -1098,6 +1109,15 @@ dependencies = [
 
 [[package]]
 name = "euclid"
+version = "0.20.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bb7ef65b3777a325d1eeefefab5b6d4959da54747e33bd6258e789640f307ad"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "euclid"
 version = "0.22.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
@@ -2029,7 +2049,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c62026ae44756f8a599ba21140f350303d4f08dcdcc71b5ad9c9bb8128c13c62"
 dependencies = [
  "arrayvec",
- "euclid",
+ "euclid 0.22.14",
  "smallvec",
 ]
 
@@ -2040,7 +2060,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce9729cc38c18d86123ab736fd2e7151763ba226ac2490ec092d1dd148825e32"
 dependencies = [
  "arrayvec",
- "euclid",
+ "euclid 0.22.14",
  "smallvec",
 ]
 
@@ -2118,6 +2138,24 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lopdf"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5c8ecfc6c72051981c0459f75ccc585e7ff67c70829560cda8e647882a9abff"
+dependencies = [
+ "encoding_rs",
+ "flate2",
+ "indexmap",
+ "itoa 1.0.17",
+ "log",
+ "md-5",
+ "nom",
+ "rangemap",
+ "time",
+ "weezl",
+]
 
 [[package]]
 name = "lopdf"
@@ -2605,6 +2643,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "pdf-extract"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbb3a5387b94b9053c1e69d8abfd4dd6dae7afda65a5c5279bc1f42ab39df575"
+dependencies = [
+ "adobe-cmap-parser",
+ "encoding_rs",
+ "euclid 0.20.14",
+ "lopdf 0.34.0",
+ "postscript",
+ "type1-encoding-parser",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "pdf-writer"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2786,6 +2839,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "pom"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60f6ce597ecdcc9a098e7fddacb1065093a3d66446fa16c675e7e71d1b5c28e6"
+
+[[package]]
+name = "postscript"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78451badbdaebaf17f053fd9152b3ffb33b516104eacb45e7864aaa9c712f306"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2839,7 +2904,7 @@ dependencies = [
  "flate2",
  "image",
  "kuchiki",
- "lopdf",
+ "lopdf 0.35.0",
  "rust-fontconfig",
  "serde",
  "serde_derive",
@@ -4558,6 +4623,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
 dependencies = [
  "core_maths",
+]
+
+[[package]]
+name = "type1-encoding-parser"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa10c302f5a53b7ad27fd42a3996e23d096ba39b5b8dd6d9e683a05b01bee749"
+dependencies = [
+ "pom",
 ]
 
 [[package]]

--- a/crates/alc-carins/Cargo.toml
+++ b/crates/alc-carins/Cargo.toml
@@ -15,3 +15,5 @@ serde_json = "1"
 tracing = "0.1"
 ts-rs = { version = "10", features = ["chrono-impl", "uuid-impl", "serde-json-impl"] }
 uuid = { version = "1", features = ["v4", "serde"] }
+pdf-extract = "0.7"
+regex = "1"

--- a/crates/alc-carins/src/carins_files.rs
+++ b/crates/alc-carins/src/carins_files.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use alc_core::auth_middleware::TenantId;
+use alc_core::repository::car_inspections::{CarInspectionRepository, CreateFileLinkParams};
 use alc_core::repository::carins_files::FileRow;
 use alc_core::AppState;
 
@@ -213,7 +214,78 @@ async fn create_file(
             StatusCode::INTERNAL_SERVER_ERROR
         })?;
 
+    // JSON ファイルの場合、車検証データをパースして UPSERT + ファイルリンク作成
+    if body.file_type == "application/json" {
+        if let Err(e) = try_parse_car_inspection(
+            state.car_inspections.as_ref(),
+            tenant_id.0,
+            file_uuid,
+            &data,
+            &body.file_type,
+        )
+        .await
+        {
+            tracing::warn!("car inspection parse skipped for {file_uuid}: {e}");
+        }
+    }
+
     Ok((StatusCode::CREATED, Json(row)))
+}
+
+/// 車検証 JSON をパースして car_inspection UPSERT + car_inspection_files_a リンク作成
+async fn try_parse_car_inspection(
+    repo: &dyn CarInspectionRepository,
+    tenant_id: Uuid,
+    file_uuid: Uuid,
+    data: &[u8],
+    file_type: &str,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let json: serde_json::Value = serde_json::from_slice(data)?;
+
+    let cert_info = json.get("CertInfo").ok_or("missing CertInfo")?;
+
+    let elect_cert_mg_no = cert_info
+        .get("ElectCertMgNo")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .ok_or("missing or empty ElectCertMgNo")?;
+
+    let version = json
+        .get("CertInfoImportFileVersion")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+
+    // GrantdateE/Y/M/D をスペース除去して取得
+    let grantdate_e = strip_spaces_field(cert_info, "GrantdateE");
+    let grantdate_y = strip_spaces_field(cert_info, "GrantdateY");
+    let grantdate_m = strip_spaces_field(cert_info, "GrantdateM");
+    let grantdate_d = strip_spaces_field(cert_info, "GrantdateD");
+
+    repo.upsert_from_json(tenant_id, cert_info, version).await?;
+
+    repo.create_file_link(&CreateFileLinkParams {
+        tenant_id,
+        file_uuid,
+        file_type,
+        elect_cert_mg_no,
+        grantdate_e: &grantdate_e,
+        grantdate_y: &grantdate_y,
+        grantdate_m: &grantdate_m,
+        grantdate_d: &grantdate_d,
+    })
+    .await?;
+
+    tracing::info!(
+        "car inspection parsed: ElectCertMgNo={}, file={}",
+        elect_cert_mg_no,
+        file_uuid
+    );
+    Ok(())
+}
+
+fn strip_spaces_field(v: &serde_json::Value, key: &str) -> String {
+    let s = v.get(key).and_then(|v| v.as_str()).unwrap_or("");
+    s.replace([' ', '\u{3000}'], "")
 }
 
 async fn delete_file(

--- a/crates/alc-carins/src/carins_files.rs
+++ b/crates/alc-carins/src/carins_files.rs
@@ -190,7 +190,9 @@ async fn create_file(
         .map_err(|_| StatusCode::BAD_REQUEST)?;
 
     state
-        .storage
+        .carins_storage
+        .as_ref()
+        .unwrap_or(&state.storage)
         .upload(&gcs_key, &data, &body.file_type)
         .await
         .map_err(|e| {

--- a/crates/alc-carins/src/carins_files.rs
+++ b/crates/alc-carins/src/carins_files.rs
@@ -214,31 +214,40 @@ async fn create_file(
             StatusCode::INTERNAL_SERVER_ERROR
         })?;
 
-    // JSON ファイルの場合、車検証データをパースして UPSERT + ファイルリンク作成
+    // 車検証ファイル自動パース (JSON / PDF)
     if body.file_type == "application/json" {
-        if let Err(e) = try_parse_car_inspection(
+        if let Err(e) = try_parse_car_inspection_json(
             state.car_inspections.as_ref(),
             tenant_id.0,
             file_uuid,
             &data,
-            &body.file_type,
         )
         .await
         {
-            tracing::warn!("car inspection parse skipped for {file_uuid}: {e}");
+            tracing::warn!("car inspection JSON parse skipped for {file_uuid}: {e}");
+        }
+    } else if body.file_type == "application/pdf" {
+        if let Err(e) = try_parse_car_inspection_pdf(
+            state.car_inspections.as_ref(),
+            tenant_id.0,
+            file_uuid,
+            &data,
+        )
+        .await
+        {
+            tracing::warn!("car inspection PDF parse skipped for {file_uuid}: {e}");
         }
     }
 
     Ok((StatusCode::CREATED, Json(row)))
 }
 
-/// 車検証 JSON をパースして car_inspection UPSERT + car_inspection_files_a リンク作成
-async fn try_parse_car_inspection(
+/// 車検証 JSON をパースして car_inspection UPSERT + files_a リンク + pending PDF チェック
+async fn try_parse_car_inspection_json(
     repo: &dyn CarInspectionRepository,
     tenant_id: Uuid,
     file_uuid: Uuid,
     data: &[u8],
-    file_type: &str,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let json: serde_json::Value = serde_json::from_slice(data)?;
 
@@ -255,18 +264,19 @@ async fn try_parse_car_inspection(
         .and_then(|v| v.as_str())
         .unwrap_or("");
 
-    // GrantdateE/Y/M/D をスペース除去して取得
     let grantdate_e = strip_spaces_field(cert_info, "GrantdateE");
     let grantdate_y = strip_spaces_field(cert_info, "GrantdateY");
     let grantdate_m = strip_spaces_field(cert_info, "GrantdateM");
     let grantdate_d = strip_spaces_field(cert_info, "GrantdateD");
 
+    // 1. car_inspection UPSERT
     repo.upsert_from_json(tenant_id, cert_info, version).await?;
 
+    // 2. car_inspection_files_a リンク
     repo.create_file_link(&CreateFileLinkParams {
         tenant_id,
         file_uuid,
-        file_type,
+        file_type: "application/json",
         elect_cert_mg_no,
         grantdate_e: &grantdate_e,
         grantdate_y: &grantdate_y,
@@ -276,15 +286,171 @@ async fn try_parse_car_inspection(
     .await?;
 
     tracing::info!(
-        "car inspection parsed: ElectCertMgNo={}, file={}",
+        "car inspection JSON parsed: ElectCertMgNo={}, file={}",
         elect_cert_mg_no,
         file_uuid
     );
+
+    // 3. pending PDF チェック — PDF が先にアップロードされていれば files_b にリンク
+    if let Ok(Some(pdf_uuid_str)) = repo.find_pending_pdf(tenant_id, elect_cert_mg_no).await {
+        if let Ok(pdf_uuid) = pdf_uuid_str.parse::<Uuid>() {
+            let _ = repo
+                .create_file_link(&CreateFileLinkParams {
+                    tenant_id,
+                    file_uuid: pdf_uuid,
+                    file_type: "application/pdf",
+                    elect_cert_mg_no,
+                    grantdate_e: &grantdate_e,
+                    grantdate_y: &grantdate_y,
+                    grantdate_m: &grantdate_m,
+                    grantdate_d: &grantdate_d,
+                })
+                .await;
+            let _ = repo.delete_pending_pdf(tenant_id, elect_cert_mg_no).await;
+            tracing::info!(
+                "linked pending PDF: pdf={}, ElectCertMgNo={}",
+                pdf_uuid,
+                elect_cert_mg_no
+            );
+        }
+    }
+
+    Ok(())
+}
+
+// PDF 解析用の正規表現パターン (rust-logi file_auto_parser.rs から移植)
+use std::sync::LazyLock;
+
+/// 車検証判定
+static RE_CAR_INSPECTION: LazyLock<regex::Regex> = LazyLock::new(|| {
+    regex::Regex::new(r"自\s*動\s*車\s*検\s*査\s*証\s*記\s*録\s*事\s*項").unwrap()
+});
+
+/// ElectCertMgNo: 12桁数字
+static RE_ELECT_CERT_MG_NO: LazyLock<regex::Regex> =
+    LazyLock::new(|| regex::Regex::new(r"\d{12}").unwrap());
+
+/// Grantdate: pdf-extract 形式 "令 和  8  2  13 月 日"
+static RE_GRANTDATE_HEADER: LazyLock<regex::Regex> = LazyLock::new(|| {
+    regex::Regex::new(
+        r"(?s)記録年月日.*?(令\s*和|平\s*成|昭\s*和)\s+(\d{1,2})\s+(\d{1,2})\s+(\d{1,2})",
+    )
+    .unwrap()
+});
+
+/// Grantdate: 標準日本語形式 "令和8年2月13日"
+static RE_GRANTDATE_STANDARD: LazyLock<regex::Regex> = LazyLock::new(|| {
+    regex::Regex::new(
+        r"(?s)記録年月日.*?(令\s*和|平\s*成|昭\s*和)\s*(\d{1,2})\s*年\s*(\d{1,2})\s*月\s*(\d{1,2})\s*日",
+    )
+    .unwrap()
+});
+
+/// Grantdate: 備考セクション内フォールバック
+static RE_GRANTDATE_BIKO: LazyLock<regex::Regex> = LazyLock::new(|| {
+    regex::Regex::new(
+        r"(?s)４[.．]\s*備考.*?(令\s*和|平\s*成|昭\s*和)\s+(\d{1,2})\s+(\d{1,2})\s+(\d{1,2})",
+    )
+    .unwrap()
+});
+
+/// PDF アップロード時の車検証自動パース
+async fn try_parse_car_inspection_pdf(
+    repo: &dyn CarInspectionRepository,
+    tenant_id: Uuid,
+    file_uuid: Uuid,
+    data: &[u8],
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    // 1. PDF テキスト抽出 (1ページ目のみ)
+    let pages = pdf_extract::extract_text_from_mem_by_pages(data)?;
+    let page1 = pages.first().ok_or("PDF has no pages")?;
+    if page1.is_empty() {
+        return Err("PDF page 1 has no text".into());
+    }
+
+    // 2. 車検証 PDF 判定
+    if !RE_CAR_INSPECTION.is_match(page1) {
+        return Ok(()); // 車検証ではない PDF → スキップ
+    }
+
+    // 3. ElectCertMgNo 抽出 (12桁数字)
+    let elect_cert_mg_no = RE_ELECT_CERT_MG_NO
+        .find(page1)
+        .ok_or("car inspection PDF but no ElectCertMgNo found")?
+        .as_str();
+
+    // 4. Grantdate 抽出 (3パターンのフォールバック)
+    let caps = RE_GRANTDATE_HEADER
+        .captures(page1)
+        .or_else(|| RE_GRANTDATE_STANDARD.captures(page1))
+        .or_else(|| RE_GRANTDATE_BIKO.captures(page1))
+        .ok_or("car inspection PDF but Grantdate not found")?;
+
+    let grantdate_e = strip_spaces_str(&caps[1]);
+    let grantdate_y = strip_spaces_str(&caps[2]);
+    let grantdate_m = strip_spaces_str(&caps[3]);
+    let grantdate_d = strip_spaces_str(&caps[4]);
+
+    tracing::info!(
+        "car inspection PDF parsed: ElectCertMgNo={}, Grantdate={}-{}-{}-{}, file={}",
+        elect_cert_mg_no,
+        grantdate_e,
+        grantdate_y,
+        grantdate_m,
+        grantdate_d,
+        file_uuid
+    );
+
+    let params = CreateFileLinkParams {
+        tenant_id,
+        file_uuid,
+        file_type: "application/pdf",
+        elect_cert_mg_no,
+        grantdate_e: &grantdate_e,
+        grantdate_y: &grantdate_y,
+        grantdate_m: &grantdate_m,
+        grantdate_d: &grantdate_d,
+    };
+
+    // 5. JSON が既に存在するか確認
+    let json_exists = repo
+        .json_file_exists(
+            tenant_id,
+            elect_cert_mg_no,
+            &grantdate_e,
+            &grantdate_y,
+            &grantdate_m,
+            &grantdate_d,
+        )
+        .await?;
+
+    if json_exists {
+        // JSON あり → files_b に直接リンク
+        repo.create_file_link(&params).await?;
+        tracing::info!(
+            "PDF linked to files_b: uuid={}, ElectCertMgNo={}",
+            file_uuid,
+            elect_cert_mg_no
+        );
+    } else {
+        // JSON なし → pending に保存 (JSON 待ち)
+        repo.upsert_pending_pdf(&params).await?;
+        tracing::info!(
+            "PDF stored as pending: uuid={}, ElectCertMgNo={}",
+            file_uuid,
+            elect_cert_mg_no
+        );
+    }
+
     Ok(())
 }
 
 fn strip_spaces_field(v: &serde_json::Value, key: &str) -> String {
     let s = v.get(key).and_then(|v| v.as_str()).unwrap_or("");
+    s.replace([' ', '\u{3000}'], "")
+}
+
+fn strip_spaces_str(s: &str) -> String {
     s.replace([' ', '\u{3000}'], "")
 }
 

--- a/crates/alc-carins/src/repo/car_inspections.rs
+++ b/crates/alc-carins/src/repo/car_inspections.rs
@@ -1,10 +1,19 @@
 use async_trait::async_trait;
+use serde_json::Value;
 use sqlx::PgPool;
 use uuid::Uuid;
 
 use alc_core::tenant::TenantConn;
 
 pub use alc_core::repository::car_inspections::*;
+
+fn get_str<'a>(v: &'a Value, key: &str) -> &'a str {
+    v.get(key).and_then(|v| v.as_str()).unwrap_or("")
+}
+
+fn strip_spaces(s: &str) -> String {
+    s.replace([' ', '\u{3000}'], "")
+}
 
 pub struct PgCarInspectionRepository {
     pool: PgPool,
@@ -139,5 +148,292 @@ impl CarInspectionRepository for PgCarInspectionRepository {
         )
         .fetch_all(&mut *tc.conn)
         .await
+    }
+
+    async fn upsert_from_json(
+        &self,
+        tenant_id: Uuid,
+        cert_info: &Value,
+        cert_info_import_file_version: &str,
+    ) -> Result<(), sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+
+        let grantdate_e = strip_spaces(get_str(cert_info, "GrantdateE"));
+        let grantdate_y = strip_spaces(get_str(cert_info, "GrantdateY"));
+        let grantdate_m = strip_spaces(get_str(cert_info, "GrantdateM"));
+        let grantdate_d = strip_spaces(get_str(cert_info, "GrantdateD"));
+
+        sqlx::query(
+            r#"
+            INSERT INTO car_inspection (
+                tenant_id,
+                "CertInfoImportFileVersion", "Acceptoutputno", "FormType", "ElectCertMgNo", "CarId",
+                "ElectCertPublishdateE", "ElectCertPublishdateY", "ElectCertPublishdateM", "ElectCertPublishdateD",
+                "GrantdateE", "GrantdateY", "GrantdateM", "GrantdateD",
+                "TranspotationBureauchiefName", "EntryNoCarNo",
+                "ReggrantdateE", "ReggrantdateY", "ReggrantdateM", "ReggrantdateD",
+                "FirstregistdateE", "FirstregistdateY", "FirstregistdateM",
+                "CarName", "CarNameCode", "CarNo", "Model", "EngineModel",
+                "OwnernameLowLevelChar", "OwnernameHighLevelChar", "OwnerAddressChar", "OwnerAddressNumValue", "OwnerAddressCode",
+                "UsernameLowLevelChar", "UsernameHighLevelChar", "UserAddressChar", "UserAddressNumValue", "UserAddressCode",
+                "UseheadqrterChar", "UseheadqrterNumValue", "UseheadqrterCode",
+                "CarKind", "Use", "PrivateBusiness", "CarShape", "CarShapeCode",
+                "NoteCap", "Cap", "NoteMaxloadage", "Maxloadage",
+                "NoteCarWgt", "CarWgt", "NoteCarTotalWgt", "CarTotalWgt",
+                "NoteLength", "Length", "NoteWidth", "Width", "NoteHeight", "Height",
+                "FfAxWgt", "FrAxWgt", "RfAxWgt", "RrAxWgt",
+                "Displacement", "FuelClass", "ModelSpecifyNo", "ClassifyAroundNo",
+                "ValidPeriodExpirdateE", "ValidPeriodExpirdateY", "ValidPeriodExpirdateM", "ValidPeriodExpirdateD",
+                "NoteInfo",
+                "TwodimensionCodeInfoEntryNoCarNo", "TwodimensionCodeInfoCarNo", "TwodimensionCodeInfoValidPeriodExpirdate",
+                "TwodimensionCodeInfoModel", "TwodimensionCodeInfoModelSpecifyNoClassifyAroundNo",
+                "TwodimensionCodeInfoCharInfo", "TwodimensionCodeInfoEngineModel", "TwodimensionCodeInfoCarNoStampPlace",
+                "TwodimensionCodeInfoFirstregistdate",
+                "TwodimensionCodeInfoFfAxWgt", "TwodimensionCodeInfoFrAxWgt", "TwodimensionCodeInfoRfAxWgt", "TwodimensionCodeInfoRrAxWgt",
+                "TwodimensionCodeInfoNoiseReg", "TwodimensionCodeInfoNearNoiseReg", "TwodimensionCodeInfoDriveMethod",
+                "TwodimensionCodeInfoOpacimeterMeasCar", "TwodimensionCodeInfoNoxPmMeasMode",
+                "TwodimensionCodeInfoNoxValue", "TwodimensionCodeInfoPmValue",
+                "TwodimensionCodeInfoSafeStdDate", "TwodimensionCodeInfoFuelClassCode",
+                "RegistCarLightCar"
+            ) VALUES (
+                $1,
+                $2, $3, $4, $5, $6, $7, $8, $9, $10,
+                $11, $12, $13, $14, $15, $16, $17, $18, $19, $20,
+                $21, $22, $23, $24, $25, $26, $27, $28, $29, $30,
+                $31, $32, $33, $34, $35, $36, $37, $38, $39, $40,
+                $41, $42, $43, $44, $45, $46, $47, $48, $49, $50,
+                $51, $52, $53, $54, $55, $56, $57, $58, $59, $60,
+                $61, $62, $63, $64, $65, $66, $67, $68, $69, $70,
+                $71, $72, $73, $74, $75, $76, $77, $78, $79, $80,
+                $81, $82, $83, $84, $85, $86, $87, $88, $89, $90,
+                $91, $92, $93, $94, $95, $96
+            )
+            ON CONFLICT (tenant_id, "ElectCertMgNo", "GrantdateE", "GrantdateY", "GrantdateM", "GrantdateD")
+            DO UPDATE SET
+                "CertInfoImportFileVersion" = EXCLUDED."CertInfoImportFileVersion",
+                "Acceptoutputno" = EXCLUDED."Acceptoutputno",
+                "FormType" = EXCLUDED."FormType",
+                "CarId" = EXCLUDED."CarId",
+                "ElectCertPublishdateE" = EXCLUDED."ElectCertPublishdateE",
+                "ElectCertPublishdateY" = EXCLUDED."ElectCertPublishdateY",
+                "ElectCertPublishdateM" = EXCLUDED."ElectCertPublishdateM",
+                "ElectCertPublishdateD" = EXCLUDED."ElectCertPublishdateD",
+                "TranspotationBureauchiefName" = EXCLUDED."TranspotationBureauchiefName",
+                "EntryNoCarNo" = EXCLUDED."EntryNoCarNo",
+                "ReggrantdateE" = EXCLUDED."ReggrantdateE",
+                "ReggrantdateY" = EXCLUDED."ReggrantdateY",
+                "ReggrantdateM" = EXCLUDED."ReggrantdateM",
+                "ReggrantdateD" = EXCLUDED."ReggrantdateD",
+                "FirstregistdateE" = EXCLUDED."FirstregistdateE",
+                "FirstregistdateY" = EXCLUDED."FirstregistdateY",
+                "FirstregistdateM" = EXCLUDED."FirstregistdateM",
+                "CarName" = EXCLUDED."CarName",
+                "CarNameCode" = EXCLUDED."CarNameCode",
+                "CarNo" = EXCLUDED."CarNo",
+                "Model" = EXCLUDED."Model",
+                "EngineModel" = EXCLUDED."EngineModel",
+                "OwnernameLowLevelChar" = EXCLUDED."OwnernameLowLevelChar",
+                "OwnernameHighLevelChar" = EXCLUDED."OwnernameHighLevelChar",
+                "OwnerAddressChar" = EXCLUDED."OwnerAddressChar",
+                "OwnerAddressNumValue" = EXCLUDED."OwnerAddressNumValue",
+                "OwnerAddressCode" = EXCLUDED."OwnerAddressCode",
+                "UsernameLowLevelChar" = EXCLUDED."UsernameLowLevelChar",
+                "UsernameHighLevelChar" = EXCLUDED."UsernameHighLevelChar",
+                "UserAddressChar" = EXCLUDED."UserAddressChar",
+                "UserAddressNumValue" = EXCLUDED."UserAddressNumValue",
+                "UserAddressCode" = EXCLUDED."UserAddressCode",
+                "UseheadqrterChar" = EXCLUDED."UseheadqrterChar",
+                "UseheadqrterNumValue" = EXCLUDED."UseheadqrterNumValue",
+                "UseheadqrterCode" = EXCLUDED."UseheadqrterCode",
+                "CarKind" = EXCLUDED."CarKind",
+                "Use" = EXCLUDED."Use",
+                "PrivateBusiness" = EXCLUDED."PrivateBusiness",
+                "CarShape" = EXCLUDED."CarShape",
+                "CarShapeCode" = EXCLUDED."CarShapeCode",
+                "NoteCap" = EXCLUDED."NoteCap",
+                "Cap" = EXCLUDED."Cap",
+                "NoteMaxloadage" = EXCLUDED."NoteMaxloadage",
+                "Maxloadage" = EXCLUDED."Maxloadage",
+                "NoteCarWgt" = EXCLUDED."NoteCarWgt",
+                "CarWgt" = EXCLUDED."CarWgt",
+                "NoteCarTotalWgt" = EXCLUDED."NoteCarTotalWgt",
+                "CarTotalWgt" = EXCLUDED."CarTotalWgt",
+                "NoteLength" = EXCLUDED."NoteLength",
+                "Length" = EXCLUDED."Length",
+                "NoteWidth" = EXCLUDED."NoteWidth",
+                "Width" = EXCLUDED."Width",
+                "NoteHeight" = EXCLUDED."NoteHeight",
+                "Height" = EXCLUDED."Height",
+                "FfAxWgt" = EXCLUDED."FfAxWgt",
+                "FrAxWgt" = EXCLUDED."FrAxWgt",
+                "RfAxWgt" = EXCLUDED."RfAxWgt",
+                "RrAxWgt" = EXCLUDED."RrAxWgt",
+                "Displacement" = EXCLUDED."Displacement",
+                "FuelClass" = EXCLUDED."FuelClass",
+                "ModelSpecifyNo" = EXCLUDED."ModelSpecifyNo",
+                "ClassifyAroundNo" = EXCLUDED."ClassifyAroundNo",
+                "ValidPeriodExpirdateE" = EXCLUDED."ValidPeriodExpirdateE",
+                "ValidPeriodExpirdateY" = EXCLUDED."ValidPeriodExpirdateY",
+                "ValidPeriodExpirdateM" = EXCLUDED."ValidPeriodExpirdateM",
+                "ValidPeriodExpirdateD" = EXCLUDED."ValidPeriodExpirdateD",
+                "NoteInfo" = EXCLUDED."NoteInfo",
+                "TwodimensionCodeInfoEntryNoCarNo" = EXCLUDED."TwodimensionCodeInfoEntryNoCarNo",
+                "TwodimensionCodeInfoCarNo" = EXCLUDED."TwodimensionCodeInfoCarNo",
+                "TwodimensionCodeInfoValidPeriodExpirdate" = EXCLUDED."TwodimensionCodeInfoValidPeriodExpirdate",
+                "TwodimensionCodeInfoModel" = EXCLUDED."TwodimensionCodeInfoModel",
+                "TwodimensionCodeInfoModelSpecifyNoClassifyAroundNo" = EXCLUDED."TwodimensionCodeInfoModelSpecifyNoClassifyAroundNo",
+                "TwodimensionCodeInfoCharInfo" = EXCLUDED."TwodimensionCodeInfoCharInfo",
+                "TwodimensionCodeInfoEngineModel" = EXCLUDED."TwodimensionCodeInfoEngineModel",
+                "TwodimensionCodeInfoCarNoStampPlace" = EXCLUDED."TwodimensionCodeInfoCarNoStampPlace",
+                "TwodimensionCodeInfoFirstregistdate" = EXCLUDED."TwodimensionCodeInfoFirstregistdate",
+                "TwodimensionCodeInfoFfAxWgt" = EXCLUDED."TwodimensionCodeInfoFfAxWgt",
+                "TwodimensionCodeInfoFrAxWgt" = EXCLUDED."TwodimensionCodeInfoFrAxWgt",
+                "TwodimensionCodeInfoRfAxWgt" = EXCLUDED."TwodimensionCodeInfoRfAxWgt",
+                "TwodimensionCodeInfoRrAxWgt" = EXCLUDED."TwodimensionCodeInfoRrAxWgt",
+                "TwodimensionCodeInfoNoiseReg" = EXCLUDED."TwodimensionCodeInfoNoiseReg",
+                "TwodimensionCodeInfoNearNoiseReg" = EXCLUDED."TwodimensionCodeInfoNearNoiseReg",
+                "TwodimensionCodeInfoDriveMethod" = EXCLUDED."TwodimensionCodeInfoDriveMethod",
+                "TwodimensionCodeInfoOpacimeterMeasCar" = EXCLUDED."TwodimensionCodeInfoOpacimeterMeasCar",
+                "TwodimensionCodeInfoNoxPmMeasMode" = EXCLUDED."TwodimensionCodeInfoNoxPmMeasMode",
+                "TwodimensionCodeInfoNoxValue" = EXCLUDED."TwodimensionCodeInfoNoxValue",
+                "TwodimensionCodeInfoPmValue" = EXCLUDED."TwodimensionCodeInfoPmValue",
+                "TwodimensionCodeInfoSafeStdDate" = EXCLUDED."TwodimensionCodeInfoSafeStdDate",
+                "TwodimensionCodeInfoFuelClassCode" = EXCLUDED."TwodimensionCodeInfoFuelClassCode",
+                "RegistCarLightCar" = EXCLUDED."RegistCarLightCar",
+                modified_at = NOW()
+            "#,
+        )
+        .bind(tenant_id)                                                              // $1
+        .bind(cert_info_import_file_version)                                          // $2
+        .bind(get_str(cert_info, "Acceptoutputno"))                                   // $3
+        .bind(get_str(cert_info, "FormType"))                                         // $4
+        .bind(get_str(cert_info, "ElectCertMgNo"))                                    // $5
+        .bind(get_str(cert_info, "CarId"))                                            // $6
+        .bind(get_str(cert_info, "ElectCertPublishdateE"))                            // $7
+        .bind(get_str(cert_info, "ElectCertPublishdateY"))                            // $8
+        .bind(get_str(cert_info, "ElectCertPublishdateM"))                            // $9
+        .bind(get_str(cert_info, "ElectCertPublishdateD"))                            // $10
+        .bind(&grantdate_e)                                                           // $11
+        .bind(&grantdate_y)                                                           // $12
+        .bind(&grantdate_m)                                                           // $13
+        .bind(&grantdate_d)                                                           // $14
+        .bind(get_str(cert_info, "TranspotationBureauchiefName"))                     // $15
+        .bind(get_str(cert_info, "EntryNoCarNo"))                                     // $16
+        .bind(get_str(cert_info, "ReggrantdateE"))                                    // $17
+        .bind(get_str(cert_info, "ReggrantdateY"))                                    // $18
+        .bind(get_str(cert_info, "ReggrantdateM"))                                    // $19
+        .bind(get_str(cert_info, "ReggrantdateD"))                                    // $20
+        .bind(get_str(cert_info, "FirstregistdateE"))                                 // $21
+        .bind(get_str(cert_info, "FirstregistdateY"))                                 // $22
+        .bind(get_str(cert_info, "FirstregistdateM"))                                 // $23
+        .bind(get_str(cert_info, "CarName"))                                          // $24
+        .bind(get_str(cert_info, "CarNameCode"))                                      // $25
+        .bind(get_str(cert_info, "CarNo"))                                            // $26
+        .bind(get_str(cert_info, "Model"))                                            // $27
+        .bind(get_str(cert_info, "EngineModel"))                                      // $28
+        .bind(get_str(cert_info, "OwnernameLowLevelChar"))                            // $29
+        .bind(get_str(cert_info, "OwnernameHighLevelChar"))                           // $30
+        .bind(get_str(cert_info, "OwnerAddressChar"))                                 // $31
+        .bind(get_str(cert_info, "OwnerAddressNumValue"))                             // $32
+        .bind(get_str(cert_info, "OwnerAddressCode"))                                 // $33
+        .bind(get_str(cert_info, "UsernameLowLevelChar"))                             // $34
+        .bind(get_str(cert_info, "UsernameHighLevelChar"))                            // $35
+        .bind(get_str(cert_info, "UserAddressChar"))                                  // $36
+        .bind(get_str(cert_info, "UserAddressNumValue"))                              // $37
+        .bind(get_str(cert_info, "UserAddressCode"))                                  // $38
+        .bind(get_str(cert_info, "UseheadqrterChar"))                                 // $39
+        .bind(get_str(cert_info, "UseheadqrterNumValue"))                             // $40
+        .bind(get_str(cert_info, "UseheadqrterCode"))                                 // $41
+        .bind(get_str(cert_info, "CarKind"))                                          // $42
+        .bind(get_str(cert_info, "Use"))                                              // $43
+        .bind(get_str(cert_info, "PrivateBusiness"))                                  // $44
+        .bind(get_str(cert_info, "CarShape"))                                         // $45
+        .bind(get_str(cert_info, "CarShapeCode"))                                     // $46
+        .bind(get_str(cert_info, "NoteCap"))                                          // $47
+        .bind(get_str(cert_info, "Cap"))                                              // $48
+        .bind(get_str(cert_info, "NoteMaxloadage"))                                   // $49
+        .bind(get_str(cert_info, "Maxloadage"))                                       // $50
+        .bind(get_str(cert_info, "NoteCarWgt"))                                       // $51
+        .bind(get_str(cert_info, "CarWgt"))                                           // $52
+        .bind(get_str(cert_info, "NoteCarTotalWgt"))                                  // $53
+        .bind(get_str(cert_info, "CarTotalWgt"))                                      // $54
+        .bind(get_str(cert_info, "NoteLength"))                                       // $55
+        .bind(get_str(cert_info, "Length"))                                            // $56
+        .bind(get_str(cert_info, "NoteWidth"))                                        // $57
+        .bind(get_str(cert_info, "Width"))                                            // $58
+        .bind(get_str(cert_info, "NoteHeight"))                                       // $59
+        .bind(get_str(cert_info, "Height"))                                           // $60
+        .bind(get_str(cert_info, "FfAxWgt"))                                          // $61
+        .bind(get_str(cert_info, "FrAxWgt"))                                          // $62
+        .bind(get_str(cert_info, "RfAxWgt"))                                          // $63
+        .bind(get_str(cert_info, "RrAxWgt"))                                          // $64
+        .bind(get_str(cert_info, "Displacement"))                                     // $65
+        .bind(get_str(cert_info, "FuelClass"))                                        // $66
+        .bind(get_str(cert_info, "ModelSpecifyNo"))                                   // $67
+        .bind(get_str(cert_info, "ClassifyAroundNo"))                                 // $68
+        .bind(get_str(cert_info, "ValidPeriodExpirdateE"))                             // $69
+        .bind(get_str(cert_info, "ValidPeriodExpirdateY"))                             // $70
+        .bind(get_str(cert_info, "ValidPeriodExpirdateM"))                             // $71
+        .bind(get_str(cert_info, "ValidPeriodExpirdateD"))                             // $72
+        .bind(get_str(cert_info, "NoteInfo"))                                         // $73
+        .bind(get_str(cert_info, "TwodimensionCodeInfoEntryNoCarNo"))                 // $74
+        .bind(get_str(cert_info, "TwodimensionCodeInfoCarNo"))                        // $75
+        .bind(get_str(cert_info, "TwodimensionCodeInfoValidPeriodExpirdate"))          // $76
+        .bind(get_str(cert_info, "TwodimensionCodeInfoModel"))                        // $77
+        .bind(get_str(cert_info, "TwodimensionCodeInfoModelSpecifyNoClassifyAroundNo")) // $78
+        .bind(get_str(cert_info, "TwodimensionCodeInfoCharInfo"))                     // $79
+        .bind(get_str(cert_info, "TwodimensionCodeInfoEngineModel"))                  // $80
+        .bind(get_str(cert_info, "TwodimensionCodeInfoCarNoStampPlace"))              // $81
+        .bind(get_str(cert_info, "TwodimensionCodeInfoFirstregistdate"))              // $82
+        .bind(get_str(cert_info, "TwodimensionCodeInfoFfAxWgt"))                      // $83
+        .bind(get_str(cert_info, "TwodimensionCodeInfoFrAxWgt"))                      // $84
+        .bind(get_str(cert_info, "TwodimensionCodeInfoRfAxWgt"))                      // $85
+        .bind(get_str(cert_info, "TwodimensionCodeInfoRrAxWgt"))                      // $86
+        .bind(get_str(cert_info, "TwodimensionCodeInfoNoiseReg"))                     // $87
+        .bind(get_str(cert_info, "TwodimensionCodeInfoNearNoiseReg"))                 // $88
+        .bind(get_str(cert_info, "TwodimensionCodeInfoDriveMethod"))                  // $89
+        .bind(get_str(cert_info, "TwodimensionCodeInfoOpacimeterMeasCar"))            // $90
+        .bind(get_str(cert_info, "TwodimensionCodeInfoNoxPmMeasMode"))               // $91
+        .bind(get_str(cert_info, "TwodimensionCodeInfoNoxValue"))                     // $92
+        .bind(get_str(cert_info, "TwodimensionCodeInfoPmValue"))                      // $93
+        .bind(get_str(cert_info, "TwodimensionCodeInfoSafeStdDate"))                  // $94
+        .bind(get_str(cert_info, "TwodimensionCodeInfoFuelClassCode"))                // $95
+        .bind(get_str(cert_info, "RegistCarLightCar"))                                // $96
+        .execute(&mut *tc.conn)
+        .await?;
+
+        Ok(())
+    }
+
+    async fn create_file_link(&self, params: &CreateFileLinkParams<'_>) -> Result<(), sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &params.tenant_id.to_string()).await?;
+
+        let table = if params.file_type == "application/pdf" {
+            "car_inspection_files_b"
+        } else {
+            "car_inspection_files_a"
+        };
+
+        let sql = format!(
+            r#"
+            INSERT INTO {table} (uuid, tenant_id, type, "ElectCertMgNo", "GrantdateE", "GrantdateY", "GrantdateM", "GrantdateD")
+            VALUES ($1::uuid, $2::uuid, $3, $4, $5, $6, $7, $8)
+            ON CONFLICT (uuid) DO UPDATE SET modified_at = NOW()
+            "#,
+        );
+
+        sqlx::query(&sql)
+            .bind(params.file_uuid)
+            .bind(params.tenant_id)
+            .bind(params.file_type)
+            .bind(params.elect_cert_mg_no)
+            .bind(params.grantdate_e)
+            .bind(params.grantdate_y)
+            .bind(params.grantdate_m)
+            .bind(params.grantdate_d)
+            .execute(&mut *tc.conn)
+            .await?;
+
+        Ok(())
     }
 }

--- a/crates/alc-carins/src/repo/car_inspections.rs
+++ b/crates/alc-carins/src/repo/car_inspections.rs
@@ -436,4 +436,94 @@ impl CarInspectionRepository for PgCarInspectionRepository {
 
         Ok(())
     }
+
+    async fn find_pending_pdf(
+        &self,
+        tenant_id: Uuid,
+        elect_cert_mg_no: &str,
+    ) -> Result<Option<String>, sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        let row = sqlx::query_as::<_, (String,)>(
+            r#"SELECT file_uuid::text FROM pending_car_inspection_pdfs WHERE "ElectCertMgNo" = $1"#,
+        )
+        .bind(elect_cert_mg_no)
+        .fetch_optional(&mut *tc.conn)
+        .await?;
+        Ok(row.map(|r| r.0))
+    }
+
+    async fn delete_pending_pdf(
+        &self,
+        tenant_id: Uuid,
+        elect_cert_mg_no: &str,
+    ) -> Result<(), sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        sqlx::query(r#"DELETE FROM pending_car_inspection_pdfs WHERE "ElectCertMgNo" = $1"#)
+            .bind(elect_cert_mg_no)
+            .execute(&mut *tc.conn)
+            .await?;
+        Ok(())
+    }
+
+    async fn upsert_pending_pdf(
+        &self,
+        params: &CreateFileLinkParams<'_>,
+    ) -> Result<(), sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &params.tenant_id.to_string()).await?;
+        sqlx::query(
+            r#"
+            INSERT INTO pending_car_inspection_pdfs (tenant_id, file_uuid, "ElectCertMgNo", "GrantdateE", "GrantdateY", "GrantdateM", "GrantdateD")
+            VALUES ($1::uuid, $2::uuid, $3, $4, $5, $6, $7)
+            ON CONFLICT (tenant_id, "ElectCertMgNo")
+            DO UPDATE SET file_uuid = EXCLUDED.file_uuid,
+                          "GrantdateE" = EXCLUDED."GrantdateE",
+                          "GrantdateY" = EXCLUDED."GrantdateY",
+                          "GrantdateM" = EXCLUDED."GrantdateM",
+                          "GrantdateD" = EXCLUDED."GrantdateD",
+                          created_at = NOW()
+            "#,
+        )
+        .bind(params.tenant_id)
+        .bind(params.file_uuid)
+        .bind(params.elect_cert_mg_no)
+        .bind(params.grantdate_e)
+        .bind(params.grantdate_y)
+        .bind(params.grantdate_m)
+        .bind(params.grantdate_d)
+        .execute(&mut *tc.conn)
+        .await?;
+        Ok(())
+    }
+
+    async fn json_file_exists(
+        &self,
+        tenant_id: Uuid,
+        elect_cert_mg_no: &str,
+        grantdate_e: &str,
+        grantdate_y: &str,
+        grantdate_m: &str,
+        grantdate_d: &str,
+    ) -> Result<bool, sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        let exists = sqlx::query_scalar::<_, bool>(
+            r#"
+            SELECT EXISTS(
+                SELECT 1 FROM car_inspection_files_a
+                WHERE "ElectCertMgNo" = $1
+                  AND "GrantdateE" = $2 AND "GrantdateY" = $3
+                  AND "GrantdateM" = $4 AND "GrantdateD" = $5
+                  AND type = 'application/json'
+                  AND deleted_at IS NULL
+            )
+            "#,
+        )
+        .bind(elect_cert_mg_no)
+        .bind(grantdate_e)
+        .bind(grantdate_y)
+        .bind(grantdate_m)
+        .bind(grantdate_d)
+        .fetch_one(&mut *tc.conn)
+        .await?;
+        Ok(exists)
+    }
 }

--- a/crates/alc-core/src/repository/car_inspections.rs
+++ b/crates/alc-core/src/repository/car_inspections.rs
@@ -17,6 +17,18 @@ pub struct CarInspectionFile {
     pub deleted_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
+/// car_inspection_files_a/b リンク作成パラメータ
+pub struct CreateFileLinkParams<'a> {
+    pub tenant_id: Uuid,
+    pub file_uuid: Uuid,
+    pub file_type: &'a str,
+    pub elect_cert_mg_no: &'a str,
+    pub grantdate_e: &'a str,
+    pub grantdate_y: &'a str,
+    pub grantdate_m: &'a str,
+    pub grantdate_d: &'a str,
+}
+
 /// 車両カテゴリ集計
 #[derive(Debug, serde::Serialize, sqlx::FromRow)]
 pub struct VehicleCategories {
@@ -52,4 +64,15 @@ pub trait CarInspectionRepository: Send + Sync {
         &self,
         tenant_id: Uuid,
     ) -> Result<Vec<CarInspectionFile>, sqlx::Error>;
+
+    /// 車検証 JSON から UPSERT (95 カラム)
+    async fn upsert_from_json(
+        &self,
+        tenant_id: Uuid,
+        cert_info: &serde_json::Value,
+        cert_info_import_file_version: &str,
+    ) -> Result<(), sqlx::Error>;
+
+    /// car_inspection_files_a/b にリンクレコード挿入
+    async fn create_file_link(&self, params: &CreateFileLinkParams<'_>) -> Result<(), sqlx::Error>;
 }

--- a/crates/alc-core/src/repository/car_inspections.rs
+++ b/crates/alc-core/src/repository/car_inspections.rs
@@ -75,4 +75,35 @@ pub trait CarInspectionRepository: Send + Sync {
 
     /// car_inspection_files_a/b にリンクレコード挿入
     async fn create_file_link(&self, params: &CreateFileLinkParams<'_>) -> Result<(), sqlx::Error>;
+
+    /// pending_car_inspection_pdfs から ElectCertMgNo でマッチする PDF を検索
+    async fn find_pending_pdf(
+        &self,
+        tenant_id: Uuid,
+        elect_cert_mg_no: &str,
+    ) -> Result<Option<String>, sqlx::Error>;
+
+    /// pending_car_inspection_pdfs を削除
+    async fn delete_pending_pdf(
+        &self,
+        tenant_id: Uuid,
+        elect_cert_mg_no: &str,
+    ) -> Result<(), sqlx::Error>;
+
+    /// pending_car_inspection_pdfs に UPSERT (PDF 先着時)
+    async fn upsert_pending_pdf(
+        &self,
+        params: &CreateFileLinkParams<'_>,
+    ) -> Result<(), sqlx::Error>;
+
+    /// car_inspection_files_a に対応する JSON が存在するか確認
+    async fn json_file_exists(
+        &self,
+        tenant_id: Uuid,
+        elect_cert_mg_no: &str,
+        grantdate_e: &str,
+        grantdate_y: &str,
+        grantdate_m: &str,
+        grantdate_d: &str,
+    ) -> Result<bool, sqlx::Error>;
 }

--- a/tests/mock_helpers/repos_a.rs
+++ b/tests/mock_helpers/repos_a.rs
@@ -431,6 +431,24 @@ impl CarInspectionRepository for MockCarInspectionRepository {
         check_fail!(self);
         Ok(vec![])
     }
+
+    async fn upsert_from_json(
+        &self,
+        _tenant_id: Uuid,
+        _cert_info: &serde_json::Value,
+        _cert_info_import_file_version: &str,
+    ) -> Result<(), sqlx::Error> {
+        check_fail!(self);
+        Ok(())
+    }
+
+    async fn create_file_link(
+        &self,
+        _params: &alc_core::repository::car_inspections::CreateFileLinkParams<'_>,
+    ) -> Result<(), sqlx::Error> {
+        check_fail!(self);
+        Ok(())
+    }
 }
 
 // ============================================================

--- a/tests/mock_helpers/repos_a.rs
+++ b/tests/mock_helpers/repos_a.rs
@@ -449,6 +449,45 @@ impl CarInspectionRepository for MockCarInspectionRepository {
         check_fail!(self);
         Ok(())
     }
+
+    async fn find_pending_pdf(
+        &self,
+        _tenant_id: Uuid,
+        _elect_cert_mg_no: &str,
+    ) -> Result<Option<String>, sqlx::Error> {
+        check_fail!(self);
+        Ok(None)
+    }
+
+    async fn delete_pending_pdf(
+        &self,
+        _tenant_id: Uuid,
+        _elect_cert_mg_no: &str,
+    ) -> Result<(), sqlx::Error> {
+        check_fail!(self);
+        Ok(())
+    }
+
+    async fn upsert_pending_pdf(
+        &self,
+        _params: &alc_core::repository::car_inspections::CreateFileLinkParams<'_>,
+    ) -> Result<(), sqlx::Error> {
+        check_fail!(self);
+        Ok(())
+    }
+
+    async fn json_file_exists(
+        &self,
+        _tenant_id: Uuid,
+        _elect_cert_mg_no: &str,
+        _grantdate_e: &str,
+        _grantdate_y: &str,
+        _grantdate_m: &str,
+        _grantdate_d: &str,
+    ) -> Result<bool, sqlx::Error> {
+        check_fail!(self);
+        Ok(false)
+    }
 }
 
 // ============================================================

--- a/tests/mock_tests/mock_car_inspections_test.rs
+++ b/tests/mock_tests/mock_car_inspections_test.rs
@@ -87,6 +87,28 @@ impl CarInspectionRepository for SuccessMockCarInspectionRepository {
         }
         Ok(vec![])
     }
+
+    async fn upsert_from_json(
+        &self,
+        _tenant_id: Uuid,
+        _cert_info: &serde_json::Value,
+        _cert_info_import_file_version: &str,
+    ) -> Result<(), sqlx::Error> {
+        if self.fail_next.swap(false, Ordering::SeqCst) {
+            return Err(sqlx::Error::RowNotFound);
+        }
+        Ok(())
+    }
+
+    async fn create_file_link(
+        &self,
+        _params: &alc_core::repository::car_inspections::CreateFileLinkParams<'_>,
+    ) -> Result<(), sqlx::Error> {
+        if self.fail_next.swap(false, Ordering::SeqCst) {
+            return Err(sqlx::Error::RowNotFound);
+        }
+        Ok(())
+    }
 }
 
 // ============================================================

--- a/tests/mock_tests/mock_car_inspections_test.rs
+++ b/tests/mock_tests/mock_car_inspections_test.rs
@@ -109,6 +109,53 @@ impl CarInspectionRepository for SuccessMockCarInspectionRepository {
         }
         Ok(())
     }
+
+    async fn find_pending_pdf(
+        &self,
+        _tenant_id: Uuid,
+        _elect_cert_mg_no: &str,
+    ) -> Result<Option<String>, sqlx::Error> {
+        if self.fail_next.swap(false, Ordering::SeqCst) {
+            return Err(sqlx::Error::RowNotFound);
+        }
+        Ok(None)
+    }
+
+    async fn delete_pending_pdf(
+        &self,
+        _tenant_id: Uuid,
+        _elect_cert_mg_no: &str,
+    ) -> Result<(), sqlx::Error> {
+        if self.fail_next.swap(false, Ordering::SeqCst) {
+            return Err(sqlx::Error::RowNotFound);
+        }
+        Ok(())
+    }
+
+    async fn upsert_pending_pdf(
+        &self,
+        _params: &alc_core::repository::car_inspections::CreateFileLinkParams<'_>,
+    ) -> Result<(), sqlx::Error> {
+        if self.fail_next.swap(false, Ordering::SeqCst) {
+            return Err(sqlx::Error::RowNotFound);
+        }
+        Ok(())
+    }
+
+    async fn json_file_exists(
+        &self,
+        _tenant_id: Uuid,
+        _elect_cert_mg_no: &str,
+        _grantdate_e: &str,
+        _grantdate_y: &str,
+        _grantdate_m: &str,
+        _grantdate_d: &str,
+    ) -> Result<bool, sqlx::Error> {
+        if self.fail_next.swap(false, Ordering::SeqCst) {
+            return Err(sqlx::Error::RowNotFound);
+        }
+        Ok(false)
+    }
 }
 
 // ============================================================


### PR DESCRIPTION
## Summary
- POST /api/files で車検証 JSON アップロード時に CertInfo.ElectCertMgNo を検出し、car_inspection テーブルに 95 カラム UPSERT + car_inspection_files_a にリンク挿入を自動実行
- hono-logi の createFiles.ts ロジックを rust-alc-api に移植（GrantdateE/Y/M/D スペース除去含む）
- パース失敗時はファイルアップロード自体は成功を返す（warn ログのみ）

## Test plan
- [ ] CI (cargo check + clippy + unit tests) パス確認
- [ ] staging デプロイ後、車検証 JSON アップロード → car-inspections/current に表示確認
- [ ] 同一 JSON 再アップロード → UPSERT でエラーにならないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)