### PR TITLE
ci: add clippy component to cache-warm toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.92.0
         with:
-          components: llvm-tools-preview
+          components: llvm-tools-preview, clippy
       - uses: mozilla-actions/sccache-action@v0.0.9
       - uses: swatinem/rust-cache@v2
         with:


### PR DESCRIPTION
cache-warm の check target が cargo clippy を使うが toolchain に clippy コンポーネントがなかった