### PR TITLE
ci: split into 5 parallel build-image matrix jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,14 +257,54 @@ jobs:
           path: /tmp/llvm-cov-output.txt
           retention-days: 30
 
-  docker-push:
-    name: Docker Image → GHCR
+  # Bazel build → artifact upload (shared by parallel docker jobs)
+  build-image:
+    name: "Build ${{ matrix.name }}"
     needs: [pr-limit]
     if: "always() && github.event_name == 'pull_request' && (needs.pr-limit.result == 'success' || needs.pr-limit.result == 'skipped')"
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - name: backend
+            targets: "//:rust-alc-api //:migrate //:archive"
+            binaries: "rust-alc-api migrate archive"
+            bin-paths: "bazel-bin/rust-alc-api bazel-bin/migrate bazel-bin/archive"
+            dockerfile: Dockerfile
+            tag-suffix: ""
+            extra-copy: "migrations"
+          - name: gateway
+            targets: "//crates/gateway"
+            binaries: "gateway"
+            bin-paths: "bazel-bin/crates/gateway/gateway"
+            dockerfile: Dockerfile.gateway
+            tag-suffix: "-gateway"
+            extra-copy: ""
+          - name: tenko
+            targets: "//crates/tenko-api"
+            binaries: "tenko-api"
+            bin-paths: "bazel-bin/crates/tenko-api/tenko-api"
+            dockerfile: Dockerfile.tenko
+            tag-suffix: "-tenko"
+            extra-copy: ""
+          - name: carins
+            targets: "//crates/carins-api"
+            binaries: "carins-api"
+            bin-paths: "bazel-bin/crates/carins-api/carins-api"
+            dockerfile: Dockerfile.carins
+            tag-suffix: "-carins"
+            extra-copy: ""
+          - name: dtako
+            targets: "//crates/dtako-api"
+            binaries: "dtako-api"
+            bin-paths: "bazel-bin/crates/dtako-api/dtako-api"
+            dockerfile: Dockerfile.dtako
+            tag-suffix: "-dtako"
+            extra-copy: ""
     steps:
       - uses: actions/checkout@v4
 
@@ -276,30 +316,19 @@ jobs:
           r2-access-key-id: ${{ secrets.BAZEL_R2_ACCESS_KEY_ID }}
           r2-secret-access-key: ${{ secrets.BAZEL_R2_SECRET_ACCESS_KEY }}
 
-      - name: Build release binaries (Bazel)
-        run: bazel build -c opt //:rust-alc-api //:migrate //:archive //crates/gateway //crates/tenko-api //crates/carins-api //crates/dtako-api
+      - name: Build (Bazel)
+        run: bazel build -c opt ${{ matrix.targets }}
 
-      - name: Prepare Docker context (backend)
+      - name: Prepare Docker context
         run: |
-          mkdir -p docker-context
-          cp bazel-bin/rust-alc-api docker-context/
-          cp bazel-bin/migrate docker-context/
-          cp bazel-bin/archive docker-context/
-          cp bazel-bin/crates/tenko-api/tenko-api docker-context/
-          cp bazel-bin/crates/carins-api/carins-api docker-context/
-          cp bazel-bin/crates/dtako-api/dtako-api docker-context/
-          chmod u+w docker-context/rust-alc-api docker-context/migrate docker-context/archive docker-context/tenko-api docker-context/carins-api docker-context/dtako-api
-          strip docker-context/rust-alc-api docker-context/migrate docker-context/archive docker-context/tenko-api docker-context/carins-api docker-context/dtako-api
-          cp -r migrations docker-context/
-          cp Dockerfile docker-context/
-
-      - name: Prepare Docker context (gateway)
-        run: |
-          mkdir -p gateway-context
-          cp bazel-bin/crates/gateway/gateway gateway-context/
-          chmod u+w gateway-context/gateway
-          strip gateway-context/gateway
-          cp Dockerfile.gateway gateway-context/Dockerfile
+          mkdir -p ctx
+          cp ${{ matrix.bin-paths }} ctx/
+          chmod u+w ctx/*
+          strip ctx/*
+          cp ${{ matrix.dockerfile }} ctx/Dockerfile
+          if [ -n "${{ matrix.extra-copy }}" ]; then
+            cp -r ${{ matrix.extra-copy }} ctx/
+          fi
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -311,28 +340,19 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build and push backend (sha tag)
+      - name: Build and push
         uses: docker/build-push-action@v6
         with:
-          context: docker-context
+          context: ctx
           push: true
-          tags: ghcr.io/${{ github.repository }}:${{ github.sha }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: Build and push gateway (sha tag)
-        uses: docker/build-push-action@v6
-        with:
-          context: gateway-context
-          push: true
-          tags: ghcr.io/${{ github.repository }}-gateway:${{ github.sha }}
-          cache-from: type=gha,scope=gateway
-          cache-to: type=gha,mode=max,scope=gateway
+          tags: "ghcr.io/${{ github.repository }}${{ matrix.tag-suffix }}:${{ github.sha }}"
+          cache-from: "type=gha,scope=${{ matrix.name }}"
+          cache-to: "type=gha,mode=max,scope=${{ matrix.name }}"
 
   docker-dev:
     name: Tag dev
     if: github.event_name == 'pull_request'
-    needs: [docker-push]
+    needs: [build-image]
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -344,17 +364,15 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Copy sha tag to dev (backend)
+      - name: Copy sha tag to dev (all images)
         run: |
-          docker pull ghcr.io/${{ github.repository }}:${{ github.sha }}
-          docker tag ghcr.io/${{ github.repository }}:${{ github.sha }} ghcr.io/${{ github.repository }}:dev
-          docker push ghcr.io/${{ github.repository }}:dev
-
-      - name: Copy sha tag to dev (gateway)
-        run: |
-          docker pull ghcr.io/${{ github.repository }}-gateway:${{ github.sha }}
-          docker tag ghcr.io/${{ github.repository }}-gateway:${{ github.sha }} ghcr.io/${{ github.repository }}-gateway:dev
-          docker push ghcr.io/${{ github.repository }}-gateway:dev
+          REPO="ghcr.io/${{ github.repository }}"
+          SHA="${{ github.sha }}"
+          for suffix in "" "-gateway" "-tenko" "-carins" "-dtako"; do
+            docker pull "${REPO}${suffix}:${SHA}"
+            docker tag "${REPO}${suffix}:${SHA}" "${REPO}${suffix}:dev"
+            docker push "${REPO}${suffix}:dev"
+          done
 
   docker-latest:
     name: Tag latest
@@ -371,26 +389,22 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Retag dev → sha + latest (no rebuild)
+      - name: Retag dev → sha + latest (all images)
         run: |
-          docker pull ghcr.io/${{ github.repository }}:dev
-          docker tag ghcr.io/${{ github.repository }}:dev ghcr.io/${{ github.repository }}:${{ github.sha }}
-          docker tag ghcr.io/${{ github.repository }}:dev ghcr.io/${{ github.repository }}:latest
-          docker push ghcr.io/${{ github.repository }}:${{ github.sha }}
-          docker push ghcr.io/${{ github.repository }}:latest
-
-      - name: Retag gateway dev → sha + latest
-        run: |
-          docker pull ghcr.io/${{ github.repository }}-gateway:dev
-          docker tag ghcr.io/${{ github.repository }}-gateway:dev ghcr.io/${{ github.repository }}-gateway:${{ github.sha }}
-          docker tag ghcr.io/${{ github.repository }}-gateway:dev ghcr.io/${{ github.repository }}-gateway:latest
-          docker push ghcr.io/${{ github.repository }}-gateway:${{ github.sha }}
-          docker push ghcr.io/${{ github.repository }}-gateway:latest
+          REPO="ghcr.io/${{ github.repository }}"
+          SHA="${{ github.sha }}"
+          for suffix in "" "-gateway" "-tenko" "-carins" "-dtako"; do
+            docker pull "${REPO}${suffix}:dev"
+            docker tag "${REPO}${suffix}:dev" "${REPO}${suffix}:${SHA}"
+            docker tag "${REPO}${suffix}:dev" "${REPO}${suffix}:latest"
+            docker push "${REPO}${suffix}:${SHA}"
+            docker push "${REPO}${suffix}:latest"
+          done
 
   deploy-staging:
     name: Deploy Staging
     if: github.event_name == 'pull_request'
-    needs: [docker-push, coverage-check]
+    needs: [build-image, coverage-check]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -637,7 +651,7 @@ jobs:
 
       - name: Deploy tenko-api to Cloud Run
         run: |
-          AR_IMAGE="asia-northeast1-docker.pkg.dev/cloudsql-sv/ghcr/ghcr.io/${{ github.repository }}:${{ github.sha }}"
+          AR_IMAGE="asia-northeast1-docker.pkg.dev/cloudsql-sv/ghcr/ghcr.io/${{ github.repository }}-tenko:${{ github.sha }}"
 
           gcloud run deploy rust-alc-api-tenko \
             --image "$AR_IMAGE" \
@@ -646,7 +660,6 @@ jobs:
             --ingress internal \
             --set-secrets "DATABASE_URL=alc-app-database-url:latest" \
             --set-env-vars "RUST_LOG=tenko_api=info" \
-            --command "tenko-api" \
             --port 8080 \
             --memory 256Mi \
             --cpu 1 \
@@ -675,7 +688,7 @@ jobs:
 
       - name: Deploy carins-api to Cloud Run
         run: |
-          AR_IMAGE="asia-northeast1-docker.pkg.dev/cloudsql-sv/ghcr/ghcr.io/${{ github.repository }}:${{ github.sha }}"
+          AR_IMAGE="asia-northeast1-docker.pkg.dev/cloudsql-sv/ghcr/ghcr.io/${{ github.repository }}-carins:${{ github.sha }}"
 
           gcloud run deploy rust-alc-api-carins \
             --image "$AR_IMAGE" \
@@ -684,7 +697,6 @@ jobs:
             --ingress internal \
             --set-secrets "DATABASE_URL=alc-app-database-url:latest,CARINS_R2_ACCESS_KEY=carins-r2-access-key:latest,CARINS_R2_SECRET_KEY=carins-r2-secret-key:latest" \
             --set-env-vars "RUST_LOG=carins_api=info,CARINS_R2_BUCKET=rust-logi-files,CARINS_R2_ACCOUNT_ID=8556e484b273a868db8ec6800b074834" \
-            --command "carins-api" \
             --port 8080 \
             --memory 256Mi \
             --cpu 1 \
@@ -713,7 +725,7 @@ jobs:
 
       - name: Deploy dtako-api to Cloud Run
         run: |
-          AR_IMAGE="asia-northeast1-docker.pkg.dev/cloudsql-sv/ghcr/ghcr.io/${{ github.repository }}:${{ github.sha }}"
+          AR_IMAGE="asia-northeast1-docker.pkg.dev/cloudsql-sv/ghcr/ghcr.io/${{ github.repository }}-dtako:${{ github.sha }}"
 
           gcloud run deploy rust-alc-api-dtako \
             --image "$AR_IMAGE" \
@@ -722,7 +734,6 @@ jobs:
             --ingress internal \
             --set-secrets "DATABASE_URL=alc-app-database-url:latest,DTAKO_R2_ACCESS_KEY=dtako-r2-access-key:latest,DTAKO_R2_SECRET_KEY=dtako-r2-secret-key:latest" \
             --set-env-vars "RUST_LOG=dtako_api=info,DTAKO_R2_BUCKET=ohishi-dtako,DTAKO_R2_ACCOUNT_ID=8556e484b273a868db8ec6800b074834" \
-            --command "dtako-api" \
             --port 8080 \
             --memory 512Mi \
             --cpu 1 \
@@ -759,13 +770,13 @@ jobs:
 
   auto-merge:
     name: Auto Merge
-    needs: [check, coverage-check, docker-push]
+    needs: [check, coverage-check, build-image]
     if: >-
       always() &&
       github.event_name == 'pull_request' &&
       needs.check.result == 'success' &&
       needs.coverage-check.result == 'success' &&
-      needs.docker-push.result == 'success'
+      needs.build-image.result == 'success'
     uses: ippoan/ci-workflows/.github/workflows/auto-merge.yml@main
     permissions:
       contents: write

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,6 @@ RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/
 COPY rust-alc-api /usr/local/bin/
 COPY migrate /usr/local/bin/
 COPY archive /usr/local/bin/
-COPY tenko-api /usr/local/bin/
-COPY carins-api /usr/local/bin/
-COPY dtako-api /usr/local/bin/
 COPY migrations /app/migrations
 
 WORKDIR /app

--- a/Dockerfile.carins
+++ b/Dockerfile.carins
@@ -1,0 +1,10 @@
+FROM debian:trixie-slim
+
+RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+
+COPY carins-api /usr/local/bin/
+
+ENV PORT=8080
+EXPOSE 8080
+
+CMD ["carins-api"]

--- a/Dockerfile.dtako
+++ b/Dockerfile.dtako
@@ -1,0 +1,10 @@
+FROM debian:trixie-slim
+
+RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+
+COPY dtako-api /usr/local/bin/
+
+ENV PORT=8080
+EXPOSE 8080
+
+CMD ["dtako-api"]

--- a/Dockerfile.tenko
+++ b/Dockerfile.tenko
@@ -1,0 +1,10 @@
+FROM debian:trixie-slim
+
+RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+
+COPY tenko-api /usr/local/bin/
+
+ENV PORT=8080
+EXPOSE 8080
+
+CMD ["tenko-api"]


### PR DESCRIPTION
## Summary
- 各マイクロサービスに個別 Dockerfile (Dockerfile.tenko/carins/dtako)
- build-image matrix で 5 並列 Bazel build + Docker push
- 個別 GHCR イメージ (repo-tenko, repo-carins, repo-dtako)
- deploy ジョブは個別イメージを参照 (--command 不要)
- docker-dev/docker-latest で 5 イメージ retag

🤖 Generated with [Claude Code](https://claude.com/claude-code)