### PR TITLE
fix: trouble-api file upload 503 + lineworks/members 404

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4729,6 +4729,9 @@ name = "trouble-api"
 version = "0.1.0"
 dependencies = [
  "alc-core",
+ "alc-misc",
+ "alc-notify",
+ "alc-storage",
  "alc-trouble",
  "axum",
  "sqlx",

--- a/cloudrun/render.sh
+++ b/cloudrun/render.sh
@@ -161,6 +161,18 @@ YAML
                 secretKeyRef:
                   key: latest
                   name: dtako-r2-secret-key
+            - name: TROUBLE_R2_BUCKET
+              value: "${ENV_TROUBLE_R2_BUCKET:-trouble-files}"
+            - name: TROUBLE_R2_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: latest
+                  name: trouble-r2-access-key
+            - name: TROUBLE_R2_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: latest
+                  name: trouble-r2-secret-key
             - name: LINE_LOGIN_CHANNEL_ID
               valueFrom:
                 secretKeyRef:
@@ -257,6 +269,20 @@ emit_env_trouble() {
   cat <<YAML
             - name: RUST_LOG
               value: "trouble_api=info"
+            - name: R2_ACCOUNT_ID
+              value: "24b45709d060d957340180e995f0d373"
+            - name: TROUBLE_R2_BUCKET
+              value: "${ENV_TROUBLE_R2_BUCKET:-trouble-files}"
+            - name: TROUBLE_R2_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: latest
+                  name: trouble-r2-access-key
+            - name: TROUBLE_R2_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: latest
+                  name: trouble-r2-secret-key
 YAML
   emit_database_url
 }

--- a/crates/alc-notify/src/clients/lineworks.rs
+++ b/crates/alc-notify/src/clients/lineworks.rs
@@ -12,6 +12,7 @@ use uuid::Uuid;
 
 const AUTH_TOKEN_ENDPOINT: &str = "https://auth.worksmobile.com/oauth2/v2.0/token";
 const BOT_ENDPOINT: &str = "https://www.worksapis.com/v1.0/bots/";
+const USERS_ENDPOINT: &str = "https://www.worksapis.com/v1.0/users";
 
 #[derive(Debug, thiserror::Error)]
 pub enum LineworksBotError {
@@ -89,11 +90,49 @@ impl CachedToken {
     }
 }
 
+/// LINE WORKS API レスポンスから変換した組織メンバー
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LineworksMember {
+    pub user_id: String,
+    pub user_name: Option<String>,
+    pub email: Option<String>,
+}
+
+/// LINE WORKS Users API レスポンス
+#[derive(Debug, Deserialize)]
+struct UsersResponse {
+    users: Option<Vec<UserEntry>>,
+    #[serde(rename = "responseMetaData")]
+    response_meta_data: Option<ResponseMetaData>,
+}
+
+#[derive(Debug, Deserialize)]
+struct UserEntry {
+    #[serde(rename = "userId")]
+    user_id: String,
+    #[serde(rename = "userName")]
+    user_name: Option<UserName>,
+    email: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct UserName {
+    #[serde(rename = "lastName")]
+    last_name: Option<String>,
+    #[serde(rename = "firstName")]
+    first_name: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ResponseMetaData {
+    cursor: Option<String>,
+}
+
 /// マルチテナント対応の LINE WORKS Bot クライアント
-/// bot_config_id ごとにトークンをキャッシュ
+/// (config_id, scope) ごとにトークンをキャッシュ
 pub struct LineworksBotClient {
     client: reqwest::Client,
-    cache: Arc<RwLock<HashMap<Uuid, CachedToken>>>,
+    cache: Arc<RwLock<HashMap<(Uuid, String), CachedToken>>>,
 }
 
 impl Default for LineworksBotClient {
@@ -114,11 +153,13 @@ impl LineworksBotClient {
         &self,
         config_id: Uuid,
         config: &LineworksBotConfig,
+        scope: &str,
     ) -> Result<String, LineworksBotError> {
+        let cache_key = (config_id, scope.to_string());
         // キャッシュチェック
         {
             let cache = self.cache.read().await;
-            if let Some(cached) = cache.get(&config_id) {
+            if let Some(cached) = cache.get(&cache_key) {
                 if !cached.is_expired() {
                     return Ok(cached.token.access_token.clone());
                 }
@@ -126,12 +167,12 @@ impl LineworksBotClient {
         }
 
         // 新規トークン発行
-        let token = self.issue_token(config).await?;
+        let token = self.issue_token(config, scope).await?;
         let access_token = token.access_token.clone();
 
         let mut cache = self.cache.write().await;
         cache.insert(
-            config_id,
+            cache_key,
             CachedToken {
                 token,
                 issued_at: SystemTime::now()
@@ -147,6 +188,7 @@ impl LineworksBotClient {
     async fn issue_token(
         &self,
         config: &LineworksBotConfig,
+        scope: &str,
     ) -> Result<TokenResponse, LineworksBotError> {
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -171,7 +213,7 @@ impl LineworksBotClient {
             ),
             ("client_id", config.client_id.clone()),
             ("client_secret", config.client_secret.clone()),
-            ("scope", "bot".to_string()),
+            ("scope", scope.to_string()),
         ];
 
         let resp = self
@@ -202,7 +244,7 @@ impl LineworksBotClient {
         user_id: &str,
         text: &str,
     ) -> Result<(), LineworksBotError> {
-        let token = self.get_access_token(config_id, config).await?;
+        let token = self.get_access_token(config_id, config, "bot").await?;
         let url = format!(
             "{}{}/users/{}/messages",
             BOT_ENDPOINT, config.bot_id, user_id
@@ -231,5 +273,67 @@ impl LineworksBotClient {
         }
 
         Ok(())
+    }
+
+    /// 組織メンバー一覧を取得 (directory.read scope)
+    pub async fn list_org_users(
+        &self,
+        config_id: Uuid,
+        config: &LineworksBotConfig,
+    ) -> Result<Vec<LineworksMember>, LineworksBotError> {
+        let token = self
+            .get_access_token(config_id, config, "directory.read")
+            .await?;
+
+        let mut members = Vec::new();
+        let mut cursor: Option<String> = None;
+
+        loop {
+            let mut url = USERS_ENDPOINT.to_string();
+            if let Some(ref c) = cursor {
+                url = format!("{}?cursor={}", url, c);
+            }
+
+            let resp = self
+                .client
+                .get(&url)
+                .header("Authorization", format!("Bearer {}", token))
+                .send()
+                .await?;
+
+            if !resp.status().is_success() {
+                let status = resp.status();
+                let body = resp.text().await.unwrap_or_default();
+                tracing::error!("LINE WORKS list users failed: {status} - {body}");
+                return Err(LineworksBotError::SendFailed(format!("{status}: {body}")));
+            }
+
+            let body: UsersResponse = resp
+                .json()
+                .await
+                .map_err(|e| LineworksBotError::SendFailed(format!("parse users response: {e}")))?;
+
+            if let Some(users) = body.users {
+                for u in users {
+                    let display_name = u.user_name.map(|n| {
+                        let last = n.last_name.unwrap_or_default();
+                        let first = n.first_name.unwrap_or_default();
+                        format!("{} {}", last, first).trim().to_string()
+                    });
+                    members.push(LineworksMember {
+                        user_id: u.user_id,
+                        user_name: display_name,
+                        email: u.email,
+                    });
+                }
+            }
+
+            cursor = body.response_meta_data.and_then(|m| m.cursor);
+            if cursor.is_none() {
+                break;
+            }
+        }
+
+        Ok(members)
     }
 }

--- a/crates/alc-trouble/src/lib.rs
+++ b/crates/alc-trouble/src/lib.rs
@@ -2,6 +2,7 @@ pub mod categories;
 pub mod cloud_tasks;
 pub mod comments;
 pub mod files;
+pub mod lineworks_members;
 pub mod notifications;
 pub mod notifier;
 pub mod offices;

--- a/crates/alc-trouble/src/lineworks_members.rs
+++ b/crates/alc-trouble/src/lineworks_members.rs
@@ -1,0 +1,43 @@
+use std::sync::Arc;
+
+use axum::{extract::Extension, http::StatusCode, routing::get, Json, Router};
+
+use alc_core::auth_middleware::TenantId;
+use alc_core::repository::bot_admin::BotAdminRepository;
+use alc_notify::clients::lineworks::{LineworksBotClient, LineworksMember};
+
+use crate::notifier::resolve_lineworks_config;
+
+/// lineworks/members ルーター (tenant_protected 内に merge)
+/// BotAdminRepository と LineworksBotClient は Extension で注入
+pub fn tenant_router<S>() -> Router<S>
+where
+    S: Clone + Send + Sync + 'static,
+{
+    Router::new().route("/trouble/lineworks/members", get(list_members))
+}
+
+async fn list_members(
+    tenant: Extension<TenantId>,
+    bot_admin: Extension<Arc<dyn BotAdminRepository>>,
+    lw_client: Extension<Arc<LineworksBotClient>>,
+) -> Result<Json<Vec<LineworksMember>>, StatusCode> {
+    let tenant_id = tenant.0 .0;
+
+    let (config_id, config) = resolve_lineworks_config(bot_admin.as_ref(), tenant_id)
+        .await
+        .map_err(|e| {
+            tracing::warn!("resolve_lineworks_config: {e}");
+            StatusCode::SERVICE_UNAVAILABLE
+        })?;
+
+    let members = lw_client
+        .list_org_users(config_id, &config)
+        .await
+        .map_err(|e| {
+            tracing::error!("list_org_users: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    Ok(Json(members))
+}

--- a/crates/alc-trouble/src/notifier.rs
+++ b/crates/alc-trouble/src/notifier.rs
@@ -25,7 +25,7 @@ fn encryption_key() -> Result<String, String> {
         .map_err(|_| "SSO_ENCRYPTION_KEY or JWT_SECRET not set".to_string())
 }
 
-async fn resolve_lineworks_config(
+pub async fn resolve_lineworks_config(
     bot_admin: &dyn BotAdminRepository,
     tenant_id: Uuid,
 ) -> Result<(Uuid, LineworksBotConfig), String> {

--- a/crates/trouble-api/BUILD.bazel
+++ b/crates/trouble-api/BUILD.bazel
@@ -6,6 +6,9 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     deps = all_crate_deps(normal = True) + [
         "//crates/alc-core",
+        "//crates/alc-misc",
+        "//crates/alc-notify",
+        "//crates/alc-storage",
         "//crates/alc-trouble",
     ],
     proc_macro_deps = all_crate_deps(proc_macro = True),

--- a/crates/trouble-api/Cargo.toml
+++ b/crates/trouble-api/Cargo.toml
@@ -9,6 +9,9 @@ path = "src/main.rs"
 
 [dependencies]
 alc-core = { path = "../alc-core" }
+alc-misc = { path = "../alc-misc" }
+alc-notify = { path = "../alc-notify" }
+alc-storage = { path = "../alc-storage" }
 alc-trouble = { path = "../alc-trouble" }
 axum = "0.8"
 sqlx = { version = "0.8", features = ["runtime-tokio", "tls-rustls", "postgres"] }

--- a/crates/trouble-api/src/main.rs
+++ b/crates/trouble-api/src/main.rs
@@ -9,7 +9,12 @@ use tower_http::{
 };
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
+use axum::Extension;
+
 use alc_core::auth_middleware::require_tenant_header;
+use alc_core::repository::bot_admin::BotAdminRepository;
+use alc_misc::repo::PgBotAdminRepository;
+use alc_notify::clients::lineworks::LineworksBotClient;
 use alc_trouble::repo::{
     trouble_categories::PgTroubleCategoriesRepository,
     trouble_comments::PgTroubleCommentsRepository, trouble_files::PgTroubleFilesRepository,
@@ -44,8 +49,20 @@ async fn main() {
         .expect("Failed to connect to database");
 
     // trouble_storage は R2 バケットが設定されている場合のみ有効化
-    // (trouble-api 単体では storage 設定は optional)
-    let trouble_storage = None;
+    let trouble_storage: Option<Arc<dyn alc_core::storage::StorageBackend>> =
+        std::env::var("TROUBLE_R2_BUCKET").ok().map(|bucket| {
+            let account_id = std::env::var("R2_ACCOUNT_ID")
+                .expect("R2_ACCOUNT_ID required for TROUBLE_R2_BUCKET");
+            let access_key =
+                std::env::var("TROUBLE_R2_ACCESS_KEY").expect("TROUBLE_R2_ACCESS_KEY required");
+            let secret_key =
+                std::env::var("TROUBLE_R2_SECRET_KEY").expect("TROUBLE_R2_SECRET_KEY required");
+            tracing::info!("Trouble storage: R2 (bucket={})", bucket);
+            Arc::new(
+                alc_storage::R2Backend::new(bucket, account_id, access_key, secret_key, None)
+                    .expect("Failed to init trouble R2 backend"),
+            ) as Arc<dyn alc_core::storage::StorageBackend>
+        });
 
     let state = TroubleState {
         trouble_tickets: Arc::new(PgTroubleTicketsRepository::new(pool.clone())),
@@ -65,6 +82,10 @@ async fn main() {
         notifier: None,
     };
 
+    // LINE WORKS メンバー一覧用
+    let bot_admin: Arc<dyn BotAdminRepository> = Arc::new(PgBotAdminRepository::new(pool.clone()));
+    let lw_client = Arc::new(LineworksBotClient::new());
+
     let tenant_protected = Router::new()
         .merge(alc_trouble::tickets::tenant_router())
         .merge(alc_trouble::files::tenant_router())
@@ -75,6 +96,9 @@ async fn main() {
         .merge(alc_trouble::progress_statuses::tenant_router())
         .merge(alc_trouble::notifications::tenant_router())
         .merge(alc_trouble::schedules::tenant_router())
+        .merge(alc_trouble::lineworks_members::tenant_router())
+        .layer(Extension(bot_admin))
+        .layer(Extension(lw_client))
         .layer(axum_middleware::from_fn(require_tenant_header));
 
     let cors = CorsLayer::new()

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,6 +141,9 @@ async fn main() -> anyhow::Result<()> {
 
     let auth = Arc::new(PgAuthRepository::new(pool.clone()));
     let bot_admin = Arc::new(PgBotAdminRepository::new(pool.clone()));
+    let lw_client = Arc::new(alc_notify::clients::lineworks::LineworksBotClient::new());
+    let bot_admin_ext: Arc<dyn alc_core::repository::bot_admin::BotAdminRepository> =
+        bot_admin.clone();
     let car_inspections = Arc::new(PgCarInspectionRepository::new(pool.clone()));
     let carins_files = Arc::new(PgCarinsFilesRepository::new(pool.clone()));
     let carrying_items = Arc::new(PgCarryingItemsRepository::new(pool.clone()));
@@ -335,6 +338,8 @@ async fn main() -> anyhow::Result<()> {
         .layer(Extension(rust_alc_api::routes::dtako_scraper::ScraperUrl(
             scraper_url,
         )))
+        .layer(Extension(bot_admin_ext))
+        .layer(Extension(lw_client))
         .layer(cors)
         .layer(TraceLayer::new_for_http())
         .with_state(state);

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -49,6 +49,7 @@ pub use alc_tenko::tenko_webhooks;
 pub use alc_trouble::categories as trouble_categories;
 pub use alc_trouble::comments as trouble_comments;
 pub use alc_trouble::files as trouble_files;
+pub use alc_trouble::lineworks_members as trouble_lineworks_members;
 pub use alc_trouble::notifications as trouble_notifications;
 pub use alc_trouble::offices as trouble_offices;
 pub use alc_trouble::progress_statuses as trouble_progress_statuses;
@@ -121,6 +122,7 @@ pub fn router() -> Router<AppState> {
         .merge(trouble_progress_statuses::tenant_router())
         .merge(trouble_notifications::tenant_router())
         .merge(trouble_schedules::tenant_router())
+        .merge(trouble_lineworks_members::tenant_router())
         .layer(axum_middleware::from_fn(require_tenant));
 
     // 公開ルート (認証不要)


### PR DESCRIPTION
## Summary
- trouble-api の R2 ストレージが未設定 (None ハードコード) でファイルアップロードが 503 → 環境変数から R2Backend を初期化
- cloudrun/render.sh に TROUBLE_R2_* 環境変数を追加 (backend + trouble-api)
- GET /trouble/lineworks/members エンドポイント新規追加 — LINE WORKS Users API で組織メンバー一覧を返す
- LineworksBotClient のトークンキャッシュを scope 対応 (bot vs directory.read)