### PR TITLE
fix: LINE Login global env vars

### DIFF
--- a/crates/alc-core/src/auth_line.rs
+++ b/crates/alc-core/src/auth_line.rs
@@ -25,6 +25,37 @@ pub struct TokenResponse {
     pub access_token: String,
 }
 
+/// Code → Token 交換 (channel_secret 方式)
+pub async fn exchange_code(
+    client: &reqwest::Client,
+    channel_id: &str,
+    channel_secret: &str,
+    code: &str,
+    redirect_uri: &str,
+) -> Result<TokenResponse, String> {
+    let resp = client
+        .post("https://api.line.me/oauth2/v2.1/token")
+        .form(&[
+            ("grant_type", "authorization_code"),
+            ("code", code),
+            ("redirect_uri", redirect_uri),
+            ("client_id", channel_id),
+            ("client_secret", channel_secret),
+        ])
+        .send()
+        .await
+        .map_err(|e| format!("LINE token request failed: {e}"))?;
+
+    if !resp.status().is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        return Err(format!("LINE token exchange failed: {body}"));
+    }
+
+    resp.json::<TokenResponse>()
+        .await
+        .map_err(|e| format!("LINE token parse failed: {e}"))
+}
+
 #[derive(Debug, Serialize)]
 struct JwtClaims {
     iss: String,

--- a/crates/alc-core/src/repository/notify_line_config.rs
+++ b/crates/alc-core/src/repository/notify_line_config.rs
@@ -9,14 +9,12 @@ pub struct NotifyLineConfig {
     pub channel_id: String,
     pub bot_basic_id: Option<String>,
     pub public_key_jwk: Option<String>,
-    pub login_channel_id: Option<String>,
-    pub login_key_id: Option<String>,
     pub enabled: bool,
     pub created_at: chrono::DateTime<chrono::Utc>,
     pub updated_at: chrono::DateTime<chrono::Utc>,
 }
 
-/// 暗号化フィールド含む完全版 (内��利用のみ)
+/// 暗号化フィールド含む完全版 (内部利用のみ)
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct NotifyLineConfigFull {
     pub id: Uuid,
@@ -26,8 +24,6 @@ pub struct NotifyLineConfigFull {
     pub channel_access_token_encrypted: Option<String>,
     pub key_id: Option<String>,
     pub private_key_encrypted: Option<String>,
-    pub login_channel_id: Option<String>,
-    pub login_key_id: Option<String>,
 }
 
 #[derive(Debug, serde::Deserialize)]
@@ -39,8 +35,6 @@ pub struct UpsertLineConfig {
     pub private_key: String,
     pub bot_basic_id: Option<String>,
     pub public_key_jwk: Option<String>,
-    pub login_channel_id: Option<String>,
-    pub login_key_id: Option<String>,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -61,13 +55,11 @@ pub trait NotifyLineConfigRepository: Send + Sync {
         private_key_encrypted: &str,
         bot_basic_id: Option<&str>,
         public_key_jwk: Option<&str>,
-        login_channel_id: Option<&str>,
-        login_key_id: Option<&str>,
     ) -> Result<NotifyLineConfig, sqlx::Error>;
 
     async fn delete(&self, tenant_id: Uuid) -> Result<(), sqlx::Error>;
 
-    /// LINE webhook: channel_id からテナン���特定 (SECURITY DEFINER, テナント不要)
+    /// LINE webhook: channel_id からテナント特定 (SECURITY DEFINER, テナント不要)
     async fn lookup_by_channel(
         &self,
         channel_id: &str,

--- a/crates/alc-misc/src/auth.rs
+++ b/crates/alc-misc/src/auth.rs
@@ -615,48 +615,26 @@ async fn lineworks_callback(
 #[derive(Debug, Deserialize)]
 struct LineRedirectParams {
     redirect_uri: String,
-    /// Messaging API の channel_id (テナント特定用)
-    channel_id: String,
 }
 
-/// LINE Login OAuth 開始: DB から LINE Login 設定を取得 → LINE authorize URL にリダイレクト
+/// LINE Login OAuth 開始: グローバル LINE Login チャネル (env var) で LINE authorize URL にリダイレクト
 async fn line_redirect(
-    State(state): State<AppState>,
     Query(params): Query<LineRedirectParams>,
 ) -> Result<impl IntoResponse, StatusCode> {
     let oauth_state_secret = std::env::var("OAUTH_STATE_SECRET").map_err(|_| {
         tracing::error!("OAUTH_STATE_SECRET not set");
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
-
-    // Messaging API channel_id → notify_line_configs から LINE Login 設定を取得
-    let config = state
-        .notify_line_config
-        .lookup_by_channel(&params.channel_id)
-        .await
-        .map_err(|e| {
-            tracing::error!("LINE config lookup failed: {e}");
-            StatusCode::INTERNAL_SERVER_ERROR
-        })?
-        .ok_or_else(|| {
-            tracing::warn!("No LINE config for channel_id: {}", params.channel_id);
-            StatusCode::NOT_FOUND
-        })?;
-
-    let login_channel_id = config.login_channel_id.as_deref().ok_or_else(|| {
-        tracing::warn!(
-            "LINE Login not configured for channel_id: {}",
-            params.channel_id
-        );
-        StatusCode::NOT_FOUND
+    let channel_id = std::env::var("LINE_LOGIN_CHANNEL_ID").map_err(|_| {
+        tracing::error!("LINE_LOGIN_CHANNEL_ID not set");
+        StatusCode::INTERNAL_SERVER_ERROR
     })?;
 
-    // state に channel_id を保存 (callback で再取得に使う)
     let state_payload = auth_lineworks::state::StatePayload {
         redirect_uri: params.redirect_uri,
         nonce: Uuid::new_v4().to_string(),
         provider: "line".to_string(),
-        external_org_id: params.channel_id,
+        external_org_id: String::new(),
     };
     let signed_state = auth_lineworks::state::sign(&state_payload, &oauth_state_secret);
 
@@ -665,7 +643,7 @@ async fn line_redirect(
     let callback_uri = format!("{api_origin}/api/auth/line/callback");
 
     let authorize_url = auth_line::authorize_url(
-        login_channel_id,
+        &channel_id,
         &urlencoding::encode(&callback_uri),
         &urlencoding::encode(&signed_state),
     );
@@ -694,38 +672,12 @@ async fn line_callback(
             StatusCode::BAD_REQUEST
         })?;
 
-    // state.external_org_id に保存した channel_id で LINE config を再取得
-    let config = state
-        .notify_line_config
-        .lookup_by_channel(&state_payload.external_org_id)
-        .await
-        .map_err(|e| {
-            tracing::error!("LINE config lookup failed: {e}");
-            StatusCode::INTERNAL_SERVER_ERROR
-        })?
-        .ok_or(StatusCode::NOT_FOUND)?;
-
-    let login_channel_id = config
-        .login_channel_id
-        .as_deref()
-        .ok_or(StatusCode::NOT_FOUND)?;
-    let login_key_id = config
-        .login_key_id
-        .as_deref()
-        .ok_or(StatusCode::NOT_FOUND)?;
-
-    // Messaging API と同じ秘密鍵を復号
-    let encryption_key = std::env::var("SSO_ENCRYPTION_KEY")
-        .unwrap_or_else(|_| std::env::var("JWT_SECRET").unwrap_or_default());
-    let private_key = auth_lineworks::decrypt_secret(
-        config
-            .private_key_encrypted
-            .as_deref()
-            .ok_or(StatusCode::NOT_FOUND)?,
-        &encryption_key,
-    )
-    .map_err(|e| {
-        tracing::error!("decrypt private_key: {e}");
+    let channel_id = std::env::var("LINE_LOGIN_CHANNEL_ID").map_err(|_| {
+        tracing::error!("LINE_LOGIN_CHANNEL_ID not set");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+    let channel_secret = std::env::var("LINE_LOGIN_CHANNEL_SECRET").map_err(|_| {
+        tracing::error!("LINE_LOGIN_CHANNEL_SECRET not set");
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
 
@@ -734,11 +686,10 @@ async fn line_callback(
     let callback_uri = format!("{api_origin}/api/auth/line/callback");
 
     let http_client = reqwest::Client::new();
-    let token_resp = auth_line::exchange_code_jwt(
+    let token_resp = auth_line::exchange_code(
         &http_client,
-        login_channel_id,
-        login_key_id,
-        &private_key,
+        &channel_id,
+        &channel_secret,
         &params.code,
         &callback_uri,
     )

--- a/crates/alc-notify/src/line_config.rs
+++ b/crates/alc-notify/src/line_config.rs
@@ -59,8 +59,6 @@ async fn upsert_config(
             &private_key_encrypted,
             input.bot_basic_id.as_deref(),
             input.public_key_jwk.as_deref(),
-            input.login_channel_id.as_deref(),
-            input.login_key_id.as_deref(),
         )
         .await
         .map_err(|e| {

--- a/crates/alc-notify/src/repo/notify_line_config.rs
+++ b/crates/alc-notify/src/repo/notify_line_config.rs
@@ -20,7 +20,7 @@ impl NotifyLineConfigRepository for PgNotifyLineConfigRepository {
     async fn get(&self, tenant_id: Uuid) -> Result<Option<NotifyLineConfig>, sqlx::Error> {
         let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
         sqlx::query_as::<_, NotifyLineConfig>(
-            "SELECT id, tenant_id, name, channel_id, bot_basic_id, public_key_jwk, login_channel_id, login_key_id, enabled, created_at, updated_at FROM notify_line_configs LIMIT 1",
+            "SELECT id, tenant_id, name, channel_id, bot_basic_id, public_key_jwk, enabled, created_at, updated_at FROM notify_line_configs LIMIT 1",
         )
         .fetch_optional(&mut *tc.conn)
         .await
@@ -29,7 +29,7 @@ impl NotifyLineConfigRepository for PgNotifyLineConfigRepository {
     async fn get_full(&self, tenant_id: Uuid) -> Result<Option<NotifyLineConfigFull>, sqlx::Error> {
         let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
         sqlx::query_as::<_, NotifyLineConfigFull>(
-            "SELECT id, tenant_id, channel_id, channel_secret_encrypted, channel_access_token_encrypted, key_id, private_key_encrypted, login_channel_id, login_key_id FROM notify_line_configs LIMIT 1",
+            "SELECT id, tenant_id, channel_id, channel_secret_encrypted, channel_access_token_encrypted, key_id, private_key_encrypted FROM notify_line_configs LIMIT 1",
         )
         .fetch_optional(&mut *tc.conn)
         .await
@@ -45,14 +45,12 @@ impl NotifyLineConfigRepository for PgNotifyLineConfigRepository {
         private_key_encrypted: &str,
         bot_basic_id: Option<&str>,
         public_key_jwk: Option<&str>,
-        login_channel_id: Option<&str>,
-        login_key_id: Option<&str>,
     ) -> Result<NotifyLineConfig, sqlx::Error> {
         let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
         sqlx::query_as::<_, NotifyLineConfig>(
             r#"
-            INSERT INTO notify_line_configs (tenant_id, name, channel_id, channel_secret_encrypted, key_id, private_key_encrypted, bot_basic_id, public_key_jwk, login_channel_id, login_key_id)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+            INSERT INTO notify_line_configs (tenant_id, name, channel_id, channel_secret_encrypted, key_id, private_key_encrypted, bot_basic_id, public_key_jwk)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
             ON CONFLICT (tenant_id) DO UPDATE SET
                 name = EXCLUDED.name,
                 channel_id = EXCLUDED.channel_id,
@@ -61,10 +59,8 @@ impl NotifyLineConfigRepository for PgNotifyLineConfigRepository {
                 private_key_encrypted = EXCLUDED.private_key_encrypted,
                 bot_basic_id = EXCLUDED.bot_basic_id,
                 public_key_jwk = EXCLUDED.public_key_jwk,
-                login_channel_id = EXCLUDED.login_channel_id,
-                login_key_id = EXCLUDED.login_key_id,
                 updated_at = NOW()
-            RETURNING id, tenant_id, name, channel_id, bot_basic_id, public_key_jwk, login_channel_id, login_key_id, enabled, created_at, updated_at
+            RETURNING id, tenant_id, name, channel_id, bot_basic_id, public_key_jwk, enabled, created_at, updated_at
             "#,
         )
         .bind(tenant_id)
@@ -75,8 +71,6 @@ impl NotifyLineConfigRepository for PgNotifyLineConfigRepository {
         .bind(private_key_encrypted)
         .bind(bot_basic_id)
         .bind(public_key_jwk)
-        .bind(login_channel_id)
-        .bind(login_key_id)
         .fetch_one(&mut *tc.conn)
         .await
     }

--- a/migrations/080_remove_login_columns.sql
+++ b/migrations/080_remove_login_columns.sql
@@ -1,0 +1,27 @@
+-- LINE Login をグローバル env var 方式に戻す
+-- login_channel_id / login_key_id / login_channel_secret_encrypted はテナントごと不要
+
+ALTER TABLE alc_api.notify_line_configs
+    DROP COLUMN IF EXISTS login_channel_id,
+    DROP COLUMN IF EXISTS login_key_id,
+    DROP COLUMN IF EXISTS login_channel_secret_encrypted;
+
+-- lookup 関数から login 関連カラムを除外
+DROP FUNCTION IF EXISTS alc_api.lookup_line_config_by_channel(TEXT);
+CREATE OR REPLACE FUNCTION alc_api.lookup_line_config_by_channel(p_channel_id TEXT)
+RETURNS TABLE(
+    id UUID,
+    tenant_id UUID,
+    channel_id TEXT,
+    channel_secret_encrypted TEXT,
+    channel_access_token_encrypted TEXT,
+    key_id TEXT,
+    private_key_encrypted TEXT
+)
+LANGUAGE sql SECURITY DEFINER SET search_path = alc_api
+AS $$
+    SELECT id, tenant_id, channel_id, channel_secret_encrypted, channel_access_token_encrypted,
+           key_id, private_key_encrypted
+    FROM alc_api.notify_line_configs
+    WHERE channel_id = p_channel_id AND enabled = TRUE;
+$$;

--- a/tests/mock_helpers/repos_d.rs
+++ b/tests/mock_helpers/repos_d.rs
@@ -335,8 +335,6 @@ impl NotifyLineConfigRepository for MockNotifyLineConfigRepository {
         _private_key: &str,
         _bot_basic_id: Option<&str>,
         _public_key_jwk: Option<&str>,
-        _login_channel_id: Option<&str>,
-        _login_key_id: Option<&str>,
     ) -> Result<NotifyLineConfig, sqlx::Error> {
         check_fail!(self);
         Ok(NotifyLineConfig {
@@ -346,8 +344,6 @@ impl NotifyLineConfigRepository for MockNotifyLineConfigRepository {
             channel_id: channel_id.into(),
             bot_basic_id: None,
             public_key_jwk: None,
-            login_channel_id: None,
-            login_key_id: None,
             enabled: true,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),


### PR DESCRIPTION
## Summary
- LINE Login を per-tenant DB 設定からグローバル env var 方式に変更
- notify_line_configs から login_channel_id / login_key_id / login_channel_secret_encrypted を削除
- LINE Login チャネルは全テナント共通、tenant 特定は notify_recipients.line_user_id で逆引き

## Test plan
- [ ] LINE_LOGIN_CHANNEL_ID + LINE_LOGIN_CHANNEL_SECRET を Secret Manager に設定
- [ ] /api/auth/line/redirect?redirect_uri=... で LINE Login 画面にリダイレクト

🤖 Generated with [Claude Code](https://claude.com/claude-code)