### PR TITLE
ci: enable R2 cache-save for all events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,7 +199,6 @@ jobs:
       - uses: ippoan/setup-bazel@main
         with:
           disk-cache: bazel
-          cache-save: ${{ github.event_name != 'pull_request' }}
           r2-endpoint: ${{ vars.BAZEL_R2_ENDPOINT }}
           r2-bucket: ${{ vars.BAZEL_R2_BUCKET }}
           r2-access-key-id: ${{ secrets.BAZEL_R2_ACCESS_KEY_ID }}


### PR DESCRIPTION
## Summary
- `cache-save` 制限を削除 — R2 は永続共有ストレージなので PR からも書き込み OK
- 最初の PR ビルドで R2 にキャッシュが蓄積され、以降は全ブランチで高速化

🤖 Generated with [Claude Code](https://claude.com/claude-code)