### PR TITLE
fix: accept null DataDateTime in bulk upsert

### DIFF
--- a/crates/alc-core/src/models.rs
+++ b/crates/alc-core/src/models.rs
@@ -1179,8 +1179,8 @@ pub struct DtakologSelectQuery {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct DtakologInput {
-    // PK fields
-    pub data_date_time: String,
+    // PK fields (DataDateTime は null 許容 — スクレイパーが GPS 未取得車両で null を送る)
+    pub data_date_time: Option<String>,
     #[serde(rename = "VehicleCD")]
     pub vehicle_cd: i32,
 

--- a/crates/alc-dtako/src/repo/dtako_logs.rs
+++ b/crates/alc-dtako/src/repo/dtako_logs.rs
@@ -108,7 +108,11 @@ impl DtakoLogsRepository for PgDtakoLogsRepository {
                 Vec::with_capacity(chunk.len());
 
             for r in chunk {
-                data_date_time.push(&r.data_date_time);
+                data_date_time.push(
+                    r.data_date_time
+                        .as_deref()
+                        .unwrap_or("2020-01-01T00:00:00+09:00"),
+                );
                 vehicle_cd.push(r.vehicle_cd);
                 r#type.push(&r.r#type);
                 all_state_font_color_index.push(r.all_state_font_color_index);


### PR DESCRIPTION
## Summary
- `DtakologInput.data_date_time` を `String` → `Option<String>` に変更
- null の場合はデフォルト値 `2020-01-01T00:00:00+09:00` を使用
- スクレイパーが GPS 未取得車両で DataDateTime=null を送り 422 エラーになっていた

## Test plan
- [ ] CI pass
- [ ] デプロイ後 scraper ジョブ成功確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)