### PR TITLE
fix: sort dtako-logs current by vehicle_cd

### DIFF
--- a/crates/alc-dtako/src/repo/dtako_logs.rs
+++ b/crates/alc-dtako/src/repo/dtako_logs.rs
@@ -339,7 +339,7 @@ impl DtakoLogsRepository for PgDtakoLogsRepository {
                    GROUP BY vehicle_cd
                ) latest ON d.vehicle_cd = latest.vehicle_cd
                        AND d.data_date_time = latest.max_dt
-               ORDER BY d.data_date_time DESC"#
+               ORDER BY d.vehicle_cd"#
         );
         sqlx::query_as::<_, DtakologRow>(&sql)
             .fetch_all(&mut *tc.conn)
@@ -399,7 +399,7 @@ impl DtakoLogsRepository for PgDtakoLogsRepository {
                WHERE ($1::TEXT IS NULL OR d.address_disp_p = $1)
                  AND ($2::INTEGER IS NULL OR d.branch_cd = $2)
                  AND ($3::INTEGER[] IS NULL OR array_length($3, 1) IS NULL OR d.vehicle_cd = ANY($3))
-               ORDER BY d.data_date_time DESC"#
+               ORDER BY d.vehicle_cd"#
         );
         let vehicle_cds_param: Option<&[i32]> = if vehicle_cds.is_empty() {
             None


### PR DESCRIPTION
## Summary
- `current_list_all` と `current_list_select` の ORDER BY を `data_date_time DESC` → `vehicle_cd` に変更
- rust-logi と同じ車番順ソートに合わせる

## Test plan
- [ ] CI pass
- [ ] ohishi2.mtamaramu.com で車番順に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)