### PR TITLE
ci: add auto-merge job using reusable workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -363,3 +363,17 @@ jobs:
             --region asia-northeast1 --project cloudsql-sv \
             --format 'value(status.url)')
           echo "::notice ::Production URL: $URL (${GITHUB_REF_NAME})"
+
+  auto-merge:
+    name: Auto Merge
+    needs: [check, full-tests, deploy-staging]
+    if: >-
+      always() &&
+      github.event_name == 'pull_request' &&
+      needs.check.result == 'success' &&
+      needs.full-tests.result == 'success' &&
+      (needs.deploy-staging.result == 'success' || needs.deploy-staging.result == 'skipped')
+    uses: ippoan/ci-workflows/.github/workflows/auto-merge.yml@main
+    permissions:
+      contents: write
+      pull-requests: write


### PR DESCRIPTION
## Summary
- CI pass 後に自動 squash merge する auto-merge ジョブを追加
- ippoan/ci-workflows の reusable workflow を使用

## Test plan
- [ ] この PR 自体が auto-merge で自動マージされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)