### PR TITLE
feat: auto-schedule due date reminders via Cloud Tasks

### DIFF
--- a/crates/alc-core/src/models.rs
+++ b/crates/alc-core/src/models.rs
@@ -1765,6 +1765,7 @@ pub struct TroubleSchedule {
     pub id: Uuid,
     pub tenant_id: Uuid,
     pub ticket_id: Uuid,
+    pub task_id: Option<Uuid>,
     pub scheduled_at: DateTime<Utc>,
     pub message: String,
     pub lineworks_user_ids: Vec<String>,
@@ -1779,6 +1780,8 @@ pub struct TroubleSchedule {
 #[ts(export)]
 pub struct CreateTroubleSchedule {
     pub ticket_id: Uuid,
+    #[serde(default)]
+    pub task_id: Option<Uuid>,
     pub scheduled_at: DateTime<Utc>,
     pub message: String,
     pub lineworks_user_ids: Vec<String>,

--- a/crates/alc-core/src/repository/trouble_schedules.rs
+++ b/crates/alc-core/src/repository/trouble_schedules.rs
@@ -34,6 +34,12 @@ pub trait TroubleSchedulesRepository: Send + Sync {
         task_name: &str,
     ) -> Result<bool, sqlx::Error>;
 
+    async fn cancel_pending_by_task(
+        &self,
+        tenant_id: Uuid,
+        task_id: Uuid,
+    ) -> Result<Vec<TroubleSchedule>, sqlx::Error>;
+
     /// RLS バイパス — Cloud Tasks fire 用 (SECURITY DEFINER 関数経由)
     async fn get_for_fire(&self, id: Uuid) -> Result<Option<TroubleSchedule>, sqlx::Error>;
 

--- a/crates/alc-trouble/src/lib.rs
+++ b/crates/alc-trouble/src/lib.rs
@@ -38,11 +38,11 @@ pub const DEFAULT_TASK_TYPES: &[&str] = &[
 use std::sync::Arc;
 
 use alc_core::repository::{
-    TroubleActivityFilesRepository, TroubleCategoriesRepository, TroubleCommentsRepository,
-    TroubleFilesRepository, TroubleNotificationPrefsRepository, TroubleOfficesRepository,
-    TroubleProgressStatusesRepository, TroubleSchedulesRepository, TroubleTaskActivitiesRepository,
-    TroubleTaskTypesRepository, TroubleTasksRepository, TroubleTicketsRepository,
-    TroubleWorkflowRepository,
+    EmployeeRepository, TroubleActivityFilesRepository, TroubleCategoriesRepository,
+    TroubleCommentsRepository, TroubleFilesRepository, TroubleNotificationPrefsRepository,
+    TroubleOfficesRepository, TroubleProgressStatusesRepository, TroubleSchedulesRepository,
+    TroubleTaskActivitiesRepository, TroubleTaskTypesRepository, TroubleTasksRepository,
+    TroubleTicketsRepository, TroubleWorkflowRepository,
 };
 use alc_core::storage::StorageBackend;
 use alc_core::webhook::WebhookService;
@@ -71,6 +71,7 @@ pub struct TroubleState {
     pub webhook: Option<Arc<dyn WebhookService>>,
     pub cloud_tasks: Option<Arc<dyn CloudTasksClient>>,
     pub notifier: Option<Arc<dyn TroubleNotifier>>,
+    pub employees: Option<Arc<dyn EmployeeRepository>>,
 }
 
 impl axum::extract::FromRef<alc_core::AppState> for TroubleState {
@@ -93,6 +94,7 @@ impl axum::extract::FromRef<alc_core::AppState> for TroubleState {
             webhook: state.webhook.clone(),
             cloud_tasks: None,
             notifier: None,
+            employees: Some(state.employees.clone()),
         }
     }
 }

--- a/crates/alc-trouble/src/notifications.rs
+++ b/crates/alc-trouble/src/notifications.rs
@@ -15,6 +15,8 @@ const VALID_EVENT_TYPES: &[&str] = &[
     "trouble_status_changed",
     "trouble_comment_added",
     "trouble_assigned",
+    "task_assigned",
+    "task_due_reminder",
 ];
 
 const VALID_CHANNELS: &[&str] = &["lineworks"];

--- a/crates/alc-trouble/src/repo/trouble_schedules.rs
+++ b/crates/alc-trouble/src/repo/trouble_schedules.rs
@@ -29,13 +29,14 @@ impl TroubleSchedulesRepository for PgTroubleSchedulesRepository {
         sqlx::query_as::<_, TroubleSchedule>(
             r#"
             INSERT INTO trouble_schedules
-                (tenant_id, ticket_id, scheduled_at, message, lineworks_user_ids, created_by)
-            VALUES ($1, $2, $3, $4, $5, $6)
+                (tenant_id, ticket_id, task_id, scheduled_at, message, lineworks_user_ids, created_by)
+            VALUES ($1, $2, $3, $4, $5, $6, $7)
             RETURNING *
             "#,
         )
         .bind(tenant_id)
         .bind(input.ticket_id)
+        .bind(input.task_id)
         .bind(input.scheduled_at)
         .bind(&input.message)
         .bind(&input.lineworks_user_ids)
@@ -108,6 +109,26 @@ impl TroubleSchedulesRepository for PgTroubleSchedulesRepository {
         .execute(&mut *tc.conn)
         .await?;
         Ok(result.rows_affected() > 0)
+    }
+
+    async fn cancel_pending_by_task(
+        &self,
+        tenant_id: Uuid,
+        task_id: Uuid,
+    ) -> Result<Vec<TroubleSchedule>, sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        sqlx::query_as::<_, TroubleSchedule>(
+            r#"
+            UPDATE trouble_schedules
+            SET status = 'cancelled'
+            WHERE tenant_id = $1 AND task_id = $2 AND status = 'pending'
+            RETURNING *
+            "#,
+        )
+        .bind(tenant_id)
+        .bind(task_id)
+        .fetch_all(&mut *tc.conn)
+        .await
     }
 
     async fn get_for_fire(&self, id: Uuid) -> Result<Option<TroubleSchedule>, sqlx::Error> {

--- a/crates/alc-trouble/src/tasks.rs
+++ b/crates/alc-trouble/src/tasks.rs
@@ -4,13 +4,14 @@ use axum::{
     routing::{delete, get, post},
     Json, Router,
 };
+use chrono::{DateTime, Utc};
 use uuid::Uuid;
 
 use crate::TroubleState;
 use alc_core::auth_middleware::TenantId;
 use alc_core::models::{
-    CreateTroubleTask, CreateTroubleTaskActivity, TroubleActivityFile, TroubleTask,
-    TroubleTaskActivity, UpdateTroubleTask,
+    CreateTroubleSchedule, CreateTroubleTask, CreateTroubleTaskActivity, TroubleActivityFile,
+    TroubleTask, TroubleTaskActivity, UpdateTroubleTask,
 };
 
 const VALID_STATUSES: &[&str] = &["open", "in_progress", "done"];
@@ -108,6 +109,11 @@ async fn create_task(
         }
     }
 
+    // 期限リマインダー自動スケジュール
+    if let Some(due_date) = task.due_date {
+        schedule_due_reminder(&state, tenant_id, &task, due_date).await;
+    }
+
     Ok((StatusCode::CREATED, Json(task)))
 }
 
@@ -193,6 +199,16 @@ async fn update_task(
                         .await;
                 }
             }
+        }
+    }
+
+    // 期限リマインダー再スケジュール
+    if body.due_date.is_some() {
+        // Cancel existing reminders for this task
+        cancel_task_reminders(&state, tenant_id, task.id).await;
+        // Schedule new reminder if due_date is set
+        if let Some(due_date) = task.due_date {
+            schedule_due_reminder(&state, tenant_id, &task, due_date).await;
         }
     }
 
@@ -410,5 +426,100 @@ async fn delete_activity_file(
         Ok(StatusCode::NO_CONTENT)
     } else {
         Err(StatusCode::NOT_FOUND)
+    }
+}
+
+/// Cancel all pending reminders for a task
+async fn cancel_task_reminders(state: &TroubleState, tenant_id: Uuid, task_id: Uuid) {
+    match state
+        .trouble_schedules
+        .cancel_pending_by_task(tenant_id, task_id)
+        .await
+    {
+        Ok(cancelled) => {
+            // Also delete from Cloud Tasks
+            if let Some(ct) = &state.cloud_tasks {
+                for schedule in &cancelled {
+                    if let Some(task_name) = &schedule.cloud_task_name {
+                        if let Err(e) = ct.delete_task(task_name).await {
+                            tracing::error!(
+                                "Cloud Tasks delete error for schedule {}: {e}",
+                                schedule.id
+                            );
+                        }
+                    }
+                }
+            }
+        }
+        Err(e) => tracing::error!("cancel_pending_by_task error: {e}"),
+    }
+}
+
+/// Schedule a reminder 1 hour before due date
+async fn schedule_due_reminder(
+    state: &TroubleState,
+    tenant_id: Uuid,
+    task: &TroubleTask,
+    due_date: DateTime<Utc>,
+) {
+    let reminder_at = due_date - chrono::Duration::hours(1);
+    if reminder_at <= chrono::Utc::now() {
+        return; // Already past the reminder time
+    }
+
+    // Check if notification pref exists for task_due_reminder
+    let pref = match state
+        .trouble_notification_prefs
+        .find_enabled(tenant_id, "task_due_reminder", "lineworks")
+        .await
+    {
+        Ok(Some(pref)) => pref,
+        _ => return, // No pref configured
+    };
+
+    // Get ticket_no for the message
+    let ticket_no = state
+        .trouble_tickets
+        .get(tenant_id, task.ticket_id)
+        .await
+        .ok()
+        .flatten()
+        .map(|t| t.ticket_no)
+        .unwrap_or(0);
+
+    let msg = format!(
+        "タスク期限リマインダー: #{} {} (期限: {})",
+        ticket_no,
+        task.title,
+        due_date.format("%Y-%m-%d %H:%M"),
+    );
+
+    let schedule_input = CreateTroubleSchedule {
+        ticket_id: task.ticket_id,
+        task_id: Some(task.id),
+        scheduled_at: reminder_at,
+        message: msg,
+        lineworks_user_ids: pref.lineworks_user_ids.clone(),
+    };
+
+    match state
+        .trouble_schedules
+        .create(tenant_id, &schedule_input, None)
+        .await
+    {
+        Ok(schedule) => {
+            if let Some(ct) = &state.cloud_tasks {
+                match ct.create_task(schedule.id, schedule.scheduled_at).await {
+                    Ok(task_name) => {
+                        let _ = state
+                            .trouble_schedules
+                            .set_cloud_task_name(tenant_id, schedule.id, &task_name)
+                            .await;
+                    }
+                    Err(e) => tracing::error!("Cloud Tasks create error: {e}"),
+                }
+            }
+        }
+        Err(e) => tracing::error!("create due reminder schedule error: {e}"),
     }
 }

--- a/crates/alc-trouble/src/tasks.rs
+++ b/crates/alc-trouble/src/tasks.rs
@@ -69,6 +69,45 @@ async fn create_task(
             StatusCode::INTERNAL_SERVER_ERROR
         })?;
 
+    // タスクアサイン通知
+    if let Some(assigned_to_id) = body.assigned_to {
+        if let Some(notifier) = &state.notifier {
+            if let Ok(Some(pref)) = state
+                .trouble_notification_prefs
+                .find_enabled(tenant_id, "task_assigned", "lineworks")
+                .await
+            {
+                let ticket_no = state
+                    .trouble_tickets
+                    .get(tenant_id, ticket_id)
+                    .await
+                    .ok()
+                    .flatten()
+                    .map(|t| t.ticket_no)
+                    .unwrap_or(0);
+                let emp_name = if let Some(ref employees) = state.employees {
+                    employees
+                        .get(tenant_id, assigned_to_id)
+                        .await
+                        .ok()
+                        .flatten()
+                        .map(|e| e.name)
+                } else {
+                    None
+                };
+                let msg = format!(
+                    "タスクアサイン: #{} {} → {}",
+                    ticket_no,
+                    task.title,
+                    emp_name.as_deref().unwrap_or("不明"),
+                );
+                notifier
+                    .notify(tenant_id, "task_assigned", &msg, &pref.lineworks_user_ids)
+                    .await;
+            }
+        }
+    }
+
     Ok((StatusCode::CREATED, Json(task)))
 }
 
@@ -103,6 +142,9 @@ async fn update_task(
 
     let tenant_id = tenant.0 .0;
 
+    // assigned_to が提供され、かつ Some(uuid) の場合に通知対象
+    let has_assigned_to = matches!(body.assigned_to, Some(Some(_)));
+
     let task = state
         .trouble_tasks
         .update(tenant_id, task_id, &body)
@@ -112,6 +154,47 @@ async fn update_task(
             StatusCode::INTERNAL_SERVER_ERROR
         })?
         .ok_or(StatusCode::NOT_FOUND)?;
+
+    // タスクアサイン通知
+    if has_assigned_to {
+        if let Some(assigned_to_id) = task.assigned_to {
+            if let Some(notifier) = &state.notifier {
+                if let Ok(Some(pref)) = state
+                    .trouble_notification_prefs
+                    .find_enabled(tenant_id, "task_assigned", "lineworks")
+                    .await
+                {
+                    let ticket_no = state
+                        .trouble_tickets
+                        .get(tenant_id, task.ticket_id)
+                        .await
+                        .ok()
+                        .flatten()
+                        .map(|t| t.ticket_no)
+                        .unwrap_or(0);
+                    let emp_name = if let Some(ref employees) = state.employees {
+                        employees
+                            .get(tenant_id, assigned_to_id)
+                            .await
+                            .ok()
+                            .flatten()
+                            .map(|e| e.name)
+                    } else {
+                        None
+                    };
+                    let msg = format!(
+                        "タスクアサイン: #{} {} → {}",
+                        ticket_no,
+                        task.title,
+                        emp_name.as_deref().unwrap_or("不明"),
+                    );
+                    notifier
+                        .notify(tenant_id, "task_assigned", &msg, &pref.lineworks_user_ids)
+                        .await;
+                }
+            }
+        }
+    }
 
     Ok(Json(task))
 }

--- a/crates/trouble-api/src/main.rs
+++ b/crates/trouble-api/src/main.rs
@@ -87,6 +87,7 @@ async fn main() {
         webhook: None,
         cloud_tasks: None,
         notifier: None,
+        employees: None,
     };
 
     // LINE WORKS メンバー一覧用

--- a/migrations/092_add_task_id_to_schedules.sql
+++ b/migrations/092_add_task_id_to_schedules.sql
@@ -1,0 +1,4 @@
+ALTER TABLE alc_api.trouble_schedules
+    ADD COLUMN task_id UUID REFERENCES alc_api.trouble_tasks(id) ON DELETE CASCADE;
+
+CREATE INDEX idx_trouble_schedules_task ON alc_api.trouble_schedules(task_id);

--- a/tests/mock_helpers/repos_e.rs
+++ b/tests/mock_helpers/repos_e.rs
@@ -898,6 +898,7 @@ impl TroubleSchedulesRepository for MockTroubleSchedulesRepository {
             id: Uuid::new_v4(),
             tenant_id,
             ticket_id: input.ticket_id,
+            task_id: input.task_id,
             scheduled_at: input.scheduled_at,
             message: input.message.clone(),
             lineworks_user_ids: input.lineworks_user_ids.clone(),
@@ -945,6 +946,15 @@ impl TroubleSchedulesRepository for MockTroubleSchedulesRepository {
     ) -> Result<bool, sqlx::Error> {
         check_fail!(self);
         Ok(true)
+    }
+
+    async fn cancel_pending_by_task(
+        &self,
+        _tenant_id: Uuid,
+        _task_id: Uuid,
+    ) -> Result<Vec<TroubleSchedule>, sqlx::Error> {
+        check_fail!(self);
+        Ok(vec![])
     }
 
     async fn get_for_fire(&self, _id: Uuid) -> Result<Option<TroubleSchedule>, sqlx::Error> {


### PR DESCRIPTION
## Summary
- Migration 092: `task_id` カラムを `trouble_schedules` に追加 (FK → `trouble_tasks`)
- タスク作成/更新時に `due_date` があれば1時間前にCloud Tasks自動スケジュール
- `due_date` 変更時は既存リマインダーをキャンセルして再スケジュール
- `task_due_reminder` 通知設定で送信先を制御

## Dependencies
- PR #211 (task_assigned notification) — employees field + event types

## Test plan
- [ ] CI pass (fmt + clippy + unit + integration)
- [ ] staging デプロイ後、期限付きタスク作成 → スケジュール確認
- [ ] 期限変更 → 旧スケジュールキャンセル + 新スケジュール確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)