### PR TITLE
fix: auto-seed default categories on first list

### DIFF
--- a/crates/alc-trouble/src/categories.rs
+++ b/crates/alc-trouble/src/categories.rs
@@ -30,12 +30,32 @@ async fn list_categories(
     State(state): State<TroubleState>,
     tenant: axum::Extension<TenantId>,
 ) -> Result<Json<Vec<TroubleCategory>>, StatusCode> {
+    let tenant_id = tenant.0 .0;
     let categories = state
         .trouble_categories
-        .list(tenant.0 .0)
+        .list(tenant_id)
         .await
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    Ok(Json(categories))
+
+    if !categories.is_empty() {
+        return Ok(Json(categories));
+    }
+
+    // Auto-seed default categories
+    let mut seeded = Vec::new();
+    for (i, name) in crate::DEFAULT_CATEGORIES.iter().enumerate() {
+        let input = CreateTroubleCategory {
+            name: name.to_string(),
+            sort_order: Some(i as i32 + 1),
+        };
+        match state.trouble_categories.create(tenant_id, &input).await {
+            Ok(cat) => seeded.push(cat),
+            Err(e) => {
+                tracing::warn!("auto-seed category {name}: {e}");
+            }
+        }
+    }
+    Ok(Json(seeded))
 }
 
 async fn create_category(

--- a/crates/alc-trouble/src/lib.rs
+++ b/crates/alc-trouble/src/lib.rs
@@ -7,6 +7,16 @@ pub mod repo;
 pub mod tickets;
 pub mod workflow;
 
+pub const DEFAULT_CATEGORIES: &[&str] = &[
+    "苦情・トラブル",
+    "貨物事故",
+    "被害事故",
+    "対物事故(他損)",
+    "対物事故(自損)",
+    "人身事故",
+    "その他",
+];
+
 use std::sync::Arc;
 
 use alc_core::repository::{

--- a/crates/alc-trouble/src/tickets.rs
+++ b/crates/alc-trouble/src/tickets.rs
@@ -36,22 +36,13 @@ async fn create_ticket(
 ) -> Result<(StatusCode, Json<TroubleTicket>), StatusCode> {
     let tenant_id = tenant.0 .0;
 
-    let fallback_categories = [
-        "苦情・トラブル",
-        "貨物事故",
-        "被害事故",
-        "対物事故(他損)",
-        "対物事故(自損)",
-        "人身事故",
-        "その他",
-    ];
     let db_categories = state
         .trouble_categories
         .list(tenant_id)
         .await
         .unwrap_or_default();
     let valid = if db_categories.is_empty() {
-        fallback_categories.contains(&body.category.as_str())
+        crate::DEFAULT_CATEGORIES.contains(&body.category.as_str())
     } else {
         db_categories.iter().any(|c| c.name == body.category)
     };


### PR DESCRIPTION
## Summary
- GET /api/trouble/categories が 0 件のとき、既定 7 カテゴリを自動シード
- `DEFAULT_CATEGORIES` 定数を `lib.rs` に共有化（tickets.rs の fallback と統一）

## 背景
設定ページで順位変更ボタンが動作しない原因: 既定カテゴリは DB レコードではなく builtin 表示のため ID がなく、PUT API を呼べなかった

## Test plan
- [ ] staging デプロイ後、/settings でカテゴリが「既定」バッジなしで表示される
- [ ] 上下矢印で順位変更可能
- [ ] リロード後も順位保持

🤖 Generated with [Claude Code](https://claude.com/claude-code)