### PR TITLE
chore: ignore ts-rs generated bindings/ and types/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ nuxt-dtako-admin
 git-status-all.sh
 client_secret_*.json
 front/
+**/bindings/
+types/
 workers/
 node_modules/
 .wrangler/


### PR DESCRIPTION
## Summary
- `**/bindings/` と `types/` を .gitignore に追加（ts-rs 生成物）

🤖 Generated with [Claude Code](https://claude.com/claude-code)