### PR TITLE
feat: extract carins-api and dtako-api as standalone binaries (Phase 3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
           external-cache: true
           repository-cache: true
       - name: Build release binaries (Bazel)
-        run: bazel build -c opt //:rust-alc-api //:migrate //:archive //crates/gateway //crates/tenko-api
+        run: bazel build -c opt //:rust-alc-api //:migrate //:archive //crates/gateway //crates/tenko-api //crates/carins-api //crates/dtako-api
 
   cache-cleanup:
     name: Cache Cleanup
@@ -277,7 +277,7 @@ jobs:
           r2-secret-access-key: ${{ secrets.BAZEL_R2_SECRET_ACCESS_KEY }}
 
       - name: Build release binaries (Bazel)
-        run: bazel build -c opt //:rust-alc-api //:migrate //:archive //crates/gateway //crates/tenko-api
+        run: bazel build -c opt //:rust-alc-api //:migrate //:archive //crates/gateway //crates/tenko-api //crates/carins-api //crates/dtako-api
 
       - name: Prepare Docker context (backend)
         run: |
@@ -286,8 +286,10 @@ jobs:
           cp bazel-bin/migrate docker-context/
           cp bazel-bin/archive docker-context/
           cp bazel-bin/crates/tenko-api/tenko-api docker-context/
-          chmod u+w docker-context/rust-alc-api docker-context/migrate docker-context/archive docker-context/tenko-api
-          strip docker-context/rust-alc-api docker-context/migrate docker-context/archive docker-context/tenko-api
+          cp bazel-bin/crates/carins-api/carins-api docker-context/
+          cp bazel-bin/crates/dtako-api/dtako-api docker-context/
+          chmod u+w docker-context/rust-alc-api docker-context/migrate docker-context/archive docker-context/tenko-api docker-context/carins-api docker-context/dtako-api
+          strip docker-context/rust-alc-api docker-context/migrate docker-context/archive docker-context/tenko-api docker-context/carins-api docker-context/dtako-api
           cp -r migrations docker-context/
           cp Dockerfile docker-context/
 
@@ -582,10 +584,22 @@ jobs:
           TENKO_URL=$(gcloud run services describe rust-alc-api-tenko \
             --region asia-northeast1 --project cloudsql-sv \
             --format 'value(status.url)' 2>/dev/null || echo "")
+          CARINS_URL=$(gcloud run services describe rust-alc-api-carins \
+            --region asia-northeast1 --project cloudsql-sv \
+            --format 'value(status.url)' 2>/dev/null || echo "")
+          DTAKO_URL=$(gcloud run services describe rust-alc-api-dtako \
+            --region asia-northeast1 --project cloudsql-sv \
+            --format 'value(status.url)' 2>/dev/null || echo "")
 
           ENV_VARS="BACKEND_URL=${BACKEND_URL}"
           if [ -n "$TENKO_URL" ]; then
             ENV_VARS="${ENV_VARS},TENKO_API_URL=${TENKO_URL}"
+          fi
+          if [ -n "$CARINS_URL" ]; then
+            ENV_VARS="${ENV_VARS},CARINS_API_URL=${CARINS_URL}"
+          fi
+          if [ -n "$DTAKO_URL" ]; then
+            ENV_VARS="${ENV_VARS},DTAKO_API_URL=${DTAKO_URL}"
           fi
 
           gcloud run deploy rust-alc-api-gateway \
@@ -644,6 +658,82 @@ jobs:
             --region asia-northeast1 --project cloudsql-sv \
             --format 'value(status.url)')
           echo "::notice ::Tenko API URL: $URL (${GITHUB_REF_NAME})"
+
+  deploy-carins-api:
+    name: Deploy Carins API
+    needs: [migrate, coverage-check]
+    if: "always() && needs.migrate.result == 'success' && (needs.coverage-check.result == 'success' || needs.coverage-check.result == 'skipped')"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Deploy carins-api to Cloud Run
+        run: |
+          AR_IMAGE="asia-northeast1-docker.pkg.dev/cloudsql-sv/ghcr/ghcr.io/${{ github.repository }}:${{ github.sha }}"
+
+          gcloud run deploy rust-alc-api-carins \
+            --image "$AR_IMAGE" \
+            --region asia-northeast1 \
+            --project cloudsql-sv \
+            --ingress internal \
+            --set-secrets "DATABASE_URL=alc-app-database-url:latest,CARINS_R2_ACCESS_KEY=carins-r2-access-key:latest,CARINS_R2_SECRET_KEY=carins-r2-secret-key:latest" \
+            --set-env-vars "RUST_LOG=carins_api=info,CARINS_R2_BUCKET=rust-logi-files,CARINS_R2_ACCOUNT_ID=8556e484b273a868db8ec6800b074834" \
+            --command "carins-api" \
+            --port 8080 \
+            --memory 256Mi \
+            --cpu 1 \
+            --max-instances 5
+
+      - name: Print carins-api URL
+        run: |
+          URL=$(gcloud run services describe rust-alc-api-carins \
+            --region asia-northeast1 --project cloudsql-sv \
+            --format 'value(status.url)')
+          echo "::notice ::Carins API URL: $URL (${GITHUB_REF_NAME})"
+
+  deploy-dtako-api:
+    name: Deploy Dtako API
+    needs: [migrate, coverage-check]
+    if: "always() && needs.migrate.result == 'success' && (needs.coverage-check.result == 'success' || needs.coverage-check.result == 'skipped')"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Deploy dtako-api to Cloud Run
+        run: |
+          AR_IMAGE="asia-northeast1-docker.pkg.dev/cloudsql-sv/ghcr/ghcr.io/${{ github.repository }}:${{ github.sha }}"
+
+          gcloud run deploy rust-alc-api-dtako \
+            --image "$AR_IMAGE" \
+            --region asia-northeast1 \
+            --project cloudsql-sv \
+            --ingress internal \
+            --set-secrets "DATABASE_URL=alc-app-database-url:latest,DTAKO_R2_ACCESS_KEY=dtako-r2-access-key:latest,DTAKO_R2_SECRET_KEY=dtako-r2-secret-key:latest" \
+            --set-env-vars "RUST_LOG=dtako_api=info,DTAKO_R2_BUCKET=ohishi-dtako,DTAKO_R2_ACCOUNT_ID=8556e484b273a868db8ec6800b074834" \
+            --command "dtako-api" \
+            --port 8080 \
+            --memory 512Mi \
+            --cpu 1 \
+            --max-instances 5
+
+      - name: Print dtako-api URL
+        run: |
+          URL=$(gcloud run services describe rust-alc-api-dtako \
+            --region asia-northeast1 --project cloudsql-sv \
+            --format 'value(status.url)')
+          echo "::notice ::Dtako API URL: $URL (${GITHUB_REF_NAME})"
 
   update-archive-job:
     name: Update Archive Job

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -711,6 +711,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "carins-api"
+version = "0.1.0"
+dependencies = [
+ "alc-carins",
+ "alc-core",
+ "alc-storage",
+ "axum",
+ "sqlx",
+ "tokio",
+ "tower-http",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "cbc"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1093,6 +1108,21 @@ name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "dtako-api"
+version = "0.1.0"
+dependencies = [
+ "alc-core",
+ "alc-dtako",
+ "alc-storage",
+ "axum",
+ "sqlx",
+ "tokio",
+ "tower-http",
+ "tracing",
+ "tracing-subscriber",
+]
 
 [[package]]
 name = "dtoa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = [".", "crates/alc-carins", "crates/alc-core", "crates/alc-csv-parser", "crates/alc-compare", "crates/alc-devices", "crates/alc-dtako", "crates/alc-misc", "crates/alc-notify", "crates/alc-pdf", "crates/alc-storage", "crates/alc-tenko", "crates/gateway", "crates/tenko-api"]
+members = [".", "crates/alc-carins", "crates/alc-core", "crates/alc-csv-parser", "crates/alc-compare", "crates/alc-devices", "crates/alc-dtako", "crates/alc-misc", "crates/alc-notify", "crates/alc-pdf", "crates/alc-storage", "crates/alc-tenko", "crates/carins-api", "crates/dtako-api", "crates/gateway", "crates/tenko-api"]
 resolver = "2"
 
 [package]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ COPY rust-alc-api /usr/local/bin/
 COPY migrate /usr/local/bin/
 COPY archive /usr/local/bin/
 COPY tenko-api /usr/local/bin/
+COPY carins-api /usr/local/bin/
+COPY dtako-api /usr/local/bin/
 COPY migrations /app/migrations
 
 WORKDIR /app

--- a/crates/alc-carins/src/car_inspection_files.rs
+++ b/crates/alc-carins/src/car_inspection_files.rs
@@ -1,11 +1,15 @@
 use axum::{extract::State, http::StatusCode, routing::get, Extension, Json, Router};
 use serde::Serialize;
 
+use crate::CarinsState;
 use alc_core::auth_middleware::TenantId;
 use alc_core::repository::car_inspections::CarInspectionFile;
-use alc_core::AppState;
 
-pub fn tenant_router() -> Router<AppState> {
+pub fn tenant_router<S>() -> Router<S>
+where
+    CarinsState: axum::extract::FromRef<S>,
+    S: Clone + Send + Sync + 'static,
+{
     Router::new().route("/car-inspection-files/current", get(list_current))
 }
 
@@ -15,7 +19,7 @@ struct ListResponse {
 }
 
 async fn list_current(
-    State(state): State<AppState>,
+    State(state): State<CarinsState>,
     Extension(tenant_id): Extension<TenantId>,
 ) -> Result<Json<ListResponse>, StatusCode> {
     let rows = state

--- a/crates/alc-carins/src/car_inspections.rs
+++ b/crates/alc-carins/src/car_inspections.rs
@@ -6,10 +6,14 @@ use axum::{
 };
 use serde::Serialize;
 
+use crate::CarinsState;
 use alc_core::auth_middleware::TenantId;
-use alc_core::AppState;
 
-pub fn tenant_router() -> Router<AppState> {
+pub fn tenant_router<S>() -> Router<S>
+where
+    CarinsState: axum::extract::FromRef<S>,
+    S: Clone + Send + Sync + 'static,
+{
     Router::new()
         .route("/car-inspections/current", get(list_current))
         .route("/car-inspections/expired", get(list_expired))
@@ -29,7 +33,7 @@ struct ListResponse {
 }
 
 async fn list_current(
-    State(state): State<AppState>,
+    State(state): State<CarinsState>,
     Extension(tenant_id): Extension<TenantId>,
 ) -> Result<Json<ListResponse>, StatusCode> {
     let rows = state
@@ -47,7 +51,7 @@ async fn list_current(
 }
 
 async fn get_by_id(
-    State(state): State<AppState>,
+    State(state): State<CarinsState>,
     Extension(tenant_id): Extension<TenantId>,
     Path(id): Path<i32>,
 ) -> Result<Json<serde_json::Value>, StatusCode> {
@@ -65,7 +69,7 @@ async fn get_by_id(
 }
 
 async fn vehicle_categories(
-    State(state): State<AppState>,
+    State(state): State<CarinsState>,
     Extension(tenant_id): Extension<TenantId>,
 ) -> Result<Json<alc_core::repository::car_inspections::VehicleCategories>, StatusCode> {
     let row = state
@@ -81,7 +85,7 @@ async fn vehicle_categories(
 }
 
 async fn list_expired(
-    State(state): State<AppState>,
+    State(state): State<CarinsState>,
     Extension(tenant_id): Extension<TenantId>,
 ) -> Result<Json<ListResponse>, StatusCode> {
     let rows = state
@@ -99,7 +103,7 @@ async fn list_expired(
 }
 
 async fn list_renew(
-    State(state): State<AppState>,
+    State(state): State<CarinsState>,
     Extension(tenant_id): Extension<TenantId>,
 ) -> Result<Json<ListResponse>, StatusCode> {
     let rows = state

--- a/crates/alc-carins/src/carins_files.rs
+++ b/crates/alc-carins/src/carins_files.rs
@@ -8,12 +8,16 @@ use axum::{
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+use crate::CarinsState;
 use alc_core::auth_middleware::TenantId;
 use alc_core::repository::car_inspections::{CarInspectionRepository, CreateFileLinkParams};
 use alc_core::repository::carins_files::FileRow;
-use alc_core::AppState;
 
-pub fn tenant_router() -> Router<AppState> {
+pub fn tenant_router<S>() -> Router<S>
+where
+    CarinsState: axum::extract::FromRef<S>,
+    S: Clone + Send + Sync + 'static,
+{
     Router::new()
         .route("/files", get(list_files).post(create_file))
         .route("/files/recent", get(list_recent))
@@ -37,7 +41,7 @@ struct ListQuery {
 }
 
 async fn list_files(
-    State(state): State<AppState>,
+    State(state): State<CarinsState>,
     Extension(tenant_id): Extension<TenantId>,
     Query(q): Query<ListQuery>,
 ) -> Result<Json<ListResponse>, StatusCode> {
@@ -54,7 +58,7 @@ async fn list_files(
 }
 
 async fn list_recent(
-    State(state): State<AppState>,
+    State(state): State<CarinsState>,
     Extension(tenant_id): Extension<TenantId>,
 ) -> Result<Json<ListResponse>, StatusCode> {
     let rows = state
@@ -70,7 +74,7 @@ async fn list_recent(
 }
 
 async fn list_not_attached(
-    State(state): State<AppState>,
+    State(state): State<CarinsState>,
     Extension(tenant_id): Extension<TenantId>,
 ) -> Result<Json<ListResponse>, StatusCode> {
     let rows = state
@@ -86,7 +90,7 @@ async fn list_not_attached(
 }
 
 async fn get_file(
-    State(state): State<AppState>,
+    State(state): State<CarinsState>,
     Extension(tenant_id): Extension<TenantId>,
     Path(uuid): Path<String>,
 ) -> Result<Json<FileRow>, StatusCode> {
@@ -104,7 +108,7 @@ async fn get_file(
 }
 
 async fn download_file(
-    State(state): State<AppState>,
+    State(state): State<CarinsState>,
     Extension(tenant_id): Extension<TenantId>,
     Path(uuid): Path<String>,
 ) -> Result<impl IntoResponse, StatusCode> {
@@ -118,16 +122,10 @@ async fn download_file(
 
     // Download from GCS
     if let Some(ref s3_key) = row.s3_key {
-        let data = state
-            .carins_storage
-            .as_ref()
-            .unwrap_or(&state.storage)
-            .download(s3_key)
-            .await
-            .map_err(|e| {
-                tracing::error!("GCS download failed: {e}");
-                StatusCode::INTERNAL_SERVER_ERROR
-            })?;
+        let data = state.storage.download(s3_key).await.map_err(|e| {
+            tracing::error!("GCS download failed: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
 
         let content_type = row.file_type.clone();
         let filename = row.filename.clone();
@@ -175,7 +173,7 @@ struct CreateFileRequest {
 }
 
 async fn create_file(
-    State(state): State<AppState>,
+    State(state): State<CarinsState>,
     Extension(tenant_id): Extension<TenantId>,
     Json(body): Json<CreateFileRequest>,
 ) -> Result<(StatusCode, Json<FileRow>), StatusCode> {
@@ -190,9 +188,7 @@ async fn create_file(
         .map_err(|_| StatusCode::BAD_REQUEST)?;
 
     state
-        .carins_storage
-        .as_ref()
-        .unwrap_or(&state.storage)
+        .storage
         .upload(&gcs_key, &data, &body.file_type)
         .await
         .map_err(|e| {
@@ -444,7 +440,7 @@ fn strip_spaces_str(s: &str) -> String {
 }
 
 async fn delete_file(
-    State(state): State<AppState>,
+    State(state): State<CarinsState>,
     Extension(tenant_id): Extension<TenantId>,
     Path(uuid): Path<String>,
 ) -> Result<StatusCode, StatusCode> {
@@ -462,7 +458,7 @@ async fn delete_file(
 }
 
 async fn restore_file(
-    State(state): State<AppState>,
+    State(state): State<CarinsState>,
     Extension(tenant_id): Extension<TenantId>,
     Path(uuid): Path<String>,
 ) -> Result<StatusCode, StatusCode> {

--- a/crates/alc-carins/src/lib.rs
+++ b/crates/alc-carins/src/lib.rs
@@ -3,3 +3,34 @@ pub mod car_inspections;
 pub mod carins_files;
 pub mod nfc_tags;
 pub mod repo;
+
+use std::sync::Arc;
+
+use alc_core::repository::car_inspections::CarInspectionRepository;
+use alc_core::repository::carins_files::CarinsFilesRepository;
+use alc_core::repository::nfc_tags::NfcTagRepository;
+use alc_core::storage::StorageBackend;
+
+/// carins-api 用の最小 State。
+/// モノリスでは `FromRef<AppState>` 経由で自動変換される。
+#[derive(Clone)]
+pub struct CarinsState {
+    pub car_inspections: Arc<dyn CarInspectionRepository>,
+    pub carins_files: Arc<dyn CarinsFilesRepository>,
+    pub nfc_tags: Arc<dyn NfcTagRepository>,
+    pub storage: Arc<dyn StorageBackend>,
+}
+
+impl axum::extract::FromRef<alc_core::AppState> for CarinsState {
+    fn from_ref(state: &alc_core::AppState) -> Self {
+        Self {
+            car_inspections: state.car_inspections.clone(),
+            carins_files: state.carins_files.clone(),
+            nfc_tags: state.nfc_tags.clone(),
+            storage: state
+                .carins_storage
+                .clone()
+                .unwrap_or_else(|| state.storage.clone()),
+        }
+    }
+}

--- a/crates/alc-carins/src/nfc_tags.rs
+++ b/crates/alc-carins/src/nfc_tags.rs
@@ -6,11 +6,15 @@ use axum::{
 };
 use serde::{Deserialize, Serialize};
 
+use crate::CarinsState;
 use alc_core::auth_middleware::TenantId;
 use alc_core::models::NfcTag;
-use alc_core::AppState;
 
-pub fn tenant_router() -> Router<AppState> {
+pub fn tenant_router<S>() -> Router<S>
+where
+    CarinsState: axum::extract::FromRef<S>,
+    S: Clone + Send + Sync + 'static,
+{
     Router::new()
         .route("/nfc-tags", get(list_tags).post(register_tag))
         .route("/nfc-tags/search", get(search_by_uuid))
@@ -34,7 +38,7 @@ struct SearchResponse {
 }
 
 async fn search_by_uuid(
-    State(state): State<AppState>,
+    State(state): State<CarinsState>,
     Extension(tenant_id): Extension<TenantId>,
     Query(q): Query<SearchQuery>,
 ) -> Result<Json<SearchResponse>, StatusCode> {
@@ -65,7 +69,7 @@ struct ListQuery {
 }
 
 async fn list_tags(
-    State(state): State<AppState>,
+    State(state): State<CarinsState>,
     Extension(tenant_id): Extension<TenantId>,
     Query(q): Query<ListQuery>,
 ) -> Result<Json<Vec<NfcTag>>, StatusCode> {
@@ -85,7 +89,7 @@ struct RegisterRequest {
 }
 
 async fn register_tag(
-    State(state): State<AppState>,
+    State(state): State<CarinsState>,
     Extension(tenant_id): Extension<TenantId>,
     Json(body): Json<RegisterRequest>,
 ) -> Result<(StatusCode, Json<NfcTag>), StatusCode> {
@@ -104,7 +108,7 @@ async fn register_tag(
 }
 
 async fn delete_tag(
-    State(state): State<AppState>,
+    State(state): State<CarinsState>,
     Extension(tenant_id): Extension<TenantId>,
     Path(nfc_uuid): Path<String>,
 ) -> Result<StatusCode, StatusCode> {

--- a/crates/alc-dtako/src/dtako_csv_proxy.rs
+++ b/crates/alc-dtako/src/dtako_csv_proxy.rs
@@ -6,10 +6,14 @@ use axum::{
 };
 use serde::Serialize;
 
+use crate::DtakoState;
 use alc_core::auth_middleware::TenantId;
-use alc_core::AppState;
 
-pub fn tenant_router() -> Router<AppState> {
+pub fn tenant_router<S>() -> Router<S>
+where
+    DtakoState: axum::extract::FromRef<S>,
+    S: Clone + Send + Sync + 'static,
+{
     Router::new().route("/operations/{unko_no}/csv/{csv_type}", get(get_csv_as_json))
 }
 
@@ -20,7 +24,7 @@ pub struct CsvJsonResponse {
 }
 
 async fn get_csv_as_json(
-    State(state): State<AppState>,
+    State(state): State<DtakoState>,
     tenant: axum::Extension<TenantId>,
     Path((unko_no, csv_type)): Path<(String, String)>,
 ) -> Result<Json<CsvJsonResponse>, StatusCode> {

--- a/crates/alc-dtako/src/dtako_daily_hours.rs
+++ b/crates/alc-dtako/src/dtako_daily_hours.rs
@@ -7,11 +7,15 @@ use axum::{
 use chrono::NaiveDate;
 use uuid::Uuid;
 
+use crate::DtakoState;
 use alc_core::auth_middleware::TenantId;
 use alc_core::models::{DtakoDailyHoursFilter, DtakoDailyHoursResponse, DtakoSegmentsResponse};
-use alc_core::AppState;
 
-pub fn tenant_router() -> Router<AppState> {
+pub fn tenant_router<S>() -> Router<S>
+where
+    DtakoState: axum::extract::FromRef<S>,
+    S: Clone + Send + Sync + 'static,
+{
     Router::new()
         .route("/daily-hours", get(list_daily_hours))
         .route(
@@ -21,7 +25,7 @@ pub fn tenant_router() -> Router<AppState> {
 }
 
 async fn list_daily_hours(
-    State(state): State<AppState>,
+    State(state): State<DtakoState>,
     tenant: axum::Extension<TenantId>,
     Query(filter): Query<DtakoDailyHoursFilter>,
 ) -> Result<Json<DtakoDailyHoursResponse>, StatusCode> {
@@ -63,7 +67,7 @@ async fn list_daily_hours(
 }
 
 async fn get_daily_segments(
-    State(state): State<AppState>,
+    State(state): State<DtakoState>,
     tenant: axum::Extension<TenantId>,
     Path((driver_id, date)): Path<(Uuid, NaiveDate)>,
 ) -> Result<Json<DtakoSegmentsResponse>, StatusCode> {

--- a/crates/alc-dtako/src/dtako_drivers.rs
+++ b/crates/alc-dtako/src/dtako_drivers.rs
@@ -1,15 +1,19 @@
 use axum::{extract::State, http::StatusCode, routing::get, Json, Router};
 
+use crate::DtakoState;
 use alc_core::auth_middleware::TenantId;
 use alc_core::repository::dtako_drivers::Driver;
-use alc_core::AppState;
 
-pub fn tenant_router() -> Router<AppState> {
+pub fn tenant_router<S>() -> Router<S>
+where
+    DtakoState: axum::extract::FromRef<S>,
+    S: Clone + Send + Sync + 'static,
+{
     Router::new().route("/drivers", get(list_drivers))
 }
 
 async fn list_drivers(
-    State(state): State<AppState>,
+    State(state): State<DtakoState>,
     tenant: axum::Extension<TenantId>,
 ) -> Result<Json<Vec<Driver>>, StatusCode> {
     let tenant_id = tenant.0 .0;

--- a/crates/alc-dtako/src/dtako_event_classifications.rs
+++ b/crates/alc-dtako/src/dtako_event_classifications.rs
@@ -6,18 +6,22 @@ use axum::{
 };
 use uuid::Uuid;
 
+use crate::DtakoState;
 use alc_core::auth_middleware::TenantId;
 use alc_core::models::{DtakoEventClassification, UpdateDtakoClassification};
-use alc_core::AppState;
 
-pub fn tenant_router() -> Router<AppState> {
+pub fn tenant_router<S>() -> Router<S>
+where
+    DtakoState: axum::extract::FromRef<S>,
+    S: Clone + Send + Sync + 'static,
+{
     Router::new()
         .route("/event-classifications", get(list_event_classifications))
         .route("/event-classifications/{id}", put(update_classification))
 }
 
 async fn list_event_classifications(
-    State(state): State<AppState>,
+    State(state): State<DtakoState>,
     tenant: axum::Extension<TenantId>,
 ) -> Result<Json<Vec<DtakoEventClassification>>, StatusCode> {
     let tenant_id = tenant.0 .0;
@@ -32,7 +36,7 @@ async fn list_event_classifications(
 }
 
 async fn update_classification(
-    State(state): State<AppState>,
+    State(state): State<DtakoState>,
     tenant: axum::Extension<TenantId>,
     Path(id): Path<Uuid>,
     Json(body): Json<UpdateDtakoClassification>,

--- a/crates/alc-dtako/src/dtako_logs.rs
+++ b/crates/alc-dtako/src/dtako_logs.rs
@@ -5,14 +5,18 @@ use axum::{
     Json, Router,
 };
 
+use crate::DtakoState;
 use alc_core::auth_middleware::TenantId;
 use alc_core::models::{
     BulkUpsertResponse, DtakologDateQuery, DtakologDateRangeQuery, DtakologInput,
     DtakologSelectQuery, DtakologView,
 };
-use alc_core::AppState;
 
-pub fn tenant_router() -> Router<AppState> {
+pub fn tenant_router<S>() -> Router<S>
+where
+    DtakoState: axum::extract::FromRef<S>,
+    S: Clone + Send + Sync + 'static,
+{
     Router::new()
         .route("/current", get(current_list_all))
         .route("/by-date", get(get_by_date))
@@ -22,7 +26,7 @@ pub fn tenant_router() -> Router<AppState> {
 }
 
 async fn current_list_all(
-    State(state): State<AppState>,
+    State(state): State<DtakoState>,
     tenant: axum::Extension<TenantId>,
 ) -> Result<Json<Vec<DtakologView>>, StatusCode> {
     let rows = state
@@ -34,7 +38,7 @@ async fn current_list_all(
 }
 
 async fn get_by_date(
-    State(state): State<AppState>,
+    State(state): State<DtakoState>,
     tenant: axum::Extension<TenantId>,
     Query(q): Query<DtakologDateQuery>,
 ) -> Result<Json<Vec<DtakologView>>, StatusCode> {
@@ -47,7 +51,7 @@ async fn get_by_date(
 }
 
 async fn current_list_select(
-    State(state): State<AppState>,
+    State(state): State<DtakoState>,
     tenant: axum::Extension<TenantId>,
     Query(q): Query<DtakologSelectQuery>,
 ) -> Result<Json<Vec<DtakologView>>, StatusCode> {
@@ -72,7 +76,7 @@ async fn current_list_select(
 }
 
 async fn get_by_date_range(
-    State(state): State<AppState>,
+    State(state): State<DtakoState>,
     tenant: axum::Extension<TenantId>,
     Query(q): Query<DtakologDateRangeQuery>,
 ) -> Result<Json<Vec<DtakologView>>, StatusCode> {
@@ -122,7 +126,7 @@ fn extract_date(datetime_str: &str) -> String {
 }
 
 async fn bulk_upsert(
-    State(state): State<AppState>,
+    State(state): State<DtakoState>,
     tenant: axum::Extension<TenantId>,
     Json(records): Json<Vec<DtakologInput>>,
 ) -> Result<Json<BulkUpsertResponse>, StatusCode> {

--- a/crates/alc-dtako/src/dtako_operations.rs
+++ b/crates/alc-dtako/src/dtako_operations.rs
@@ -5,11 +5,15 @@ use axum::{
     Json, Router,
 };
 
+use crate::DtakoState;
 use alc_core::auth_middleware::TenantId;
 use alc_core::models::DtakoOperationFilter;
-use alc_core::AppState;
 
-pub fn tenant_router() -> Router<AppState> {
+pub fn tenant_router<S>() -> Router<S>
+where
+    DtakoState: axum::extract::FromRef<S>,
+    S: Clone + Send + Sync + 'static,
+{
     Router::new()
         .route("/operations", get(list_operations))
         .route("/operations/calendar", get(calendar_dates))
@@ -37,7 +41,7 @@ struct CalendarDateEntry {
 }
 
 async fn calendar_dates(
-    State(state): State<AppState>,
+    State(state): State<DtakoState>,
     tenant: axum::Extension<TenantId>,
     Query(q): Query<CalendarQuery>,
 ) -> Result<Json<CalendarResponse>, StatusCode> {
@@ -73,7 +77,7 @@ async fn calendar_dates(
 }
 
 async fn list_operations(
-    State(state): State<AppState>,
+    State(state): State<DtakoState>,
     tenant: axum::Extension<TenantId>,
     Query(filter): Query<DtakoOperationFilter>,
 ) -> Result<Json<alc_core::models::DtakoOperationsResponse>, StatusCode> {
@@ -87,7 +91,7 @@ async fn list_operations(
 }
 
 async fn get_operation(
-    State(state): State<AppState>,
+    State(state): State<DtakoState>,
     tenant: axum::Extension<TenantId>,
     Path(unko_no): Path<String>,
 ) -> Result<Json<Vec<alc_core::models::DtakoOperation>>, StatusCode> {
@@ -104,7 +108,7 @@ async fn get_operation(
 }
 
 async fn delete_operation(
-    State(state): State<AppState>,
+    State(state): State<DtakoState>,
     tenant: axum::Extension<TenantId>,
     Path(unko_no): Path<String>,
 ) -> Result<StatusCode, StatusCode> {

--- a/crates/alc-dtako/src/dtako_restraint_report.rs
+++ b/crates/alc-dtako/src/dtako_restraint_report.rs
@@ -12,6 +12,7 @@ pub use alc_pdf::types::{
     MonthlyTotal, OperationDetail, RestraintDayRow, RestraintReportResponse, WeeklySubtotal,
 };
 
+use crate::DtakoState;
 use alc_compare::{
     self, annotate_known_bugs, parse_restraint_csv, CsvDayRow, CsvDriverData, DiffItem,
 };
@@ -19,9 +20,12 @@ use alc_core::auth_middleware::TenantId;
 use alc_core::repository::dtako_restraint_report::{
     DailyWorkHoursRow, DtakoRestraintReportRepository, OpTimesRow, SegmentRow,
 };
-use alc_core::AppState;
 
-pub fn tenant_router() -> Router<AppState> {
+pub fn tenant_router<S>() -> Router<S>
+where
+    DtakoState: axum::extract::FromRef<S>,
+    S: Clone + Send + Sync + 'static,
+{
     Router::new()
         .route("/restraint-report", get(get_restraint_report))
         .route("/restraint-report/compare-csv", post(compare_csv))
@@ -40,7 +44,7 @@ pub struct CompareQuery {
 }
 
 async fn get_restraint_report(
-    State(state): State<AppState>,
+    State(state): State<DtakoState>,
     tenant: axum::Extension<TenantId>,
     Query(filter): Query<RestraintReportFilter>,
 ) -> Result<Json<RestraintReportResponse>, (StatusCode, String)> {
@@ -532,7 +536,7 @@ pub fn parse_hhmm(s: &str) -> i32 {
 }
 
 async fn compare_csv(
-    State(state): State<AppState>,
+    State(state): State<DtakoState>,
     tenant: axum::Extension<TenantId>,
     Query(query): Query<CompareQuery>,
     mut multipart: Multipart,

--- a/crates/alc-dtako/src/dtako_restraint_report_pdf.rs
+++ b/crates/alc-dtako/src/dtako_restraint_report_pdf.rs
@@ -1,6 +1,6 @@
 use crate::dtako_restraint_report::build_report_with_name;
+use crate::DtakoState;
 use alc_core::auth_middleware::TenantId;
-use alc_core::AppState;
 use alc_pdf::generate_pdf;
 use axum::{
     body::Body,
@@ -14,7 +14,11 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
 use tokio_stream::StreamExt;
 
-pub fn tenant_router() -> Router<AppState> {
+pub fn tenant_router<S>() -> Router<S>
+where
+    DtakoState: axum::extract::FromRef<S>,
+    S: Clone + Send + Sync + 'static,
+{
     Router::new()
         .route("/restraint-report/pdf", get(get_restraint_report_pdf))
         .route(
@@ -44,7 +48,7 @@ struct PdfProgressEvent {
 }
 
 async fn get_restraint_report_pdf(
-    State(state): State<AppState>,
+    State(state): State<DtakoState>,
     tenant: axum::Extension<TenantId>,
     Query(filter): Query<PdfFilter>,
 ) -> Result<Response<Body>, (StatusCode, String)> {
@@ -106,7 +110,7 @@ async fn get_restraint_report_pdf(
 }
 
 async fn get_restraint_report_pdf_stream(
-    State(state): State<AppState>,
+    State(state): State<DtakoState>,
     tenant: axum::Extension<TenantId>,
     Query(filter): Query<PdfFilter>,
 ) -> Response<Body> {

--- a/crates/alc-dtako/src/dtako_scraper.rs
+++ b/crates/alc-dtako/src/dtako_scraper.rs
@@ -13,8 +13,8 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 
+use crate::DtakoState;
 use alc_core::auth_middleware::TenantId;
-use alc_core::AppState;
 
 #[derive(Clone)]
 pub struct ScraperUrl(pub String);
@@ -90,7 +90,7 @@ async fn get_id_token(client: &Client, audience: &str) -> Result<String, String>
 
 /// SSE ストリームプロキシ: dtako-scraper の SSE レスポンスを中継 + DB 保存
 async fn trigger_scrape(
-    State(state): State<AppState>,
+    State(state): State<DtakoState>,
     Extension(scraper_url): Extension<ScraperUrl>,
     Extension(tenant_id): Extension<TenantId>,
     Json(req): Json<ScrapeRequest>,
@@ -204,7 +204,7 @@ async fn trigger_scrape(
 
 /// スクレイプ履歴を取得
 async fn get_scrape_history(
-    State(state): State<AppState>,
+    State(state): State<DtakoState>,
     Extension(tenant_id): Extension<TenantId>,
     Query(query): Query<HistoryQuery>,
 ) -> Result<Json<Vec<ScrapeHistoryItem>>, (axum::http::StatusCode, String)> {
@@ -222,7 +222,11 @@ async fn get_scrape_history(
     Ok(Json(rows))
 }
 
-pub fn tenant_router() -> Router<AppState> {
+pub fn tenant_router<S>() -> Router<S>
+where
+    DtakoState: axum::extract::FromRef<S>,
+    S: Clone + Send + Sync + 'static,
+{
     Router::new()
         .route("/scraper/trigger", post(trigger_scrape))
         .route("/scraper/history", get(get_scrape_history))

--- a/crates/alc-dtako/src/dtako_upload.rs
+++ b/crates/alc-dtako/src/dtako_upload.rs
@@ -9,18 +9,22 @@ use axum::{
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+use crate::DtakoState;
 use alc_core::auth_middleware::TenantId;
 use alc_core::repository::dtako_upload::{
     InsertDailyWorkHoursParams, InsertOperationParams, InsertSegmentParams,
 };
-use alc_core::AppState;
 use alc_csv_parser;
 use alc_csv_parser::kudgivt::{parse_kudgivt, KudgivtRow};
 use alc_csv_parser::kudguri::{parse_kudguri, KudguriRow};
 use alc_csv_parser::work_segments::EventClass;
 use tokio_stream::StreamExt;
 
-pub fn tenant_router() -> Router<AppState> {
+pub fn tenant_router<S>() -> Router<S>
+where
+    DtakoState: axum::extract::FromRef<S>,
+    S: Clone + Send + Sync + 'static,
+{
     Router::new()
         .route("/upload", post(upload_zip))
         .route("/recalculate", post(internal_recalculate_all))
@@ -42,7 +46,7 @@ pub struct UploadResponse {
 }
 
 async fn upload_zip(
-    State(state): State<AppState>,
+    State(state): State<DtakoState>,
     tenant: axum::Extension<TenantId>,
     mut multipart: Multipart,
 ) -> Result<Json<UploadResponse>, (StatusCode, String)> {
@@ -110,7 +114,7 @@ async fn extract_file(
 }
 
 async fn process_zip(
-    state: &AppState,
+    state: &DtakoState,
     tenant_id: Uuid,
     upload_id: Uuid,
     filename: &str,
@@ -257,7 +261,7 @@ struct FerryData {
 /// R2のKUDGFRYからフェリー乗船時間(分)を取得
 /// Returns: unko_no → FerryData のマッピング
 async fn load_ferry_minutes(
-    state: &AppState,
+    state: &DtakoState,
     tenant_id: Uuid,
     rows: &[KudguriRow],
 ) -> std::collections::HashMap<String, FerryData> {
@@ -327,7 +331,7 @@ async fn load_ferry_minutes(
 }
 
 async fn calculate_daily_hours(
-    state: &AppState,
+    state: &DtakoState,
     tenant_id: Uuid,
     rows: &[KudguriRow],
     kudgivt_rows: &[KudgivtRow],
@@ -706,7 +710,7 @@ async fn calculate_daily_hours(
 
 /// R2のZIPからKUDGIVTを取得（テナント・月の全ZIPを走査）
 async fn load_kudgivt_from_zips(
-    state: &AppState,
+    state: &DtakoState,
     tenant_id: Uuid,
     month_start: chrono::NaiveDate,
     _month_end: chrono::NaiveDate,
@@ -766,7 +770,7 @@ async fn load_kudgivt_from_zips(
 
 /// イベント分類をDBから取得、なければデフォルトで初期化
 async fn load_or_init_classifications(
-    state: &AppState,
+    state: &DtakoState,
     tenant_id: Uuid,
     kudgivt_rows: &[KudgivtRow],
 ) -> Result<std::collections::HashMap<String, EventClass>, anyhow::Error> {
@@ -846,7 +850,7 @@ pub fn compute_month_range(
 }
 
 /// CSV split を試行 (失敗してもブロックしない)
-pub(crate) async fn try_split_csv(state: &AppState, upload_id: Uuid) {
+pub(crate) async fn try_split_csv(state: &DtakoState, upload_id: Uuid) {
     if let Err(e) = split_csv_from_r2(state, upload_id).await {
         tracing::warn!("CSV split failed (will not block): {e}");
     }
@@ -854,7 +858,7 @@ pub(crate) async fn try_split_csv(state: &AppState, upload_id: Uuid) {
 
 /// R2 から ZIP をダウンロードして CSV を unko_no 別に分割アップロード
 pub(crate) async fn split_csv_from_r2(
-    state: &AppState,
+    state: &DtakoState,
     upload_id: Uuid,
 ) -> Result<(), anyhow::Error> {
     let record = state
@@ -955,7 +959,7 @@ pub(crate) async fn split_csv_from_r2(
 
 /// R2 に保存済みの ZIP をダウンロード
 async fn internal_download(
-    State(state): State<AppState>,
+    State(state): State<DtakoState>,
     Path(upload_id): Path<Uuid>,
 ) -> Result<Response, (StatusCode, String)> {
     let record = state
@@ -1009,7 +1013,7 @@ async fn internal_download(
 
 /// R2 に保存済みの ZIP を再処理
 async fn internal_rerun(
-    State(state): State<AppState>,
+    State(state): State<DtakoState>,
     Path(upload_id): Path<Uuid>,
 ) -> Result<Json<UploadResponse>, (StatusCode, String)> {
     // upload_history から r2_zip_key を取得
@@ -1084,7 +1088,7 @@ struct RecalcFilter {
 
 /// 月指定再計算のコアロジック (テスト可能)
 pub async fn recalculate_all_core(
-    state: &AppState,
+    state: &DtakoState,
     tenant_id: Uuid,
     year: i32,
     month: u32,
@@ -1196,7 +1200,7 @@ pub async fn recalculate_all_core(
 /// 月指定で再計算（R2の個別CSVから。SSEで進捗通知）
 #[allow(clippy::redundant_closure)]
 async fn internal_recalculate_all(
-    State(state): State<AppState>,
+    State(state): State<DtakoState>,
     tenant: axum::Extension<TenantId>,
     Query(params): Query<RecalcFilter>,
 ) -> Response<Body> {
@@ -1240,7 +1244,7 @@ async fn internal_recalculate_all(
 
 /// pending_retry / failed のアップロード一覧
 async fn list_pending_uploads(
-    State(state): State<AppState>,
+    State(state): State<DtakoState>,
     tenant: axum::Extension<TenantId>,
 ) -> Result<Json<Vec<serde_json::Value>>, (StatusCode, String)> {
     let tenant_id = tenant.0 .0;
@@ -1261,7 +1265,7 @@ struct RecalcDriverFilter {
 
 /// recalculate 共通: ドライバーの operations を KudguriRow として取得
 async fn load_driver_ops_as_kudguri(
-    state: &AppState,
+    state: &DtakoState,
     tenant_id: Uuid,
     driver_id: Uuid,
     driver_cd: &str,
@@ -1306,7 +1310,7 @@ async fn load_driver_ops_as_kudguri(
 
 /// recalculate のコア処理 (SSE なし、テストから直接呼び出し可能)
 pub async fn recalculate_driver_core(
-    state: &AppState,
+    state: &DtakoState,
     tenant_id: Uuid,
     driver_id: Uuid,
     year: i32,
@@ -1358,7 +1362,7 @@ pub async fn recalculate_driver_core(
 /// 1ドライバー分の月次再計算（R2からKUDGIVT取得→再計算）— SSE ラッパー
 #[allow(clippy::redundant_closure)]
 async fn recalculate_driver(
-    State(state): State<AppState>,
+    State(state): State<DtakoState>,
     tenant: axum::Extension<TenantId>,
     Query(params): Query<RecalcDriverFilter>,
 ) -> Response<Body> {
@@ -1410,7 +1414,7 @@ async fn recalculate_driver(
 
 /// バッチ再計算: 1ドライバー分の処理 (事前ロード済み KUDGIVT を使用)
 async fn process_single_driver_batch(
-    state: &AppState,
+    state: &DtakoState,
     tenant_id: Uuid,
     driver_id: Uuid,
     month_start: chrono::NaiveDate,
@@ -1448,7 +1452,7 @@ struct BatchRecalcBody {
 
 /// バッチ再計算コアロジック (テスト可能)
 pub async fn recalculate_drivers_batch_core(
-    state: &AppState,
+    state: &DtakoState,
     tenant_id: Uuid,
     year: i32,
     month: u32,
@@ -1505,7 +1509,7 @@ pub async fn recalculate_drivers_batch_core(
 
 #[allow(clippy::redundant_closure)]
 async fn recalculate_drivers_batch(
-    State(state): State<AppState>,
+    State(state): State<DtakoState>,
     tenant: axum::Extension<TenantId>,
     Json(body): Json<BatchRecalcBody>,
 ) -> Response<Body> {
@@ -1552,7 +1556,7 @@ async fn recalculate_drivers_batch(
 
 /// アップロード一覧
 async fn list_uploads(
-    State(state): State<AppState>,
+    State(state): State<DtakoState>,
     tenant: axum::Extension<TenantId>,
 ) -> Result<Json<Vec<serde_json::Value>>, (StatusCode, String)> {
     let tenant_id = tenant.0 .0;
@@ -1566,7 +1570,7 @@ async fn list_uploads(
 
 /// 認証付きCSV分割エンドポイント
 async fn split_csv_handler(
-    State(state): State<AppState>,
+    State(state): State<DtakoState>,
     _tenant: axum::Extension<TenantId>,
     Path(upload_id): Path<Uuid>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
@@ -1583,7 +1587,7 @@ async fn split_csv_handler(
 
 /// CSV 一括分割コアロジック (テスト可能)
 pub async fn split_csv_all_core(
-    state: &AppState,
+    state: &DtakoState,
     tenant_id: Uuid,
 ) -> Result<(usize, usize), anyhow::Error> {
     let uploads = state
@@ -1638,7 +1642,7 @@ pub async fn split_csv_all_core(
 /// 全completedアップロードのCSV分割（SSE進捗）
 #[allow(clippy::redundant_closure)]
 async fn split_csv_all_handler(
-    State(state): State<AppState>,
+    State(state): State<DtakoState>,
     tenant: axum::Extension<TenantId>,
 ) -> Response<Body> {
     let tenant_id = tenant.0 .0;

--- a/crates/alc-dtako/src/dtako_vehicles.rs
+++ b/crates/alc-dtako/src/dtako_vehicles.rs
@@ -1,15 +1,19 @@
 use axum::{extract::State, http::StatusCode, routing::get, Json, Router};
 
+use crate::DtakoState;
 use alc_core::auth_middleware::TenantId;
 use alc_core::models::DtakoVehicle;
-use alc_core::AppState;
 
-pub fn tenant_router() -> Router<AppState> {
+pub fn tenant_router<S>() -> Router<S>
+where
+    DtakoState: axum::extract::FromRef<S>,
+    S: Clone + Send + Sync + 'static,
+{
     Router::new().route("/vehicles", get(list_vehicles))
 }
 
 async fn list_vehicles(
-    State(state): State<AppState>,
+    State(state): State<DtakoState>,
     tenant: axum::Extension<TenantId>,
 ) -> Result<Json<Vec<DtakoVehicle>>, StatusCode> {
     let tenant_id = tenant.0 .0;

--- a/crates/alc-dtako/src/dtako_work_times.rs
+++ b/crates/alc-dtako/src/dtako_work_times.rs
@@ -5,16 +5,20 @@ use axum::{
     Json, Router,
 };
 
+use crate::DtakoState;
 use alc_core::auth_middleware::TenantId;
 use alc_core::repository::dtako_work_times::{WorkTimesFilter, WorkTimesResponse};
-use alc_core::AppState;
 
-pub fn tenant_router() -> Router<AppState> {
+pub fn tenant_router<S>() -> Router<S>
+where
+    DtakoState: axum::extract::FromRef<S>,
+    S: Clone + Send + Sync + 'static,
+{
     Router::new().route("/work-times", get(list_work_times))
 }
 
 async fn list_work_times(
-    State(state): State<AppState>,
+    State(state): State<DtakoState>,
     tenant: axum::Extension<TenantId>,
     Query(filter): Query<WorkTimesFilter>,
 ) -> Result<Json<WorkTimesResponse>, StatusCode> {

--- a/crates/alc-dtako/src/lib.rs
+++ b/crates/alc-dtako/src/lib.rs
@@ -17,3 +17,58 @@ pub mod dtako_scraper;
 pub mod dtako_upload;
 pub mod dtako_vehicles;
 pub mod dtako_work_times;
+
+use std::sync::Arc;
+
+use alc_core::repository::{
+    DtakoCsvProxyRepository, DtakoDailyHoursRepository, DtakoDriversRepository,
+    DtakoEventClassificationsRepository, DtakoLogsRepository, DtakoOperationsRepository,
+    DtakoRestraintReportPdfRepository, DtakoRestraintReportRepository, DtakoScraperRepository,
+    DtakoUploadRepository, DtakoVehiclesRepository, DtakoWorkTimesRepository,
+};
+use alc_core::storage::StorageBackend;
+
+/// dtako-api 用の最小 State。
+/// モノリスでは `FromRef<AppState>` 経由で自動変換される。
+#[derive(Clone)]
+pub struct DtakoState {
+    pub dtako_csv_proxy: Arc<dyn DtakoCsvProxyRepository>,
+    pub dtako_daily_hours: Arc<dyn DtakoDailyHoursRepository>,
+    pub dtako_drivers: Arc<dyn DtakoDriversRepository>,
+    pub dtako_event_classifications: Arc<dyn DtakoEventClassificationsRepository>,
+    pub dtako_logs: Arc<dyn DtakoLogsRepository>,
+    pub dtako_operations: Arc<dyn DtakoOperationsRepository>,
+    pub dtako_restraint_report: Arc<dyn DtakoRestraintReportRepository>,
+    pub dtako_restraint_report_pdf: Arc<dyn DtakoRestraintReportPdfRepository>,
+    pub dtako_scraper: Arc<dyn DtakoScraperRepository>,
+    pub dtako_upload: Arc<dyn DtakoUploadRepository>,
+    pub dtako_vehicles: Arc<dyn DtakoVehiclesRepository>,
+    pub dtako_work_times: Arc<dyn DtakoWorkTimesRepository>,
+    pub dtako_storage: Option<Arc<dyn StorageBackend>>,
+}
+
+impl axum::extract::FromRef<DtakoState> for DtakoState {
+    fn from_ref(state: &DtakoState) -> Self {
+        state.clone()
+    }
+}
+
+impl axum::extract::FromRef<alc_core::AppState> for DtakoState {
+    fn from_ref(state: &alc_core::AppState) -> Self {
+        Self {
+            dtako_csv_proxy: state.dtako_csv_proxy.clone(),
+            dtako_daily_hours: state.dtako_daily_hours.clone(),
+            dtako_drivers: state.dtako_drivers.clone(),
+            dtako_event_classifications: state.dtako_event_classifications.clone(),
+            dtako_logs: state.dtako_logs.clone(),
+            dtako_operations: state.dtako_operations.clone(),
+            dtako_restraint_report: state.dtako_restraint_report.clone(),
+            dtako_restraint_report_pdf: state.dtako_restraint_report_pdf.clone(),
+            dtako_scraper: state.dtako_scraper.clone(),
+            dtako_upload: state.dtako_upload.clone(),
+            dtako_vehicles: state.dtako_vehicles.clone(),
+            dtako_work_times: state.dtako_work_times.clone(),
+            dtako_storage: state.dtako_storage.clone(),
+        }
+    }
+}

--- a/crates/alc-dtako/src/lib.rs
+++ b/crates/alc-dtako/src/lib.rs
@@ -47,12 +47,6 @@ pub struct DtakoState {
     pub dtako_storage: Option<Arc<dyn StorageBackend>>,
 }
 
-impl axum::extract::FromRef<DtakoState> for DtakoState {
-    fn from_ref(state: &DtakoState) -> Self {
-        state.clone()
-    }
-}
-
 impl axum::extract::FromRef<alc_core::AppState> for DtakoState {
     fn from_ref(state: &alc_core::AppState) -> Self {
         Self {

--- a/crates/carins-api/BUILD.bazel
+++ b/crates/carins-api/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@rules_rust//rust:defs.bzl", "rust_binary")
+load("@crates//:defs.bzl", "all_crate_deps")
+
+rust_binary(
+    name = "carins-api",
+    srcs = glob(["src/**/*.rs"]),
+    deps = all_crate_deps(normal = True) + [
+        "//crates/alc-core",
+        "//crates/alc-carins",
+        "//crates/alc-storage",
+    ],
+    proc_macro_deps = all_crate_deps(proc_macro = True),
+    visibility = ["//visibility:public"],
+)

--- a/crates/carins-api/Cargo.toml
+++ b/crates/carins-api/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "carins-api"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "carins-api"
+path = "src/main.rs"
+
+[dependencies]
+alc-core = { path = "../alc-core" }
+alc-carins = { path = "../alc-carins" }
+alc-storage = { path = "../alc-storage" }
+axum = "0.8"
+sqlx = { version = "0.8", features = ["runtime-tokio", "tls-rustls", "postgres"] }
+tokio = { version = "1", features = ["full"] }
+tower-http = { version = "0.6", features = ["cors", "trace"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/crates/carins-api/src/main.rs
+++ b/crates/carins-api/src/main.rs
@@ -1,0 +1,84 @@
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use axum::{middleware as axum_middleware, Router};
+use sqlx::postgres::PgPoolOptions;
+use tower_http::{
+    cors::{Any, CorsLayer},
+    trace::TraceLayer,
+};
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+use alc_carins::repo::{PgCarInspectionRepository, PgCarinsFilesRepository, PgNfcTagRepository};
+use alc_carins::CarinsState;
+use alc_core::auth_middleware::require_tenant_header;
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::registry()
+        .with(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "carins_api=info,tower_http=info".into()),
+        )
+        .with(tracing_subscriber::fmt::layer())
+        .init();
+
+    let database_url = std::env::var("DATABASE_URL").expect("DATABASE_URL is required");
+    let port: u16 = std::env::var("PORT")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(8080);
+
+    let pool = PgPoolOptions::new()
+        .max_connections(10)
+        .connect(&database_url)
+        .await
+        .expect("Failed to connect to database");
+
+    // R2 storage for carins files
+    let storage = {
+        let bucket = std::env::var("CARINS_R2_BUCKET").expect("CARINS_R2_BUCKET is required");
+        let account_id =
+            std::env::var("CARINS_R2_ACCOUNT_ID").expect("CARINS_R2_ACCOUNT_ID is required");
+        let access_key =
+            std::env::var("CARINS_R2_ACCESS_KEY").expect("CARINS_R2_ACCESS_KEY is required");
+        let secret_key =
+            std::env::var("CARINS_R2_SECRET_KEY").expect("CARINS_R2_SECRET_KEY is required");
+        let public_url = std::env::var("CARINS_R2_PUBLIC_URL").ok();
+
+        alc_storage::R2Backend::new(bucket, account_id, access_key, secret_key, public_url)
+            .expect("Failed to create R2 storage")
+    };
+
+    let state = CarinsState {
+        car_inspections: Arc::new(PgCarInspectionRepository::new(pool.clone())),
+        carins_files: Arc::new(PgCarinsFilesRepository::new(pool.clone())),
+        nfc_tags: Arc::new(PgNfcTagRepository::new(pool.clone())),
+        storage: Arc::new(storage),
+    };
+
+    let tenant_protected = Router::new()
+        .merge(alc_carins::car_inspections::tenant_router())
+        .merge(alc_carins::car_inspection_files::tenant_router())
+        .merge(alc_carins::carins_files::tenant_router())
+        .merge(alc_carins::nfc_tags::tenant_router())
+        .layer(axum_middleware::from_fn(require_tenant_header));
+
+    let cors = CorsLayer::new()
+        .allow_origin(Any)
+        .allow_methods(Any)
+        .allow_headers(Any);
+
+    let app = Router::new()
+        .route("/health", axum::routing::get(|| async { "ok" }))
+        .merge(tenant_protected)
+        .with_state(state)
+        .layer(cors)
+        .layer(TraceLayer::new_for_http());
+
+    let addr = SocketAddr::from(([0, 0, 0, 0], port));
+    tracing::info!("carins-api listening on {addr}");
+
+    let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
+    axum::serve(listener, app).await.unwrap();
+}

--- a/crates/dtako-api/BUILD.bazel
+++ b/crates/dtako-api/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@rules_rust//rust:defs.bzl", "rust_binary")
+load("@crates//:defs.bzl", "all_crate_deps")
+
+rust_binary(
+    name = "dtako-api",
+    srcs = glob(["src/**/*.rs"]),
+    deps = all_crate_deps(normal = True) + [
+        "//crates/alc-core",
+        "//crates/alc-dtako",
+        "//crates/alc-storage",
+    ],
+    proc_macro_deps = all_crate_deps(proc_macro = True),
+    visibility = ["//visibility:public"],
+)

--- a/crates/dtako-api/Cargo.toml
+++ b/crates/dtako-api/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "dtako-api"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "dtako-api"
+path = "src/main.rs"
+
+[dependencies]
+alc-core = { path = "../alc-core" }
+alc-dtako = { path = "../alc-dtako" }
+alc-storage = { path = "../alc-storage" }
+axum = { version = "0.8", features = ["multipart"] }
+sqlx = { version = "0.8", features = ["runtime-tokio", "tls-rustls", "postgres"] }
+tokio = { version = "1", features = ["full"] }
+tower-http = { version = "0.6", features = ["cors", "trace"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/crates/dtako-api/src/main.rs
+++ b/crates/dtako-api/src/main.rs
@@ -1,0 +1,121 @@
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use axum::{middleware as axum_middleware, Router};
+use sqlx::postgres::PgPoolOptions;
+use tower_http::{
+    cors::{Any, CorsLayer},
+    trace::TraceLayer,
+};
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+use alc_core::auth_middleware::require_tenant_header;
+use alc_dtako::repo::{
+    PgDtakoCsvProxyRepository, PgDtakoDailyHoursRepository, PgDtakoDriversRepository,
+    PgDtakoEventClassificationsRepository, PgDtakoLogsRepository, PgDtakoOperationsRepository,
+    PgDtakoRestraintReportPdfRepository, PgDtakoRestraintReportRepository,
+    PgDtakoScraperRepository, PgDtakoUploadRepository, PgDtakoVehiclesRepository,
+    PgDtakoWorkTimesRepository,
+};
+use alc_dtako::DtakoState;
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::registry()
+        .with(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "dtako_api=info,tower_http=info".into()),
+        )
+        .with(tracing_subscriber::fmt::layer())
+        .init();
+
+    let database_url = std::env::var("DATABASE_URL").expect("DATABASE_URL is required");
+    let port: u16 = std::env::var("PORT")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(8080);
+
+    let pool = PgPoolOptions::new()
+        .max_connections(10)
+        .connect(&database_url)
+        .await
+        .expect("Failed to connect to database");
+
+    // R2 storage (optional)
+    let dtako_storage = match (
+        std::env::var("DTAKO_R2_BUCKET"),
+        std::env::var("CF_ACCOUNT_ID"),
+        std::env::var("DTAKO_R2_ACCESS_KEY"),
+        std::env::var("DTAKO_R2_SECRET_KEY"),
+    ) {
+        (Ok(bucket), Ok(account_id), Ok(access_key), Ok(secret_key)) => {
+            match alc_storage::R2Backend::new(bucket, account_id, access_key, secret_key, None) {
+                Ok(backend) => {
+                    tracing::info!("DTAKO R2 storage configured");
+                    Some(Arc::new(backend) as Arc<dyn alc_core::storage::StorageBackend>)
+                }
+                Err(e) => {
+                    tracing::warn!("Failed to create R2 backend: {e}");
+                    None
+                }
+            }
+        }
+        _ => {
+            tracing::info!("DTAKO R2 storage not configured (env vars missing)");
+            None
+        }
+    };
+
+    let state = DtakoState {
+        dtako_csv_proxy: Arc::new(PgDtakoCsvProxyRepository::new(pool.clone())),
+        dtako_daily_hours: Arc::new(PgDtakoDailyHoursRepository::new(pool.clone())),
+        dtako_drivers: Arc::new(PgDtakoDriversRepository::new(pool.clone())),
+        dtako_event_classifications: Arc::new(PgDtakoEventClassificationsRepository::new(
+            pool.clone(),
+        )),
+        dtako_logs: Arc::new(PgDtakoLogsRepository::new(pool.clone())),
+        dtako_operations: Arc::new(PgDtakoOperationsRepository::new(pool.clone())),
+        dtako_restraint_report: Arc::new(PgDtakoRestraintReportRepository::new(pool.clone())),
+        dtako_restraint_report_pdf: Arc::new(PgDtakoRestraintReportPdfRepository::new(
+            pool.clone(),
+        )),
+        dtako_scraper: Arc::new(PgDtakoScraperRepository::new(pool.clone())),
+        dtako_upload: Arc::new(PgDtakoUploadRepository::new(pool.clone())),
+        dtako_vehicles: Arc::new(PgDtakoVehiclesRepository::new(pool.clone())),
+        dtako_work_times: Arc::new(PgDtakoWorkTimesRepository::new(pool.clone())),
+        dtako_storage,
+    };
+
+    let tenant_protected = Router::new()
+        .merge(alc_dtako::dtako_csv_proxy::tenant_router())
+        .merge(alc_dtako::dtako_daily_hours::tenant_router())
+        .merge(alc_dtako::dtako_drivers::tenant_router())
+        .merge(alc_dtako::dtako_event_classifications::tenant_router())
+        .merge(alc_dtako::dtako_operations::tenant_router())
+        .merge(alc_dtako::dtako_restraint_report::tenant_router())
+        .merge(alc_dtako::dtako_restraint_report_pdf::tenant_router())
+        .merge(alc_dtako::dtako_scraper::tenant_router())
+        .merge(alc_dtako::dtako_upload::tenant_router())
+        .merge(alc_dtako::dtako_vehicles::tenant_router())
+        .merge(alc_dtako::dtako_work_times::tenant_router())
+        .nest("/dtako-logs", alc_dtako::dtako_logs::tenant_router())
+        .layer(axum_middleware::from_fn(require_tenant_header));
+
+    let cors = CorsLayer::new()
+        .allow_origin(Any)
+        .allow_methods(Any)
+        .allow_headers(Any);
+
+    let app = Router::new()
+        .route("/health", axum::routing::get(|| async { "ok" }))
+        .merge(tenant_protected)
+        .with_state(state)
+        .layer(cors)
+        .layer(TraceLayer::new_for_http());
+
+    let addr = SocketAddr::from(([0, 0, 0, 0], port));
+    tracing::info!("dtako-api listening on {addr}");
+
+    let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
+    axum::serve(listener, app).await.unwrap();
+}

--- a/crates/gateway/src/config.rs
+++ b/crates/gateway/src/config.rs
@@ -6,6 +6,10 @@ pub struct Config {
     pub jwt_secret: String,
     /// tenko-api の URL。未設定時は backend_url にフォールバック。
     pub tenko_url: Option<String>,
+    /// carins-api の URL。未設定時は backend_url にフォールバック。
+    pub carins_url: Option<String>,
+    /// dtako-api の URL。未設定時は backend_url にフォールバック。
+    pub dtako_url: Option<String>,
 }
 
 impl Config {
@@ -18,6 +22,8 @@ impl Config {
             backend_url: env::var("BACKEND_URL").expect("BACKEND_URL is required"),
             jwt_secret: env::var("JWT_SECRET").expect("JWT_SECRET is required"),
             tenko_url: env::var("TENKO_API_URL").ok(),
+            carins_url: env::var("CARINS_API_URL").ok(),
+            dtako_url: env::var("DTAKO_API_URL").ok(),
         }
     }
 }

--- a/crates/gateway/src/main.rs
+++ b/crates/gateway/src/main.rs
@@ -38,12 +38,20 @@ async fn main() {
     if let Some(ref tenko_url) = config.tenko_url {
         tracing::info!("tenko-api: {tenko_url}");
     }
+    if let Some(ref carins_url) = config.carins_url {
+        tracing::info!("carins-api: {carins_url}");
+    }
+    if let Some(ref dtako_url) = config.dtako_url {
+        tracing::info!("dtako-api: {dtako_url}");
+    }
 
     let proxy_state = ProxyState {
         client,
         backend_url: config.backend_url.clone(),
         jwt_secret: config.jwt_secret,
         tenko_url: config.tenko_url,
+        carins_url: config.carins_url,
+        dtako_url: config.dtako_url,
     };
 
     let cors = CorsLayer::new()

--- a/crates/gateway/src/proxy.rs
+++ b/crates/gateway/src/proxy.rs
@@ -15,6 +15,8 @@ pub struct ProxyState {
     pub backend_url: String,
     pub jwt_secret: String,
     pub tenko_url: Option<String>,
+    pub carins_url: Option<String>,
+    pub dtako_url: Option<String>,
 }
 
 /// パスに応じてバックエンド URL を選択する
@@ -22,6 +24,27 @@ fn resolve_backend<'a>(path: &str, state: &'a ProxyState) -> &'a str {
     let api_path = path.strip_prefix("/api").unwrap_or(path);
     if api_path.starts_with("/tenko") || api_path.starts_with("/tenko-call") {
         state.tenko_url.as_deref().unwrap_or(&state.backend_url)
+    } else if api_path.starts_with("/car-inspection")
+        || api_path.starts_with("/files")
+        || api_path.starts_with("/nfc-tags")
+    {
+        state.carins_url.as_deref().unwrap_or(&state.backend_url)
+    } else if api_path.starts_with("/dtako-")
+        || api_path.starts_with("/upload")
+        || api_path.starts_with("/uploads")
+        || api_path.starts_with("/recalculate")
+        || api_path.starts_with("/split-csv")
+        || api_path.starts_with("/drivers")
+        || api_path.starts_with("/vehicles")
+        || api_path.starts_with("/operations")
+        || api_path.starts_with("/daily-hours")
+        || api_path.starts_with("/work-times")
+        || api_path.starts_with("/event-classifications")
+        || api_path.starts_with("/restraint-report")
+        || api_path.starts_with("/scraper/")
+        || api_path.starts_with("/internal/")
+    {
+        state.dtako_url.as_deref().unwrap_or(&state.backend_url)
     } else {
         &state.backend_url
     }
@@ -134,14 +157,20 @@ fn inject_auth_headers(
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_resolve_backend_tenko() {
-        let state = ProxyState {
+    fn test_state() -> ProxyState {
+        ProxyState {
             client: Client::new(),
             backend_url: "http://backend:8081".to_string(),
             jwt_secret: "secret".to_string(),
             tenko_url: Some("http://tenko:8082".to_string()),
-        };
+            carins_url: Some("http://carins:8083".to_string()),
+            dtako_url: Some("http://dtako:8084".to_string()),
+        }
+    }
+
+    #[test]
+    fn test_resolve_backend_tenko() {
+        let state = test_state();
         assert_eq!(
             resolve_backend("/api/tenko/sessions", &state),
             "http://tenko:8082"
@@ -157,15 +186,98 @@ mod tests {
     }
 
     #[test]
+    fn test_resolve_backend_carins() {
+        let state = test_state();
+        assert_eq!(
+            resolve_backend("/api/car-inspections/current", &state),
+            "http://carins:8083"
+        );
+        assert_eq!(
+            resolve_backend("/api/car-inspection-files/current", &state),
+            "http://carins:8083"
+        );
+        assert_eq!(
+            resolve_backend("/api/files/recent", &state),
+            "http://carins:8083"
+        );
+        assert_eq!(
+            resolve_backend("/api/nfc-tags", &state),
+            "http://carins:8083"
+        );
+    }
+
+    #[test]
+    fn test_resolve_backend_dtako() {
+        let state = test_state();
+        assert_eq!(
+            resolve_backend("/api/dtako-logs/current", &state),
+            "http://dtako:8084"
+        );
+        assert_eq!(resolve_backend("/api/upload", &state), "http://dtako:8084");
+        assert_eq!(resolve_backend("/api/uploads", &state), "http://dtako:8084");
+        assert_eq!(
+            resolve_backend("/api/recalculate", &state),
+            "http://dtako:8084"
+        );
+        assert_eq!(
+            resolve_backend("/api/split-csv/123", &state),
+            "http://dtako:8084"
+        );
+        assert_eq!(resolve_backend("/api/drivers", &state), "http://dtako:8084");
+        assert_eq!(
+            resolve_backend("/api/vehicles", &state),
+            "http://dtako:8084"
+        );
+        assert_eq!(
+            resolve_backend("/api/operations", &state),
+            "http://dtako:8084"
+        );
+        assert_eq!(
+            resolve_backend("/api/daily-hours", &state),
+            "http://dtako:8084"
+        );
+        assert_eq!(
+            resolve_backend("/api/work-times", &state),
+            "http://dtako:8084"
+        );
+        assert_eq!(
+            resolve_backend("/api/event-classifications", &state),
+            "http://dtako:8084"
+        );
+        assert_eq!(
+            resolve_backend("/api/restraint-report", &state),
+            "http://dtako:8084"
+        );
+        assert_eq!(
+            resolve_backend("/api/scraper/trigger", &state),
+            "http://dtako:8084"
+        );
+        assert_eq!(
+            resolve_backend("/api/internal/pending", &state),
+            "http://dtako:8084"
+        );
+    }
+
+    #[test]
     fn test_resolve_backend_fallback() {
         let state = ProxyState {
             client: Client::new(),
             backend_url: "http://backend:8081".to_string(),
             jwt_secret: "secret".to_string(),
             tenko_url: None,
+            carins_url: None,
+            dtako_url: None,
         };
         assert_eq!(
             resolve_backend("/api/tenko/sessions", &state),
+            "http://backend:8081"
+        );
+        assert_eq!(
+            resolve_backend("/api/car-inspections/current", &state),
+            "http://backend:8081"
+        );
+        assert_eq!(
+            resolve_backend("/api/dtako-logs/current", &state),
             "http://backend:8081"
         );
     }


### PR DESCRIPTION
## Summary

- CarinsState (4 repos) + DtakoState (12 repos) を定義、FromRef<AppState> で monolith 互換
- carins 4ファイル + dtako 12ファイルの Router を generic 化 (`Router<S> where XxxState: FromRef<S>`)
- carins-api / dtako-api バイナリ crate を作成 (tenko-api と同パターン)
- Gateway に CARINS_API_URL / DTAKO_API_URL ルーティング追加
- CI に deploy-carins-api / deploy-dtako-api ジョブ追加

## Test plan

- [x] `cargo check --workspace` 成功
- [x] `cargo test --lib` 全61テスト合格
- [ ] CI check (fmt + clippy)
- [ ] CI unit-tests + coverage
- [ ] CI docker-push (Bazel build with new binaries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)