### PR TITLE
ci: run tests + coverage on tag push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
   check:
     name: Format & Lint
     needs: [pr-limit]
-    if: "always() && !startsWith(github.ref, 'refs/tags/') && (needs.pr-limit.result == 'success' || needs.pr-limit.result == 'skipped')"
+    if: "always() && (needs.pr-limit.result == 'success' || needs.pr-limit.result == 'skipped')"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -53,7 +53,7 @@ jobs:
   test-matrix:
     name: Tests (${{ matrix.group.name }})
     needs: [pr-limit]
-    if: "always() && !startsWith(github.ref, 'refs/tags/') && (needs.pr-limit.result == 'success' || needs.pr-limit.result == 'skipped')"
+    if: "always() && (needs.pr-limit.result == 'success' || needs.pr-limit.result == 'skipped')"
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -116,7 +116,7 @@ jobs:
   coverage-check:
     name: Coverage Check
     needs: [test-matrix]
-    if: "always() && !startsWith(github.ref, 'refs/tags/') && needs.test-matrix.result == 'success'"
+    if: "always() && needs.test-matrix.result == 'success'"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -466,3 +466,5 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+    secrets:
+      AUTO_MERGE_PAT: ${{ secrets.TAG_RELEASE_PAT }}


### PR DESCRIPTION
## Summary
- check, test-matrix, coverage-check から tag 除外フィルター (`!startsWith(github.ref, 'refs/tags/')`) を除去
- tag push 時もテスト + カバレッジチェックを実行

## Background
複数 PR が merge された後にタグを打つと、個別 PR では通過したが組み合わせでリグレッションが起きる可能性がある。
リリース時にもテスト + カバレッジを実行して安全性を担保する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)