### PR TITLE
ci: switch Bazel cache to ippoan/setup-bazel + R2

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -3,6 +3,5 @@ build --incompatible_strict_action_env
 build --action_env=PATH
 build --jobs=auto
 
-# CI config: GH Actions remote cache (bazel-github-actions-cache) + strip
-build:ci --remote_cache=http://localhost:3055
+# CI config: strip (disk_cache is managed by ippoan/setup-bazel + R2)
 build:ci --strip=always

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,10 +67,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: bazelbuild/setup-bazelisk@v3
-      - uses: tsawada/bazel-github-actions-cache@v0
+      - uses: ippoan/setup-bazel@main
+        with:
+          disk-cache: bazel
+          r2-endpoint: ${{ vars.BAZEL_R2_ENDPOINT }}
+          r2-bucket: ${{ vars.BAZEL_R2_BUCKET }}
+          r2-access-key-id: ${{ secrets.BAZEL_R2_ACCESS_KEY_ID }}
+          r2-secret-access-key: ${{ secrets.BAZEL_R2_SECRET_ACCESS_KEY }}
       - name: Build
-        run: bazel build --config=ci -c opt //:rust-alc-api //:migrate //:archive //crates/gateway
+        run: bazel build -c opt //:rust-alc-api //:migrate //:archive //crates/gateway
 
   check:
     name: Format & Lint
@@ -207,11 +212,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: bazelbuild/setup-bazelisk@v3
-      - uses: tsawada/bazel-github-actions-cache@v0
+      - uses: ippoan/setup-bazel@main
+        with:
+          disk-cache: bazel
+          cache-save: ${{ github.event_name != 'pull_request' }}
+          r2-endpoint: ${{ vars.BAZEL_R2_ENDPOINT }}
+          r2-bucket: ${{ vars.BAZEL_R2_BUCKET }}
+          r2-access-key-id: ${{ secrets.BAZEL_R2_ACCESS_KEY_ID }}
+          r2-secret-access-key: ${{ secrets.BAZEL_R2_SECRET_ACCESS_KEY }}
 
       - name: Build release binaries (Bazel)
-        run: bazel build --config=ci -c opt //:rust-alc-api //:migrate //:archive //crates/gateway
+        run: bazel build -c opt //:rust-alc-api //:migrate //:archive //crates/gateway
 
       - name: Prepare Docker context (backend)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,22 +61,6 @@ jobs:
           RUSTC_WRAPPER: "sccache"
         run: ${{ matrix.target.cmd }}
 
-  cache-warm-bazel:
-    name: Cache Warm (Bazel)
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ippoan/setup-bazel@main
-        with:
-          disk-cache: bazel
-          r2-endpoint: ${{ vars.BAZEL_R2_ENDPOINT }}
-          r2-bucket: ${{ vars.BAZEL_R2_BUCKET }}
-          r2-access-key-id: ${{ secrets.BAZEL_R2_ACCESS_KEY_ID }}
-          r2-secret-access-key: ${{ secrets.BAZEL_R2_SECRET_ACCESS_KEY }}
-      - name: Build
-        run: bazel build -c opt //:rust-alc-api //:migrate //:archive //crates/gateway
-
   check:
     name: Format & Lint
     needs: [pr-limit]


### PR DESCRIPTION
## Summary
- tsawada/bazel-github-actions-cache (不安定、500エラー) → ippoan/setup-bazel + R2 に切替
- tar 圧縮/展開なし (aws s3 sync で直接同期)
- R2 credentials は vars (endpoint, bucket) + secrets (keys)
- PR は cache-save: false で読み取りのみ

## Test plan
- [ ] CI: Bazel build が R2 キャッシュで動作
- [ ] cache-warm-bazel が main push でキャッシュ書き込み

🤖 Generated with [Claude Code](https://claude.com/claude-code)