### PR TITLE
ci: cache-warm matrix for all shared-keys (7 parallel)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,21 +30,32 @@ jobs:
           fi
 
   cache-warm:
-    name: Cache Warm
+    name: Cache Warm (${{ matrix.target.name }})
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - { name: "release", key: "release-build", cmd: "cargo build --release" }
+          - { name: "test", key: "test-lib", cmd: "cargo test --no-run --lib --workspace" }
+          - { name: "mock-tenko", key: "test-mock-tenko", cmd: "cargo test --no-run --test mock_tenko" }
+          - { name: "mock-dtako", key: "test-mock-dtako", cmd: "cargo test --no-run --test mock_dtako" }
+          - { name: "mock-devices", key: "test-mock-devices", cmd: "cargo test --no-run --test mock_devices" }
+          - { name: "mock-carins", key: "test-mock-carins", cmd: "cargo test --no-run --test mock_carins" }
+          - { name: "mock-misc", key: "test-mock-misc", cmd: "cargo test --no-run --test mock_misc --test archive_repo_test" }
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.92.0
       - uses: mozilla-actions/sccache-action@v0.0.9
       - uses: swatinem/rust-cache@v2
         with:
-          shared-key: release-build
-      - name: Build release (cache warm)
+          shared-key: ${{ matrix.target.key }}
+      - name: Build (${{ matrix.target.name }})
         env:
           SCCACHE_GHA_ENABLED: "true"
           RUSTC_WRAPPER: "sccache"
-        run: cargo build --release
+        run: ${{ matrix.target.cmd }}
 
   check:
     name: Format & Lint


### PR DESCRIPTION
## Summary
- cache-warm を matrix 化: release + test 6グループ = 7並列
- 各 `--no-run` でビルドのみ (DB 不要)
- shared-key が PR ジョブと一致 → main スコープに保存 → 次の PR で warm cache

## Test plan
- [ ] main push で 7 並列 cache-warm が実行される
- [ ] 次の PR で rust-cache が "Restoring cache..." になる

🤖 Generated with [Claude Code](https://claude.com/claude-code)