### PR TITLE
chore: add setup-bazel symlink to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ node_modules/
 /bazel-*
 MODULE.bazel.lock
 backup/
+setup-bazel


### PR DESCRIPTION
## Summary
- setup-bazel リポの symlink を .gitignore に追加
- bazel-r2-sync v0.2.0 (watch mode) の CI 実測トリガー

## Test plan
- [ ] docker-push ジョブで bazel-r2-sync が正常動作すること
- [ ] watch モードが build 中にバックグラウンドで動作すること
- [ ] manifest.json が R2 に作成されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)