### PR TITLE
ci: switch Bazel cache from R2 to GitHub Actions cache

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -3,10 +3,6 @@ build --incompatible_strict_action_env
 build --action_env=PATH
 build --jobs=auto
 
-# Strip binaries in opt mode (match cargo --release behavior)
+# CI config: disk cache (persisted by actions/cache) + strip
+build:ci --disk_cache=/tmp/bazel-disk-cache
 build:ci --strip=always
-
-# Remote cache (R2 via bazel-remote proxy)
-build:ci --remote_cache=grpc://localhost:9092
-build:ci --remote_upload_local_results=true
-build:ci --remote_accept_cached=true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,29 +196,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install bazelisk
-        run: |
-          mkdir -p "$HOME/.local/bin"
-          curl -fsSL https://github.com/bazelbuild/bazelisk/releases/download/v1.25.0/bazelisk-linux-amd64 -o "$HOME/.local/bin/bazel"
-          chmod +x "$HOME/.local/bin/bazel"
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - uses: bazelbuild/setup-bazelisk@v3
 
-      - name: Start bazel-remote
-        run: |
-          curl -fsSL https://github.com/buchgr/bazel-remote/releases/download/v2.6.1/bazel-remote-2.6.1-linux-amd64 -o "$HOME/.local/bin/bazel-remote"
-          chmod +x "$HOME/.local/bin/bazel-remote"
-          bazel-remote \
-            --s3.endpoint 24b45709d060d957340180e995f0d373.r2.cloudflarestorage.com \
-            --s3.bucket bazel-cache \
-            --s3.auth_method access_key \
-            --s3.access_key_id "${{ secrets.BAZEL_R2_ACCESS_KEY_ID }}" \
-            --s3.secret_access_key "${{ secrets.BAZEL_R2_SECRET_ACCESS_KEY }}" \
-            --s3.region auto \
-            --max_size 10 \
-            --dir /tmp/bazel-remote-data \
-            --http_address :9080 \
-            --grpc_address :9092 &
-          sleep 2
+      - name: Restore Bazel cache
+        uses: actions/cache@v4
+        with:
+          path: /tmp/bazel-disk-cache
+          key: bazel-opt-${{ hashFiles('Cargo.lock', 'MODULE.bazel') }}
+          restore-keys: bazel-opt-
 
       - name: Build release binaries (Bazel)
         run: bazel build --config=ci -c opt //:rust-alc-api //:migrate //:archive

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
 

--- a/staging/Dockerfile.app
+++ b/staging/Dockerfile.app
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 RUN apt-get update && apt-get install -y ca-certificates postgresql-client && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
bazel-remote + R2 → actions/cache disk_cache に切り替え。ダウンロード不要で高速。trixie-slim も含む。