### PR TITLE
ci: add production deploy on version tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   push:
     branches: [main]
+    tags: ['v*']
   pull_request:
     branches: [main]
 
@@ -31,7 +32,7 @@ jobs:
   check:
     name: Format & Lint
     needs: [pr-limit]
-    if: always() && (needs.pr-limit.result == 'success' || needs.pr-limit.result == 'skipped')
+    if: "always() && !startsWith(github.ref, 'refs/tags/') && (needs.pr-limit.result == 'success' || needs.pr-limit.result == 'skipped')"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -45,7 +46,7 @@ jobs:
   full-tests:
     name: Full Tests + Coverage
     needs: [pr-limit]
-    if: always() && (needs.pr-limit.result == 'success' || needs.pr-limit.result == 'skipped')
+    if: "always() && !startsWith(github.ref, 'refs/tags/') && (needs.pr-limit.result == 'success' || needs.pr-limit.result == 'skipped')"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -82,7 +83,7 @@ jobs:
   ts-bindings:
     name: TypeScript Bindings
     needs: [pr-limit]
-    if: always() && (needs.pr-limit.result == 'success' || needs.pr-limit.result == 'skipped')
+    if: "always() && !startsWith(github.ref, 'refs/tags/') && (needs.pr-limit.result == 'success' || needs.pr-limit.result == 'skipped')"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -286,3 +287,79 @@ jobs:
             --region asia-northeast1 --project cloudsql-sv \
             --format 'value(status.url)')
           echo "::notice ::Staging URL: $URL"
+
+  deploy-production:
+    name: Deploy Production
+    if: startsWith(github.ref, 'refs/tags/v') && github.event_name == 'push'
+    needs: [docker-push]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Tag image with version
+        run: |
+          docker pull ghcr.io/${{ github.repository }}:${{ github.sha }}
+          docker tag ghcr.io/${{ github.repository }}:${{ github.sha }} ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+          docker tag ghcr.io/${{ github.repository }}:${{ github.sha }} ghcr.io/${{ github.repository }}:latest
+          docker push ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+          docker push ghcr.io/${{ github.repository }}:latest
+
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Run migrations
+        run: |
+          AR_IMAGE="asia-northeast1-docker.pkg.dev/cloudsql-sv/ghcr/ghcr.io/${{ github.repository }}:${{ github.sha }}"
+          JOB_NAME="rust-alc-api-migrate"
+          REGION="asia-northeast1"
+
+          if gcloud run jobs describe $JOB_NAME --region $REGION --project cloudsql-sv &>/dev/null; then
+            gcloud run jobs update $JOB_NAME \
+              --region $REGION --project cloudsql-sv \
+              --image "$AR_IMAGE"
+          else
+            gcloud run jobs create $JOB_NAME \
+              --region $REGION --project cloudsql-sv \
+              --image "$AR_IMAGE" \
+              --set-secrets "DATABASE_URL=alc-app-database-url:latest" \
+              --command "migrate" \
+              --memory 512Mi --task-timeout 120s --max-retries 0
+          fi
+
+          gcloud run jobs execute $JOB_NAME \
+            --region $REGION --project cloudsql-sv --wait
+
+      - name: Deploy to Cloud Run
+        run: |
+          AR_IMAGE="asia-northeast1-docker.pkg.dev/cloudsql-sv/ghcr/ghcr.io/${{ github.repository }}:${{ github.sha }}"
+          gcloud run deploy rust-alc-api \
+            --image "$AR_IMAGE" \
+            --region asia-northeast1 \
+            --platform managed \
+            --allow-unauthenticated \
+            --set-secrets "DATABASE_URL=alc-app-database-url:latest,GOOGLE_CLIENT_ID=GOOGLE_CLIENT_ID:latest,GOOGLE_CLIENT_SECRET=GOOGLE_CLIENT_SECRET:latest,JWT_SECRET=JWT_SECRET:latest,R2_ACCESS_KEY=alc-r2-access-key:latest,R2_SECRET_KEY=alc-r2-secret-key:latest,OAUTH_STATE_SECRET=alc-oauth-state-secret:latest,CARINS_R2_ACCESS_KEY=carins-r2-access-key:latest,CARINS_R2_SECRET_KEY=carins-r2-secret-key:latest,DTAKO_R2_ACCESS_KEY=dtako-r2-access-key:latest,DTAKO_R2_SECRET_KEY=dtako-r2-secret-key:latest" \
+            --set-env-vars "STORAGE_BACKEND=r2,R2_BUCKET=alc-face-photos,R2_ACCOUNT_ID=24b45709d060d957340180e995f0d373,FCM_PROJECT_ID=alc-fcm,API_ORIGIN=https://alc-api.ippoan.org,CARINS_R2_BUCKET=carins-files,DTAKO_R2_BUCKET=ohishi-dtako,SCRAPER_URL=https://dtako-scraper-566bls5vfq-an.a.run.app" \
+            --port 8080 --memory 1Gi --cpu 1 --max-instances 3 \
+            --project cloudsql-sv
+
+      - name: Print production URL
+        run: |
+          URL=$(gcloud run services describe rust-alc-api \
+            --region asia-northeast1 --project cloudsql-sv \
+            --format 'value(status.url)')
+          echo "::notice ::Production URL: $URL (${GITHUB_REF_NAME})"


### PR DESCRIPTION
## Summary
- v* タグ push → docker-push → migrate → Cloud Run deploy (本番)
- タグ時はテスト/lint/ts-bindings スキップ (PR で通過済み)
- deploy.sh の内容を CI に移植

🤖 Generated with [Claude Code](https://claude.com/claude-code)