### PR TITLE
ci: switch to bazel-github-actions-cache

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -3,6 +3,6 @@ build --incompatible_strict_action_env
 build --action_env=PATH
 build --jobs=auto
 
-# CI config: disk cache (persisted by actions/cache) + strip
-build:ci --disk_cache=/tmp/bazel-disk-cache
+# CI config: GH Actions remote cache (bazel-github-actions-cache) + strip
+build:ci --remote_cache=http://localhost:3055
 build:ci --strip=always

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,12 +68,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: bazelbuild/setup-bazelisk@v3
-      - name: Restore Bazel cache
-        uses: actions/cache@v4
-        with:
-          path: /tmp/bazel-disk-cache
-          key: bazel-opt-${{ hashFiles('Cargo.lock', 'MODULE.bazel') }}
-          restore-keys: bazel-opt-
+      - uses: tsawada/bazel-github-actions-cache@v0
       - name: Build
         run: bazel build --config=ci -c opt //:rust-alc-api //:migrate //:archive
 
@@ -213,13 +208,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: bazelbuild/setup-bazelisk@v3
-
-      - name: Restore Bazel cache
-        uses: actions/cache@v4
-        with:
-          path: /tmp/bazel-disk-cache
-          key: bazel-opt-${{ hashFiles('Cargo.lock', 'MODULE.bazel') }}
-          restore-keys: bazel-opt-
+      - uses: tsawada/bazel-github-actions-cache@v0
 
       - name: Build release binaries (Bazel)
         run: bazel build --config=ci -c opt //:rust-alc-api //:migrate //:archive


### PR DESCRIPTION
actions/cache disk_cache → tsawada/bazel-github-actions-cache。tar展開不要で高速。