### PR TITLE
ci: include serde_json in ts-bindings artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: ts-bindings-${{ github.sha }}
-          path: crates/*/bindings/*.ts
+          path: crates/*/bindings/**/*.ts
           retention-days: 90
 
   test-matrix:


### PR DESCRIPTION
## Summary
- `crates/*/bindings/*.ts` → `crates/*/bindings/**/*.ts`
- `serde_json/JsonValue.ts` が漏れていた (TroubleTicket 等が依存)

## Test plan
- [ ] CI check ジョブが pass
- [ ] artifact に serde_json/JsonValue.ts が含まれることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)