### PR TITLE
feat: add POST /dtako-logs/bulk UPSERT endpoint

### DIFF
--- a/crates/alc-core/src/models.rs
+++ b/crates/alc-core/src/models.rs
@@ -1175,6 +1175,118 @@ pub struct DtakologSelectQuery {
     pub vehicle_cds: Option<String>,
 }
 
+/// POST /dtako-logs/bulk リクエストボディ (PascalCase JSON)
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct DtakologInput {
+    // PK fields
+    pub data_date_time: String,
+    #[serde(rename = "VehicleCD")]
+    pub vehicle_cd: i32,
+
+    // Required fields with defaults
+    #[serde(rename = "__type", default)]
+    pub r#type: String,
+    #[serde(default)]
+    pub all_state_font_color_index: i32,
+    #[serde(default = "default_transparent")]
+    pub all_state_ryout_color: String,
+    #[serde(rename = "BranchCD", default)]
+    pub branch_cd: i32,
+    #[serde(default)]
+    pub branch_name: String,
+    #[serde(rename = "CurrentWorkCD", default)]
+    pub current_work_cd: i32,
+    #[serde(default)]
+    pub data_filter_type: i32,
+    #[serde(default)]
+    pub disp_flag: i32,
+    #[serde(rename = "DriverCD", default)]
+    pub driver_cd: i32,
+    #[serde(rename = "GPSDirection", default)]
+    pub gps_direction: i32,
+    #[serde(rename = "GPSEnable", default)]
+    pub gps_enable: i32,
+    #[serde(rename = "GPSLatitude", default)]
+    pub gps_latitude: i32,
+    #[serde(rename = "GPSLongitude", default)]
+    pub gps_longitude: i32,
+    #[serde(rename = "GPSSatelliteNum", default)]
+    pub gps_satellite_num: i32,
+    #[serde(default)]
+    pub operation_state: i32,
+    #[serde(default)]
+    pub recive_event_type: i32,
+    #[serde(default)]
+    pub recive_packet_type: i32,
+    #[serde(rename = "ReciveWorkCD", default)]
+    pub recive_work_cd: i32,
+    #[serde(default)]
+    pub revo: i32,
+    #[serde(default)]
+    pub setting_temp: String,
+    #[serde(default)]
+    pub setting_temp1: String,
+    #[serde(default)]
+    pub setting_temp3: String,
+    #[serde(default)]
+    pub setting_temp4: String,
+    #[serde(default)]
+    pub speed: f32,
+    #[serde(rename = "SubDriverCD", default)]
+    pub sub_driver_cd: i32,
+    #[serde(default)]
+    pub temp_state: i32,
+    #[serde(default)]
+    pub vehicle_name: String,
+
+    // Optional fields
+    #[serde(rename = "AddressDispC")]
+    pub address_disp_c: Option<String>,
+    #[serde(rename = "AddressDispP")]
+    pub address_disp_p: Option<String>,
+    pub all_state: Option<String>,
+    pub all_state_ex: Option<String>,
+    pub all_state_font_color: Option<String>,
+    pub comu_date_time: Option<String>,
+    pub current_work_name: Option<String>,
+    pub driver_name: Option<String>,
+    pub event_val: Option<String>,
+    #[serde(rename = "GPSLatiAndLong")]
+    pub gps_lati_and_long: Option<String>,
+    #[serde(rename = "ODOMeter")]
+    pub odometer: Option<String>,
+    pub recive_type_color_name: Option<String>,
+    pub recive_type_name: Option<String>,
+    pub start_work_date_time: Option<String>,
+    pub state: Option<String>,
+    pub state1: Option<String>,
+    pub state2: Option<String>,
+    pub state3: Option<String>,
+    pub state_flag: Option<String>,
+    pub temp1: Option<String>,
+    pub temp2: Option<String>,
+    pub temp3: Option<String>,
+    pub temp4: Option<String>,
+    pub vehicle_icon_color: Option<String>,
+    pub vehicle_icon_label_for_datetime: Option<String>,
+    pub vehicle_icon_label_for_driver: Option<String>,
+    pub vehicle_icon_label_for_vehicle: Option<String>,
+}
+
+fn default_transparent() -> String {
+    "Transparent".to_string()
+}
+
+/// POST /dtako-logs/bulk レスポンス
+#[derive(Debug, Serialize)]
+pub struct BulkUpsertResponse {
+    pub success: bool,
+    pub records_added: i32,
+    pub total_records: i32,
+    pub message: String,
+}
+
 #[cfg(test)]
 mod dtakolog_tests {
     use super::*;

--- a/crates/alc-core/src/repository/dtako_logs.rs
+++ b/crates/alc-core/src/repository/dtako_logs.rs
@@ -1,10 +1,16 @@
 use async_trait::async_trait;
 use uuid::Uuid;
 
-use crate::models::DtakologRow;
+use crate::models::{DtakologInput, DtakologRow};
 
 #[async_trait]
 pub trait DtakoLogsRepository: Send + Sync {
+    async fn bulk_upsert(
+        &self,
+        tenant_id: Uuid,
+        records: &[DtakologInput],
+    ) -> Result<u64, sqlx::Error>;
+
     async fn current_list_all(&self, tenant_id: Uuid) -> Result<Vec<DtakologRow>, sqlx::Error>;
 
     async fn get_date(

--- a/crates/alc-dtako/src/dtako_logs.rs
+++ b/crates/alc-dtako/src/dtako_logs.rs
@@ -1,13 +1,14 @@
 use axum::{
     extract::{Query, State},
     http::StatusCode,
-    routing::get,
+    routing::{get, post},
     Json, Router,
 };
 
 use alc_core::auth_middleware::TenantId;
 use alc_core::models::{
-    DtakologDateQuery, DtakologDateRangeQuery, DtakologSelectQuery, DtakologView,
+    BulkUpsertResponse, DtakologDateQuery, DtakologDateRangeQuery, DtakologInput,
+    DtakologSelectQuery, DtakologView,
 };
 use alc_core::AppState;
 
@@ -17,6 +18,7 @@ pub fn tenant_router() -> Router<AppState> {
         .route("/by-date", get(get_by_date))
         .route("/current/select", get(current_list_select))
         .route("/by-date-range", get(get_by_date_range))
+        .route("/bulk", post(bulk_upsert))
 }
 
 async fn current_list_all(
@@ -85,4 +87,33 @@ async fn get_by_date_range(
         .await
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
     Ok(Json(rows.into_iter().map(DtakologView::from).collect()))
+}
+
+async fn bulk_upsert(
+    State(state): State<AppState>,
+    tenant: axum::Extension<TenantId>,
+    Json(records): Json<Vec<DtakologInput>>,
+) -> Result<Json<BulkUpsertResponse>, StatusCode> {
+    if records.is_empty() {
+        return Ok(Json(BulkUpsertResponse {
+            success: true,
+            records_added: 0,
+            total_records: 0,
+            message: "No records provided".to_string(),
+        }));
+    }
+
+    let total = records.len() as i32;
+    let affected = state
+        .dtako_logs
+        .bulk_upsert(tenant.0 .0, &records)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    Ok(Json(BulkUpsertResponse {
+        success: true,
+        records_added: affected as i32,
+        total_records: total,
+        message: format!("Upserted {} records", affected),
+    }))
 }

--- a/crates/alc-dtako/src/repo/dtako_logs.rs
+++ b/crates/alc-dtako/src/repo/dtako_logs.rs
@@ -2,10 +2,12 @@ use async_trait::async_trait;
 use sqlx::PgPool;
 use uuid::Uuid;
 
-use alc_core::models::DtakologRow;
+use alc_core::models::{DtakologInput, DtakologRow};
 use alc_core::tenant::TenantConn;
 
 pub use alc_core::repository::dtako_logs::*;
+
+const CHUNK_SIZE: usize = 500;
 
 pub struct PgDtakoLogsRepository {
     pool: PgPool,
@@ -33,6 +35,299 @@ const SELECT_COLS_SIMPLE: &str = r#"
 
 #[async_trait]
 impl DtakoLogsRepository for PgDtakoLogsRepository {
+    async fn bulk_upsert(
+        &self,
+        tenant_id: Uuid,
+        records: &[DtakologInput],
+    ) -> Result<u64, sqlx::Error> {
+        if records.is_empty() {
+            return Ok(0);
+        }
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        let mut total_affected: u64 = 0;
+
+        for chunk in records.chunks(CHUNK_SIZE) {
+            let mut data_date_time: Vec<&str> = Vec::with_capacity(chunk.len());
+            let mut vehicle_cd: Vec<i32> = Vec::with_capacity(chunk.len());
+            let mut r#type: Vec<&str> = Vec::with_capacity(chunk.len());
+            let mut all_state_font_color_index: Vec<i32> = Vec::with_capacity(chunk.len());
+            let mut all_state_ryout_color: Vec<&str> = Vec::with_capacity(chunk.len());
+            let mut branch_cd: Vec<i32> = Vec::with_capacity(chunk.len());
+            let mut branch_name: Vec<&str> = Vec::with_capacity(chunk.len());
+            let mut current_work_cd: Vec<i32> = Vec::with_capacity(chunk.len());
+            let mut data_filter_type: Vec<i32> = Vec::with_capacity(chunk.len());
+            let mut disp_flag: Vec<i32> = Vec::with_capacity(chunk.len());
+            let mut driver_cd: Vec<i32> = Vec::with_capacity(chunk.len());
+            let mut gps_direction: Vec<i32> = Vec::with_capacity(chunk.len());
+            let mut gps_enable: Vec<i32> = Vec::with_capacity(chunk.len());
+            let mut gps_latitude: Vec<i32> = Vec::with_capacity(chunk.len());
+            let mut gps_longitude: Vec<i32> = Vec::with_capacity(chunk.len());
+            let mut gps_satellite_num: Vec<i32> = Vec::with_capacity(chunk.len());
+            let mut operation_state: Vec<i32> = Vec::with_capacity(chunk.len());
+            let mut recive_event_type: Vec<i32> = Vec::with_capacity(chunk.len());
+            let mut recive_packet_type: Vec<i32> = Vec::with_capacity(chunk.len());
+            let mut recive_work_cd: Vec<i32> = Vec::with_capacity(chunk.len());
+            let mut revo: Vec<i32> = Vec::with_capacity(chunk.len());
+            let mut setting_temp: Vec<&str> = Vec::with_capacity(chunk.len());
+            let mut setting_temp1: Vec<&str> = Vec::with_capacity(chunk.len());
+            let mut setting_temp3: Vec<&str> = Vec::with_capacity(chunk.len());
+            let mut setting_temp4: Vec<&str> = Vec::with_capacity(chunk.len());
+            let mut speed: Vec<f32> = Vec::with_capacity(chunk.len());
+            let mut sub_driver_cd: Vec<i32> = Vec::with_capacity(chunk.len());
+            let mut temp_state: Vec<i32> = Vec::with_capacity(chunk.len());
+            let mut vehicle_name: Vec<&str> = Vec::with_capacity(chunk.len());
+            let mut address_disp_c: Vec<Option<&str>> = Vec::with_capacity(chunk.len());
+            let mut address_disp_p: Vec<Option<&str>> = Vec::with_capacity(chunk.len());
+            let mut all_state: Vec<Option<&str>> = Vec::with_capacity(chunk.len());
+            let mut all_state_ex: Vec<Option<&str>> = Vec::with_capacity(chunk.len());
+            let mut all_state_font_color: Vec<Option<&str>> = Vec::with_capacity(chunk.len());
+            let mut comu_date_time: Vec<Option<&str>> = Vec::with_capacity(chunk.len());
+            let mut current_work_name: Vec<Option<&str>> = Vec::with_capacity(chunk.len());
+            let mut driver_name: Vec<Option<&str>> = Vec::with_capacity(chunk.len());
+            let mut event_val: Vec<Option<&str>> = Vec::with_capacity(chunk.len());
+            let mut gps_lati_and_long: Vec<Option<&str>> = Vec::with_capacity(chunk.len());
+            let mut odometer: Vec<Option<&str>> = Vec::with_capacity(chunk.len());
+            let mut recive_type_color_name: Vec<Option<&str>> = Vec::with_capacity(chunk.len());
+            let mut recive_type_name: Vec<Option<&str>> = Vec::with_capacity(chunk.len());
+            let mut start_work_date_time: Vec<Option<&str>> = Vec::with_capacity(chunk.len());
+            let mut state: Vec<Option<&str>> = Vec::with_capacity(chunk.len());
+            let mut state1: Vec<Option<&str>> = Vec::with_capacity(chunk.len());
+            let mut state2: Vec<Option<&str>> = Vec::with_capacity(chunk.len());
+            let mut state3: Vec<Option<&str>> = Vec::with_capacity(chunk.len());
+            let mut state_flag: Vec<Option<&str>> = Vec::with_capacity(chunk.len());
+            let mut temp1: Vec<Option<&str>> = Vec::with_capacity(chunk.len());
+            let mut temp2: Vec<Option<&str>> = Vec::with_capacity(chunk.len());
+            let mut temp3: Vec<Option<&str>> = Vec::with_capacity(chunk.len());
+            let mut temp4: Vec<Option<&str>> = Vec::with_capacity(chunk.len());
+            let mut vehicle_icon_color: Vec<Option<&str>> = Vec::with_capacity(chunk.len());
+            let mut vehicle_icon_label_for_datetime: Vec<Option<&str>> =
+                Vec::with_capacity(chunk.len());
+            let mut vehicle_icon_label_for_driver: Vec<Option<&str>> =
+                Vec::with_capacity(chunk.len());
+            let mut vehicle_icon_label_for_vehicle: Vec<Option<&str>> =
+                Vec::with_capacity(chunk.len());
+
+            for r in chunk {
+                data_date_time.push(&r.data_date_time);
+                vehicle_cd.push(r.vehicle_cd);
+                r#type.push(&r.r#type);
+                all_state_font_color_index.push(r.all_state_font_color_index);
+                all_state_ryout_color.push(&r.all_state_ryout_color);
+                branch_cd.push(r.branch_cd);
+                branch_name.push(&r.branch_name);
+                current_work_cd.push(r.current_work_cd);
+                data_filter_type.push(r.data_filter_type);
+                disp_flag.push(r.disp_flag);
+                driver_cd.push(r.driver_cd);
+                gps_direction.push(r.gps_direction);
+                gps_enable.push(r.gps_enable);
+                gps_latitude.push(r.gps_latitude);
+                gps_longitude.push(r.gps_longitude);
+                gps_satellite_num.push(r.gps_satellite_num);
+                operation_state.push(r.operation_state);
+                recive_event_type.push(r.recive_event_type);
+                recive_packet_type.push(r.recive_packet_type);
+                recive_work_cd.push(r.recive_work_cd);
+                revo.push(r.revo);
+                setting_temp.push(&r.setting_temp);
+                setting_temp1.push(&r.setting_temp1);
+                setting_temp3.push(&r.setting_temp3);
+                setting_temp4.push(&r.setting_temp4);
+                speed.push(r.speed);
+                sub_driver_cd.push(r.sub_driver_cd);
+                temp_state.push(r.temp_state);
+                vehicle_name.push(&r.vehicle_name);
+                address_disp_c.push(r.address_disp_c.as_deref());
+                address_disp_p.push(r.address_disp_p.as_deref());
+                all_state.push(r.all_state.as_deref());
+                all_state_ex.push(r.all_state_ex.as_deref());
+                all_state_font_color.push(r.all_state_font_color.as_deref());
+                comu_date_time.push(r.comu_date_time.as_deref());
+                current_work_name.push(r.current_work_name.as_deref());
+                driver_name.push(r.driver_name.as_deref());
+                event_val.push(r.event_val.as_deref());
+                gps_lati_and_long.push(r.gps_lati_and_long.as_deref());
+                odometer.push(r.odometer.as_deref());
+                recive_type_color_name.push(r.recive_type_color_name.as_deref());
+                recive_type_name.push(r.recive_type_name.as_deref());
+                start_work_date_time.push(r.start_work_date_time.as_deref());
+                state.push(r.state.as_deref());
+                state1.push(r.state1.as_deref());
+                state2.push(r.state2.as_deref());
+                state3.push(r.state3.as_deref());
+                state_flag.push(r.state_flag.as_deref());
+                temp1.push(r.temp1.as_deref());
+                temp2.push(r.temp2.as_deref());
+                temp3.push(r.temp3.as_deref());
+                temp4.push(r.temp4.as_deref());
+                vehicle_icon_color.push(r.vehicle_icon_color.as_deref());
+                vehicle_icon_label_for_datetime.push(r.vehicle_icon_label_for_datetime.as_deref());
+                vehicle_icon_label_for_driver.push(r.vehicle_icon_label_for_driver.as_deref());
+                vehicle_icon_label_for_vehicle.push(r.vehicle_icon_label_for_vehicle.as_deref());
+            }
+
+            let result = sqlx::query(
+                r#"INSERT INTO alc_api.dtakologs (
+                    tenant_id, data_date_time, vehicle_cd,
+                    type, all_state_font_color_index, all_state_ryout_color,
+                    branch_cd, branch_name, current_work_cd, data_filter_type,
+                    disp_flag, driver_cd, gps_direction, gps_enable,
+                    gps_latitude, gps_longitude, gps_satellite_num,
+                    operation_state, recive_event_type, recive_packet_type,
+                    recive_work_cd, revo, setting_temp, setting_temp1,
+                    setting_temp3, setting_temp4, speed, sub_driver_cd,
+                    temp_state, vehicle_name,
+                    address_disp_c, address_disp_p, all_state, all_state_ex,
+                    all_state_font_color, comu_date_time, current_work_name,
+                    driver_name, event_val, gps_lati_and_long, odometer,
+                    recive_type_color_name, recive_type_name,
+                    start_work_date_time, state, state1, state2, state3,
+                    state_flag, temp1, temp2, temp3, temp4,
+                    vehicle_icon_color, vehicle_icon_label_for_datetime,
+                    vehicle_icon_label_for_driver, vehicle_icon_label_for_vehicle
+                )
+                SELECT
+                    $1::UUID,
+                    UNNEST($2::TEXT[]), UNNEST($3::INTEGER[]),
+                    UNNEST($4::TEXT[]), UNNEST($5::INTEGER[]), UNNEST($6::TEXT[]),
+                    UNNEST($7::INTEGER[]), UNNEST($8::TEXT[]), UNNEST($9::INTEGER[]), UNNEST($10::INTEGER[]),
+                    UNNEST($11::INTEGER[]), UNNEST($12::INTEGER[]), UNNEST($13::INTEGER[]), UNNEST($14::INTEGER[]),
+                    UNNEST($15::INTEGER[]), UNNEST($16::INTEGER[]), UNNEST($17::INTEGER[]),
+                    UNNEST($18::INTEGER[]), UNNEST($19::INTEGER[]), UNNEST($20::INTEGER[]),
+                    UNNEST($21::INTEGER[]), UNNEST($22::INTEGER[]), UNNEST($23::TEXT[]), UNNEST($24::TEXT[]),
+                    UNNEST($25::TEXT[]), UNNEST($26::TEXT[]), UNNEST($27::REAL[]), UNNEST($28::INTEGER[]),
+                    UNNEST($29::INTEGER[]), UNNEST($30::TEXT[]),
+                    UNNEST($31::TEXT[]), UNNEST($32::TEXT[]), UNNEST($33::TEXT[]), UNNEST($34::TEXT[]),
+                    UNNEST($35::TEXT[]), UNNEST($36::TEXT[]), UNNEST($37::TEXT[]),
+                    UNNEST($38::TEXT[]), UNNEST($39::TEXT[]), UNNEST($40::TEXT[]), UNNEST($41::TEXT[]),
+                    UNNEST($42::TEXT[]), UNNEST($43::TEXT[]),
+                    UNNEST($44::TEXT[]), UNNEST($45::TEXT[]), UNNEST($46::TEXT[]), UNNEST($47::TEXT[]), UNNEST($48::TEXT[]),
+                    UNNEST($49::TEXT[]), UNNEST($50::TEXT[]), UNNEST($51::TEXT[]), UNNEST($52::TEXT[]), UNNEST($53::TEXT[]),
+                    UNNEST($54::TEXT[]), UNNEST($55::TEXT[]),
+                    UNNEST($56::TEXT[]), UNNEST($57::TEXT[])
+                ON CONFLICT (tenant_id, data_date_time, vehicle_cd) DO UPDATE SET
+                    type = EXCLUDED.type,
+                    all_state_font_color_index = EXCLUDED.all_state_font_color_index,
+                    all_state_ryout_color = EXCLUDED.all_state_ryout_color,
+                    branch_cd = EXCLUDED.branch_cd,
+                    branch_name = EXCLUDED.branch_name,
+                    current_work_cd = EXCLUDED.current_work_cd,
+                    data_filter_type = EXCLUDED.data_filter_type,
+                    disp_flag = EXCLUDED.disp_flag,
+                    driver_cd = EXCLUDED.driver_cd,
+                    gps_direction = EXCLUDED.gps_direction,
+                    gps_enable = EXCLUDED.gps_enable,
+                    gps_latitude = EXCLUDED.gps_latitude,
+                    gps_longitude = EXCLUDED.gps_longitude,
+                    gps_satellite_num = EXCLUDED.gps_satellite_num,
+                    operation_state = EXCLUDED.operation_state,
+                    recive_event_type = EXCLUDED.recive_event_type,
+                    recive_packet_type = EXCLUDED.recive_packet_type,
+                    recive_work_cd = EXCLUDED.recive_work_cd,
+                    revo = EXCLUDED.revo,
+                    setting_temp = EXCLUDED.setting_temp,
+                    setting_temp1 = EXCLUDED.setting_temp1,
+                    setting_temp3 = EXCLUDED.setting_temp3,
+                    setting_temp4 = EXCLUDED.setting_temp4,
+                    speed = EXCLUDED.speed,
+                    sub_driver_cd = EXCLUDED.sub_driver_cd,
+                    temp_state = EXCLUDED.temp_state,
+                    vehicle_name = EXCLUDED.vehicle_name,
+                    address_disp_c = EXCLUDED.address_disp_c,
+                    address_disp_p = EXCLUDED.address_disp_p,
+                    all_state = EXCLUDED.all_state,
+                    all_state_ex = EXCLUDED.all_state_ex,
+                    all_state_font_color = EXCLUDED.all_state_font_color,
+                    comu_date_time = EXCLUDED.comu_date_time,
+                    current_work_name = EXCLUDED.current_work_name,
+                    driver_name = EXCLUDED.driver_name,
+                    event_val = EXCLUDED.event_val,
+                    gps_lati_and_long = EXCLUDED.gps_lati_and_long,
+                    odometer = EXCLUDED.odometer,
+                    recive_type_color_name = EXCLUDED.recive_type_color_name,
+                    recive_type_name = EXCLUDED.recive_type_name,
+                    start_work_date_time = EXCLUDED.start_work_date_time,
+                    state = EXCLUDED.state,
+                    state1 = EXCLUDED.state1,
+                    state2 = EXCLUDED.state2,
+                    state3 = EXCLUDED.state3,
+                    state_flag = EXCLUDED.state_flag,
+                    temp1 = EXCLUDED.temp1,
+                    temp2 = EXCLUDED.temp2,
+                    temp3 = EXCLUDED.temp3,
+                    temp4 = EXCLUDED.temp4,
+                    vehicle_icon_color = EXCLUDED.vehicle_icon_color,
+                    vehicle_icon_label_for_datetime = EXCLUDED.vehicle_icon_label_for_datetime,
+                    vehicle_icon_label_for_driver = EXCLUDED.vehicle_icon_label_for_driver,
+                    vehicle_icon_label_for_vehicle = EXCLUDED.vehicle_icon_label_for_vehicle
+                "#,
+            )
+            .bind(tenant_id)
+            .bind(&data_date_time)
+            .bind(&vehicle_cd)
+            .bind(&r#type)
+            .bind(&all_state_font_color_index)
+            .bind(&all_state_ryout_color)
+            .bind(&branch_cd)
+            .bind(&branch_name)
+            .bind(&current_work_cd)
+            .bind(&data_filter_type)
+            .bind(&disp_flag)
+            .bind(&driver_cd)
+            .bind(&gps_direction)
+            .bind(&gps_enable)
+            .bind(&gps_latitude)
+            .bind(&gps_longitude)
+            .bind(&gps_satellite_num)
+            .bind(&operation_state)
+            .bind(&recive_event_type)
+            .bind(&recive_packet_type)
+            .bind(&recive_work_cd)
+            .bind(&revo)
+            .bind(&setting_temp)
+            .bind(&setting_temp1)
+            .bind(&setting_temp3)
+            .bind(&setting_temp4)
+            .bind(&speed)
+            .bind(&sub_driver_cd)
+            .bind(&temp_state)
+            .bind(&vehicle_name)
+            .bind(&address_disp_c)
+            .bind(&address_disp_p)
+            .bind(&all_state)
+            .bind(&all_state_ex)
+            .bind(&all_state_font_color)
+            .bind(&comu_date_time)
+            .bind(&current_work_name)
+            .bind(&driver_name)
+            .bind(&event_val)
+            .bind(&gps_lati_and_long)
+            .bind(&odometer)
+            .bind(&recive_type_color_name)
+            .bind(&recive_type_name)
+            .bind(&start_work_date_time)
+            .bind(&state)
+            .bind(&state1)
+            .bind(&state2)
+            .bind(&state3)
+            .bind(&state_flag)
+            .bind(&temp1)
+            .bind(&temp2)
+            .bind(&temp3)
+            .bind(&temp4)
+            .bind(&vehicle_icon_color)
+            .bind(&vehicle_icon_label_for_datetime)
+            .bind(&vehicle_icon_label_for_driver)
+            .bind(&vehicle_icon_label_for_vehicle)
+            .execute(&mut *tc.conn)
+            .await?;
+
+            total_affected += result.rows_affected();
+        }
+
+        Ok(total_affected)
+    }
+
     async fn current_list_all(&self, tenant_id: Uuid) -> Result<Vec<DtakologRow>, sqlx::Error> {
         let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
         let sql = format!(

--- a/tests/mock_helpers/repos_a.rs
+++ b/tests/mock_helpers/repos_a.rs
@@ -1697,6 +1697,15 @@ impl Default for MockDtakoLogsRepository {
 
 #[async_trait::async_trait]
 impl DtakoLogsRepository for MockDtakoLogsRepository {
+    async fn bulk_upsert(
+        &self,
+        _tenant_id: Uuid,
+        records: &[alc_core::models::DtakologInput],
+    ) -> Result<u64, sqlx::Error> {
+        check_fail!(self);
+        Ok(records.len() as u64)
+    }
+
     async fn current_list_all(&self, _tenant_id: Uuid) -> Result<Vec<DtakologRow>, sqlx::Error> {
         check_fail!(self);
         Ok(vec![])

--- a/tests/mock_tests/mock_dtako_logs_test.rs
+++ b/tests/mock_tests/mock_dtako_logs_test.rs
@@ -340,3 +340,130 @@ async fn get_by_date_range_db_error_returns_500() {
 
     assert_eq!(res.status(), 500);
 }
+
+// =============================================================================
+// POST /api/dtako-logs/bulk
+// =============================================================================
+
+fn sample_bulk_body() -> serde_json::Value {
+    serde_json::json!([{
+        "DataDateTime": "2024-11-28T10:37:00+09:00",
+        "VehicleCD": 1,
+        "__type": "Vehicle",
+        "VehicleName": "Truck-1",
+        "DriverName": "Driver A",
+        "GPSDirection": 180,
+        "GPSLatitude": 35123456,
+        "GPSLongitude": 139123456,
+        "Speed": 60.5,
+        "AllState": "Drive",
+        "AddressDispP": "Shibuya"
+    }])
+}
+
+#[tokio::test]
+async fn bulk_upsert_success() {
+    let state = setup_mock_app_state();
+    let base_url = crate::common::spawn_test_server(state).await;
+    let client = reqwest::Client::new();
+    let tenant_id = uuid::Uuid::new_v4();
+    let token = crate::common::create_test_jwt(tenant_id, "admin");
+
+    let res = client
+        .post(format!("{base_url}/api/dtako-logs/bulk"))
+        .header("Authorization", format!("Bearer {token}"))
+        .json(&sample_bulk_body())
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(body["success"], true);
+    assert_eq!(body["records_added"], 1);
+    assert_eq!(body["total_records"], 1);
+}
+
+#[tokio::test]
+async fn bulk_upsert_empty_array() {
+    let state = setup_mock_app_state();
+    let base_url = crate::common::spawn_test_server(state).await;
+    let client = reqwest::Client::new();
+    let tenant_id = uuid::Uuid::new_v4();
+    let token = crate::common::create_test_jwt(tenant_id, "admin");
+
+    let res = client
+        .post(format!("{base_url}/api/dtako-logs/bulk"))
+        .header("Authorization", format!("Bearer {token}"))
+        .json(&serde_json::json!([]))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(body["success"], true);
+    assert_eq!(body["records_added"], 0);
+    assert_eq!(body["total_records"], 0);
+}
+
+#[tokio::test]
+async fn bulk_upsert_no_auth_returns_401() {
+    let state = setup_mock_app_state();
+    let base_url = crate::common::spawn_test_server(state).await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/dtako-logs/bulk"))
+        .json(&sample_bulk_body())
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 401);
+}
+
+#[tokio::test]
+async fn bulk_upsert_db_error_returns_500() {
+    let mock = Arc::new(MockDtakoLogsRepository::default());
+    mock.fail_next.store(true, Ordering::SeqCst);
+
+    let mut state = setup_mock_app_state();
+    state.dtako_logs = mock;
+
+    let base_url = crate::common::spawn_test_server(state).await;
+    let client = reqwest::Client::new();
+    let tenant_id = uuid::Uuid::new_v4();
+    let token = crate::common::create_test_jwt(tenant_id, "admin");
+
+    let res = client
+        .post(format!("{base_url}/api/dtako-logs/bulk"))
+        .header("Authorization", format!("Bearer {token}"))
+        .json(&sample_bulk_body())
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 500);
+}
+
+#[tokio::test]
+async fn bulk_upsert_with_tenant_header_returns_200() {
+    let state = setup_mock_app_state();
+    let base_url = crate::common::spawn_test_server(state).await;
+    let client = reqwest::Client::new();
+    let tenant_id = uuid::Uuid::new_v4();
+
+    let res = client
+        .post(format!("{base_url}/api/dtako-logs/bulk"))
+        .header("X-Tenant-ID", tenant_id.to_string())
+        .json(&sample_bulk_body())
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), 200);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(body["success"], true);
+    assert_eq!(body["records_added"], 1);
+}


### PR DESCRIPTION
## Summary
- browser-render-rust の gRPC→REST 移行に向けた `POST /api/dtako-logs/bulk` エンドポイント追加
- PascalCase JSON 配列を受け取り、UNNEST ベースの bulk UPSERT (`ON CONFLICT DO UPDATE`) で効率的に挿入・更新
- `DtakologInput` モデル (56フィールド, serde rename) + `BulkUpsertResponse` 追加
- Mock テスト 5件追加 (成功, 空配列, 401, 500, X-Tenant-ID)

## Test plan
- [x] `cargo check` pass
- [x] `cargo test mock_dtako_logs` — 21/21 pass (既存16 + 新規5)
- [ ] CI (unit + integration tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)