### PR TITLE
fix: check R2 upload response status code

### DIFF
--- a/crates/alc-storage/src/r2.rs
+++ b/crates/alc-storage/src/r2.rs
@@ -52,10 +52,20 @@ impl StorageBackend for R2Backend {
         data: &[u8],
         content_type: &str,
     ) -> Result<String, StorageError> {
-        self.bucket
+        let response = self
+            .bucket
             .put_object_with_content_type(key, data, content_type)
             .await
             .map_err(|e| StorageError::Upload(format!("R2 upload: {e}")))?;
+
+        let status = response.status_code();
+        if !(200..300).contains(&status) {
+            return Err(StorageError::Upload(format!(
+                "R2 upload status {}: {}",
+                status,
+                String::from_utf8_lossy(response.as_slice())
+            )));
+        }
 
         tracing::info!("R2 upload: bucket={}, key={}", self.bucket_name, key);
         Ok(self.public_url(key))


### PR DESCRIPTION
## Summary
- `put_object_with_content_type` が 403 等の非 2xx ステータスでも `Ok` を返す問題を修正
- download と同じステータスコードチェックを upload にも追加
- これにより R2 権限エラー時にアップロード成功と誤認識されるバグを防止

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>