### PR TITLE
ci: fix deploy-service/archive-job skipped on tag push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -405,6 +405,7 @@ jobs:
   deploy-service:
     name: Deploy Service
     needs: [migrate, coverage-check]
+    if: "always() && needs.migrate.result == 'success' && (needs.coverage-check.result == 'success' || needs.coverage-check.result == 'skipped')"
     runs-on: ubuntu-latest
     steps:
       - name: Authenticate to GCP
@@ -433,6 +434,7 @@ jobs:
   update-archive-job:
     name: Update Archive Job
     needs: [migrate, coverage-check]
+    if: "always() && needs.migrate.result == 'success' && (needs.coverage-check.result == 'success' || needs.coverage-check.result == 'skipped')"
     runs-on: ubuntu-latest
     steps:
       - name: Authenticate to GCP


### PR DESCRIPTION
## Summary
- `deploy-service` と `update-archive-job` に `if` 条件追加
- tag push 時は `coverage-check` が skipped になるため、`needs` だけだと依存ジョブも全てスキップされる
- `coverage-check` が success OR skipped の両方を許可

## Background
PR#141 で migrate の `:dev` pull は修正されたが、v0.0.23 タグ push で deploy-service / update-archive-job がスキップされた。
原因: `needs: [migrate, coverage-check]` の coverage-check が tag push でスキップ → 依存ジョブも連鎖スキップ

🤖 Generated with [Claude Code](https://claude.com/claude-code)