### PR TITLE
feat: save public_key_jwk for re-display

### DIFF
--- a/crates/alc-core/src/repository/notify_line_config.rs
+++ b/crates/alc-core/src/repository/notify_line_config.rs
@@ -8,6 +8,9 @@ pub struct NotifyLineConfig {
     pub name: String,
     pub channel_id: String,
     pub bot_basic_id: Option<String>,
+    pub public_key_jwk: Option<String>,
+    pub login_channel_id: Option<String>,
+    pub login_key_id: Option<String>,
     pub enabled: bool,
     pub created_at: chrono::DateTime<chrono::Utc>,
     pub updated_at: chrono::DateTime<chrono::Utc>,
@@ -35,6 +38,7 @@ pub struct UpsertLineConfig {
     pub key_id: String,
     pub private_key: String,
     pub bot_basic_id: Option<String>,
+    pub public_key_jwk: Option<String>,
     pub login_channel_id: Option<String>,
     pub login_key_id: Option<String>,
 }
@@ -56,6 +60,7 @@ pub trait NotifyLineConfigRepository: Send + Sync {
         key_id: &str,
         private_key_encrypted: &str,
         bot_basic_id: Option<&str>,
+        public_key_jwk: Option<&str>,
         login_channel_id: Option<&str>,
         login_key_id: Option<&str>,
     ) -> Result<NotifyLineConfig, sqlx::Error>;

--- a/crates/alc-notify/src/line_config.rs
+++ b/crates/alc-notify/src/line_config.rs
@@ -58,6 +58,7 @@ async fn upsert_config(
             &input.key_id,
             &private_key_encrypted,
             input.bot_basic_id.as_deref(),
+            input.public_key_jwk.as_deref(),
             input.login_channel_id.as_deref(),
             input.login_key_id.as_deref(),
         )

--- a/crates/alc-notify/src/repo/notify_line_config.rs
+++ b/crates/alc-notify/src/repo/notify_line_config.rs
@@ -20,7 +20,7 @@ impl NotifyLineConfigRepository for PgNotifyLineConfigRepository {
     async fn get(&self, tenant_id: Uuid) -> Result<Option<NotifyLineConfig>, sqlx::Error> {
         let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
         sqlx::query_as::<_, NotifyLineConfig>(
-            "SELECT id, tenant_id, name, channel_id, bot_basic_id, enabled, created_at, updated_at FROM notify_line_configs LIMIT 1",
+            "SELECT id, tenant_id, name, channel_id, bot_basic_id, public_key_jwk, login_channel_id, login_key_id, enabled, created_at, updated_at FROM notify_line_configs LIMIT 1",
         )
         .fetch_optional(&mut *tc.conn)
         .await
@@ -44,14 +44,15 @@ impl NotifyLineConfigRepository for PgNotifyLineConfigRepository {
         key_id: &str,
         private_key_encrypted: &str,
         bot_basic_id: Option<&str>,
+        public_key_jwk: Option<&str>,
         login_channel_id: Option<&str>,
         login_key_id: Option<&str>,
     ) -> Result<NotifyLineConfig, sqlx::Error> {
         let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
         sqlx::query_as::<_, NotifyLineConfig>(
             r#"
-            INSERT INTO notify_line_configs (tenant_id, name, channel_id, channel_secret_encrypted, key_id, private_key_encrypted, bot_basic_id, login_channel_id, login_key_id)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+            INSERT INTO notify_line_configs (tenant_id, name, channel_id, channel_secret_encrypted, key_id, private_key_encrypted, bot_basic_id, public_key_jwk, login_channel_id, login_key_id)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
             ON CONFLICT (tenant_id) DO UPDATE SET
                 name = EXCLUDED.name,
                 channel_id = EXCLUDED.channel_id,
@@ -59,10 +60,11 @@ impl NotifyLineConfigRepository for PgNotifyLineConfigRepository {
                 key_id = EXCLUDED.key_id,
                 private_key_encrypted = EXCLUDED.private_key_encrypted,
                 bot_basic_id = EXCLUDED.bot_basic_id,
+                public_key_jwk = EXCLUDED.public_key_jwk,
                 login_channel_id = EXCLUDED.login_channel_id,
                 login_key_id = EXCLUDED.login_key_id,
                 updated_at = NOW()
-            RETURNING id, tenant_id, name, channel_id, bot_basic_id, enabled, created_at, updated_at
+            RETURNING id, tenant_id, name, channel_id, bot_basic_id, public_key_jwk, login_channel_id, login_key_id, enabled, created_at, updated_at
             "#,
         )
         .bind(tenant_id)
@@ -72,6 +74,7 @@ impl NotifyLineConfigRepository for PgNotifyLineConfigRepository {
         .bind(key_id)
         .bind(private_key_encrypted)
         .bind(bot_basic_id)
+        .bind(public_key_jwk)
         .bind(login_channel_id)
         .bind(login_key_id)
         .fetch_one(&mut *tc.conn)

--- a/migrations/079_add_public_key_jwk.sql
+++ b/migrations/079_add_public_key_jwk.sql
@@ -1,0 +1,3 @@
+-- 公開鍵 JWK を保存して設定画面で再表示可能にする
+ALTER TABLE alc_api.notify_line_configs
+    ADD COLUMN IF NOT EXISTS public_key_jwk TEXT;

--- a/tests/mock_helpers/repos_d.rs
+++ b/tests/mock_helpers/repos_d.rs
@@ -334,6 +334,7 @@ impl NotifyLineConfigRepository for MockNotifyLineConfigRepository {
         _key_id: &str,
         _private_key: &str,
         _bot_basic_id: Option<&str>,
+        _public_key_jwk: Option<&str>,
         _login_channel_id: Option<&str>,
         _login_key_id: Option<&str>,
     ) -> Result<NotifyLineConfig, sqlx::Error> {
@@ -344,6 +345,9 @@ impl NotifyLineConfigRepository for MockNotifyLineConfigRepository {
             name: name.into(),
             channel_id: channel_id.into(),
             bot_basic_id: None,
+            public_key_jwk: None,
+            login_channel_id: None,
+            login_key_id: None,
             enabled: true,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),


### PR DESCRIPTION
## Summary
- `notify_line_configs` に `public_key_jwk` カラム追加
- 設定保存時に公開鍵 JWK も DB に保存
- GET レスポンスに含めて設定画面で再表示可能に

🤖 Generated with [Claude Code](https://claude.com/claude-code)