### PR TITLE
fix: LINE Login multi-tenant via DB config

### DIFF
--- a/crates/alc-core/src/repository/notify_line_config.rs
+++ b/crates/alc-core/src/repository/notify_line_config.rs
@@ -23,6 +23,8 @@ pub struct NotifyLineConfigFull {
     pub channel_access_token_encrypted: Option<String>,
     pub key_id: Option<String>,
     pub private_key_encrypted: Option<String>,
+    pub login_channel_id: Option<String>,
+    pub login_channel_secret_encrypted: Option<String>,
 }
 
 #[derive(Debug, serde::Deserialize)]
@@ -33,6 +35,8 @@ pub struct UpsertLineConfig {
     pub key_id: String,
     pub private_key: String,
     pub bot_basic_id: Option<String>,
+    pub login_channel_id: Option<String>,
+    pub login_channel_secret: Option<String>,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -42,6 +46,7 @@ pub trait NotifyLineConfigRepository: Send + Sync {
 
     async fn get_full(&self, tenant_id: Uuid) -> Result<Option<NotifyLineConfigFull>, sqlx::Error>;
 
+    #[allow(clippy::too_many_arguments)]
     async fn upsert(
         &self,
         tenant_id: Uuid,
@@ -51,6 +56,8 @@ pub trait NotifyLineConfigRepository: Send + Sync {
         key_id: &str,
         private_key_encrypted: &str,
         bot_basic_id: Option<&str>,
+        login_channel_id: Option<&str>,
+        login_channel_secret_encrypted: Option<&str>,
     ) -> Result<NotifyLineConfig, sqlx::Error>;
 
     async fn delete(&self, tenant_id: Uuid) -> Result<(), sqlx::Error>;

--- a/crates/alc-misc/src/auth.rs
+++ b/crates/alc-misc/src/auth.rs
@@ -615,26 +615,48 @@ async fn lineworks_callback(
 #[derive(Debug, Deserialize)]
 struct LineRedirectParams {
     redirect_uri: String,
+    /// Messaging API の channel_id (テナント特定用)
+    channel_id: String,
 }
 
-/// LINE Login OAuth 開始: LINE authorize URL にリダイレクト
+/// LINE Login OAuth 開始: DB から LINE Login 設定を取得 → LINE authorize URL にリダイレクト
 async fn line_redirect(
+    State(state): State<AppState>,
     Query(params): Query<LineRedirectParams>,
 ) -> Result<impl IntoResponse, StatusCode> {
     let oauth_state_secret = std::env::var("OAUTH_STATE_SECRET").map_err(|_| {
         tracing::error!("OAUTH_STATE_SECRET not set");
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
-    let channel_id = std::env::var("LINE_LOGIN_CHANNEL_ID").map_err(|_| {
-        tracing::error!("LINE_LOGIN_CHANNEL_ID not set");
-        StatusCode::INTERNAL_SERVER_ERROR
+
+    // Messaging API channel_id → notify_line_configs から LINE Login 設定を取得
+    let config = state
+        .notify_line_config
+        .lookup_by_channel(&params.channel_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("LINE config lookup failed: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?
+        .ok_or_else(|| {
+            tracing::warn!("No LINE config for channel_id: {}", params.channel_id);
+            StatusCode::NOT_FOUND
+        })?;
+
+    let login_channel_id = config.login_channel_id.as_deref().ok_or_else(|| {
+        tracing::warn!(
+            "LINE Login not configured for channel_id: {}",
+            params.channel_id
+        );
+        StatusCode::NOT_FOUND
     })?;
 
+    // state に channel_id を保存 (callback で再取得に使う)
     let state_payload = auth_lineworks::state::StatePayload {
         redirect_uri: params.redirect_uri,
         nonce: Uuid::new_v4().to_string(),
         provider: "line".to_string(),
-        external_org_id: String::new(),
+        external_org_id: params.channel_id,
     };
     let signed_state = auth_lineworks::state::sign(&state_payload, &oauth_state_secret);
 
@@ -643,7 +665,7 @@ async fn line_redirect(
     let callback_uri = format!("{api_origin}/api/auth/line/callback");
 
     let authorize_url = auth_line::authorize_url(
-        &channel_id,
+        login_channel_id,
         &urlencoding::encode(&callback_uri),
         &urlencoding::encode(&signed_state),
     );
@@ -672,12 +694,33 @@ async fn line_callback(
             StatusCode::BAD_REQUEST
         })?;
 
-    let channel_id = std::env::var("LINE_LOGIN_CHANNEL_ID").map_err(|_| {
-        tracing::error!("LINE_LOGIN_CHANNEL_ID not set");
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?;
-    let channel_secret = std::env::var("LINE_LOGIN_CHANNEL_SECRET").map_err(|_| {
-        tracing::error!("LINE_LOGIN_CHANNEL_SECRET not set");
+    // state.external_org_id に保存した channel_id で LINE config を再取得
+    let config = state
+        .notify_line_config
+        .lookup_by_channel(&state_payload.external_org_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("LINE config lookup failed: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?
+        .ok_or(StatusCode::NOT_FOUND)?;
+
+    let login_channel_id = config
+        .login_channel_id
+        .as_deref()
+        .ok_or(StatusCode::NOT_FOUND)?;
+
+    let encryption_key = std::env::var("SSO_ENCRYPTION_KEY")
+        .unwrap_or_else(|_| std::env::var("JWT_SECRET").unwrap_or_default());
+    let login_channel_secret = auth_lineworks::decrypt_secret(
+        config
+            .login_channel_secret_encrypted
+            .as_deref()
+            .ok_or(StatusCode::NOT_FOUND)?,
+        &encryption_key,
+    )
+    .map_err(|e| {
+        tracing::error!("decrypt login_channel_secret: {e}");
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
 
@@ -688,8 +731,8 @@ async fn line_callback(
     let http_client = reqwest::Client::new();
     let token_resp = auth_line::exchange_code(
         &http_client,
-        &channel_id,
-        &channel_secret,
+        login_channel_id,
+        &login_channel_secret,
         &params.code,
         &callback_uri,
     )

--- a/crates/alc-notify/src/line_config.rs
+++ b/crates/alc-notify/src/line_config.rs
@@ -48,6 +48,16 @@ async fn upsert_config(
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
 
+    let login_channel_secret_encrypted = input
+        .login_channel_secret
+        .as_ref()
+        .map(|s| encrypt_secret(s, &key))
+        .transpose()
+        .map_err(|e| {
+            tracing::error!("encrypt login_channel_secret: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
     let config = state
         .notify_line_config
         .upsert(
@@ -58,6 +68,8 @@ async fn upsert_config(
             &input.key_id,
             &private_key_encrypted,
             input.bot_basic_id.as_deref(),
+            input.login_channel_id.as_deref(),
+            login_channel_secret_encrypted.as_deref(),
         )
         .await
         .map_err(|e| {

--- a/crates/alc-notify/src/repo/notify_line_config.rs
+++ b/crates/alc-notify/src/repo/notify_line_config.rs
@@ -29,7 +29,7 @@ impl NotifyLineConfigRepository for PgNotifyLineConfigRepository {
     async fn get_full(&self, tenant_id: Uuid) -> Result<Option<NotifyLineConfigFull>, sqlx::Error> {
         let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
         sqlx::query_as::<_, NotifyLineConfigFull>(
-            "SELECT id, tenant_id, channel_id, channel_secret_encrypted, channel_access_token_encrypted, key_id, private_key_encrypted FROM notify_line_configs LIMIT 1",
+            "SELECT id, tenant_id, channel_id, channel_secret_encrypted, channel_access_token_encrypted, key_id, private_key_encrypted, login_channel_id, login_channel_secret_encrypted FROM notify_line_configs LIMIT 1",
         )
         .fetch_optional(&mut *tc.conn)
         .await
@@ -44,12 +44,14 @@ impl NotifyLineConfigRepository for PgNotifyLineConfigRepository {
         key_id: &str,
         private_key_encrypted: &str,
         bot_basic_id: Option<&str>,
+        login_channel_id: Option<&str>,
+        login_channel_secret_encrypted: Option<&str>,
     ) -> Result<NotifyLineConfig, sqlx::Error> {
         let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
         sqlx::query_as::<_, NotifyLineConfig>(
             r#"
-            INSERT INTO notify_line_configs (tenant_id, name, channel_id, channel_secret_encrypted, key_id, private_key_encrypted, bot_basic_id)
-            VALUES ($1, $2, $3, $4, $5, $6, $7)
+            INSERT INTO notify_line_configs (tenant_id, name, channel_id, channel_secret_encrypted, key_id, private_key_encrypted, bot_basic_id, login_channel_id, login_channel_secret_encrypted)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
             ON CONFLICT (tenant_id) DO UPDATE SET
                 name = EXCLUDED.name,
                 channel_id = EXCLUDED.channel_id,
@@ -57,6 +59,8 @@ impl NotifyLineConfigRepository for PgNotifyLineConfigRepository {
                 key_id = EXCLUDED.key_id,
                 private_key_encrypted = EXCLUDED.private_key_encrypted,
                 bot_basic_id = EXCLUDED.bot_basic_id,
+                login_channel_id = EXCLUDED.login_channel_id,
+                login_channel_secret_encrypted = EXCLUDED.login_channel_secret_encrypted,
                 updated_at = NOW()
             RETURNING id, tenant_id, name, channel_id, bot_basic_id, enabled, created_at, updated_at
             "#,
@@ -68,6 +72,8 @@ impl NotifyLineConfigRepository for PgNotifyLineConfigRepository {
         .bind(key_id)
         .bind(private_key_encrypted)
         .bind(bot_basic_id)
+        .bind(login_channel_id)
+        .bind(login_channel_secret_encrypted)
         .fetch_one(&mut *tc.conn)
         .await
     }

--- a/migrations/077_add_line_login_channel.sql
+++ b/migrations/077_add_line_login_channel.sql
@@ -1,0 +1,27 @@
+-- LINE Login チャネル設定を notify_line_configs に追加 (テナントごと)
+
+ALTER TABLE alc_api.notify_line_configs
+    ADD COLUMN login_channel_id TEXT,
+    ADD COLUMN login_channel_secret_encrypted TEXT;
+
+-- lookup 関数を更新 (login_channel_id, login_channel_secret_encrypted を追加)
+DROP FUNCTION IF EXISTS alc_api.lookup_line_config_by_channel(TEXT);
+CREATE OR REPLACE FUNCTION alc_api.lookup_line_config_by_channel(p_channel_id TEXT)
+RETURNS TABLE(
+    id UUID,
+    tenant_id UUID,
+    channel_id TEXT,
+    channel_secret_encrypted TEXT,
+    channel_access_token_encrypted TEXT,
+    key_id TEXT,
+    private_key_encrypted TEXT,
+    login_channel_id TEXT,
+    login_channel_secret_encrypted TEXT
+)
+LANGUAGE sql SECURITY DEFINER SET search_path = alc_api
+AS $$
+    SELECT id, tenant_id, channel_id, channel_secret_encrypted, channel_access_token_encrypted,
+           key_id, private_key_encrypted, login_channel_id, login_channel_secret_encrypted
+    FROM alc_api.notify_line_configs
+    WHERE channel_id = p_channel_id AND enabled = TRUE;
+$$;

--- a/tests/mock_helpers/repos_d.rs
+++ b/tests/mock_helpers/repos_d.rs
@@ -334,6 +334,8 @@ impl NotifyLineConfigRepository for MockNotifyLineConfigRepository {
         _key_id: &str,
         _private_key: &str,
         _bot_basic_id: Option<&str>,
+        _login_channel_id: Option<&str>,
+        _login_channel_secret_encrypted: Option<&str>,
     ) -> Result<NotifyLineConfig, sqlx::Error> {
         check_fail!(self);
         Ok(NotifyLineConfig {


### PR DESCRIPTION
## Summary
- LINE Login の channel_id/secret をグローバル env var からテナントごとの DB 設定に変更
- Migration 077: `login_channel_id` + `login_channel_secret_encrypted` を `notify_line_configs` に追加
- `line_redirect` は `channel_id` パラメータで DB lookup してテナントの LINE Login 設定を取得

## Test plan
- [ ] staging デプロイ後、LINE Login redirect が DB 設定を使うことを確認
- [ ] LINE Login 未設定テナントは 404 を返す

🤖 Generated with [Claude Code](https://claude.com/claude-code)