### PR TITLE
ci: remove sccache from cache-warm job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,14 +47,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.92.0
-      - uses: mozilla-actions/sccache-action@v0.0.9
       - uses: swatinem/rust-cache@v2
         with:
           shared-key: ${{ matrix.target.key }}
       - name: Build (${{ matrix.target.name }})
-        env:
-          SCCACHE_GHA_ENABLED: "true"
-          RUSTC_WRAPPER: "sccache"
         run: ${{ matrix.target.cmd }}
 
   check:


### PR DESCRIPTION
## Summary
- cache-warm から sccache を除去
- rust-cache のみで target/ 復元 → cargo が fresh と判断 → ビルドスキップ

## Background
sccache GHA cache はブランチスコープで main に空のため、
rust-cache が target/ を復元しても sccache が再コンパイルを引き起こしていた。
sccache なしなら cargo は target/ の fingerprint を正しく認識する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)