### PR TITLE
fix: change GPS fields from i32 to f64 for REST bulk upsert

### DIFF
--- a/crates/alc-core/src/models.rs
+++ b/crates/alc-core/src/models.rs
@@ -1074,9 +1074,9 @@ pub struct UpdateCommunicationItem {
 
 #[derive(Debug, Serialize, sqlx::FromRow)]
 pub struct DtakologRow {
-    pub gps_direction: i32,
-    pub gps_latitude: i32,
-    pub gps_longitude: i32,
+    pub gps_direction: f64,
+    pub gps_latitude: f64,
+    pub gps_longitude: f64,
     pub vehicle_cd: i32,
     pub vehicle_name: String,
     pub driver_name: Option<String>,
@@ -1097,11 +1097,11 @@ pub struct DtakologRow {
 #[serde(rename_all = "PascalCase")]
 pub struct DtakologView {
     #[serde(rename = "GPSDirection")]
-    pub gps_direction: i32,
+    pub gps_direction: f64,
     #[serde(rename = "GPSLatitude")]
-    pub gps_latitude: i32,
+    pub gps_latitude: f64,
     #[serde(rename = "GPSLongitude")]
-    pub gps_longitude: i32,
+    pub gps_longitude: f64,
     #[serde(rename = "VehicleCD")]
     pub vehicle_cd: i32,
     pub vehicle_name: String,
@@ -1204,13 +1204,13 @@ pub struct DtakologInput {
     #[serde(rename = "DriverCD", default)]
     pub driver_cd: i32,
     #[serde(rename = "GPSDirection", default)]
-    pub gps_direction: i32,
+    pub gps_direction: f64,
     #[serde(rename = "GPSEnable", default)]
     pub gps_enable: i32,
     #[serde(rename = "GPSLatitude", default)]
-    pub gps_latitude: i32,
+    pub gps_latitude: f64,
     #[serde(rename = "GPSLongitude", default)]
-    pub gps_longitude: i32,
+    pub gps_longitude: f64,
     #[serde(rename = "GPSSatelliteNum", default)]
     pub gps_satellite_num: i32,
     #[serde(default)]
@@ -1293,9 +1293,9 @@ mod dtakolog_tests {
 
     fn make_row(all_state: Option<&str>, state2: Option<&str>, speed: f32) -> DtakologRow {
         DtakologRow {
-            gps_direction: 180,
-            gps_latitude: 35123456,
-            gps_longitude: 139123456,
+            gps_direction: 180.0,
+            gps_latitude: 35123456.0,
+            gps_longitude: 139123456.0,
             vehicle_cd: 1,
             vehicle_name: "Truck-1".into(),
             driver_name: Some("Driver A".into()),

--- a/crates/alc-dtako/src/repo/dtako_logs.rs
+++ b/crates/alc-dtako/src/repo/dtako_logs.rs
@@ -58,10 +58,10 @@ impl DtakoLogsRepository for PgDtakoLogsRepository {
             let mut data_filter_type: Vec<i32> = Vec::with_capacity(chunk.len());
             let mut disp_flag: Vec<i32> = Vec::with_capacity(chunk.len());
             let mut driver_cd: Vec<i32> = Vec::with_capacity(chunk.len());
-            let mut gps_direction: Vec<i32> = Vec::with_capacity(chunk.len());
+            let mut gps_direction: Vec<f64> = Vec::with_capacity(chunk.len());
             let mut gps_enable: Vec<i32> = Vec::with_capacity(chunk.len());
-            let mut gps_latitude: Vec<i32> = Vec::with_capacity(chunk.len());
-            let mut gps_longitude: Vec<i32> = Vec::with_capacity(chunk.len());
+            let mut gps_latitude: Vec<f64> = Vec::with_capacity(chunk.len());
+            let mut gps_longitude: Vec<f64> = Vec::with_capacity(chunk.len());
             let mut gps_satellite_num: Vec<i32> = Vec::with_capacity(chunk.len());
             let mut operation_state: Vec<i32> = Vec::with_capacity(chunk.len());
             let mut recive_event_type: Vec<i32> = Vec::with_capacity(chunk.len());

--- a/migrations/068_dtakologs_gps_to_float.sql
+++ b/migrations/068_dtakologs_gps_to_float.sql
@@ -1,0 +1,8 @@
+-- Change GPS fields from INTEGER to DOUBLE PRECISION
+-- Scraper raw data contains float values (e.g. GPSDirection: 319.8)
+-- Previously gRPC protobuf auto-truncated to int32, REST deserialize rejects floats
+
+ALTER TABLE alc_api.dtako_logs
+    ALTER COLUMN gps_direction TYPE DOUBLE PRECISION,
+    ALTER COLUMN gps_latitude TYPE DOUBLE PRECISION,
+    ALTER COLUMN gps_longitude TYPE DOUBLE PRECISION;

--- a/migrations/068_dtakologs_gps_to_float.sql
+++ b/migrations/068_dtakologs_gps_to_float.sql
@@ -2,7 +2,7 @@
 -- Scraper raw data contains float values (e.g. GPSDirection: 319.8)
 -- Previously gRPC protobuf auto-truncated to int32, REST deserialize rejects floats
 
-ALTER TABLE alc_api.dtako_logs
+ALTER TABLE alc_api.dtakologs
     ALTER COLUMN gps_direction TYPE DOUBLE PRECISION,
     ALTER COLUMN gps_latitude TYPE DOUBLE PRECISION,
     ALTER COLUMN gps_longitude TYPE DOUBLE PRECISION;


### PR DESCRIPTION
## Summary
- Venus API が `GPSDirection: 319.8` のような float を返すが、`DtakologInput` が `i32` で定義されていたため 422 エラー
- 旧 gRPC パスでは protobuf `int32` が暗黙的に切り捨てていたが、REST 移行で顕在化
- DB カラムを `INTEGER` → `DOUBLE PRECISION`、Rust 型を `i32` → `f64` に変更

## Test plan
- [x] `cargo check` pass
- [x] `cargo test --lib -p alc-core dtakolog` 9 tests pass
- [ ] CI 全テスト pass
- [ ] デプロイ後 scraper の bulk upsert が 200 で成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)