### PR TITLE
feat: add gateway crate (reverse proxy + JWT auth)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
       - uses: bazelbuild/setup-bazelisk@v3
       - uses: tsawada/bazel-github-actions-cache@v0
       - name: Build
-        run: bazel build --config=ci -c opt //:rust-alc-api //:migrate //:archive
+        run: bazel build --config=ci -c opt //:rust-alc-api //:migrate //:archive //crates/gateway
 
   check:
     name: Format & Lint
@@ -211,9 +211,9 @@ jobs:
       - uses: tsawada/bazel-github-actions-cache@v0
 
       - name: Build release binaries (Bazel)
-        run: bazel build --config=ci -c opt //:rust-alc-api //:migrate //:archive
+        run: bazel build --config=ci -c opt //:rust-alc-api //:migrate //:archive //crates/gateway
 
-      - name: Prepare Docker context
+      - name: Prepare Docker context (backend)
         run: |
           mkdir -p docker-context
           cp bazel-bin/rust-alc-api docker-context/
@@ -223,6 +223,14 @@ jobs:
           strip docker-context/rust-alc-api docker-context/migrate docker-context/archive
           cp -r migrations docker-context/
           cp Dockerfile docker-context/
+
+      - name: Prepare Docker context (gateway)
+        run: |
+          mkdir -p gateway-context
+          cp bazel-bin/crates/gateway/gateway gateway-context/
+          chmod u+w gateway-context/gateway
+          strip gateway-context/gateway
+          cp Dockerfile.gateway gateway-context/Dockerfile
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -234,7 +242,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build and push (sha tag)
+      - name: Build and push backend (sha tag)
         uses: docker/build-push-action@v6
         with:
           context: docker-context
@@ -242,6 +250,15 @@ jobs:
           tags: ghcr.io/${{ github.repository }}:${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Build and push gateway (sha tag)
+        uses: docker/build-push-action@v6
+        with:
+          context: gateway-context
+          push: true
+          tags: ghcr.io/${{ github.repository }}-gateway:${{ github.sha }}
+          cache-from: type=gha,scope=gateway
+          cache-to: type=gha,mode=max,scope=gateway
 
   docker-dev:
     name: Tag dev
@@ -258,11 +275,17 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Copy sha tag to dev
+      - name: Copy sha tag to dev (backend)
         run: |
           docker pull ghcr.io/${{ github.repository }}:${{ github.sha }}
           docker tag ghcr.io/${{ github.repository }}:${{ github.sha }} ghcr.io/${{ github.repository }}:dev
           docker push ghcr.io/${{ github.repository }}:dev
+
+      - name: Copy sha tag to dev (gateway)
+        run: |
+          docker pull ghcr.io/${{ github.repository }}-gateway:${{ github.sha }}
+          docker tag ghcr.io/${{ github.repository }}-gateway:${{ github.sha }} ghcr.io/${{ github.repository }}-gateway:dev
+          docker push ghcr.io/${{ github.repository }}-gateway:dev
 
   docker-latest:
     name: Tag latest
@@ -286,6 +309,14 @@ jobs:
           docker tag ghcr.io/${{ github.repository }}:dev ghcr.io/${{ github.repository }}:latest
           docker push ghcr.io/${{ github.repository }}:${{ github.sha }}
           docker push ghcr.io/${{ github.repository }}:latest
+
+      - name: Retag gateway dev → sha + latest
+        run: |
+          docker pull ghcr.io/${{ github.repository }}-gateway:dev
+          docker tag ghcr.io/${{ github.repository }}-gateway:dev ghcr.io/${{ github.repository }}-gateway:${{ github.sha }}
+          docker tag ghcr.io/${{ github.repository }}-gateway:dev ghcr.io/${{ github.repository }}-gateway:latest
+          docker push ghcr.io/${{ github.repository }}-gateway:${{ github.sha }}
+          docker push ghcr.io/${{ github.repository }}-gateway:latest
 
   deploy-staging:
     name: Deploy Staging
@@ -344,8 +375,11 @@ jobs:
 
           STAGING_URL="${{ vars.STAGING_API_URL }}"
 
+          GW_IMAGE="${AR_PREFIX}/ghcr.io/${{ github.repository }}-gateway:${{ github.sha }}"
+
           sed -e "s|PLACEHOLDER_APP_IMAGE|${APP_IMAGE}|" \
               -e "s|PLACEHOLDER_DB_IMAGE|${DB_IMAGE}|" \
+              -e "s|PLACEHOLDER_GATEWAY_IMAGE|${GW_IMAGE}|" \
               -e "s|PLACEHOLDER_STAGING_URL|${STAGING_URL}|" \
               staging/cloudrun-staging.yaml > /tmp/staging-deploy.yaml
 
@@ -390,6 +424,14 @@ jobs:
           docker tag ghcr.io/${{ github.repository }}:dev ghcr.io/${{ github.repository }}:${{ github.sha }}
           docker push ghcr.io/${{ github.repository }}:${{ github.ref_name }}
           docker push ghcr.io/${{ github.repository }}:${{ github.sha }}
+
+      - name: Promote gateway dev → version + sha
+        run: |
+          docker pull ghcr.io/${{ github.repository }}-gateway:dev
+          docker tag ghcr.io/${{ github.repository }}-gateway:dev ghcr.io/${{ github.repository }}-gateway:${{ github.ref_name }}
+          docker tag ghcr.io/${{ github.repository }}-gateway:dev ghcr.io/${{ github.repository }}-gateway:${{ github.sha }}
+          docker push ghcr.io/${{ github.repository }}-gateway:${{ github.ref_name }}
+          docker push ghcr.io/${{ github.repository }}-gateway:${{ github.sha }}
 
       - name: Authenticate to GCP
         uses: google-github-actions/auth@v2
@@ -449,6 +491,46 @@ jobs:
             --region asia-northeast1 --project cloudsql-sv \
             --format 'value(status.url)')
           echo "::notice ::Production URL: $URL (${GITHUB_REF_NAME})"
+
+  deploy-gateway:
+    name: Deploy Gateway
+    needs: [migrate, coverage-check]
+    if: "always() && needs.migrate.result == 'success' && (needs.coverage-check.result == 'success' || needs.coverage-check.result == 'skipped')"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Deploy Gateway to Cloud Run
+        run: |
+          AR_IMAGE="asia-northeast1-docker.pkg.dev/cloudsql-sv/ghcr/ghcr.io/${{ github.repository }}-gateway:${{ github.sha }}"
+          BACKEND_URL=$(gcloud run services describe rust-alc-api \
+            --region asia-northeast1 --project cloudsql-sv \
+            --format 'value(status.url)')
+
+          gcloud run deploy rust-alc-api-gateway \
+            --image "$AR_IMAGE" \
+            --region asia-northeast1 \
+            --project cloudsql-sv \
+            --allow-unauthenticated \
+            --set-secrets "JWT_SECRET=JWT_SECRET:latest" \
+            --set-env-vars "BACKEND_URL=${BACKEND_URL}" \
+            --port 8080 \
+            --memory 256Mi \
+            --cpu 1 \
+            --max-instances 5
+
+      - name: Print gateway URL
+        run: |
+          URL=$(gcloud run services describe rust-alc-api-gateway \
+            --region asia-northeast1 --project cloudsql-sv \
+            --format 'value(status.url)')
+          echo "::notice ::Gateway URL: $URL (${GITHUB_REF_NAME})"
 
   update-archive-job:
     name: Update Archive Job

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1418,6 +1418,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "gateway"
+version = "0.1.0"
+dependencies = [
+ "axum",
+ "chrono",
+ "http 1.4.0",
+ "http-body-util",
+ "jsonwebtoken",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tower-http",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = [".", "crates/alc-carins", "crates/alc-core", "crates/alc-csv-parser", "crates/alc-compare", "crates/alc-devices", "crates/alc-dtako", "crates/alc-misc", "crates/alc-notify", "crates/alc-pdf", "crates/alc-storage", "crates/alc-tenko"]
+members = [".", "crates/alc-carins", "crates/alc-core", "crates/alc-csv-parser", "crates/alc-compare", "crates/alc-devices", "crates/alc-dtako", "crates/alc-misc", "crates/alc-notify", "crates/alc-pdf", "crates/alc-storage", "crates/alc-tenko", "crates/gateway"]
 resolver = "2"
 
 [package]

--- a/Dockerfile.gateway
+++ b/Dockerfile.gateway
@@ -1,0 +1,10 @@
+FROM debian:trixie-slim
+
+RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+
+COPY gateway /usr/local/bin/
+
+ENV PORT=8080
+EXPOSE 8080
+
+CMD ["gateway"]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -26,6 +26,7 @@ crate.from_cargo(
         "//crates/alc-pdf:Cargo.toml",
         "//crates/alc-storage:Cargo.toml",
         "//crates/alc-tenko:Cargo.toml",
+        "//crates/gateway:Cargo.toml",
     ],
 )
 

--- a/crates/gateway/BUILD.bazel
+++ b/crates/gateway/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_test")
+load("@crates//:defs.bzl", "all_crate_deps")
+
+rust_binary(
+    name = "gateway",
+    srcs = glob(["src/**/*.rs"]),
+    deps = all_crate_deps(normal = True),
+    proc_macro_deps = all_crate_deps(proc_macro = True),
+    visibility = ["//visibility:public"],
+)
+
+rust_test(
+    name = "gateway_test",
+    crate = ":gateway",
+    deps = all_crate_deps(normal_dev = True),
+    proc_macro_deps = all_crate_deps(proc_macro_dev = True),
+)

--- a/crates/gateway/Cargo.toml
+++ b/crates/gateway/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "gateway"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+axum = "0.8"
+chrono = { version = "0.4", features = ["serde"] }
+http = "1"
+http-body-util = "0.1"
+jsonwebtoken = "9"
+reqwest = { version = "0.12", features = ["stream"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tokio = { version = "1", features = ["full"] }
+tower-http = { version = "0.6", features = ["cors", "trace"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+uuid = { version = "1", features = ["serde", "v4"] }

--- a/crates/gateway/src/auth.rs
+++ b/crates/gateway/src/auth.rs
@@ -1,0 +1,97 @@
+use jsonwebtoken::{decode, Algorithm, DecodingKey, Validation};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// JWT クレーム (alc-core::auth_jwt::AppClaims と同一)
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct AppClaims {
+    pub sub: Uuid,
+    pub email: String,
+    pub name: String,
+    pub tenant_id: Uuid,
+    pub role: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub org_slug: Option<String>,
+    pub iat: i64,
+    pub exp: i64,
+}
+
+/// JWT を検証してクレームを返す
+pub fn verify_jwt(token: &str, secret: &str) -> Result<AppClaims, jsonwebtoken::errors::Error> {
+    let mut validation = Validation::new(Algorithm::HS256);
+    validation.validate_exp = true;
+
+    let token_data = decode::<AppClaims>(
+        token,
+        &DecodingKey::from_secret(secret.as_bytes()),
+        &validation,
+    )?;
+
+    Ok(token_data.claims)
+}
+
+/// Authorization ヘッダーから Bearer トークンを抽出
+pub fn extract_bearer_token(header_value: &str) -> Option<&str> {
+    header_value.strip_prefix("Bearer ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{Duration, Utc};
+    use jsonwebtoken::{encode, EncodingKey, Header};
+
+    fn create_test_token(secret: &str, expired: bool) -> String {
+        let now = Utc::now();
+        let exp = if expired {
+            (now - Duration::hours(1)).timestamp()
+        } else {
+            (now + Duration::hours(1)).timestamp()
+        };
+        let claims = AppClaims {
+            sub: Uuid::new_v4(),
+            email: "test@example.com".to_string(),
+            name: "Test User".to_string(),
+            tenant_id: Uuid::new_v4(),
+            role: "admin".to_string(),
+            org_slug: None,
+            iat: now.timestamp(),
+            exp,
+        };
+        encode(
+            &Header::new(Algorithm::HS256),
+            &claims,
+            &EncodingKey::from_secret(secret.as_bytes()),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn test_verify_valid_token() {
+        let secret = "test-secret-key-256-bits-long!!!";
+        let token = create_test_token(secret, false);
+        let claims = verify_jwt(&token, secret).unwrap();
+        assert_eq!(claims.email, "test@example.com");
+        assert_eq!(claims.role, "admin");
+    }
+
+    #[test]
+    fn test_verify_expired_token() {
+        let secret = "test-secret-key-256-bits-long!!!";
+        let token = create_test_token(secret, true);
+        assert!(verify_jwt(&token, secret).is_err());
+    }
+
+    #[test]
+    fn test_verify_wrong_secret() {
+        let token = create_test_token("correct-secret-key!!", false);
+        assert!(verify_jwt(&token, "wrong-secret-key!!!!").is_err());
+    }
+
+    #[test]
+    fn test_extract_bearer_token() {
+        assert_eq!(extract_bearer_token("Bearer abc123"), Some("abc123"));
+        assert_eq!(extract_bearer_token("Basic abc123"), None);
+        assert_eq!(extract_bearer_token("abc123"), None);
+    }
+}

--- a/crates/gateway/src/config.rs
+++ b/crates/gateway/src/config.rs
@@ -1,0 +1,20 @@
+use std::env;
+
+pub struct Config {
+    pub port: u16,
+    pub backend_url: String,
+    pub jwt_secret: String,
+}
+
+impl Config {
+    pub fn from_env() -> Self {
+        Self {
+            port: env::var("PORT")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(8080),
+            backend_url: env::var("BACKEND_URL").expect("BACKEND_URL is required"),
+            jwt_secret: env::var("JWT_SECRET").expect("JWT_SECRET is required"),
+        }
+    }
+}

--- a/crates/gateway/src/main.rs
+++ b/crates/gateway/src/main.rs
@@ -1,0 +1,68 @@
+mod auth;
+mod config;
+mod proxy;
+mod routes;
+
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use axum::{routing::get, Router};
+use reqwest::Client;
+use tower_http::{
+    cors::{Any, CorsLayer},
+    trace::TraceLayer,
+};
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+use crate::config::Config;
+use crate::proxy::ProxyState;
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::registry()
+        .with(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "gateway=info,tower_http=info".into()),
+        )
+        .with(tracing_subscriber::fmt::layer())
+        .init();
+
+    let config = Config::from_env();
+
+    let client = Client::builder()
+        .timeout(Duration::from_secs(30))
+        .pool_max_idle_per_host(20)
+        .build()
+        .expect("Failed to create HTTP client");
+
+    let proxy_state = ProxyState {
+        client,
+        backend_url: config.backend_url.clone(),
+        jwt_secret: config.jwt_secret,
+    };
+
+    let cors = CorsLayer::new()
+        .allow_origin(Any)
+        .allow_methods(Any)
+        .allow_headers(Any);
+
+    let app = Router::new()
+        .route("/health", get(health))
+        .fallback(proxy::proxy_handler)
+        .with_state(proxy_state)
+        .layer(cors)
+        .layer(TraceLayer::new_for_http());
+
+    let addr = SocketAddr::from(([0, 0, 0, 0], config.port));
+    tracing::info!(
+        "Gateway listening on {addr}, backend: {}",
+        config.backend_url
+    );
+
+    let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
+    axum::serve(listener, app).await.unwrap();
+}
+
+async fn health() -> &'static str {
+    "ok"
+}

--- a/crates/gateway/src/proxy.rs
+++ b/crates/gateway/src/proxy.rs
@@ -1,0 +1,172 @@
+use axum::{
+    body::Body,
+    extract::Request,
+    http::{HeaderMap, HeaderName, HeaderValue, StatusCode},
+    response::{IntoResponse, Response},
+};
+use reqwest::Client;
+
+use crate::auth::{extract_bearer_token, verify_jwt, AppClaims};
+use crate::routes::is_public_route;
+
+#[derive(Clone)]
+pub struct ProxyState {
+    pub client: Client,
+    pub backend_url: String,
+    pub jwt_secret: String,
+}
+
+/// リクエストを backend に転送する
+pub async fn proxy_handler(
+    axum::extract::State(state): axum::extract::State<ProxyState>,
+    req: Request,
+) -> Response {
+    let (parts, body) = req.into_parts();
+    let path = parts.uri.path();
+    let path_and_query = parts
+        .uri
+        .path_and_query()
+        .map(|pq| pq.as_str())
+        .unwrap_or(path);
+
+    // JWT 検証 (public ルート以外)
+    let claims = if is_public_route(path) {
+        None
+    } else {
+        try_verify_jwt(&parts.headers, &state.jwt_secret)
+    };
+
+    // backend URL 構築
+    let url = format!("{}{}", state.backend_url, path_and_query);
+
+    // reqwest リクエスト構築
+    let method = reqwest::Method::from_bytes(parts.method.as_str().as_bytes())
+        .unwrap_or(reqwest::Method::GET);
+
+    let mut builder = state.client.request(method, &url);
+
+    // ヘッダーコピー (host 除外)
+    for (name, value) in &parts.headers {
+        if name == "host" {
+            continue;
+        }
+        if let Ok(val) = reqwest::header::HeaderValue::from_bytes(value.as_bytes()) {
+            if let Ok(name) = reqwest::header::HeaderName::from_bytes(name.as_ref()) {
+                builder = builder.header(name, val);
+            }
+        }
+    }
+
+    // JWT 検証成功時にヘッダー追加
+    if let Some(claims) = &claims {
+        builder = inject_auth_headers(builder, claims);
+    }
+
+    // Body をストリーミング転送
+    let body_stream = body.into_data_stream();
+    builder = builder.body(reqwest::Body::wrap_stream(body_stream));
+
+    // backend にリクエスト送信
+    let response = match builder.send().await {
+        Ok(resp) => resp,
+        Err(e) => {
+            if e.is_timeout() {
+                tracing::error!("Backend timeout: {e}");
+                return (StatusCode::GATEWAY_TIMEOUT, "gateway timeout").into_response();
+            }
+            tracing::error!("Backend unreachable: {e}");
+            return (StatusCode::BAD_GATEWAY, "backend unavailable").into_response();
+        }
+    };
+
+    // レスポンスを axum Response に変換
+    let status =
+        StatusCode::from_u16(response.status().as_u16()).unwrap_or(StatusCode::BAD_GATEWAY);
+
+    let mut headers = HeaderMap::new();
+    for (name, value) in response.headers() {
+        if let (Ok(n), Ok(v)) = (
+            HeaderName::from_bytes(name.as_ref()),
+            HeaderValue::from_bytes(value.as_bytes()),
+        ) {
+            headers.insert(n, v);
+        }
+    }
+
+    let body_stream = response.bytes_stream();
+    let body = Body::from_stream(body_stream);
+
+    (status, headers, body).into_response()
+}
+
+/// Authorization ヘッダーから JWT を検証する (失敗時は None)
+fn try_verify_jwt(headers: &HeaderMap, jwt_secret: &str) -> Option<AppClaims> {
+    let auth_header = headers.get("authorization")?.to_str().ok()?;
+    let token = extract_bearer_token(auth_header)?;
+    verify_jwt(token, jwt_secret).ok()
+}
+
+/// 認証情報をヘッダーとして注入
+fn inject_auth_headers(
+    builder: reqwest::RequestBuilder,
+    claims: &AppClaims,
+) -> reqwest::RequestBuilder {
+    builder
+        .header("X-Tenant-ID", claims.tenant_id.to_string())
+        .header("X-User-ID", claims.sub.to_string())
+        .header("X-User-Email", &claims.email)
+        .header("X-User-Role", &claims.role)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_try_verify_jwt_no_header() {
+        let headers = HeaderMap::new();
+        assert!(try_verify_jwt(&headers, "secret").is_none());
+    }
+
+    #[test]
+    fn test_try_verify_jwt_invalid_token() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "authorization",
+            "Bearer invalid.token.here".parse().unwrap(),
+        );
+        assert!(try_verify_jwt(&headers, "secret").is_none());
+    }
+
+    #[test]
+    fn test_try_verify_jwt_valid_token() {
+        use chrono::{Duration, Utc};
+        use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
+
+        let secret = "test-secret-key-256-bits-long!!!";
+        let now = Utc::now();
+        let claims = AppClaims {
+            sub: uuid::Uuid::new_v4(),
+            email: "test@example.com".to_string(),
+            name: "Test".to_string(),
+            tenant_id: uuid::Uuid::new_v4(),
+            role: "admin".to_string(),
+            org_slug: None,
+            iat: now.timestamp(),
+            exp: (now + Duration::hours(1)).timestamp(),
+        };
+        let token = encode(
+            &Header::new(Algorithm::HS256),
+            &claims,
+            &EncodingKey::from_secret(secret.as_bytes()),
+        )
+        .unwrap();
+
+        let mut headers = HeaderMap::new();
+        headers.insert("authorization", format!("Bearer {token}").parse().unwrap());
+
+        let result = try_verify_jwt(&headers, secret);
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().email, "test@example.com");
+    }
+}

--- a/crates/gateway/src/routes.rs
+++ b/crates/gateway/src/routes.rs
@@ -1,0 +1,81 @@
+/// public ルートかどうかを判定
+///
+/// src/routes/mod.rs の public_routes セクションに対応。
+/// これらのルートは JWT 検証をスキップしてそのまま backend に proxy する。
+pub fn is_public_route(path: &str) -> bool {
+    // /api プレフィックスを除去して判定
+    let api_path = path.strip_prefix("/api").unwrap_or(path);
+
+    matches!(api_path, "/health" | "/health/")
+        || api_path.starts_with("/auth/")
+        || api_path.starts_with("/tenko-call/register")
+        || api_path.starts_with("/tenko-call/tenko")
+        || api_path.starts_with("/devices/register/request")
+        || api_path.starts_with("/devices/register/status/")
+        || api_path.starts_with("/devices/register/claim")
+        || api_path.starts_with("/staging/")
+        || api_path.starts_with("/notify/line-webhook")
+        || api_path.starts_with("/notify/read/")
+        || api_path.starts_with("/access-requests")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_public_routes() {
+        // health
+        assert!(is_public_route("/api/health"));
+        assert!(is_public_route("/api/health/"));
+
+        // auth (all sub-routes are public: login, callback, refresh, etc.)
+        assert!(is_public_route("/api/auth/google"));
+        assert!(is_public_route("/api/auth/google/code"));
+        assert!(is_public_route("/api/auth/refresh"));
+        assert!(is_public_route("/api/auth/lineworks/redirect"));
+        assert!(is_public_route("/api/auth/lineworks/callback"));
+        assert!(is_public_route("/api/auth/line/redirect"));
+        assert!(is_public_route("/api/auth/tenants"));
+
+        // tenko-call public
+        assert!(is_public_route("/api/tenko-call/register"));
+        assert!(is_public_route("/api/tenko-call/tenko"));
+
+        // devices public
+        assert!(is_public_route("/api/devices/register/request"));
+        assert!(is_public_route("/api/devices/register/status/abc123"));
+        assert!(is_public_route("/api/devices/register/claim"));
+
+        // staging
+        assert!(is_public_route("/api/staging/export"));
+        assert!(is_public_route("/api/staging/import"));
+
+        // notify public
+        assert!(is_public_route("/api/notify/line-webhook"));
+        assert!(is_public_route("/api/notify/read/abc"));
+
+        // access-requests (public POST)
+        assert!(is_public_route("/api/access-requests"));
+    }
+
+    #[test]
+    fn test_protected_routes() {
+        // JWT protected
+        assert!(!is_public_route("/api/sso/configs"));
+        assert!(!is_public_route("/api/bot-admin/bots"));
+        assert!(!is_public_route("/api/tenant-users"));
+
+        // Tenant protected
+        assert!(!is_public_route("/api/employees"));
+        assert!(!is_public_route("/api/measurements"));
+        assert!(!is_public_route("/api/tenko-schedules"));
+        assert!(!is_public_route("/api/devices"));
+        assert!(!is_public_route("/api/car-inspections/current"));
+        assert!(!is_public_route("/api/dtako-logs"));
+        assert!(!is_public_route("/api/timecard/cards"));
+
+        // devices tenant routes (not register/*)
+        assert!(!is_public_route("/api/devices/pending"));
+    }
+}

--- a/staging/cloudrun-staging.yaml
+++ b/staging/cloudrun-staging.yaml
@@ -10,18 +10,43 @@ spec:
   template:
     metadata:
       annotations:
-        run.googleapis.com/container-dependencies: '{"app":["postgres"]}'
+        run.googleapis.com/container-dependencies: '{"gateway":["app"],"app":["postgres"]}'
         autoscaling.knative.dev/maxScale: "1"
         autoscaling.knative.dev/minScale: "0"
     spec:
       containerConcurrency: 80
       timeoutSeconds: 300
       containers:
-        - name: app
-          image: PLACEHOLDER_APP_IMAGE
+        - name: gateway
+          image: PLACEHOLDER_GATEWAY_IMAGE
           ports:
             - containerPort: 8080
           env:
+            - name: BACKEND_URL
+              value: "http://localhost:8081"
+            - name: JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: latest
+                  name: alc-api-staging-jwt-secret
+            - name: RUST_LOG
+              value: "gateway=info,tower_http=info"
+          resources:
+            limits:
+              memory: 128Mi
+              cpu: "0.5"
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 2
+            periodSeconds: 2
+            failureThreshold: 10
+        - name: app
+          image: PLACEHOLDER_APP_IMAGE
+          env:
+            - name: PORT
+              value: "8081"
             - name: DATABASE_URL
               value: "postgresql://postgres:staging@localhost:5432/postgres?options=-c search_path=alc_api"
             - name: STORAGE_BACKEND
@@ -110,7 +135,7 @@ spec:
           startupProbe:
             httpGet:
               path: /api/health
-              port: 8080
+              port: 8081
             initialDelaySeconds: 5
             periodSeconds: 3
             failureThreshold: 20


### PR DESCRIPTION
## Summary
- Phase 1 of gateway split: new `crates/gateway/` binary
- JWT verification + reqwest reverse proxy (no alc-core dependency, minimal binary)
- Route classification: public routes bypass JWT, protected routes get X-Tenant-ID/X-User-ID headers
- Bazel BUILD.bazel + MODULE.bazel for gateway
- Dockerfile.gateway + CI build/push/deploy jobs
- Staging: 3-container setup (gateway:8080 → app:8081 → postgres:5432)
- Backend code unchanged

## Test plan
- [x] `cargo build -p gateway` — ビルド成功
- [x] `cargo test -p gateway` — 9 テスト通過
- [x] `cargo clippy -p gateway` — 警告なし
- [ ] CI: Bazel build + Docker push (gateway image)
- [ ] Staging: 3-container deploy 動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)