### PR TITLE
ci: benchmark Bazel disk-cache tar.zst restore

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,7 @@
 # rust-alc-api
 
 Axum + PostgreSQL RLS による ALC (アルコールチェック) API バックエンド
+<!-- Bazel disk-cache: tar.zst + actions/cache (ippoan/setup-bazel) -->
 
 ## プロジェクト構成
 


### PR DESCRIPTION
## Summary
- Bazel disk-cache tar.zst restore 時間の実測トリガー
- main push (#169) で warm up 済みの cache からの restore を計測

## Test plan
- [ ] cache-warm-bazel で save された tar.zst が restore されること
- [ ] restore の download + extract 時間をログで確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)