### PR TITLE
fix: round speed to avoid f32→f64 precision noise

### DIFF
--- a/crates/alc-core/src/models.rs
+++ b/crates/alc-core/src/models.rs
@@ -1132,7 +1132,9 @@ impl From<DtakologRow> for DtakologView {
         let speed: serde_json::Value = if r.speed == 0.0 {
             serde_json::Value::String(String::new())
         } else {
-            serde_json::json!(r.speed)
+            // f32→f64 変換時の精度ノイズを除去 (74.9000015258789 → 74.9)
+            let rounded = (r.speed as f64 * 10.0).round() / 10.0;
+            serde_json::json!(rounded)
         };
         Self {
             gps_direction: r.gps_direction,


### PR DESCRIPTION
## Summary
- 速度表示が `74.9000015258789` のように精度ノイズを含む問題を修正
- DB の `REAL` (f32) → JSON シリアライズ時の f64 変換で発生
- 小数1桁に丸めて表示 (`74.9`)

## Test plan
- [x] `cargo test --lib -p alc-core dtakolog` 9 tests pass
- [ ] CI pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)