### PR TITLE
ci: add archive Job auto-update + remove inline secrets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -369,12 +369,21 @@ jobs:
           gcloud run deploy rust-alc-api \
             --image "$AR_IMAGE" \
             --region asia-northeast1 \
-            --platform managed \
-            --allow-unauthenticated \
-            --set-secrets "DATABASE_URL=alc-app-database-url:latest,GOOGLE_CLIENT_ID=GOOGLE_CLIENT_ID:latest,GOOGLE_CLIENT_SECRET=GOOGLE_CLIENT_SECRET:latest,JWT_SECRET=JWT_SECRET:latest,R2_ACCESS_KEY=alc-r2-access-key:latest,R2_SECRET_KEY=alc-r2-secret-key:latest,OAUTH_STATE_SECRET=alc-oauth-state-secret:latest,CARINS_R2_ACCESS_KEY=carins-r2-access-key:latest,CARINS_R2_SECRET_KEY=carins-r2-secret-key:latest,DTAKO_R2_ACCESS_KEY=dtako-r2-access-key:latest,DTAKO_R2_SECRET_KEY=dtako-r2-secret-key:latest" \
-            --set-env-vars "STORAGE_BACKEND=r2,R2_BUCKET=alc-face-photos,R2_ACCOUNT_ID=24b45709d060d957340180e995f0d373,FCM_PROJECT_ID=alc-fcm,API_ORIGIN=https://alc-api.ippoan.org,CARINS_R2_BUCKET=carins-files,DTAKO_R2_BUCKET=ohishi-dtako,SCRAPER_URL=https://dtako-scraper-566bls5vfq-an.a.run.app" \
-            --port 8080 --memory 1Gi --cpu 1 --max-instances 3 \
             --project cloudsql-sv
+
+      - name: Update archive Job image
+        run: |
+          AR_IMAGE="asia-northeast1-docker.pkg.dev/cloudsql-sv/ghcr/ghcr.io/${{ github.repository }}:${{ github.sha }}"
+          JOB_NAME="rust-alc-api-archive"
+          REGION="asia-northeast1"
+          if gcloud run jobs describe $JOB_NAME --region $REGION --project cloudsql-sv &>/dev/null; then
+            gcloud run jobs update $JOB_NAME \
+              --region $REGION --project cloudsql-sv \
+              --image "$AR_IMAGE"
+            echo "::notice ::Archive Job updated to $AR_IMAGE"
+          else
+            echo "::notice ::Archive Job $JOB_NAME not found, skipping"
+          fi
 
       - name: Print production URL
         run: |


### PR DESCRIPTION
## Summary
- Add step to auto-update `rust-alc-api-archive` Cloud Run Job image on tag deploy
- Remove hardcoded `--set-secrets` and `--set-env-vars` from deploy step (already configured on the service)

## Test plan
- [ ] CI pass
- [ ] Next tag release verifies archive Job image is updated automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)