### PR TITLE
ci: add cache-warm job on main push, skip heavy jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,27 @@ jobs:
             exit 1
           fi
 
+  cache-warm:
+    name: Cache Warm
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@1.92.0
+      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: swatinem/rust-cache@v2
+        with:
+          shared-key: release-build
+      - name: Build release (cache warm)
+        env:
+          SCCACHE_GHA_ENABLED: "true"
+          RUSTC_WRAPPER: "sccache"
+        run: cargo build --release
+
   check:
     name: Format & Lint
     needs: [pr-limit]
-    if: "always() && (needs.pr-limit.result == 'success' || needs.pr-limit.result == 'skipped')"
+    if: "always() && !(github.ref == 'refs/heads/main' && github.event_name == 'push') && (needs.pr-limit.result == 'success' || needs.pr-limit.result == 'skipped')"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -53,7 +70,7 @@ jobs:
   test-matrix:
     name: Tests (${{ matrix.group.name }})
     needs: [pr-limit]
-    if: "always() && (needs.pr-limit.result == 'success' || needs.pr-limit.result == 'skipped')"
+    if: "always() && !(github.ref == 'refs/heads/main' && github.event_name == 'push') && (needs.pr-limit.result == 'success' || needs.pr-limit.result == 'skipped')"
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary
- main push 時に `cache-warm` ジョブのみ実行 (`cargo build --release` + cache save)
- check, test-matrix は main push 時スキップ (PR + tag push で検証済み)
- main スコープにキャッシュ保存 → 以降の全 PR で warm cache

## Background
GitHub Actions キャッシュはブランチスコープ。PR 間でキャッシュ共有不可、main スコープのみ全 PR から参照可能。
PAT auto-merge で main push CI が発火するようになったが、フルビルド+テストは無駄。
cache-warm だけに絞ることで、キャッシュ保存の目的を達成しつつ CI 時間を最小化。

🤖 Generated with [Claude Code](https://claude.com/claude-code)