### PR TITLE
fix: pass secrets to tag-release workflow

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -9,3 +9,4 @@ permissions:
 jobs:
   release:
     uses: ippoan/ci-workflows/.github/workflows/tag-release.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary
- `secrets: inherit` を追加して org secret (TAG_RELEASE_PAT) を渡す
- PAT で tag push することで CI deploy-production がトリガーされる

🤖 Generated with [Claude Code](https://claude.com/claude-code)