### PR TITLE
fix: deploy-production skipped on tag push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,7 +290,7 @@ jobs:
 
   deploy-production:
     name: Deploy Production
-    if: startsWith(github.ref, 'refs/tags/v') && github.event_name == 'push'
+    if: always() && startsWith(github.ref, 'refs/tags/v') && github.event_name == 'push' && needs.docker-push.result == 'success'
     needs: [docker-push]
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary
- docker-push の always() が downstream に伝播して deploy-production が skipped になるバグ修正

🤖 Generated with [Claude Code](https://claude.com/claude-code)