### PR TITLE
fix: use debian:trixie-slim for GLIBC 2.39 compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
 

--- a/staging/Dockerfile.app
+++ b/staging/Dockerfile.app
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 RUN apt-get update && apt-get install -y ca-certificates postgresql-client && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
CI runner (Ubuntu 24.04) のバイナリが GLIBC 2.39 を要求。bookworm-slim (2.36) → trixie-slim (2.41) に変更。staging startup probe 失敗の根本原因。