### PR TITLE
ci: add tag-release caller workflow

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,11 @@
+name: Tag Release
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    uses: ippoan/ci-workflows/.github/workflows/tag-release.yml@main


### PR DESCRIPTION
## Summary
- `workflow_dispatch` で tag-release reusable workflow を呼ぶ薄いラッパー
- ci-dashboard の Deploy ボタンからトリガーされる

## Test plan
- [ ] `gh workflow run tag-release.yml` で手動実行確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)