### PR TITLE
fix: raise body limit to 20MB for file uploads

### DIFF
--- a/crates/trouble-api/src/main.rs
+++ b/crates/trouble-api/src/main.rs
@@ -111,6 +111,7 @@ async fn main() {
         .merge(alc_trouble::schedules::fire_router())
         .merge(tenant_protected)
         .with_state(state)
+        .layer(axum::extract::DefaultBodyLimit::max(20 * 1024 * 1024)) // 20MB
         .layer(cors)
         .layer(TraceLayer::new_for_http());
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -340,6 +340,7 @@ async fn main() -> anyhow::Result<()> {
         )))
         .layer(Extension(bot_admin_ext))
         .layer(Extension(lw_client))
+        .layer(axum::extract::DefaultBodyLimit::max(20 * 1024 * 1024)) // 20MB
         .layer(cors)
         .layer(TraceLayer::new_for_http())
         .with_state(state);


### PR DESCRIPTION
## Summary
- Axum デフォルト body limit 2MB → 20MB に引き上げ
- 5MB の画像アップロードで 400 エラーになっていた問題を修正
- monolith + trouble-api 両方に適用

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>