### PR TITLE
ci: add Bazel disk-cache warm up on main push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,18 @@ jobs:
           RUSTC_WRAPPER: "sccache"
         run: ${{ matrix.target.cmd }}
 
+  cache-warm-bazel:
+    name: Cache Warm (bazel)
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ippoan/setup-bazel@main
+        with:
+          disk-cache: bazel
+      - name: Build release binaries (Bazel)
+        run: bazel build -c opt //:rust-alc-api //:migrate //:archive //crates/gateway
+
   check:
     name: Format & Lint
     needs: [pr-limit]


### PR DESCRIPTION
## Summary
- main push 時に Bazel disk-cache を tar.zst で warm up するジョブ追加
- `ippoan/setup-bazel@main` の tar.zst 方式 (actions/cache 1ファイル) の実測

## Test plan
- [ ] cache-warm-bazel ジョブが main push で動作すること
- [ ] disk-cache tar.zst が actions/cache に save されること
- [ ] 次回 PR で tar.zst cache が restore されること (要確認)

🤖 Generated with [Claude Code](https://claude.com/claude-code)