### PR TITLE
fix: LINE Login JWT assertion

### DIFF
--- a/crates/alc-core/src/auth_line.rs
+++ b/crates/alc-core/src/auth_line.rs
@@ -2,7 +2,9 @@
 //!
 //! Global channel (env vars only, no per-tenant SSO config).
 
-use serde::Deserialize;
+use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
+use serde::{Deserialize, Serialize};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 /// LINE Login authorize URL を構築
 ///
@@ -23,22 +25,59 @@ pub struct TokenResponse {
     pub access_token: String,
 }
 
-/// Code → Token 交換
-pub async fn exchange_code(
+#[derive(Debug, Serialize)]
+struct JwtClaims {
+    iss: String,
+    sub: String,
+    aud: String,
+    exp: u64,
+    token_id: String,
+}
+
+/// Code → Token 交換 (JWT assertion 方式)
+///
+/// Messaging API と同じ秘密鍵を使い、LINE Login チャネルの kid で署名。
+pub async fn exchange_code_jwt(
     client: &reqwest::Client,
-    channel_id: &str,
-    channel_secret: &str,
+    login_channel_id: &str,
+    login_key_id: &str,
+    private_key_pem: &str,
     code: &str,
     redirect_uri: &str,
 ) -> Result<TokenResponse, String> {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+
+    let claims = JwtClaims {
+        iss: login_channel_id.to_string(),
+        sub: login_channel_id.to_string(),
+        aud: "https://api.line.me/".to_string(),
+        exp: now + 300, // 5分
+        token_id: uuid::Uuid::new_v4().to_string(),
+    };
+
+    let mut header = Header::new(Algorithm::RS256);
+    header.kid = Some(login_key_id.to_string());
+    header.typ = Some("JWT".to_string());
+
+    let key = EncodingKey::from_rsa_pem(private_key_pem.as_bytes())
+        .map_err(|e| format!("RSA key parse failed: {e}"))?;
+    let jwt = encode(&header, &claims, &key).map_err(|e| format!("JWT encode failed: {e}"))?;
+
     let resp = client
         .post("https://api.line.me/oauth2/v2.1/token")
         .form(&[
             ("grant_type", "authorization_code"),
             ("code", code),
             ("redirect_uri", redirect_uri),
-            ("client_id", channel_id),
-            ("client_secret", channel_secret),
+            ("client_id", login_channel_id),
+            (
+                "client_assertion_type",
+                "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+            ),
+            ("client_assertion", &jwt),
         ])
         .send()
         .await

--- a/crates/alc-core/src/repository/notify_line_config.rs
+++ b/crates/alc-core/src/repository/notify_line_config.rs
@@ -24,7 +24,7 @@ pub struct NotifyLineConfigFull {
     pub key_id: Option<String>,
     pub private_key_encrypted: Option<String>,
     pub login_channel_id: Option<String>,
-    pub login_channel_secret_encrypted: Option<String>,
+    pub login_key_id: Option<String>,
 }
 
 #[derive(Debug, serde::Deserialize)]
@@ -36,7 +36,7 @@ pub struct UpsertLineConfig {
     pub private_key: String,
     pub bot_basic_id: Option<String>,
     pub login_channel_id: Option<String>,
-    pub login_channel_secret: Option<String>,
+    pub login_key_id: Option<String>,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -57,7 +57,7 @@ pub trait NotifyLineConfigRepository: Send + Sync {
         private_key_encrypted: &str,
         bot_basic_id: Option<&str>,
         login_channel_id: Option<&str>,
-        login_channel_secret_encrypted: Option<&str>,
+        login_key_id: Option<&str>,
     ) -> Result<NotifyLineConfig, sqlx::Error>;
 
     async fn delete(&self, tenant_id: Uuid) -> Result<(), sqlx::Error>;

--- a/crates/alc-misc/src/auth.rs
+++ b/crates/alc-misc/src/auth.rs
@@ -709,18 +709,23 @@ async fn line_callback(
         .login_channel_id
         .as_deref()
         .ok_or(StatusCode::NOT_FOUND)?;
+    let login_key_id = config
+        .login_key_id
+        .as_deref()
+        .ok_or(StatusCode::NOT_FOUND)?;
 
+    // Messaging API と同じ秘密鍵を復号
     let encryption_key = std::env::var("SSO_ENCRYPTION_KEY")
         .unwrap_or_else(|_| std::env::var("JWT_SECRET").unwrap_or_default());
-    let login_channel_secret = auth_lineworks::decrypt_secret(
+    let private_key = auth_lineworks::decrypt_secret(
         config
-            .login_channel_secret_encrypted
+            .private_key_encrypted
             .as_deref()
             .ok_or(StatusCode::NOT_FOUND)?,
         &encryption_key,
     )
     .map_err(|e| {
-        tracing::error!("decrypt login_channel_secret: {e}");
+        tracing::error!("decrypt private_key: {e}");
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
 
@@ -729,10 +734,11 @@ async fn line_callback(
     let callback_uri = format!("{api_origin}/api/auth/line/callback");
 
     let http_client = reqwest::Client::new();
-    let token_resp = auth_line::exchange_code(
+    let token_resp = auth_line::exchange_code_jwt(
         &http_client,
         login_channel_id,
-        &login_channel_secret,
+        login_key_id,
+        &private_key,
         &params.code,
         &callback_uri,
     )

--- a/crates/alc-notify/src/line_config.rs
+++ b/crates/alc-notify/src/line_config.rs
@@ -48,16 +48,6 @@ async fn upsert_config(
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
 
-    let login_channel_secret_encrypted = input
-        .login_channel_secret
-        .as_ref()
-        .map(|s| encrypt_secret(s, &key))
-        .transpose()
-        .map_err(|e| {
-            tracing::error!("encrypt login_channel_secret: {e}");
-            StatusCode::INTERNAL_SERVER_ERROR
-        })?;
-
     let config = state
         .notify_line_config
         .upsert(
@@ -69,7 +59,7 @@ async fn upsert_config(
             &private_key_encrypted,
             input.bot_basic_id.as_deref(),
             input.login_channel_id.as_deref(),
-            login_channel_secret_encrypted.as_deref(),
+            input.login_key_id.as_deref(),
         )
         .await
         .map_err(|e| {

--- a/crates/alc-notify/src/repo/notify_line_config.rs
+++ b/crates/alc-notify/src/repo/notify_line_config.rs
@@ -29,7 +29,7 @@ impl NotifyLineConfigRepository for PgNotifyLineConfigRepository {
     async fn get_full(&self, tenant_id: Uuid) -> Result<Option<NotifyLineConfigFull>, sqlx::Error> {
         let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
         sqlx::query_as::<_, NotifyLineConfigFull>(
-            "SELECT id, tenant_id, channel_id, channel_secret_encrypted, channel_access_token_encrypted, key_id, private_key_encrypted, login_channel_id, login_channel_secret_encrypted FROM notify_line_configs LIMIT 1",
+            "SELECT id, tenant_id, channel_id, channel_secret_encrypted, channel_access_token_encrypted, key_id, private_key_encrypted, login_channel_id, login_key_id FROM notify_line_configs LIMIT 1",
         )
         .fetch_optional(&mut *tc.conn)
         .await
@@ -45,12 +45,12 @@ impl NotifyLineConfigRepository for PgNotifyLineConfigRepository {
         private_key_encrypted: &str,
         bot_basic_id: Option<&str>,
         login_channel_id: Option<&str>,
-        login_channel_secret_encrypted: Option<&str>,
+        login_key_id: Option<&str>,
     ) -> Result<NotifyLineConfig, sqlx::Error> {
         let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
         sqlx::query_as::<_, NotifyLineConfig>(
             r#"
-            INSERT INTO notify_line_configs (tenant_id, name, channel_id, channel_secret_encrypted, key_id, private_key_encrypted, bot_basic_id, login_channel_id, login_channel_secret_encrypted)
+            INSERT INTO notify_line_configs (tenant_id, name, channel_id, channel_secret_encrypted, key_id, private_key_encrypted, bot_basic_id, login_channel_id, login_key_id)
             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
             ON CONFLICT (tenant_id) DO UPDATE SET
                 name = EXCLUDED.name,
@@ -60,7 +60,7 @@ impl NotifyLineConfigRepository for PgNotifyLineConfigRepository {
                 private_key_encrypted = EXCLUDED.private_key_encrypted,
                 bot_basic_id = EXCLUDED.bot_basic_id,
                 login_channel_id = EXCLUDED.login_channel_id,
-                login_channel_secret_encrypted = EXCLUDED.login_channel_secret_encrypted,
+                login_key_id = EXCLUDED.login_key_id,
                 updated_at = NOW()
             RETURNING id, tenant_id, name, channel_id, bot_basic_id, enabled, created_at, updated_at
             "#,
@@ -73,7 +73,7 @@ impl NotifyLineConfigRepository for PgNotifyLineConfigRepository {
         .bind(private_key_encrypted)
         .bind(bot_basic_id)
         .bind(login_channel_id)
-        .bind(login_channel_secret_encrypted)
+        .bind(login_key_id)
         .fetch_one(&mut *tc.conn)
         .await
     }

--- a/migrations/078_line_login_jwt_assertion.sql
+++ b/migrations/078_line_login_jwt_assertion.sql
@@ -1,0 +1,28 @@
+-- LINE Login を JWT assertion 方式に変更
+-- login_channel_secret_encrypted → login_key_id (同じ秘密鍵を使い kid だけ別)
+
+ALTER TABLE alc_api.notify_line_configs
+    DROP COLUMN IF EXISTS login_channel_secret_encrypted,
+    ADD COLUMN IF NOT EXISTS login_key_id TEXT;
+
+-- lookup 関数を更新
+DROP FUNCTION IF EXISTS alc_api.lookup_line_config_by_channel(TEXT);
+CREATE OR REPLACE FUNCTION alc_api.lookup_line_config_by_channel(p_channel_id TEXT)
+RETURNS TABLE(
+    id UUID,
+    tenant_id UUID,
+    channel_id TEXT,
+    channel_secret_encrypted TEXT,
+    channel_access_token_encrypted TEXT,
+    key_id TEXT,
+    private_key_encrypted TEXT,
+    login_channel_id TEXT,
+    login_key_id TEXT
+)
+LANGUAGE sql SECURITY DEFINER SET search_path = alc_api
+AS $$
+    SELECT id, tenant_id, channel_id, channel_secret_encrypted, channel_access_token_encrypted,
+           key_id, private_key_encrypted, login_channel_id, login_key_id
+    FROM alc_api.notify_line_configs
+    WHERE channel_id = p_channel_id AND enabled = TRUE;
+$$;

--- a/tests/mock_helpers/repos_d.rs
+++ b/tests/mock_helpers/repos_d.rs
@@ -335,7 +335,7 @@ impl NotifyLineConfigRepository for MockNotifyLineConfigRepository {
         _private_key: &str,
         _bot_basic_id: Option<&str>,
         _login_channel_id: Option<&str>,
-        _login_channel_secret_encrypted: Option<&str>,
+        _login_key_id: Option<&str>,
     ) -> Result<NotifyLineConfig, sqlx::Error> {
         check_fail!(self);
         Ok(NotifyLineConfig {


### PR DESCRIPTION
## Summary
- LINE Login を channel_secret から JWT assertion (公開鍵) 方式に変更
- Messaging API と同じ RSA 鍵ペアを共有、login_key_id だけ別管理
- `login_channel_secret_encrypted` → `login_key_id` に置換

## Test plan
- [ ] LINE Login チャネルに同じ公開鍵を登録 → kid 取得
- [ ] 設定画面で login_channel_id + login_key_id を入力・保存
- [ ] LINE Login → JWT assertion で code exchange 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)