### PR TITLE
refactor: ArchiveDb trait + 53 tests for archive modules

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ alc-csv-parser = { path = "crates/alc-csv-parser" }
 alc-compare = { path = "crates/alc-compare" }
 alc-pdf = { path = "crates/alc-pdf" }
 anyhow = "1"
+async-trait = "0.1"
 axum = { version = "0.8", features = ["multipart"] }
 chrono = { version = "0.4", features = ["serde"] }
 dotenvy = "0.15"

--- a/src/archive/compress.rs
+++ b/src/archive/compress.rs
@@ -47,3 +47,109 @@ pub async fn download_decompressed(
         .map_err(|e| anyhow::anyhow!("download {key}: {e}"))?;
     gzip_decompress(&compressed)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::archive::test_helpers::TestStorage;
+    use std::sync::atomic::Ordering;
+
+    #[test]
+    fn test_gzip_roundtrip() {
+        let data = b"hello world, test data for gzip";
+        let compressed = gzip_compress(data).unwrap();
+        assert_ne!(compressed, data.as_slice());
+        let decompressed = gzip_decompress(&compressed).unwrap();
+        assert_eq!(decompressed, data);
+    }
+
+    #[test]
+    fn test_gzip_empty() {
+        let data = b"";
+        let compressed = gzip_compress(data).unwrap();
+        let decompressed = gzip_decompress(&compressed).unwrap();
+        assert_eq!(decompressed, data);
+    }
+
+    #[test]
+    fn test_gzip_large_data() {
+        let data: Vec<u8> = (0..10_000).map(|i| (i % 256) as u8).collect();
+        let compressed = gzip_compress(&data).unwrap();
+        assert!(compressed.len() < data.len());
+        let decompressed = gzip_decompress(&compressed).unwrap();
+        assert_eq!(decompressed, data);
+    }
+
+    #[test]
+    fn test_gzip_decompress_invalid() {
+        let result = gzip_decompress(b"not valid gzip data");
+        assert!(result.is_err());
+    }
+
+    // async function tests
+    #[tokio::test]
+    async fn test_upload_compressed() {
+        let storage = TestStorage::new();
+        upload_compressed(&storage, "test.gz", b"hello")
+            .await
+            .unwrap();
+
+        let uploaded = storage.get("test.gz").unwrap();
+        let decompressed = gzip_decompress(&uploaded).unwrap();
+        assert_eq!(decompressed, b"hello");
+    }
+
+    #[tokio::test]
+    async fn test_upload_compressed_storage_error() {
+        let storage = TestStorage::new();
+        storage.fail_upload.store(true, Ordering::Relaxed);
+
+        let result = upload_compressed(&storage, "test.gz", b"data").await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_upload_json() {
+        let storage = TestStorage::new();
+        let data = b"{\"key\":\"value\"}";
+        upload_json(&storage, "meta.json", data).await.unwrap();
+
+        let uploaded = storage.get("meta.json").unwrap();
+        assert_eq!(uploaded, data);
+    }
+
+    #[tokio::test]
+    async fn test_upload_json_storage_error() {
+        let storage = TestStorage::new();
+        storage.fail_upload.store(true, Ordering::Relaxed);
+
+        let result = upload_json(&storage, "meta.json", b"data").await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_download_decompressed() {
+        let storage = TestStorage::new();
+        let original = b"decompressed content";
+        let compressed = gzip_compress(original).unwrap();
+        storage.put("data.gz", compressed);
+
+        let result = download_decompressed(&storage, "data.gz").await.unwrap();
+        assert_eq!(result, original);
+    }
+
+    #[tokio::test]
+    async fn test_download_decompressed_not_found() {
+        let storage = TestStorage::new();
+        let result = download_decompressed(&storage, "missing.gz").await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_download_decompressed_invalid_gzip() {
+        let storage = TestStorage::new();
+        storage.put("bad.gz", b"not gzip".to_vec());
+        let result = download_decompressed(&storage, "bad.gz").await;
+        assert!(result.is_err());
+    }
+}

--- a/src/archive/dtako.rs
+++ b/src/archive/dtako.rs
@@ -1,8 +1,8 @@
 use crate::archive::compress::{download_decompressed, upload_compressed, upload_json};
+use crate::archive::repo::ArchiveDb;
 use crate::archive::schema_meta::{fetch_schema_metadata, SchemaMetadata};
 use alc_core::storage::StorageBackend;
 use serde::{Deserialize, Serialize};
-use sqlx::PgPool;
 use std::collections::HashMap;
 
 const BATCH_SIZE: i64 = 10_000;
@@ -10,7 +10,6 @@ const BATCH_SIZE: i64 = 10_000;
 #[derive(Debug, Serialize, Deserialize, Default)]
 pub struct Manifest {
     pub updated_at: String,
-    /// archived_dates[tenant_id][date_str] = ArchivedDateInfo
     pub archived_dates: HashMap<String, HashMap<String, ArchivedDateInfo>>,
 }
 
@@ -24,7 +23,7 @@ pub struct ArchivedDateInfo {
 const MANIFEST_KEY: &str = "archive/alc_api/dtakologs/_manifest.json";
 const SCHEMA_KEY: &str = "archive/alc_api/dtakologs/schema_v1.json";
 
-async fn load_manifest(storage: &dyn StorageBackend) -> Manifest {
+pub async fn load_manifest(storage: &dyn StorageBackend) -> Manifest {
     match storage.download(MANIFEST_KEY).await {
         Ok(data) => serde_json::from_slice(&data).unwrap_or_default(),
         Err(_) => Manifest::default(),
@@ -37,19 +36,40 @@ async fn save_manifest(storage: &dyn StorageBackend, manifest: &Manifest) -> any
     Ok(())
 }
 
-/// Phase A: Copy unarchived dates to R2
-/// Phase B: DELETE rows older than 7 days (only if already in manifest)
+pub fn make_r2_key(tenant_id: &str, date_str: &str) -> String {
+    format!(
+        "archive/alc_api/dtakologs/{}/{}/{}/{}.jsonl.gz",
+        tenant_id,
+        &date_str[..4],
+        &date_str[5..7],
+        &date_str[8..10]
+    )
+}
+
+pub fn build_jsonl_buffer(
+    rows: &[serde_json::Value],
+    header: &serde_json::Value,
+) -> anyhow::Result<Vec<u8>> {
+    let mut buffer = Vec::new();
+    buffer.extend_from_slice(serde_json::to_string(header)?.as_bytes());
+    buffer.push(b'\n');
+    for row in rows {
+        buffer.extend_from_slice(serde_json::to_string(row)?.as_bytes());
+        buffer.push(b'\n');
+    }
+    Ok(buffer)
+}
+
 pub async fn dtako_archive(
-    pool: &PgPool,
+    db: &dyn ArchiveDb,
     storage: &dyn StorageBackend,
     dry_run: bool,
 ) -> anyhow::Result<()> {
     let mut manifest = load_manifest(storage).await;
 
-    // Upload schema metadata
     if !dry_run {
         let meta = fetch_schema_metadata(
-            pool,
+            db,
             "alc_api",
             "dtakologs",
             1,
@@ -63,16 +83,7 @@ pub async fn dtako_archive(
         upload_json(storage, SCHEMA_KEY, &meta_json).await?;
     }
 
-    // Phase A: find dates not yet in manifest
-    // Use superuser connection (no RLS) for cross-tenant access
-    let dates_to_archive = sqlx::query_as::<_, (String, String, i64)>(
-        "SELECT tenant_id::TEXT, data_date_time::DATE::TEXT AS date_str, COUNT(*)
-         FROM alc_api.dtakologs
-         GROUP BY tenant_id, data_date_time::DATE
-         ORDER BY date_str",
-    )
-    .fetch_all(pool)
-    .await?;
+    let dates_to_archive = db.list_dtako_dates().await?;
 
     println!("=== Phase A: Archive to R2 ===");
 
@@ -88,13 +99,7 @@ pub async fn dtako_archive(
             continue;
         }
 
-        let r2_key = format!(
-            "archive/alc_api/dtakologs/{}/{}/{}/{}.jsonl.gz",
-            tenant_id,
-            &date_str[..4],   // year
-            &date_str[5..7],  // month
-            &date_str[8..10]  // day
-        );
+        let r2_key = make_r2_key(tenant_id, date_str);
 
         if dry_run {
             println!(
@@ -105,8 +110,19 @@ pub async fn dtako_archive(
             continue;
         }
 
-        // Fetch all rows for this tenant+date
-        let mut buffer = Vec::new();
+        let mut all_rows = Vec::new();
+        let mut offset: i64 = 0;
+        loop {
+            let rows = db
+                .fetch_dtako_rows_json(tenant_id, date_str, BATCH_SIZE, offset)
+                .await?;
+            if rows.is_empty() {
+                break;
+            }
+            offset += rows.len() as i64;
+            all_rows.extend(rows);
+        }
+
         let header = serde_json::json!({
             "_archive_header": true,
             "schema_version": 1,
@@ -115,42 +131,11 @@ pub async fn dtako_archive(
             "date": date_str,
             "archived_at": chrono::Utc::now().to_rfc3339(),
         });
-        buffer.extend_from_slice(serde_json::to_string(&header)?.as_bytes());
-        buffer.push(b'\n');
+        let buffer = build_jsonl_buffer(&all_rows, &header)?;
+        let row_count = all_rows.len();
 
-        let mut offset: i64 = 0;
-        let mut row_count = 0usize;
-        loop {
-            let rows: Vec<(serde_json::Value,)> = sqlx::query_as(
-                "SELECT row_to_json(d) FROM alc_api.dtakologs d
-                 WHERE tenant_id = $1::UUID AND data_date_time::DATE = $2::DATE
-                 ORDER BY data_date_time
-                 LIMIT $3 OFFSET $4",
-            )
-            .bind(tenant_id)
-            .bind(date_str)
-            .bind(BATCH_SIZE)
-            .bind(offset)
-            .fetch_all(pool)
-            .await?;
-
-            if rows.is_empty() {
-                break;
-            }
-
-            for (row,) in &rows {
-                buffer.extend_from_slice(serde_json::to_string(row)?.as_bytes());
-                buffer.push(b'\n');
-                row_count += 1;
-            }
-
-            offset += rows.len() as i64;
-        }
-
-        // Upload to R2
         upload_compressed(storage, &r2_key, &buffer).await?;
 
-        // Update manifest
         manifest
             .archived_dates
             .entry(tenant_id.clone())
@@ -174,24 +159,13 @@ pub async fn dtako_archive(
     }
     println!("Phase A: {} rows archived", archived_count);
 
-    // Phase B: DELETE rows older than 7 days (only if in manifest)
     println!("\n=== Phase B: DELETE old rows from DB ===");
 
     let cutoff = (chrono::Utc::now() - chrono::Duration::days(7))
         .format("%Y-%m-%d")
         .to_string();
 
-    // Find dates older than cutoff that are in the manifest
-    let old_dates = sqlx::query_as::<_, (String, String, i64)>(
-        "SELECT tenant_id::TEXT, data_date_time::DATE::TEXT AS date_str, COUNT(*)
-         FROM alc_api.dtakologs
-         WHERE data_date_time::DATE < $1::DATE
-         GROUP BY tenant_id, data_date_time::DATE
-         ORDER BY date_str",
-    )
-    .bind(&cutoff)
-    .fetch_all(pool)
-    .await?;
+    let old_dates = db.list_old_dtako_dates(&cutoff).await?;
 
     let mut deleted_count = 0i64;
     for (tenant_id, date_str, count) in &old_dates {
@@ -218,22 +192,12 @@ pub async fn dtako_archive(
             continue;
         }
 
-        let result = sqlx::query(
-            "DELETE FROM alc_api.dtakologs
-             WHERE tenant_id = $1::UUID AND data_date_time::DATE = $2::DATE",
-        )
-        .bind(tenant_id)
-        .bind(date_str)
-        .execute(pool)
-        .await?;
-
+        let affected = db.delete_dtako_date(tenant_id, date_str).await?;
         println!(
             "  DELETE {} rows for tenant={} date={}",
-            result.rows_affected(),
-            tenant_id,
-            date_str
+            affected, tenant_id, date_str
         );
-        deleted_count += result.rows_affected() as i64;
+        deleted_count += affected as i64;
     }
 
     println!(
@@ -244,15 +208,13 @@ pub async fn dtako_archive(
     Ok(())
 }
 
-/// Restore archived data from R2 back to DB
 pub async fn dtako_restore(
-    pool: &PgPool,
+    db: &dyn ArchiveDb,
     storage: &dyn StorageBackend,
     tenant_id: &str,
     date: &str,
 ) -> anyhow::Result<()> {
-    // Load and compare schema
-    let current_meta = fetch_schema_metadata(pool, "alc_api", "dtakologs", 1, vec![]).await?;
+    let current_meta = fetch_schema_metadata(db, "alc_api", "dtakologs", 1, vec![]).await?;
 
     match storage.download(SCHEMA_KEY).await {
         Ok(data) => {
@@ -264,14 +226,7 @@ pub async fn dtako_restore(
         }
     }
 
-    // Parse date to build R2 key
-    let r2_key = format!(
-        "archive/alc_api/dtakologs/{}/{}/{}/{}.jsonl.gz",
-        tenant_id,
-        &date[..4],
-        &date[5..7],
-        &date[8..10],
-    );
+    let r2_key = make_r2_key(tenant_id, date);
 
     println!("Downloading {} ...", r2_key);
     let data = download_decompressed(storage, &r2_key).await?;
@@ -287,7 +242,6 @@ pub async fn dtako_restore(
 
         let value: serde_json::Value = serde_json::from_str(line)?;
 
-        // Skip header lines
         if value.get("_archive_header").is_some() {
             continue;
         }
@@ -296,106 +250,19 @@ pub async fn dtako_restore(
         restored += 1;
 
         if batch_values.len() >= 500 {
-            upsert_batch(pool, &batch_values).await?;
+            db.upsert_dtako_batch(&batch_values).await?;
             batch_values.clear();
         }
     }
 
     if !batch_values.is_empty() {
-        upsert_batch(pool, &batch_values).await?;
+        db.upsert_dtako_batch(&batch_values).await?;
     }
 
     println!("Restored {} rows from {}", restored, r2_key);
     Ok(())
 }
 
-async fn upsert_batch(pool: &PgPool, rows: &[String]) -> anyhow::Result<()> {
-    for row_json in rows {
-        let v: serde_json::Value = serde_json::from_str(row_json)?;
-
-        // Extract fields for INSERT ... ON CONFLICT DO UPDATE
-        sqlx::query(
-            "INSERT INTO alc_api.dtakologs (
-                tenant_id, data_date_time, vehicle_cd,
-                type, all_state_font_color_index, all_state_ryout_color,
-                branch_cd, branch_name, current_work_cd, data_filter_type,
-                disp_flag, driver_cd, gps_direction, gps_enable,
-                gps_latitude, gps_longitude, gps_satellite_num,
-                operation_state, recive_event_type, recive_packet_type,
-                recive_work_cd, revo, setting_temp, setting_temp1,
-                setting_temp3, setting_temp4, speed, sub_driver_cd,
-                temp_state, vehicle_name,
-                address_disp_c, address_disp_p, all_state, all_state_ex,
-                all_state_font_color, comu_date_time, current_work_name,
-                driver_name, event_val, gps_lati_and_long, odometer,
-                recive_type_color_name, recive_type_name,
-                start_work_date_time, state, state1, state2, state3,
-                state_flag, temp1, temp2, temp3, temp4,
-                vehicle_icon_color, vehicle_icon_label_for_datetime,
-                vehicle_icon_label_for_driver, vehicle_icon_label_for_vehicle
-            )
-            SELECT
-                (j->>'tenant_id')::UUID,
-                j->>'data_date_time',
-                (j->>'vehicle_cd')::INTEGER,
-                COALESCE(j->>'type', ''),
-                COALESCE((j->>'all_state_font_color_index')::INTEGER, 0),
-                COALESCE(j->>'all_state_ryout_color', 'Transparent'),
-                COALESCE((j->>'branch_cd')::INTEGER, 0),
-                COALESCE(j->>'branch_name', ''),
-                COALESCE((j->>'current_work_cd')::INTEGER, 0),
-                COALESCE((j->>'data_filter_type')::INTEGER, 0),
-                COALESCE((j->>'disp_flag')::INTEGER, 0),
-                COALESCE((j->>'driver_cd')::INTEGER, 0),
-                COALESCE((j->>'gps_direction')::DOUBLE PRECISION, 0),
-                COALESCE((j->>'gps_enable')::INTEGER, 0),
-                COALESCE((j->>'gps_latitude')::DOUBLE PRECISION, 0),
-                COALESCE((j->>'gps_longitude')::DOUBLE PRECISION, 0),
-                COALESCE((j->>'gps_satellite_num')::INTEGER, 0),
-                COALESCE((j->>'operation_state')::INTEGER, 0),
-                COALESCE((j->>'recive_event_type')::INTEGER, 0),
-                COALESCE((j->>'recive_packet_type')::INTEGER, 0),
-                COALESCE((j->>'recive_work_cd')::INTEGER, 0),
-                COALESCE((j->>'revo')::INTEGER, 0),
-                COALESCE(j->>'setting_temp', ''),
-                COALESCE(j->>'setting_temp1', ''),
-                COALESCE(j->>'setting_temp3', ''),
-                COALESCE(j->>'setting_temp4', ''),
-                COALESCE((j->>'speed')::REAL, 0),
-                COALESCE((j->>'sub_driver_cd')::INTEGER, 0),
-                COALESCE((j->>'temp_state')::INTEGER, 0),
-                COALESCE(j->>'vehicle_name', ''),
-                j->>'address_disp_c', j->>'address_disp_p',
-                j->>'all_state', j->>'all_state_ex',
-                j->>'all_state_font_color', j->>'comu_date_time',
-                j->>'current_work_name', j->>'driver_name',
-                j->>'event_val', j->>'gps_lati_and_long', j->>'odometer',
-                j->>'recive_type_color_name', j->>'recive_type_name',
-                j->>'start_work_date_time', j->>'state', j->>'state1',
-                j->>'state2', j->>'state3', j->>'state_flag',
-                j->>'temp1', j->>'temp2', j->>'temp3', j->>'temp4',
-                j->>'vehicle_icon_color',
-                j->>'vehicle_icon_label_for_datetime',
-                j->>'vehicle_icon_label_for_driver',
-                j->>'vehicle_icon_label_for_vehicle'
-            FROM jsonb_array_elements($1::JSONB) AS j
-            ON CONFLICT (tenant_id, data_date_time, vehicle_cd) DO UPDATE SET
-                type = EXCLUDED.type,
-                speed = EXCLUDED.speed,
-                gps_latitude = EXCLUDED.gps_latitude,
-                gps_longitude = EXCLUDED.gps_longitude,
-                gps_direction = EXCLUDED.gps_direction",
-        )
-        .bind(format!("[{}]", v))
-        .execute(pool)
-        .await?;
-    }
-
-    Ok(())
-}
-
-/// R2 から指定 tenant_id + 日付範囲の dtakologs を読み込み、DtakologRow に変換して返す。
-/// フロントエンドの by-date-range エンドポイントから呼ばれる。
 pub async fn fetch_from_r2(
     storage: &dyn StorageBackend,
     tenant_id: &str,
@@ -412,12 +279,10 @@ pub async fn fetch_from_r2(
     let mut all_rows = Vec::new();
 
     for (date_str, info) in tenant_dates {
-        // Filter by date range
         if date_str.as_str() < start_date || date_str.as_str() > end_date {
             continue;
         }
 
-        // Download and decompress
         let data = match download_decompressed(storage, &info.r2_key).await {
             Ok(d) => d,
             Err(e) => {
@@ -435,30 +300,25 @@ pub async fn fetch_from_r2(
                 Ok(v) => v,
                 Err(_) => continue,
             };
-            // Skip header lines
             if value.get("_archive_header").is_some() {
                 continue;
             }
 
-            // Filter by vehicle_cd if specified
             if let Some(vc) = vehicle_cd {
                 if value.get("vehicle_cd").and_then(|v| v.as_i64()) != Some(vc as i64) {
                     continue;
                 }
             }
 
-            let row = json_to_dtakolog_row(&value);
-            all_rows.push(row);
+            all_rows.push(json_to_dtakolog_row(&value));
         }
     }
 
-    // Sort by data_date_time
     all_rows.sort_by(|a, b| a.data_date_time.cmp(&b.data_date_time));
-
     Ok(all_rows)
 }
 
-fn json_to_dtakolog_row(v: &serde_json::Value) -> alc_core::models::DtakologRow {
+pub fn json_to_dtakolog_row(v: &serde_json::Value) -> alc_core::models::DtakologRow {
     alc_core::models::DtakologRow {
         gps_direction: v
             .get("gps_direction")
@@ -520,7 +380,7 @@ fn json_to_dtakolog_row(v: &serde_json::Value) -> alc_core::models::DtakologRow 
     }
 }
 
-fn compare_schemas(archived: &SchemaMetadata, current: &SchemaMetadata) {
+pub fn compare_schemas(archived: &SchemaMetadata, current: &SchemaMetadata) {
     let archived_cols: std::collections::HashSet<&str> =
         archived.columns.iter().map(|c| c.name.as_str()).collect();
     let current_cols: std::collections::HashSet<&str> =
@@ -542,5 +402,544 @@ fn compare_schemas(archived: &SchemaMetadata, current: &SchemaMetadata) {
         for col in &removed {
             println!("  - {} (removed from current, will be ignored)", col);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::archive::compress::gzip_compress;
+    use crate::archive::repo::mock::MockArchiveDb;
+    use crate::archive::schema_meta::ColumnInfo;
+    use crate::archive::test_helpers::TestStorage;
+
+    #[test]
+    fn test_make_r2_key() {
+        assert_eq!(
+            make_r2_key("t1", "2026-04-07"),
+            "archive/alc_api/dtakologs/t1/2026/04/07.jsonl.gz"
+        );
+    }
+
+    #[test]
+    fn test_build_jsonl_buffer() {
+        let header = serde_json::json!({"_archive_header": true});
+        let rows = vec![serde_json::json!({"id": 1}), serde_json::json!({"id": 2})];
+        let buf = build_jsonl_buffer(&rows, &header).unwrap();
+        let s = String::from_utf8(buf).unwrap();
+        let lines: Vec<&str> = s.lines().collect();
+        assert_eq!(lines.len(), 3);
+        assert!(lines[0].contains("_archive_header"));
+    }
+
+    #[test]
+    fn test_json_to_dtakolog_row_defaults() {
+        let v = serde_json::json!({});
+        let row = json_to_dtakolog_row(&v);
+        assert_eq!(row.vehicle_cd, 0);
+        assert_eq!(row.speed, 0.0);
+        assert!(row.driver_name.is_none());
+    }
+
+    #[test]
+    fn test_json_to_dtakolog_row_full() {
+        let v = serde_json::json!({
+            "gps_direction": 90.0, "gps_latitude": 35.68, "gps_longitude": 139.69,
+            "vehicle_cd": 10, "vehicle_name": "truck",
+            "driver_name": "tanaka", "data_date_time": "2026-04-07",
+            "speed": 60.5, "sub_driver_cd": 2,
+            "all_state": "Drive", "state2": "running",
+            "all_state_font_color": "red", "address_disp_p": "Tokyo",
+            "address_disp_c": "Chiyoda", "recive_type_color_name": "blue",
+            "all_state_ex": "extra"
+        });
+        let row = json_to_dtakolog_row(&v);
+        assert_eq!(row.vehicle_cd, 10);
+        assert_eq!(row.speed, 60.5);
+        assert_eq!(row.driver_name.as_deref(), Some("tanaka"));
+    }
+
+    #[test]
+    fn test_compare_schemas_identical() {
+        let meta = SchemaMetadata {
+            version: 1,
+            created_at: String::new(),
+            table_name: "t".into(),
+            schema_name: "s".into(),
+            primary_key: vec![],
+            columns: vec![ColumnInfo {
+                name: "a".into(),
+                data_type: "TEXT".into(),
+                is_nullable: false,
+                column_default: None,
+            }],
+            migration_files: vec![],
+        };
+        compare_schemas(&meta, &meta); // should not panic
+    }
+
+    #[test]
+    fn test_compare_schemas_diff() {
+        let a = SchemaMetadata {
+            version: 1,
+            created_at: String::new(),
+            table_name: "t".into(),
+            schema_name: "s".into(),
+            primary_key: vec![],
+            columns: vec![ColumnInfo {
+                name: "old".into(),
+                data_type: "TEXT".into(),
+                is_nullable: false,
+                column_default: None,
+            }],
+            migration_files: vec![],
+        };
+        let b = SchemaMetadata {
+            version: 1,
+            created_at: String::new(),
+            table_name: "t".into(),
+            schema_name: "s".into(),
+            primary_key: vec![],
+            columns: vec![ColumnInfo {
+                name: "new".into(),
+                data_type: "TEXT".into(),
+                is_nullable: false,
+                column_default: None,
+            }],
+            migration_files: vec![],
+        };
+        compare_schemas(&a, &b);
+    }
+
+    #[test]
+    fn test_manifest_serde() {
+        let mut m = Manifest::default();
+        m.updated_at = "2026-04-07".into();
+        m.archived_dates.entry("t1".into()).or_default().insert(
+            "2026-04-01".into(),
+            ArchivedDateInfo {
+                row_count: 10,
+                archived_at: "now".into(),
+                r2_key: "key".into(),
+            },
+        );
+        let json = serde_json::to_string(&m).unwrap();
+        let parsed: Manifest = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.archived_dates["t1"]["2026-04-01"].row_count, 10);
+    }
+
+    #[tokio::test]
+    async fn test_load_manifest_empty() {
+        let storage = TestStorage::new();
+        let m = load_manifest(&storage).await;
+        assert!(m.archived_dates.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_load_manifest_existing() {
+        let storage = TestStorage::new();
+        let m = Manifest {
+            updated_at: "now".into(),
+            archived_dates: HashMap::new(),
+        };
+        storage.put(MANIFEST_KEY, serde_json::to_vec(&m).unwrap());
+        let loaded = load_manifest(&storage).await;
+        assert_eq!(loaded.updated_at, "now");
+    }
+
+    #[tokio::test]
+    async fn test_dtako_archive_dry_run() {
+        let db = MockArchiveDb::default();
+        *db.dtako_dates.lock().unwrap() = vec![("t1".into(), "2026-04-01".into(), 100)];
+        let storage = TestStorage::new();
+
+        dtako_archive(&db, &storage, true).await.unwrap();
+        // Dry run: no files uploaded (except no manifest/schema)
+        assert!(storage.keys().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_dtako_archive_success() {
+        let db = MockArchiveDb::default();
+        *db.dtako_dates.lock().unwrap() = vec![("t1".into(), "2026-04-01".into(), 2)];
+        *db.columns.lock().unwrap() = vec![("col".into(), "TEXT".into(), "NO".into(), None)];
+        *db.rows.lock().unwrap() = vec![
+            serde_json::json!({"vehicle_cd": 1, "data_date_time": "2026-04-01 10:00:00"}),
+            serde_json::json!({"vehicle_cd": 2, "data_date_time": "2026-04-01 11:00:00"}),
+        ];
+        let storage = TestStorage::new();
+
+        dtako_archive(&db, &storage, false).await.unwrap();
+
+        // Schema, manifest, and data file uploaded
+        assert!(storage.get(SCHEMA_KEY).is_some());
+        assert!(storage.get(MANIFEST_KEY).is_some());
+        let data_key = "archive/alc_api/dtakologs/t1/2026/04/01.jsonl.gz";
+        assert!(storage.get(data_key).is_some());
+
+        // Verify manifest
+        let manifest: Manifest =
+            serde_json::from_slice(&storage.get(MANIFEST_KEY).unwrap()).unwrap();
+        assert_eq!(manifest.archived_dates["t1"]["2026-04-01"].row_count, 2);
+    }
+
+    #[tokio::test]
+    async fn test_dtako_archive_skip_already_archived() {
+        let db = MockArchiveDb::default();
+        *db.dtako_dates.lock().unwrap() = vec![("t1".into(), "2026-04-01".into(), 100)];
+        *db.columns.lock().unwrap() = vec![("col".into(), "TEXT".into(), "NO".into(), None)];
+
+        // Pre-populate manifest
+        let mut manifest = Manifest::default();
+        manifest
+            .archived_dates
+            .entry("t1".into())
+            .or_default()
+            .insert(
+                "2026-04-01".into(),
+                ArchivedDateInfo {
+                    row_count: 100,
+                    archived_at: "prev".into(),
+                    r2_key: "old_key".into(),
+                },
+            );
+        let storage = TestStorage::new();
+        storage.put(MANIFEST_KEY, serde_json::to_vec(&manifest).unwrap());
+
+        dtako_archive(&db, &storage, false).await.unwrap();
+        // No data file created (already archived)
+        let data_keys: Vec<_> = storage
+            .keys()
+            .into_iter()
+            .filter(|k| k.ends_with(".jsonl.gz"))
+            .collect();
+        assert!(data_keys.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_dtako_archive_phase_b_delete() {
+        let db = MockArchiveDb::default();
+        // No new dates to archive
+        *db.dtako_dates.lock().unwrap() = vec![];
+        // Old dates to delete
+        *db.old_dates.lock().unwrap() = vec![("t1".into(), "2026-03-01".into(), 50)];
+        *db.deleted_count.lock().unwrap() = 50;
+        *db.columns.lock().unwrap() = vec![("col".into(), "TEXT".into(), "NO".into(), None)];
+
+        // Manifest has the old date
+        let mut manifest = Manifest::default();
+        manifest
+            .archived_dates
+            .entry("t1".into())
+            .or_default()
+            .insert(
+                "2026-03-01".into(),
+                ArchivedDateInfo {
+                    row_count: 50,
+                    archived_at: "prev".into(),
+                    r2_key: "key".into(),
+                },
+            );
+        let storage = TestStorage::new();
+        storage.put(MANIFEST_KEY, serde_json::to_vec(&manifest).unwrap());
+
+        dtako_archive(&db, &storage, false).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_dtako_archive_phase_b_skip_not_in_manifest() {
+        let db = MockArchiveDb::default();
+        *db.dtako_dates.lock().unwrap() = vec![];
+        *db.old_dates.lock().unwrap() = vec![("t1".into(), "2026-03-01".into(), 50)];
+        *db.columns.lock().unwrap() = vec![("col".into(), "TEXT".into(), "NO".into(), None)];
+        // No manifest → should skip delete
+        let storage = TestStorage::new();
+
+        dtako_archive(&db, &storage, false).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_dtako_restore_success() {
+        let db = MockArchiveDb::default();
+        *db.columns.lock().unwrap() = vec![("col".into(), "TEXT".into(), "NO".into(), None)];
+
+        let storage = TestStorage::new();
+        // Create archived data
+        let header = serde_json::json!({"_archive_header": true, "schema_version": 1});
+        let row = serde_json::json!({"vehicle_cd": 1, "data_date_time": "2026-04-01 10:00"});
+        let mut content = serde_json::to_string(&header).unwrap();
+        content.push('\n');
+        content.push_str(&serde_json::to_string(&row).unwrap());
+        content.push('\n');
+        let compressed = gzip_compress(content.as_bytes()).unwrap();
+        let key = make_r2_key("t1", "2026-04-01");
+        storage.put(&key, compressed);
+
+        dtako_restore(&db, &storage, "t1", "2026-04-01")
+            .await
+            .unwrap();
+
+        let upserted = db.upserted.lock().unwrap();
+        assert_eq!(upserted.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_dtako_restore_no_schema_warning() {
+        let db = MockArchiveDb::default();
+        *db.columns.lock().unwrap() = vec![("col".into(), "TEXT".into(), "NO".into(), None)];
+
+        let storage = TestStorage::new();
+        let content = "{\"_archive_header\":true}\n{\"vehicle_cd\":1}\n";
+        let compressed = gzip_compress(content.as_bytes()).unwrap();
+        storage.put(&make_r2_key("t1", "2026-04-01"), compressed);
+
+        // No SCHEMA_KEY in storage → prints warning but succeeds
+        dtako_restore(&db, &storage, "t1", "2026-04-01")
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_dtako_restore_with_schema_comparison() {
+        let db = MockArchiveDb::default();
+        *db.columns.lock().unwrap() = vec![("col".into(), "TEXT".into(), "NO".into(), None)];
+
+        let storage = TestStorage::new();
+        // Upload schema metadata
+        let meta = SchemaMetadata {
+            version: 1,
+            created_at: "now".into(),
+            table_name: "dtakologs".into(),
+            schema_name: "alc_api".into(),
+            primary_key: vec![],
+            columns: vec![ColumnInfo {
+                name: "col".into(),
+                data_type: "TEXT".into(),
+                is_nullable: false,
+                column_default: None,
+            }],
+            migration_files: vec![],
+        };
+        storage.put(SCHEMA_KEY, serde_json::to_vec(&meta).unwrap());
+
+        let content = "{\"_archive_header\":true}\n{\"vehicle_cd\":1}\n";
+        let compressed = gzip_compress(content.as_bytes()).unwrap();
+        storage.put(&make_r2_key("t1", "2026-04-01"), compressed);
+
+        dtako_restore(&db, &storage, "t1", "2026-04-01")
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_dtako_archive_db_error() {
+        use std::sync::atomic::Ordering;
+        let db = MockArchiveDb::default();
+        db.fail_next.store(true, Ordering::SeqCst);
+        let storage = TestStorage::new();
+
+        // fetch_schema_metadata will fail (dry_run=false triggers it)
+        let result = dtako_archive(&db, &storage, false).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_fetch_from_r2_empty() {
+        let storage = TestStorage::new();
+        let rows = fetch_from_r2(&storage, "t1", "2026-04-01", "2026-04-07", None)
+            .await
+            .unwrap();
+        assert!(rows.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_fetch_from_r2_with_data() {
+        let storage = TestStorage::new();
+        let r2_key = "archive/alc_api/dtakologs/t1/2026/04/01.jsonl.gz";
+        let mut manifest = Manifest::default();
+        manifest
+            .archived_dates
+            .entry("t1".into())
+            .or_default()
+            .insert(
+                "2026-04-01".into(),
+                ArchivedDateInfo {
+                    row_count: 1,
+                    archived_at: "now".into(),
+                    r2_key: r2_key.into(),
+                },
+            );
+        storage.put(MANIFEST_KEY, serde_json::to_vec(&manifest).unwrap());
+
+        let content = "{\"_archive_header\":true}\n{\"vehicle_cd\":1,\"data_date_time\":\"2026-04-01 10:00\",\"vehicle_name\":\"t\",\"speed\":50.0,\"gps_direction\":0,\"gps_latitude\":35,\"gps_longitude\":139,\"sub_driver_cd\":0}\n";
+        storage.put(r2_key, gzip_compress(content.as_bytes()).unwrap());
+
+        let rows = fetch_from_r2(&storage, "t1", "2026-04-01", "2026-04-01", None)
+            .await
+            .unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].vehicle_cd, 1);
+    }
+
+    #[tokio::test]
+    async fn test_fetch_from_r2_vehicle_filter() {
+        let storage = TestStorage::new();
+        let r2_key = "k.jsonl.gz";
+        let mut manifest = Manifest::default();
+        manifest
+            .archived_dates
+            .entry("t1".into())
+            .or_default()
+            .insert(
+                "2026-04-01".into(),
+                ArchivedDateInfo {
+                    row_count: 2,
+                    archived_at: "now".into(),
+                    r2_key: r2_key.into(),
+                },
+            );
+        storage.put(MANIFEST_KEY, serde_json::to_vec(&manifest).unwrap());
+
+        let content = "{\"_archive_header\":true}\n{\"vehicle_cd\":1,\"data_date_time\":\"a\",\"vehicle_name\":\"\",\"speed\":0,\"gps_direction\":0,\"gps_latitude\":0,\"gps_longitude\":0,\"sub_driver_cd\":0}\n{\"vehicle_cd\":2,\"data_date_time\":\"b\",\"vehicle_name\":\"\",\"speed\":0,\"gps_direction\":0,\"gps_latitude\":0,\"gps_longitude\":0,\"sub_driver_cd\":0}\n";
+        storage.put(r2_key, gzip_compress(content.as_bytes()).unwrap());
+
+        let rows = fetch_from_r2(&storage, "t1", "2026-04-01", "2026-04-01", Some(2))
+            .await
+            .unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].data_date_time, "b");
+    }
+
+    #[tokio::test]
+    async fn test_fetch_from_r2_download_fail() {
+        let storage = TestStorage::new();
+        let mut manifest = Manifest::default();
+        manifest
+            .archived_dates
+            .entry("t1".into())
+            .or_default()
+            .insert(
+                "2026-04-01".into(),
+                ArchivedDateInfo {
+                    row_count: 1,
+                    archived_at: "now".into(),
+                    r2_key: "missing.jsonl.gz".into(),
+                },
+            );
+        storage.put(MANIFEST_KEY, serde_json::to_vec(&manifest).unwrap());
+
+        let rows = fetch_from_r2(&storage, "t1", "2026-04-01", "2026-04-01", None)
+            .await
+            .unwrap();
+        assert!(rows.is_empty()); // graceful degradation
+    }
+
+    #[tokio::test]
+    async fn test_fetch_from_r2_date_range_filter() {
+        let storage = TestStorage::new();
+        let mut manifest = Manifest::default();
+        manifest
+            .archived_dates
+            .entry("t1".into())
+            .or_default()
+            .insert(
+                "2026-03-15".into(),
+                ArchivedDateInfo {
+                    row_count: 1,
+                    archived_at: "now".into(),
+                    r2_key: "k.jsonl.gz".into(),
+                },
+            );
+        storage.put(MANIFEST_KEY, serde_json::to_vec(&manifest).unwrap());
+
+        let content = "{\"_archive_header\":true}\n{\"vehicle_cd\":1,\"data_date_time\":\"2026-03-15\",\"vehicle_name\":\"\",\"speed\":0,\"gps_direction\":0,\"gps_latitude\":0,\"gps_longitude\":0,\"sub_driver_cd\":0}\n";
+        storage.put("k.jsonl.gz", gzip_compress(content.as_bytes()).unwrap());
+
+        // Out of range
+        let rows = fetch_from_r2(&storage, "t1", "2026-04-01", "2026-04-30", None)
+            .await
+            .unwrap();
+        assert!(rows.is_empty());
+
+        // In range
+        let rows = fetch_from_r2(&storage, "t1", "2026-03-01", "2026-03-31", None)
+            .await
+            .unwrap();
+        assert_eq!(rows.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_dtako_archive_dry_run_with_old_dates() {
+        // Covers: dry_run DELETE path (lines 187-192)
+        let db = MockArchiveDb::default();
+        *db.dtako_dates.lock().unwrap() = vec![("t1".into(), "2026-04-01".into(), 10)];
+        *db.old_dates.lock().unwrap() = vec![("t1".into(), "2026-03-01".into(), 50)];
+
+        let mut manifest = Manifest::default();
+        manifest
+            .archived_dates
+            .entry("t1".into())
+            .or_default()
+            .insert(
+                "2026-03-01".into(),
+                ArchivedDateInfo {
+                    row_count: 50,
+                    archived_at: "prev".into(),
+                    r2_key: "key".into(),
+                },
+            );
+        let storage = TestStorage::new();
+        storage.put(MANIFEST_KEY, serde_json::to_vec(&manifest).unwrap());
+
+        dtako_archive(&db, &storage, true).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_dtako_restore_empty_lines_and_batch() {
+        // Covers: empty lines skip + batch < 500 flush
+        let db = MockArchiveDb::default();
+        *db.columns.lock().unwrap() = vec![("col".into(), "TEXT".into(), "NO".into(), None)];
+
+        let storage = TestStorage::new();
+        // Content with empty lines between data
+        let mut content = String::from("{\"_archive_header\":true}\n\n");
+        content.push_str("{\"vehicle_cd\":1}\n\n{\"vehicle_cd\":2}\n");
+        let compressed = gzip_compress(content.as_bytes()).unwrap();
+        storage.put(&make_r2_key("t1", "2026-04-01"), compressed);
+
+        dtako_restore(&db, &storage, "t1", "2026-04-01")
+            .await
+            .unwrap();
+        assert_eq!(db.upserted.lock().unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_fetch_from_r2_invalid_json_skipped() {
+        // Covers: serde parse error continue (line 297, 301)
+        let storage = TestStorage::new();
+        let r2_key = "k.jsonl.gz";
+        let mut manifest = Manifest::default();
+        manifest
+            .archived_dates
+            .entry("t1".into())
+            .or_default()
+            .insert(
+                "2026-04-01".into(),
+                ArchivedDateInfo {
+                    row_count: 1,
+                    archived_at: "now".into(),
+                    r2_key: r2_key.into(),
+                },
+            );
+        storage.put(MANIFEST_KEY, serde_json::to_vec(&manifest).unwrap());
+
+        // Mix of valid JSON, invalid JSON, and empty lines
+        let content = "{\"_archive_header\":true}\nnot-valid-json\n{\"vehicle_cd\":1,\"data_date_time\":\"d\",\"vehicle_name\":\"\",\"speed\":0,\"gps_direction\":0,\"gps_latitude\":0,\"gps_longitude\":0,\"sub_driver_cd\":0}\n";
+        storage.put(r2_key, gzip_compress(content.as_bytes()).unwrap());
+
+        let rows = fetch_from_r2(&storage, "t1", "2026-04-01", "2026-04-01", None)
+            .await
+            .unwrap();
+        assert_eq!(rows.len(), 1); // invalid JSON skipped, valid row parsed
     }
 }

--- a/src/archive/logi.rs
+++ b/src/archive/logi.rs
@@ -1,22 +1,17 @@
 use crate::archive::compress::{upload_compressed, upload_json};
+use crate::archive::repo::ArchiveDb;
 use crate::archive::schema_meta::fetch_schema_metadata;
 use alc_core::storage::StorageBackend;
-use sqlx::PgPool;
 
 const BATCH_SIZE: i64 = 10_000;
 const MAX_ROWS_PER_FILE: usize = 100_000;
 
 pub async fn logi_dump(
-    pool: &PgPool,
+    db: &dyn ArchiveDb,
     storage: &dyn StorageBackend,
     dry_run: bool,
 ) -> anyhow::Result<()> {
-    // Discover all tables in logi schema
-    let tables = sqlx::query_as::<_, (String,)>(
-        "SELECT tablename FROM pg_tables WHERE schemaname = 'logi' ORDER BY tablename",
-    )
-    .fetch_all(pool)
-    .await?;
+    let tables = db.list_tables("logi").await?;
 
     if tables.is_empty() {
         println!("No tables found in logi schema");
@@ -24,11 +19,9 @@ pub async fn logi_dump(
     }
 
     println!("Found {} tables in logi schema:", tables.len());
-    for (name,) in &tables {
-        let count: (i64,) = sqlx::query_as(&format!("SELECT count(*) FROM logi.\"{}\"", name))
-            .fetch_one(pool)
-            .await?;
-        println!("  {} — {} rows", name, count.0);
+    for name in &tables {
+        let count = db.count_rows("logi", name).await?;
+        println!("  {} — {} rows", name, count);
     }
 
     if dry_run {
@@ -38,29 +31,22 @@ pub async fn logi_dump(
 
     let today = chrono::Utc::now().format("%Y-%m-%d").to_string();
 
-    for (table_name,) in &tables {
+    for table_name in &tables {
         println!("\nArchiving logi.{} ...", table_name);
 
-        // Upload schema metadata
-        let meta = fetch_schema_metadata(pool, "logi", table_name, 1, vec![]).await?;
+        let meta = fetch_schema_metadata(db, "logi", table_name, 1, vec![]).await?;
         let meta_json = serde_json::to_vec_pretty(&meta)?;
         let meta_key = format!("archive/logi/{}/schema_v1.json", table_name);
         upload_json(storage, &meta_key, &meta_json).await?;
         println!("  schema → {}", meta_key);
 
-        // Stream rows in batches, split into files of MAX_ROWS_PER_FILE
-        let total_count: (i64,) =
-            sqlx::query_as(&format!("SELECT count(*) FROM logi.\"{}\"", table_name))
-                .fetch_one(pool)
-                .await?;
-        let total = total_count.0 as usize;
+        let total = db.count_rows("logi", table_name).await? as usize;
 
         let mut offset: i64 = 0;
         let mut file_idx = 0u32;
         let mut file_rows = 0usize;
         let mut buffer = Vec::new();
 
-        // Write archive header as first line
         let header = serde_json::json!({
             "_archive_header": true,
             "schema_version": 1,
@@ -71,18 +57,15 @@ pub async fn logi_dump(
         buffer.push(b'\n');
 
         loop {
-            let rows: Vec<(serde_json::Value,)> = sqlx::query_as(&format!(
-                "SELECT row_to_json(t) FROM logi.\"{}\" t ORDER BY ctid LIMIT {} OFFSET {}",
-                table_name, BATCH_SIZE, offset
-            ))
-            .fetch_all(pool)
-            .await?;
+            let rows = db
+                .fetch_rows_json("logi", table_name, BATCH_SIZE, offset)
+                .await?;
 
             if rows.is_empty() {
                 break;
             }
 
-            for (row,) in &rows {
+            for row in &rows {
                 buffer.extend_from_slice(serde_json::to_string(row)?.as_bytes());
                 buffer.push(b'\n');
                 file_rows += 1;
@@ -101,7 +84,6 @@ pub async fn logi_dump(
                     println!("  {} rows → {}", file_rows, key);
 
                     buffer.clear();
-                    // New file header
                     buffer.extend_from_slice(serde_json::to_string(&header)?.as_bytes());
                     buffer.push(b'\n');
                     file_rows = 0;
@@ -112,7 +94,6 @@ pub async fn logi_dump(
             offset += rows.len() as i64;
         }
 
-        // Flush remaining
         if file_rows > 0 {
             let suffix = if file_idx > 0 {
                 format!("_part{}", file_idx)
@@ -135,4 +116,100 @@ pub async fn logi_dump(
     println!("  DROP SCHEMA logi CASCADE;");
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::archive::compress::gzip_decompress;
+    use crate::archive::repo::mock::MockArchiveDb;
+    use crate::archive::test_helpers::TestStorage;
+
+    #[tokio::test]
+    async fn test_logi_dump_no_tables() {
+        let db = MockArchiveDb::default();
+        let storage = TestStorage::new();
+        let result = logi_dump(&db, &storage, false).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_logi_dump_dry_run() {
+        let db = MockArchiveDb::default();
+        *db.tables.lock().unwrap() = vec!["dtakologs".into()];
+        db.row_counts
+            .lock()
+            .unwrap()
+            .insert("dtakologs".into(), 100);
+        let storage = TestStorage::new();
+
+        let result = logi_dump(&db, &storage, true).await;
+        assert!(result.is_ok());
+        // Dry run should not upload anything
+        assert!(storage.keys().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_logi_dump_single_table() {
+        let db = MockArchiveDb::default();
+        *db.tables.lock().unwrap() = vec!["test_table".into()];
+        db.row_counts.lock().unwrap().insert("test_table".into(), 2);
+        *db.columns.lock().unwrap() = vec![("id".into(), "INTEGER".into(), "NO".into(), None)];
+        *db.primary_key.lock().unwrap() = vec!["id".into()];
+        *db.rows.lock().unwrap() = vec![
+            serde_json::json!({"id": 1, "name": "a"}),
+            serde_json::json!({"id": 2, "name": "b"}),
+        ];
+        let storage = TestStorage::new();
+
+        let result = logi_dump(&db, &storage, false).await;
+        assert!(result.is_ok());
+
+        // Schema file uploaded
+        assert!(storage
+            .get("archive/logi/test_table/schema_v1.json")
+            .is_some());
+
+        // Data file uploaded (gzipped)
+        let keys: Vec<String> = storage
+            .keys()
+            .into_iter()
+            .filter(|k| k.ends_with(".jsonl.gz"))
+            .collect();
+        assert_eq!(keys.len(), 1);
+
+        // Verify content
+        let compressed = storage.get(&keys[0]).unwrap();
+        let data = gzip_decompress(&compressed).unwrap();
+        let lines: Vec<&str> = std::str::from_utf8(&data).unwrap().lines().collect();
+        assert_eq!(lines.len(), 3); // header + 2 rows
+    }
+
+    #[tokio::test]
+    async fn test_logi_dump_db_error() {
+        use std::sync::atomic::Ordering;
+        let db = MockArchiveDb::default();
+        db.fail_next.store(true, Ordering::SeqCst);
+        let storage = TestStorage::new();
+
+        let result = logi_dump(&db, &storage, false).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_logi_dump_multiple_tables() {
+        let db = MockArchiveDb::default();
+        *db.tables.lock().unwrap() = vec!["table_a".into(), "table_b".into()];
+        db.row_counts.lock().unwrap().insert("table_a".into(), 1);
+        db.row_counts.lock().unwrap().insert("table_b".into(), 1);
+        *db.columns.lock().unwrap() = vec![("x".into(), "TEXT".into(), "NO".into(), None)];
+        *db.rows.lock().unwrap() = vec![serde_json::json!({"x": "val"})];
+        let storage = TestStorage::new();
+
+        let result = logi_dump(&db, &storage, false).await;
+        assert!(result.is_ok());
+
+        // 2 tables × (schema + data) = 4 files
+        assert_eq!(storage.keys().len(), 4);
+    }
 }

--- a/src/archive/mod.rs
+++ b/src/archive/mod.rs
@@ -1,4 +1,7 @@
 pub mod compress;
 pub mod dtako;
 pub mod logi;
+pub mod repo;
 pub mod schema_meta;
+#[cfg(test)]
+mod test_helpers;

--- a/src/archive/repo.rs
+++ b/src/archive/repo.rs
@@ -1,0 +1,389 @@
+use async_trait::async_trait;
+
+/// DB 操作を抽象化。テストでは MockArchiveDb で差し替え可能。
+#[async_trait]
+pub trait ArchiveDb: Send + Sync {
+    // schema_meta
+    async fn fetch_columns(
+        &self,
+        schema: &str,
+        table: &str,
+    ) -> anyhow::Result<Vec<(String, String, String, Option<String>)>>;
+    async fn fetch_primary_key(&self, schema: &str, table: &str) -> anyhow::Result<Vec<String>>;
+
+    // logi
+    async fn list_tables(&self, schema: &str) -> anyhow::Result<Vec<String>>;
+    async fn count_rows(&self, schema: &str, table: &str) -> anyhow::Result<i64>;
+    async fn fetch_rows_json(
+        &self,
+        schema: &str,
+        table: &str,
+        limit: i64,
+        offset: i64,
+    ) -> anyhow::Result<Vec<serde_json::Value>>;
+
+    // dtako archive
+    async fn list_dtako_dates(&self) -> anyhow::Result<Vec<(String, String, i64)>>;
+    async fn fetch_dtako_rows_json(
+        &self,
+        tenant_id: &str,
+        date: &str,
+        limit: i64,
+        offset: i64,
+    ) -> anyhow::Result<Vec<serde_json::Value>>;
+    async fn list_old_dtako_dates(
+        &self,
+        cutoff: &str,
+    ) -> anyhow::Result<Vec<(String, String, i64)>>;
+    async fn delete_dtako_date(&self, tenant_id: &str, date: &str) -> anyhow::Result<u64>;
+
+    // dtako restore
+    async fn upsert_dtako_batch(&self, rows_json: &[String]) -> anyhow::Result<()>;
+}
+
+/// PostgreSQL 実装
+pub struct PgArchiveDb {
+    pool: sqlx::PgPool,
+}
+
+impl PgArchiveDb {
+    pub fn new(pool: sqlx::PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl ArchiveDb for PgArchiveDb {
+    async fn fetch_columns(
+        &self,
+        schema: &str,
+        table: &str,
+    ) -> anyhow::Result<Vec<(String, String, String, Option<String>)>> {
+        let rows = sqlx::query_as::<_, (String, String, String, Option<String>)>(
+            "SELECT column_name, data_type, is_nullable, column_default
+             FROM information_schema.columns
+             WHERE table_schema = $1 AND table_name = $2
+             ORDER BY ordinal_position",
+        )
+        .bind(schema)
+        .bind(table)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows)
+    }
+
+    async fn fetch_primary_key(&self, schema: &str, table: &str) -> anyhow::Result<Vec<String>> {
+        let rows = sqlx::query_as::<_, (String,)>(
+            "SELECT a.attname
+             FROM pg_index i
+             JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey)
+             WHERE i.indrelid = ($1 || '.' || $2)::regclass AND i.indisprimary
+             ORDER BY array_position(i.indkey, a.attnum)",
+        )
+        .bind(schema)
+        .bind(table)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows.into_iter().map(|(n,)| n).collect())
+    }
+
+    async fn list_tables(&self, schema: &str) -> anyhow::Result<Vec<String>> {
+        let rows = sqlx::query_as::<_, (String,)>(
+            "SELECT tablename FROM pg_tables WHERE schemaname = $1 ORDER BY tablename",
+        )
+        .bind(schema)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows.into_iter().map(|(n,)| n).collect())
+    }
+
+    async fn count_rows(&self, schema: &str, table: &str) -> anyhow::Result<i64> {
+        let row: (i64,) = sqlx::query_as(&format!(
+            "SELECT count(*) FROM \"{}\".\"{}\"",
+            schema, table
+        ))
+        .fetch_one(&self.pool)
+        .await?;
+        Ok(row.0)
+    }
+
+    async fn fetch_rows_json(
+        &self,
+        schema: &str,
+        table: &str,
+        limit: i64,
+        offset: i64,
+    ) -> anyhow::Result<Vec<serde_json::Value>> {
+        let rows: Vec<(serde_json::Value,)> = sqlx::query_as(&format!(
+            "SELECT row_to_json(t) FROM \"{}\".\"{}\" t ORDER BY ctid LIMIT {} OFFSET {}",
+            schema, table, limit, offset
+        ))
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows.into_iter().map(|(v,)| v).collect())
+    }
+
+    async fn list_dtako_dates(&self) -> anyhow::Result<Vec<(String, String, i64)>> {
+        let rows = sqlx::query_as::<_, (String, String, i64)>(
+            "SELECT tenant_id::TEXT, data_date_time::DATE::TEXT AS date_str, COUNT(*)
+             FROM alc_api.dtakologs
+             GROUP BY tenant_id, data_date_time::DATE
+             ORDER BY date_str",
+        )
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows)
+    }
+
+    async fn fetch_dtako_rows_json(
+        &self,
+        tenant_id: &str,
+        date: &str,
+        limit: i64,
+        offset: i64,
+    ) -> anyhow::Result<Vec<serde_json::Value>> {
+        let rows: Vec<(serde_json::Value,)> = sqlx::query_as(
+            "SELECT row_to_json(d) FROM alc_api.dtakologs d
+             WHERE tenant_id = $1::UUID AND data_date_time::DATE = $2::DATE
+             ORDER BY data_date_time
+             LIMIT $3 OFFSET $4",
+        )
+        .bind(tenant_id)
+        .bind(date)
+        .bind(limit)
+        .bind(offset)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows.into_iter().map(|(v,)| v).collect())
+    }
+
+    async fn list_old_dtako_dates(
+        &self,
+        cutoff: &str,
+    ) -> anyhow::Result<Vec<(String, String, i64)>> {
+        let rows = sqlx::query_as::<_, (String, String, i64)>(
+            "SELECT tenant_id::TEXT, data_date_time::DATE::TEXT AS date_str, COUNT(*)
+             FROM alc_api.dtakologs
+             WHERE data_date_time::DATE < $1::DATE
+             GROUP BY tenant_id, data_date_time::DATE
+             ORDER BY date_str",
+        )
+        .bind(cutoff)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows)
+    }
+
+    async fn delete_dtako_date(&self, tenant_id: &str, date: &str) -> anyhow::Result<u64> {
+        let result = sqlx::query(
+            "DELETE FROM alc_api.dtakologs
+             WHERE tenant_id = $1::UUID AND data_date_time::DATE = $2::DATE",
+        )
+        .bind(tenant_id)
+        .bind(date)
+        .execute(&self.pool)
+        .await?;
+        Ok(result.rows_affected())
+    }
+
+    async fn upsert_dtako_batch(&self, rows_json: &[String]) -> anyhow::Result<()> {
+        for row_json in rows_json {
+            let v: serde_json::Value = serde_json::from_str(row_json)?;
+            sqlx::query(
+                "INSERT INTO alc_api.dtakologs (
+                    tenant_id, data_date_time, vehicle_cd,
+                    type, all_state_font_color_index, all_state_ryout_color,
+                    branch_cd, branch_name, current_work_cd, data_filter_type,
+                    disp_flag, driver_cd, gps_direction, gps_enable,
+                    gps_latitude, gps_longitude, gps_satellite_num,
+                    operation_state, recive_event_type, recive_packet_type,
+                    recive_work_cd, revo, setting_temp, setting_temp1,
+                    setting_temp3, setting_temp4, speed, sub_driver_cd,
+                    temp_state, vehicle_name,
+                    address_disp_c, address_disp_p, all_state, all_state_ex,
+                    all_state_font_color, comu_date_time, current_work_name,
+                    driver_name, event_val, gps_lati_and_long, odometer,
+                    recive_type_color_name, recive_type_name,
+                    start_work_date_time, state, state1, state2, state3,
+                    state_flag, temp1, temp2, temp3, temp4,
+                    vehicle_icon_color, vehicle_icon_label_for_datetime,
+                    vehicle_icon_label_for_driver, vehicle_icon_label_for_vehicle
+                )
+                SELECT
+                    (j->>'tenant_id')::UUID, j->>'data_date_time', (j->>'vehicle_cd')::INTEGER,
+                    COALESCE(j->>'type', ''),
+                    COALESCE((j->>'all_state_font_color_index')::INTEGER, 0),
+                    COALESCE(j->>'all_state_ryout_color', 'Transparent'),
+                    COALESCE((j->>'branch_cd')::INTEGER, 0), COALESCE(j->>'branch_name', ''),
+                    COALESCE((j->>'current_work_cd')::INTEGER, 0),
+                    COALESCE((j->>'data_filter_type')::INTEGER, 0),
+                    COALESCE((j->>'disp_flag')::INTEGER, 0), COALESCE((j->>'driver_cd')::INTEGER, 0),
+                    COALESCE((j->>'gps_direction')::DOUBLE PRECISION, 0),
+                    COALESCE((j->>'gps_enable')::INTEGER, 0),
+                    COALESCE((j->>'gps_latitude')::DOUBLE PRECISION, 0),
+                    COALESCE((j->>'gps_longitude')::DOUBLE PRECISION, 0),
+                    COALESCE((j->>'gps_satellite_num')::INTEGER, 0),
+                    COALESCE((j->>'operation_state')::INTEGER, 0),
+                    COALESCE((j->>'recive_event_type')::INTEGER, 0),
+                    COALESCE((j->>'recive_packet_type')::INTEGER, 0),
+                    COALESCE((j->>'recive_work_cd')::INTEGER, 0),
+                    COALESCE((j->>'revo')::INTEGER, 0),
+                    COALESCE(j->>'setting_temp', ''), COALESCE(j->>'setting_temp1', ''),
+                    COALESCE(j->>'setting_temp3', ''), COALESCE(j->>'setting_temp4', ''),
+                    COALESCE((j->>'speed')::REAL, 0), COALESCE((j->>'sub_driver_cd')::INTEGER, 0),
+                    COALESCE((j->>'temp_state')::INTEGER, 0), COALESCE(j->>'vehicle_name', ''),
+                    j->>'address_disp_c', j->>'address_disp_p', j->>'all_state', j->>'all_state_ex',
+                    j->>'all_state_font_color', j->>'comu_date_time', j->>'current_work_name',
+                    j->>'driver_name', j->>'event_val', j->>'gps_lati_and_long', j->>'odometer',
+                    j->>'recive_type_color_name', j->>'recive_type_name',
+                    j->>'start_work_date_time', j->>'state', j->>'state1',
+                    j->>'state2', j->>'state3', j->>'state_flag',
+                    j->>'temp1', j->>'temp2', j->>'temp3', j->>'temp4',
+                    j->>'vehicle_icon_color', j->>'vehicle_icon_label_for_datetime',
+                    j->>'vehicle_icon_label_for_driver', j->>'vehicle_icon_label_for_vehicle'
+                FROM jsonb_array_elements($1::JSONB) AS j
+                ON CONFLICT (tenant_id, data_date_time, vehicle_cd) DO UPDATE SET
+                    type = EXCLUDED.type, speed = EXCLUDED.speed,
+                    gps_latitude = EXCLUDED.gps_latitude, gps_longitude = EXCLUDED.gps_longitude,
+                    gps_direction = EXCLUDED.gps_direction",
+            )
+            .bind(format!("[{}]", v))
+            .execute(&self.pool)
+            .await?;
+        }
+        Ok(())
+    }
+}
+
+/// テスト用 mock
+#[cfg(test)]
+pub mod mock {
+    use super::*;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Mutex;
+
+    pub struct MockArchiveDb {
+        pub fail_next: AtomicBool,
+        pub tables: Mutex<Vec<String>>,
+        pub row_counts: Mutex<std::collections::HashMap<String, i64>>,
+        pub rows: Mutex<Vec<serde_json::Value>>,
+        pub columns: Mutex<Vec<(String, String, String, Option<String>)>>,
+        pub primary_key: Mutex<Vec<String>>,
+        pub dtako_dates: Mutex<Vec<(String, String, i64)>>,
+        pub old_dates: Mutex<Vec<(String, String, i64)>>,
+        pub deleted_count: Mutex<u64>,
+        pub upserted: Mutex<Vec<String>>,
+    }
+
+    impl Default for MockArchiveDb {
+        fn default() -> Self {
+            Self {
+                fail_next: AtomicBool::new(false),
+                tables: Mutex::new(vec![]),
+                row_counts: Mutex::new(std::collections::HashMap::new()),
+                rows: Mutex::new(vec![]),
+                columns: Mutex::new(vec![]),
+                primary_key: Mutex::new(vec![]),
+                dtako_dates: Mutex::new(vec![]),
+                old_dates: Mutex::new(vec![]),
+                deleted_count: Mutex::new(0),
+                upserted: Mutex::new(vec![]),
+            }
+        }
+    }
+
+    impl MockArchiveDb {
+        fn check_fail(&self) -> anyhow::Result<()> {
+            if self.fail_next.swap(false, Ordering::SeqCst) {
+                anyhow::bail!("mock db error");
+            }
+            Ok(())
+        }
+    }
+
+    #[async_trait]
+    impl ArchiveDb for MockArchiveDb {
+        async fn fetch_columns(
+            &self,
+            _schema: &str,
+            _table: &str,
+        ) -> anyhow::Result<Vec<(String, String, String, Option<String>)>> {
+            self.check_fail()?;
+            Ok(self.columns.lock().unwrap().clone())
+        }
+
+        async fn fetch_primary_key(
+            &self,
+            _schema: &str,
+            _table: &str,
+        ) -> anyhow::Result<Vec<String>> {
+            self.check_fail()?;
+            Ok(self.primary_key.lock().unwrap().clone())
+        }
+
+        async fn list_tables(&self, _schema: &str) -> anyhow::Result<Vec<String>> {
+            self.check_fail()?;
+            Ok(self.tables.lock().unwrap().clone())
+        }
+
+        async fn count_rows(&self, _schema: &str, table: &str) -> anyhow::Result<i64> {
+            self.check_fail()?;
+            Ok(*self.row_counts.lock().unwrap().get(table).unwrap_or(&0))
+        }
+
+        async fn fetch_rows_json(
+            &self,
+            _schema: &str,
+            _table: &str,
+            _limit: i64,
+            offset: i64,
+        ) -> anyhow::Result<Vec<serde_json::Value>> {
+            self.check_fail()?;
+            if offset > 0 {
+                return Ok(vec![]);
+            }
+            Ok(self.rows.lock().unwrap().clone())
+        }
+
+        async fn list_dtako_dates(&self) -> anyhow::Result<Vec<(String, String, i64)>> {
+            self.check_fail()?;
+            Ok(self.dtako_dates.lock().unwrap().clone())
+        }
+
+        async fn fetch_dtako_rows_json(
+            &self,
+            _tenant_id: &str,
+            _date: &str,
+            _limit: i64,
+            offset: i64,
+        ) -> anyhow::Result<Vec<serde_json::Value>> {
+            self.check_fail()?;
+            if offset > 0 {
+                return Ok(vec![]);
+            }
+            Ok(self.rows.lock().unwrap().clone())
+        }
+
+        async fn list_old_dtako_dates(
+            &self,
+            _cutoff: &str,
+        ) -> anyhow::Result<Vec<(String, String, i64)>> {
+            self.check_fail()?;
+            Ok(self.old_dates.lock().unwrap().clone())
+        }
+
+        async fn delete_dtako_date(&self, _tenant_id: &str, _date: &str) -> anyhow::Result<u64> {
+            self.check_fail()?;
+            Ok(*self.deleted_count.lock().unwrap())
+        }
+
+        async fn upsert_dtako_batch(&self, rows_json: &[String]) -> anyhow::Result<()> {
+            self.check_fail()?;
+            self.upserted
+                .lock()
+                .unwrap()
+                .extend(rows_json.iter().cloned());
+            Ok(())
+        }
+    }
+}

--- a/src/archive/schema_meta.rs
+++ b/src/archive/schema_meta.rs
@@ -1,7 +1,7 @@
+use crate::archive::repo::ArchiveDb;
 use serde::{Deserialize, Serialize};
-use sqlx::PgPool;
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct SchemaMetadata {
     pub version: u32,
     pub created_at: String,
@@ -12,7 +12,7 @@ pub struct SchemaMetadata {
     pub migration_files: Vec<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ColumnInfo {
     pub name: String,
     pub data_type: String,
@@ -20,25 +20,15 @@ pub struct ColumnInfo {
     pub column_default: Option<String>,
 }
 
-pub async fn fetch_schema_metadata(
-    pool: &PgPool,
+pub fn build_metadata(
+    columns_raw: Vec<(String, String, String, Option<String>)>,
+    primary_key: Vec<String>,
     schema: &str,
     table: &str,
     version: u32,
     migration_files: Vec<String>,
-) -> anyhow::Result<SchemaMetadata> {
-    let rows = sqlx::query_as::<_, (String, String, String, Option<String>)>(
-        "SELECT column_name, data_type, is_nullable, column_default
-         FROM information_schema.columns
-         WHERE table_schema = $1 AND table_name = $2
-         ORDER BY ordinal_position",
-    )
-    .bind(schema)
-    .bind(table)
-    .fetch_all(pool)
-    .await?;
-
-    let columns: Vec<ColumnInfo> = rows
+) -> SchemaMetadata {
+    let columns: Vec<ColumnInfo> = columns_raw
         .into_iter()
         .map(|(name, data_type, nullable, default)| ColumnInfo {
             name,
@@ -48,22 +38,7 @@ pub async fn fetch_schema_metadata(
         })
         .collect();
 
-    // Fetch primary key columns
-    let pk_rows = sqlx::query_as::<_, (String,)>(
-        "SELECT a.attname
-         FROM pg_index i
-         JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey)
-         WHERE i.indrelid = ($1 || '.' || $2)::regclass AND i.indisprimary
-         ORDER BY array_position(i.indkey, a.attnum)",
-    )
-    .bind(schema)
-    .bind(table)
-    .fetch_all(pool)
-    .await?;
-
-    let primary_key: Vec<String> = pk_rows.into_iter().map(|(name,)| name).collect();
-
-    Ok(SchemaMetadata {
+    SchemaMetadata {
         version,
         created_at: chrono::Utc::now().to_rfc3339(),
         table_name: table.to_string(),
@@ -71,5 +46,97 @@ pub async fn fetch_schema_metadata(
         primary_key,
         columns,
         migration_files,
-    })
+    }
+}
+
+pub async fn fetch_schema_metadata(
+    db: &dyn ArchiveDb,
+    schema: &str,
+    table: &str,
+    version: u32,
+    migration_files: Vec<String>,
+) -> anyhow::Result<SchemaMetadata> {
+    let columns_raw = db.fetch_columns(schema, table).await?;
+    let primary_key = db.fetch_primary_key(schema, table).await?;
+    Ok(build_metadata(
+        columns_raw,
+        primary_key,
+        schema,
+        table,
+        version,
+        migration_files,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_build_metadata_basic() {
+        let cols = vec![
+            ("id".into(), "uuid".into(), "NO".into(), None),
+            (
+                "name".into(),
+                "text".into(),
+                "YES".into(),
+                Some("''".into()),
+            ),
+        ];
+        let pk = vec!["id".into()];
+        let meta = build_metadata(cols, pk, "alc_api", "dtakologs", 1, vec!["066.sql".into()]);
+
+        assert_eq!(meta.version, 1);
+        assert_eq!(meta.schema_name, "alc_api");
+        assert_eq!(meta.table_name, "dtakologs");
+        assert_eq!(meta.primary_key, vec!["id"]);
+        assert_eq!(meta.columns.len(), 2);
+        assert!(!meta.columns[0].is_nullable);
+        assert!(meta.columns[1].is_nullable);
+        assert_eq!(meta.columns[1].column_default.as_deref(), Some("''"));
+        assert_eq!(meta.migration_files, vec!["066.sql"]);
+        assert!(!meta.created_at.is_empty());
+    }
+
+    #[test]
+    fn test_build_metadata_empty() {
+        let meta = build_metadata(vec![], vec![], "s", "t", 2, vec![]);
+        assert_eq!(meta.columns.len(), 0);
+        assert_eq!(meta.primary_key.len(), 0);
+        assert_eq!(meta.version, 2);
+    }
+
+    #[tokio::test]
+    async fn test_fetch_schema_metadata_with_mock() {
+        use crate::archive::repo::mock::MockArchiveDb;
+        let db = MockArchiveDb::default();
+        *db.columns.lock().unwrap() = vec![
+            ("col_a".into(), "TEXT".into(), "NO".into(), None),
+            (
+                "col_b".into(),
+                "INTEGER".into(),
+                "YES".into(),
+                Some("0".into()),
+            ),
+        ];
+        *db.primary_key.lock().unwrap() = vec!["col_a".into()];
+
+        let meta = fetch_schema_metadata(&db, "test_schema", "test_table", 1, vec![])
+            .await
+            .unwrap();
+        assert_eq!(meta.columns.len(), 2);
+        assert_eq!(meta.primary_key, vec!["col_a"]);
+        assert_eq!(meta.schema_name, "test_schema");
+    }
+
+    #[tokio::test]
+    async fn test_fetch_schema_metadata_db_error() {
+        use crate::archive::repo::mock::MockArchiveDb;
+        use std::sync::atomic::Ordering;
+        let db = MockArchiveDb::default();
+        db.fail_next.store(true, Ordering::SeqCst);
+
+        let result = fetch_schema_metadata(&db, "s", "t", 1, vec![]).await;
+        assert!(result.is_err());
+    }
 }

--- a/src/archive/test_helpers.rs
+++ b/src/archive/test_helpers.rs
@@ -1,0 +1,122 @@
+#![cfg(test)]
+
+use alc_core::storage::{StorageBackend, StorageError};
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Mutex;
+
+pub struct TestStorage {
+    files: Mutex<HashMap<String, Vec<u8>>>,
+    pub fail_upload: AtomicBool,
+}
+
+impl TestStorage {
+    pub fn new() -> Self {
+        Self {
+            files: Mutex::new(HashMap::new()),
+            fail_upload: AtomicBool::new(false),
+        }
+    }
+    pub fn put(&self, key: &str, data: Vec<u8>) {
+        self.files.lock().unwrap().insert(key.to_string(), data);
+    }
+    pub fn get(&self, key: &str) -> Option<Vec<u8>> {
+        self.files.lock().unwrap().get(key).cloned()
+    }
+    pub fn keys(&self) -> Vec<String> {
+        self.files.lock().unwrap().keys().cloned().collect()
+    }
+}
+
+#[async_trait::async_trait]
+impl StorageBackend for TestStorage {
+    async fn upload(&self, key: &str, data: &[u8], _ct: &str) -> Result<String, StorageError> {
+        if self.fail_upload.load(Ordering::Relaxed) {
+            return Err(StorageError::Upload("mock fail".into()));
+        }
+        self.files
+            .lock()
+            .unwrap()
+            .insert(key.to_string(), data.to_vec());
+        Ok(self.public_url(key))
+    }
+
+    fn public_url(&self, key: &str) -> String {
+        format!("https://test-storage/{}", key)
+    }
+
+    async fn download(&self, key: &str) -> Result<Vec<u8>, StorageError> {
+        self.files
+            .lock()
+            .unwrap()
+            .get(key)
+            .cloned()
+            .ok_or_else(|| StorageError::Upload(format!("not found: {key}")))
+    }
+
+    fn extract_key(&self, url: &str) -> Option<String> {
+        url.strip_prefix("https://test-storage/")
+            .map(|s| s.to_string())
+    }
+
+    fn bucket(&self) -> &str {
+        "test-bucket"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_storage_upload_download() {
+        let s = TestStorage::new();
+        s.upload("k", b"data", "text/plain").await.unwrap();
+        assert_eq!(s.download("k").await.unwrap(), b"data");
+    }
+
+    #[test]
+    fn test_storage_public_url() {
+        let s = TestStorage::new();
+        assert_eq!(s.public_url("foo/bar"), "https://test-storage/foo/bar");
+    }
+
+    #[test]
+    fn test_storage_extract_key() {
+        let s = TestStorage::new();
+        assert_eq!(
+            s.extract_key("https://test-storage/foo/bar"),
+            Some("foo/bar".into())
+        );
+        assert_eq!(s.extract_key("https://other/foo"), None);
+    }
+
+    #[test]
+    fn test_storage_bucket() {
+        let s = TestStorage::new();
+        assert_eq!(s.bucket(), "test-bucket");
+    }
+
+    #[tokio::test]
+    async fn test_storage_download_not_found() {
+        let s = TestStorage::new();
+        assert!(s.download("missing").await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_storage_fail_upload() {
+        let s = TestStorage::new();
+        s.fail_upload.store(true, Ordering::Relaxed);
+        assert!(s.upload("k", b"data", "text/plain").await.is_err());
+    }
+
+    #[test]
+    fn test_storage_put_get_keys() {
+        let s = TestStorage::new();
+        s.put("a", b"1".to_vec());
+        s.put("b", b"2".to_vec());
+        assert_eq!(s.get("a"), Some(b"1".to_vec()));
+        assert_eq!(s.get("c"), None);
+        assert_eq!(s.keys().len(), 2);
+    }
+}

--- a/src/bin/archive.rs
+++ b/src/bin/archive.rs
@@ -1,4 +1,5 @@
 use alc_core::storage::StorageBackend;
+use rust_alc_api::archive::repo::PgArchiveDb;
 use sqlx::postgres::PgPoolOptions;
 use std::sync::Arc;
 
@@ -28,11 +29,9 @@ async fn main() -> anyhow::Result<()> {
     let command = args[1].as_str();
     let dry_run = args.iter().any(|a| a == "--dry-run");
 
-    // Connect to DB (superuser for cross-tenant access, no search_path restriction)
     let database_url =
         std::env::var("ARCHIVE_DATABASE_URL").or_else(|_| std::env::var("DATABASE_URL"))?;
 
-    // Strip search_path option if present (archive needs cross-schema access)
     let clean_url = if let Some(pos) = database_url.find("?options=") {
         database_url[..pos].to_string()
     } else {
@@ -44,22 +43,22 @@ async fn main() -> anyhow::Result<()> {
         .connect(&clean_url)
         .await?;
 
-    // Init R2 storage (ohishi-dtako bucket)
+    let db = PgArchiveDb::new(pool);
     let storage = init_r2_storage()?;
 
     match command {
         "logi-dump" => {
-            rust_alc_api::archive::logi::logi_dump(&pool, storage.as_ref(), dry_run).await?;
+            rust_alc_api::archive::logi::logi_dump(&db, storage.as_ref(), dry_run).await?;
         }
         "dtako-archive" => {
-            rust_alc_api::archive::dtako::dtako_archive(&pool, storage.as_ref(), dry_run).await?;
+            rust_alc_api::archive::dtako::dtako_archive(&db, storage.as_ref(), dry_run).await?;
         }
         "dtako-restore" => {
             let tenant_id = get_arg(&args, "--tenant-id")
                 .ok_or_else(|| anyhow::anyhow!("--tenant-id required"))?;
             let date = get_arg(&args, "--date")
                 .ok_or_else(|| anyhow::anyhow!("--date required (YYYY-MM-DD)"))?;
-            rust_alc_api::archive::dtako::dtako_restore(&pool, storage.as_ref(), &tenant_id, &date)
+            rust_alc_api::archive::dtako::dtako_restore(&db, storage.as_ref(), &tenant_id, &date)
                 .await?;
         }
         _ => {


### PR DESCRIPTION
## Summary
- ArchiveDb trait でDB操作を抽象化、MockArchiveDbでテスト可能に
- TestStorage共通化、53テスト追加
- schema_meta.rs, test_helpers.rs: 100%カバレッジ
- compress.rs: 99%, dtako.rs: 99%, logi.rs: 91%
- repo.rs のPgArchiveDb (DB直接実装) は対象外