### PR TITLE
feat: add PUT /trouble/activities/{id} for update

### DIFF
--- a/crates/alc-core/src/models.rs
+++ b/crates/alc-core/src/models.rs
@@ -1876,6 +1876,15 @@ pub struct CreateTroubleTaskActivity {
     pub occurred_at: Option<DateTime<Utc>>,
 }
 
+#[derive(Debug, Deserialize, TS)]
+#[ts(export)]
+pub struct UpdateTroubleTaskActivity {
+    #[serde(default)]
+    pub body: Option<String>,
+    #[serde(default)]
+    pub occurred_at: Option<Option<DateTime<Utc>>>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, FromRow, TS)]
 #[ts(export)]
 pub struct TroubleActivityFile {

--- a/crates/alc-core/src/repository/trouble_task_activities.rs
+++ b/crates/alc-core/src/repository/trouble_task_activities.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use uuid::Uuid;
 
-use crate::models::{CreateTroubleTaskActivity, TroubleTaskActivity};
+use crate::models::{CreateTroubleTaskActivity, TroubleTaskActivity, UpdateTroubleTaskActivity};
 
 #[async_trait]
 pub trait TroubleTaskActivitiesRepository: Send + Sync {
@@ -18,6 +18,13 @@ pub trait TroubleTaskActivitiesRepository: Send + Sync {
         tenant_id: Uuid,
         task_id: Uuid,
     ) -> Result<Vec<TroubleTaskActivity>, sqlx::Error>;
+
+    async fn update(
+        &self,
+        tenant_id: Uuid,
+        id: Uuid,
+        input: &UpdateTroubleTaskActivity,
+    ) -> Result<Option<TroubleTaskActivity>, sqlx::Error>;
 
     async fn delete(&self, tenant_id: Uuid, id: Uuid) -> Result<bool, sqlx::Error>;
 }

--- a/crates/alc-trouble/src/repo/trouble_task_activities.rs
+++ b/crates/alc-trouble/src/repo/trouble_task_activities.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use sqlx::PgPool;
 use uuid::Uuid;
 
-use alc_core::models::{CreateTroubleTaskActivity, TroubleTaskActivity};
+use alc_core::models::{CreateTroubleTaskActivity, TroubleTaskActivity, UpdateTroubleTaskActivity};
 use alc_core::tenant::TenantConn;
 
 pub use alc_core::repository::trouble_task_activities::*;
@@ -53,6 +53,29 @@ impl TroubleTaskActivitiesRepository for PgTroubleTaskActivitiesRepository {
         .bind(task_id)
         .bind(tenant_id)
         .fetch_all(&mut *tc.conn)
+        .await
+    }
+
+    async fn update(
+        &self,
+        tenant_id: Uuid,
+        id: Uuid,
+        input: &UpdateTroubleTaskActivity,
+    ) -> Result<Option<TroubleTaskActivity>, sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        sqlx::query_as::<_, TroubleTaskActivity>(
+            r#"UPDATE trouble_task_activities SET
+                body = COALESCE($3, body),
+                occurred_at = CASE WHEN $4 THEN $5 ELSE occurred_at END
+            WHERE id = $1 AND tenant_id = $2
+            RETURNING *"#,
+        )
+        .bind(id)
+        .bind(tenant_id)
+        .bind(&input.body)
+        .bind(input.occurred_at.is_some())
+        .bind(input.occurred_at.flatten())
+        .fetch_optional(&mut *tc.conn)
         .await
     }
 

--- a/crates/alc-trouble/src/tasks.rs
+++ b/crates/alc-trouble/src/tasks.rs
@@ -10,7 +10,7 @@ use crate::TroubleState;
 use alc_core::auth_middleware::TenantId;
 use alc_core::models::{
     CreateTroubleTask, CreateTroubleTaskActivity, TroubleActivityFile, TroubleTask,
-    TroubleTaskActivity, UpdateTroubleTask,
+    TroubleTaskActivity, UpdateTroubleTask, UpdateTroubleTaskActivity,
 };
 
 const VALID_STATUSES: &[&str] = &["open", "in_progress", "done"];
@@ -33,7 +33,10 @@ where
             "/trouble/tasks/{task_id}/activities",
             post(create_activity).get(list_activities),
         )
-        .route("/trouble/activities/{activity_id}", delete(delete_activity))
+        .route(
+            "/trouble/activities/{activity_id}",
+            axum::routing::put(update_activity).delete(delete_activity),
+        )
         .route(
             "/trouble/activities/{activity_id}/files",
             post(upload_activity_file).get(list_activity_files),
@@ -257,6 +260,25 @@ async fn list_activities(
             StatusCode::INTERNAL_SERVER_ERROR
         })?;
     Ok(Json(activities))
+}
+
+async fn update_activity(
+    State(state): State<TroubleState>,
+    tenant: axum::Extension<TenantId>,
+    Path(activity_id): Path<Uuid>,
+    Json(body): Json<UpdateTroubleTaskActivity>,
+) -> Result<Json<TroubleTaskActivity>, StatusCode> {
+    let activity = state
+        .trouble_task_activities
+        .update(tenant.0 .0, activity_id, &body)
+        .await
+        .map_err(|e| {
+            tracing::error!("update_activity error: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?
+        .ok_or(StatusCode::NOT_FOUND)?;
+
+    Ok(Json(activity))
 }
 
 async fn delete_activity(

--- a/tests/mock_helpers/repos_e.rs
+++ b/tests/mock_helpers/repos_e.rs
@@ -10,7 +10,7 @@ use rust_alc_api::db::models::{
     TroubleComment, TroubleFile, TroubleNotificationPref, TroubleOffice, TroubleProgressStatus,
     TroubleSchedule, TroubleStatusHistory, TroubleTask, TroubleTaskActivity, TroubleTicket,
     TroubleTicketFilter, TroubleTicketsResponse, TroubleWorkflowState, TroubleWorkflowTransition,
-    UpdateTroubleTask, UpdateTroubleTicket, UpsertNotificationPref,
+    UpdateTroubleTask, UpdateTroubleTaskActivity, UpdateTroubleTicket, UpsertNotificationPref,
 };
 use rust_alc_api::db::repository::{
     TroubleActivityFilesRepository, TroubleCategoriesRepository, TroubleCommentsRepository,
@@ -1088,6 +1088,24 @@ impl TroubleTaskActivitiesRepository for MockTroubleTaskActivitiesRepository {
     ) -> Result<Vec<TroubleTaskActivity>, sqlx::Error> {
         check_fail!(self);
         Ok(vec![])
+    }
+
+    async fn update(
+        &self,
+        _tenant_id: Uuid,
+        _id: Uuid,
+        input: &UpdateTroubleTaskActivity,
+    ) -> Result<Option<TroubleTaskActivity>, sqlx::Error> {
+        check_fail!(self);
+        Ok(Some(TroubleTaskActivity {
+            id: _id,
+            tenant_id: _tenant_id,
+            task_id: Uuid::nil(),
+            body: input.body.clone().unwrap_or_default(),
+            occurred_at: Utc::now(),
+            created_by: None,
+            created_at: Utc::now(),
+        }))
     }
 
     async fn delete(&self, _tenant_id: Uuid, _id: Uuid) -> Result<bool, sqlx::Error> {


### PR DESCRIPTION
## Summary
- `PUT /trouble/activities/{activity_id}` — body/occurred_at を更新
- UpdateTroubleTaskActivity モデル追加
- Repository trait + Pg 実装 + mock

🤖 Generated with [Claude Code](https://claude.com/claude-code)