### PR TITLE
fix: use timestamptz cast in dtakologs date range query

### DIFF
--- a/crates/alc-dtako/src/repo/dtako_logs.rs
+++ b/crates/alc-dtako/src/repo/dtako_logs.rs
@@ -429,7 +429,8 @@ impl DtakoLogsRepository for PgDtakoLogsRepository {
         let sql = format!(
             r#"SELECT {SELECT_COLS_SIMPLE}
                FROM alc_api.dtakologs
-               WHERE data_date_time >= $1 AND data_date_time <= $2
+               WHERE data_date_time::timestamptz >= $1::timestamptz
+                 AND data_date_time::timestamptz <= $2::timestamptz
                  AND ($3::INTEGER IS NULL OR vehicle_cd = $3)
                ORDER BY data_date_time DESC"#
         );


### PR DESCRIPTION
## Summary
- 履歴表示で JST 15:00 以降のデータが取得できない問題を修正
- 原因: フロントが UTC ISO8601 を送信、DB は JST RFC3339 で保存、TEXT 比較ではタイムゾーンが無視される
- `data_date_time::timestamptz` でキャストして正しく比較するよう修正

## Test plan
- [x] `cargo check` pass
- [ ] CI 全テスト pass
- [ ] デプロイ後、JST 15:00 以降の履歴データが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)