### PR TITLE
fix: strip Bazel binaries before Docker copy

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -3,6 +3,9 @@ build --incompatible_strict_action_env
 build --action_env=PATH
 build --jobs=auto
 
+# Strip binaries in opt mode (match cargo --release behavior)
+build:ci --strip=always
+
 # Remote cache (R2 via bazel-remote proxy)
 build:ci --remote_cache=grpc://localhost:9092
 build:ci --remote_upload_local_results=true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,6 +229,7 @@ jobs:
           cp bazel-bin/rust-alc-api docker-context/
           cp bazel-bin/migrate docker-context/
           cp bazel-bin/archive docker-context/
+          chmod u+w docker-context/rust-alc-api docker-context/migrate docker-context/archive
           strip docker-context/rust-alc-api docker-context/migrate docker-context/archive
           cp -r migrations docker-context/
           cp Dockerfile docker-context/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,6 +229,7 @@ jobs:
           cp bazel-bin/rust-alc-api docker-context/
           cp bazel-bin/migrate docker-context/
           cp bazel-bin/archive docker-context/
+          strip docker-context/rust-alc-api docker-context/migrate docker-context/archive
           cp -r migrations docker-context/
           cp Dockerfile docker-context/
 


### PR DESCRIPTION
Bazel -c opt は unstripped (46MB)。strip コマンド追加 + .bazelrc に --strip=always。staging startup probe 失敗の修正。