### PR TITLE
ci: restore sccache in cache-warm job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,10 +47,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.92.0
+      - uses: mozilla-actions/sccache-action@v0.0.9
       - uses: swatinem/rust-cache@v2
         with:
           shared-key: ${{ matrix.target.key }}
       - name: Build (${{ matrix.target.name }})
+        env:
+          SCCACHE_GHA_ENABLED: "true"
+          RUSTC_WRAPPER: "sccache"
         run: ${{ matrix.target.cmd }}
 
   check:


### PR DESCRIPTION
## Summary
- cache-warm に sccache を復元 (PR#148 で除去したもの)
- cargo fingerprint に RUSTC_WRAPPER が含まれるため、PR (sccache付き) と cache-warm (sccache無し) で fingerprint 不一致 → 全再コンパイルが発生していた

## 動作
- 初回 main push: sccache cold → フルビルド → sccache + rust-cache を main スコープに保存
- 2回目以降: sccache ヒット + rust-cache ヒット → 差分のみ
- PR: main スコープの rust-cache を復元 → fingerprint 一致 → 高速

🤖 Generated with [Claude Code](https://claude.com/claude-code)