### PR TITLE
ci: add sccache to check job + warm up export_bindings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         target:
-          - { name: "check", key: "check", cmd: "cargo clippy --workspace -- -D warnings" }
+          - { name: "check", key: "check", cmd: "cargo clippy --workspace -- -D warnings && cargo test export_bindings --workspace" }
           - { name: "test", key: "test-lib", cmd: "cargo llvm-cov nextest --no-report --ignore-run-fail --lib --workspace" }
           - { name: "mock-tenko", key: "test-mock-tenko", cmd: "cargo llvm-cov nextest --no-report --ignore-run-fail --test mock_tenko" }
           - { name: "mock-dtako", key: "test-mock-dtako", cmd: "cargo llvm-cov nextest --no-report --ignore-run-fail --test mock_dtako" }
@@ -131,13 +131,20 @@ jobs:
       - uses: dtolnay/rust-toolchain@1.92.0
         with:
           components: rustfmt, clippy
+      - uses: mozilla-actions/sccache-action@v0.0.9
       - uses: swatinem/rust-cache@v2
         with:
           shared-key: check
       - run: cargo fmt --check --all
       - run: cargo clippy --workspace -- -D warnings
+        env:
+          SCCACHE_GHA_ENABLED: "true"
+          RUSTC_WRAPPER: "sccache"
       - name: Generate TypeScript bindings
         run: cargo test export_bindings --workspace
+        env:
+          SCCACHE_GHA_ENABLED: "true"
+          RUSTC_WRAPPER: "sccache"
       - uses: actions/upload-artifact@v4
         with:
           name: ts-bindings-${{ github.sha }}


### PR DESCRIPTION
## Summary
- check ジョブに sccache 追加 (clippy と cargo test で共有)
- cache-warm check に `cargo test export_bindings` を追加
- sccache がコンパイル単位でキャッシュするので cargo mode が違っても hit する

## Test plan
- [ ] check ジョブで cargo test export_bindings がフルコンパイルしないこと
- [ ] warm up 後の次回 PR で check が ~1min 以内になること

🤖 Generated with [Claude Code](https://claude.com/claude-code)