### PR TITLE
ci: fix tag deploy with build-once-promote pattern

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -453,12 +453,13 @@ jobs:
 
   auto-merge:
     name: Auto Merge
-    needs: [check, coverage-check]
+    needs: [check, coverage-check, docker-push]
     if: >-
       always() &&
       github.event_name == 'pull_request' &&
       needs.check.result == 'success' &&
-      needs.coverage-check.result == 'success'
+      needs.coverage-check.result == 'success' &&
+      needs.docker-push.result == 'success'
     uses: ippoan/ci-workflows/.github/workflows/auto-merge.yml@main
     permissions:
       contents: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -364,11 +364,13 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Tag image with version
+      - name: Promote dev → version + sha (build once, promote)
         run: |
-          docker pull ghcr.io/${{ github.repository }}:${{ github.sha }}
-          docker tag ghcr.io/${{ github.repository }}:${{ github.sha }} ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+          docker pull ghcr.io/${{ github.repository }}:dev
+          docker tag ghcr.io/${{ github.repository }}:dev ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+          docker tag ghcr.io/${{ github.repository }}:dev ghcr.io/${{ github.repository }}:${{ github.sha }}
           docker push ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+          docker push ghcr.io/${{ github.repository }}:${{ github.sha }}
 
       - name: Authenticate to GCP
         uses: google-github-actions/auth@v2


### PR DESCRIPTION
## Summary
- migrate ジョブで `:sha` (merge commit) ではなく `:dev` (PR でビルド済み) を pull
- `:dev` → `:version` + `:sha` に retag して push
- Build once, promote パターン: Docker ビルドは PR の1回だけ

## Background
squash merge で新しい SHA が生まれるため、PR でビルドした `:pr-sha` イメージは
merge commit の `:merge-sha` では参照できない。
加えて auto-merge (GITHUB_TOKEN) による main push は GitHub の仕様で後続 CI を発火しない。

`:dev` タグは PR CI で作成済みなので、tag push 時にこれを promote するのが最もシンプル。

壊れたタグ (v0.0.23, v0.0.24) は削除済み。

## Test plan
- [ ] PR CI で docker-push + docker-dev (:dev tag) が正常動作
- [ ] main merge 後に tag push → migrate が `:dev` を pull して成功
- [ ] deploy-service が `:sha` (promote 済み) で Cloud Run にデプロイ

🤖 Generated with [Claude Code](https://claude.com/claude-code)