### PR TITLE
feat: add R2 fallback to by-date-range endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,6 +136,7 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "csv",
+ "flate2",
  "futures",
  "reqwest",
  "serde",

--- a/crates/alc-dtako/Cargo.toml
+++ b/crates/alc-dtako/Cargo.toml
@@ -15,6 +15,7 @@ alc-csv-parser = { path = "../alc-csv-parser" }
 alc-pdf = { path = "../alc-pdf" }
 anyhow = "1"
 axum = { version = "0.8", features = ["multipart"] }
+flate2 = "1"
 base64 = "0.22"
 chrono = { version = "0.4", features = ["serde"] }
 csv = "1"

--- a/crates/alc-dtako/src/archive_reader.rs
+++ b/crates/alc-dtako/src/archive_reader.rs
@@ -1,0 +1,159 @@
+//! R2 アーカイブから dtakologs を読み取るモジュール。
+//! by-date-range エンドポイントで DB にないデータを R2 からフォールバック取得する。
+
+use alc_core::models::DtakologRow;
+use alc_core::storage::StorageBackend;
+use flate2::read::GzDecoder;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::io::Read;
+
+const MANIFEST_KEY: &str = "archive/alc_api/dtakologs/_manifest.json";
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+struct Manifest {
+    #[serde(default)]
+    archived_dates: HashMap<String, HashMap<String, ArchivedDateInfo>>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct ArchivedDateInfo {
+    #[serde(default)]
+    row_count: usize,
+    #[serde(default)]
+    r2_key: String,
+    #[serde(default)]
+    archived_at: String,
+}
+
+/// R2 から指定 tenant_id + 日付範囲の dtakologs を読み込み返す。
+/// DB の重複期間のデータも含まれうるので、呼び出し側で dedup する。
+pub async fn fetch_from_r2(
+    storage: &dyn StorageBackend,
+    tenant_id: &str,
+    start_date: &str,
+    end_date: &str,
+    vehicle_cd: Option<i32>,
+) -> anyhow::Result<Vec<DtakologRow>> {
+    // Load manifest
+    let manifest: Manifest = match storage.download(MANIFEST_KEY).await {
+        Ok(data) => serde_json::from_slice(&data).unwrap_or_default(),
+        Err(_) => return Ok(vec![]),
+    };
+
+    let tenant_dates = match manifest.archived_dates.get(tenant_id) {
+        Some(dates) => dates,
+        None => return Ok(vec![]),
+    };
+
+    let mut all_rows = Vec::new();
+
+    for (date_str, info) in tenant_dates {
+        if date_str.as_str() < start_date || date_str.as_str() > end_date {
+            continue;
+        }
+
+        // Download and decompress
+        let compressed = match storage.download(&info.r2_key).await {
+            Ok(d) => d,
+            Err(e) => {
+                tracing::warn!("Failed to download archive {}: {}", info.r2_key, e);
+                continue;
+            }
+        };
+
+        let mut decoder = GzDecoder::new(compressed.as_slice());
+        let mut content = String::new();
+        if let Err(e) = decoder.read_to_string(&mut content) {
+            tracing::warn!("Failed to decompress {}: {}", info.r2_key, e);
+            continue;
+        }
+
+        for line in content.lines() {
+            if line.is_empty() {
+                continue;
+            }
+            let value: serde_json::Value = match serde_json::from_str(line) {
+                Ok(v) => v,
+                Err(_) => continue,
+            };
+            if value.get("_archive_header").is_some() {
+                continue;
+            }
+
+            // Filter by vehicle_cd if specified
+            if let Some(vc) = vehicle_cd {
+                if value.get("vehicle_cd").and_then(|v| v.as_i64()) != Some(vc as i64) {
+                    continue;
+                }
+            }
+
+            all_rows.push(json_to_dtakolog_row(&value));
+        }
+    }
+
+    all_rows.sort_by(|a, b| a.data_date_time.cmp(&b.data_date_time));
+    Ok(all_rows)
+}
+
+fn json_to_dtakolog_row(v: &serde_json::Value) -> DtakologRow {
+    DtakologRow {
+        gps_direction: v
+            .get("gps_direction")
+            .and_then(|x| x.as_f64())
+            .unwrap_or(0.0),
+        gps_latitude: v
+            .get("gps_latitude")
+            .and_then(|x| x.as_f64())
+            .unwrap_or(0.0),
+        gps_longitude: v
+            .get("gps_longitude")
+            .and_then(|x| x.as_f64())
+            .unwrap_or(0.0),
+        vehicle_cd: v.get("vehicle_cd").and_then(|x| x.as_i64()).unwrap_or(0) as i32,
+        vehicle_name: v
+            .get("vehicle_name")
+            .and_then(|x| x.as_str())
+            .unwrap_or("")
+            .to_string(),
+        driver_name: v
+            .get("driver_name")
+            .and_then(|x| x.as_str())
+            .map(|s| s.to_string()),
+        address_disp_c: v
+            .get("address_disp_c")
+            .and_then(|x| x.as_str())
+            .map(|s| s.to_string()),
+        data_date_time: v
+            .get("data_date_time")
+            .and_then(|x| x.as_str())
+            .unwrap_or("")
+            .to_string(),
+        address_disp_p: v
+            .get("address_disp_p")
+            .and_then(|x| x.as_str())
+            .map(|s| s.to_string()),
+        sub_driver_cd: v.get("sub_driver_cd").and_then(|x| x.as_i64()).unwrap_or(0) as i32,
+        all_state: v
+            .get("all_state")
+            .and_then(|x| x.as_str())
+            .map(|s| s.to_string()),
+        recive_type_color_name: v
+            .get("recive_type_color_name")
+            .and_then(|x| x.as_str())
+            .map(|s| s.to_string()),
+        all_state_ex: v
+            .get("all_state_ex")
+            .and_then(|x| x.as_str())
+            .map(|s| s.to_string()),
+        state2: v
+            .get("state2")
+            .and_then(|x| x.as_str())
+            .map(|s| s.to_string()),
+        all_state_font_color: v
+            .get("all_state_font_color")
+            .and_then(|x| x.as_str())
+            .map(|s| s.to_string()),
+        speed: v.get("speed").and_then(|x| x.as_f64()).unwrap_or(0.0) as f32,
+    }
+}

--- a/crates/alc-dtako/src/dtako_logs.rs
+++ b/crates/alc-dtako/src/dtako_logs.rs
@@ -76,7 +76,8 @@ async fn get_by_date_range(
     tenant: axum::Extension<TenantId>,
     Query(q): Query<DtakologDateRangeQuery>,
 ) -> Result<Json<Vec<DtakologView>>, StatusCode> {
-    let rows = state
+    // DB から取得 (直近7日分)
+    let mut rows = state
         .dtako_logs
         .get_date_range(
             tenant.0 .0,
@@ -86,7 +87,55 @@ async fn get_by_date_range(
         )
         .await
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    // R2 アーカイブからも取得 (dtako_storage が設定されている場合)
+    if let Some(ref storage) = state.dtako_storage {
+        let start_date = extract_date(&q.start_date_time);
+        let end_date = extract_date(&q.end_date_time);
+        let tenant_str = tenant.0 .0.to_string();
+        match crate::archive_reader::fetch_from_r2(
+            storage.as_ref(),
+            &tenant_str,
+            &start_date,
+            &end_date,
+            q.vehicle_cd,
+        )
+        .await
+        {
+            Ok(r2_rows) => {
+                rows.extend(r2_rows);
+                // data_date_time でソート
+                rows.sort_by(|a, b| a.data_date_time.cmp(&b.data_date_time));
+                // 重複除去 (DB と R2 の重複期間)
+                rows.dedup_by(|a, b| {
+                    a.data_date_time == b.data_date_time && a.vehicle_cd == b.vehicle_cd
+                });
+            }
+            Err(e) => {
+                tracing::warn!("R2 archive fetch failed (continuing with DB only): {}", e);
+            }
+        }
+    }
+
     Ok(Json(rows.into_iter().map(DtakologView::from).collect()))
+}
+
+/// 日時文字列から YYYY-MM-DD 部分を抽出
+fn extract_date(datetime_str: &str) -> String {
+    // ISO8601: "2026-04-07T12:00:00" → "2026-04-07"
+    // Locale: "26/04/07 12:00" → "2026-04-07" (best effort)
+    if datetime_str.len() >= 10 && datetime_str.as_bytes()[4] == b'-' {
+        return datetime_str[..10].to_string();
+    }
+    // Try chrono parse for flexible formats
+    if let Ok(dt) = chrono::NaiveDateTime::parse_from_str(datetime_str, "%Y-%m-%dT%H:%M:%S") {
+        return dt.format("%Y-%m-%d").to_string();
+    }
+    if let Ok(dt) = chrono::NaiveDateTime::parse_from_str(datetime_str, "%Y-%m-%d %H:%M:%S") {
+        return dt.format("%Y-%m-%d").to_string();
+    }
+    // Fallback: return as-is (first 10 chars)
+    datetime_str.chars().take(10).collect()
 }
 
 async fn bulk_upsert(

--- a/crates/alc-dtako/src/lib.rs
+++ b/crates/alc-dtako/src/lib.rs
@@ -2,6 +2,7 @@
 #[macro_use]
 mod test_macros;
 
+pub mod archive_reader;
 pub mod repo;
 
 pub mod dtako_csv_proxy;

--- a/src/archive/dtako.rs
+++ b/src/archive/dtako.rs
@@ -394,6 +394,132 @@ async fn upsert_batch(pool: &PgPool, rows: &[String]) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// R2 から指定 tenant_id + 日付範囲の dtakologs を読み込み、DtakologRow に変換して返す。
+/// フロントエンドの by-date-range エンドポイントから呼ばれる。
+pub async fn fetch_from_r2(
+    storage: &dyn StorageBackend,
+    tenant_id: &str,
+    start_date: &str,
+    end_date: &str,
+    vehicle_cd: Option<i32>,
+) -> anyhow::Result<Vec<alc_core::models::DtakologRow>> {
+    let manifest = load_manifest(storage).await;
+    let tenant_dates = match manifest.archived_dates.get(tenant_id) {
+        Some(dates) => dates,
+        None => return Ok(vec![]),
+    };
+
+    let mut all_rows = Vec::new();
+
+    for (date_str, info) in tenant_dates {
+        // Filter by date range
+        if date_str.as_str() < start_date || date_str.as_str() > end_date {
+            continue;
+        }
+
+        // Download and decompress
+        let data = match download_decompressed(storage, &info.r2_key).await {
+            Ok(d) => d,
+            Err(e) => {
+                tracing::warn!("Failed to download archive {}: {}", info.r2_key, e);
+                continue;
+            }
+        };
+
+        let content = String::from_utf8_lossy(&data);
+        for line in content.lines() {
+            if line.is_empty() {
+                continue;
+            }
+            let value: serde_json::Value = match serde_json::from_str(line) {
+                Ok(v) => v,
+                Err(_) => continue,
+            };
+            // Skip header lines
+            if value.get("_archive_header").is_some() {
+                continue;
+            }
+
+            // Filter by vehicle_cd if specified
+            if let Some(vc) = vehicle_cd {
+                if value.get("vehicle_cd").and_then(|v| v.as_i64()) != Some(vc as i64) {
+                    continue;
+                }
+            }
+
+            let row = json_to_dtakolog_row(&value);
+            all_rows.push(row);
+        }
+    }
+
+    // Sort by data_date_time
+    all_rows.sort_by(|a, b| a.data_date_time.cmp(&b.data_date_time));
+
+    Ok(all_rows)
+}
+
+fn json_to_dtakolog_row(v: &serde_json::Value) -> alc_core::models::DtakologRow {
+    alc_core::models::DtakologRow {
+        gps_direction: v
+            .get("gps_direction")
+            .and_then(|x| x.as_f64())
+            .unwrap_or(0.0),
+        gps_latitude: v
+            .get("gps_latitude")
+            .and_then(|x| x.as_f64())
+            .unwrap_or(0.0),
+        gps_longitude: v
+            .get("gps_longitude")
+            .and_then(|x| x.as_f64())
+            .unwrap_or(0.0),
+        vehicle_cd: v.get("vehicle_cd").and_then(|x| x.as_i64()).unwrap_or(0) as i32,
+        vehicle_name: v
+            .get("vehicle_name")
+            .and_then(|x| x.as_str())
+            .unwrap_or("")
+            .to_string(),
+        driver_name: v
+            .get("driver_name")
+            .and_then(|x| x.as_str())
+            .map(|s| s.to_string()),
+        address_disp_c: v
+            .get("address_disp_c")
+            .and_then(|x| x.as_str())
+            .map(|s| s.to_string()),
+        data_date_time: v
+            .get("data_date_time")
+            .and_then(|x| x.as_str())
+            .unwrap_or("")
+            .to_string(),
+        address_disp_p: v
+            .get("address_disp_p")
+            .and_then(|x| x.as_str())
+            .map(|s| s.to_string()),
+        sub_driver_cd: v.get("sub_driver_cd").and_then(|x| x.as_i64()).unwrap_or(0) as i32,
+        all_state: v
+            .get("all_state")
+            .and_then(|x| x.as_str())
+            .map(|s| s.to_string()),
+        recive_type_color_name: v
+            .get("recive_type_color_name")
+            .and_then(|x| x.as_str())
+            .map(|s| s.to_string()),
+        all_state_ex: v
+            .get("all_state_ex")
+            .and_then(|x| x.as_str())
+            .map(|s| s.to_string()),
+        state2: v
+            .get("state2")
+            .and_then(|x| x.as_str())
+            .map(|s| s.to_string()),
+        all_state_font_color: v
+            .get("all_state_font_color")
+            .and_then(|x| x.as_str())
+            .map(|s| s.to_string()),
+        speed: v.get("speed").and_then(|x| x.as_f64()).unwrap_or(0.0) as f32,
+    }
+}
+
 fn compare_schemas(archived: &SchemaMetadata, current: &SchemaMetadata) {
     let archived_cols: std::collections::HashSet<&str> =
         archived.columns.iter().map(|c| c.name.as_str()).collect();


### PR DESCRIPTION
## Summary
- dtako-logs/by-date-range が DB にないデータを R2 アーカイブから透過的に取得
- DB (直近7日) + R2 (アーカイブ) を統合して返す
- フロントエンド変更不要 (同じレスポンス形式)
- R2 取得失敗時は DB のみで返す (graceful degradation)