### PR TITLE
feat: add task_assigned notification

### DIFF
--- a/crates/alc-trouble/src/lib.rs
+++ b/crates/alc-trouble/src/lib.rs
@@ -38,11 +38,11 @@ pub const DEFAULT_TASK_TYPES: &[&str] = &[
 use std::sync::Arc;
 
 use alc_core::repository::{
-    TroubleActivityFilesRepository, TroubleCategoriesRepository, TroubleCommentsRepository,
-    TroubleFilesRepository, TroubleNotificationPrefsRepository, TroubleOfficesRepository,
-    TroubleProgressStatusesRepository, TroubleSchedulesRepository, TroubleTaskActivitiesRepository,
-    TroubleTaskTypesRepository, TroubleTasksRepository, TroubleTicketsRepository,
-    TroubleWorkflowRepository,
+    EmployeeRepository, TroubleActivityFilesRepository, TroubleCategoriesRepository,
+    TroubleCommentsRepository, TroubleFilesRepository, TroubleNotificationPrefsRepository,
+    TroubleOfficesRepository, TroubleProgressStatusesRepository, TroubleSchedulesRepository,
+    TroubleTaskActivitiesRepository, TroubleTaskTypesRepository, TroubleTasksRepository,
+    TroubleTicketsRepository, TroubleWorkflowRepository,
 };
 use alc_core::storage::StorageBackend;
 use alc_core::webhook::WebhookService;
@@ -71,6 +71,7 @@ pub struct TroubleState {
     pub webhook: Option<Arc<dyn WebhookService>>,
     pub cloud_tasks: Option<Arc<dyn CloudTasksClient>>,
     pub notifier: Option<Arc<dyn TroubleNotifier>>,
+    pub employees: Option<Arc<dyn EmployeeRepository>>,
 }
 
 impl axum::extract::FromRef<alc_core::AppState> for TroubleState {
@@ -93,6 +94,7 @@ impl axum::extract::FromRef<alc_core::AppState> for TroubleState {
             webhook: state.webhook.clone(),
             cloud_tasks: None,
             notifier: None,
+            employees: Some(state.employees.clone()),
         }
     }
 }

--- a/crates/alc-trouble/src/notifications.rs
+++ b/crates/alc-trouble/src/notifications.rs
@@ -15,6 +15,8 @@ const VALID_EVENT_TYPES: &[&str] = &[
     "trouble_status_changed",
     "trouble_comment_added",
     "trouble_assigned",
+    "task_assigned",
+    "task_due_reminder",
 ];
 
 const VALID_CHANNELS: &[&str] = &["lineworks"];

--- a/crates/alc-trouble/src/tasks.rs
+++ b/crates/alc-trouble/src/tasks.rs
@@ -69,6 +69,45 @@ async fn create_task(
             StatusCode::INTERNAL_SERVER_ERROR
         })?;
 
+    // タスクアサイン通知
+    if let Some(assigned_to_id) = body.assigned_to {
+        if let Some(notifier) = &state.notifier {
+            if let Ok(Some(pref)) = state
+                .trouble_notification_prefs
+                .find_enabled(tenant_id, "task_assigned", "lineworks")
+                .await
+            {
+                let ticket_no = state
+                    .trouble_tickets
+                    .get(tenant_id, ticket_id)
+                    .await
+                    .ok()
+                    .flatten()
+                    .map(|t| t.ticket_no)
+                    .unwrap_or(0);
+                let emp_name = if let Some(ref employees) = state.employees {
+                    employees
+                        .get(tenant_id, assigned_to_id)
+                        .await
+                        .ok()
+                        .flatten()
+                        .map(|e| e.name)
+                } else {
+                    None
+                };
+                let msg = format!(
+                    "タスクアサイン: #{} {} → {}",
+                    ticket_no,
+                    task.title,
+                    emp_name.as_deref().unwrap_or("不明"),
+                );
+                notifier
+                    .notify(tenant_id, "task_assigned", &msg, &pref.lineworks_user_ids)
+                    .await;
+            }
+        }
+    }
+
     Ok((StatusCode::CREATED, Json(task)))
 }
 
@@ -103,6 +142,9 @@ async fn update_task(
 
     let tenant_id = tenant.0 .0;
 
+    // assigned_to が提供され、かつ Some(uuid) の場合に通知対象
+    let has_assigned_to = matches!(body.assigned_to, Some(Some(_)));
+
     let task = state
         .trouble_tasks
         .update(tenant_id, task_id, &body)
@@ -112,6 +154,47 @@ async fn update_task(
             StatusCode::INTERNAL_SERVER_ERROR
         })?
         .ok_or(StatusCode::NOT_FOUND)?;
+
+    // タスクアサイン通知
+    if has_assigned_to {
+        if let Some(assigned_to_id) = task.assigned_to {
+            if let Some(notifier) = &state.notifier {
+                if let Ok(Some(pref)) = state
+                    .trouble_notification_prefs
+                    .find_enabled(tenant_id, "task_assigned", "lineworks")
+                    .await
+                {
+                    let ticket_no = state
+                        .trouble_tickets
+                        .get(tenant_id, task.ticket_id)
+                        .await
+                        .ok()
+                        .flatten()
+                        .map(|t| t.ticket_no)
+                        .unwrap_or(0);
+                    let emp_name = if let Some(ref employees) = state.employees {
+                        employees
+                            .get(tenant_id, assigned_to_id)
+                            .await
+                            .ok()
+                            .flatten()
+                            .map(|e| e.name)
+                    } else {
+                        None
+                    };
+                    let msg = format!(
+                        "タスクアサイン: #{} {} → {}",
+                        ticket_no,
+                        task.title,
+                        emp_name.as_deref().unwrap_or("不明"),
+                    );
+                    notifier
+                        .notify(tenant_id, "task_assigned", &msg, &pref.lineworks_user_ids)
+                        .await;
+                }
+            }
+        }
+    }
 
     Ok(Json(task))
 }

--- a/crates/trouble-api/src/main.rs
+++ b/crates/trouble-api/src/main.rs
@@ -87,6 +87,7 @@ async fn main() {
         webhook: None,
         cloud_tasks: None,
         notifier: None,
+        employees: None,
     };
 
     // LINE WORKS メンバー一覧用


### PR DESCRIPTION
## Summary
- タスクの create/update 時に assigned_to がセットされたら LINE WORKS Bot 通知を送信
- `task_assigned`, `task_due_reminder` を VALID_EVENT_TYPES に追加
- TroubleState に employees フィールド追加（従業員名解決用）

## Test plan
- [ ] CI pass (fmt + clippy + unit + integration)
- [ ] staging デプロイ後、タスクアサイン → LINE WORKS 通知確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)