### PR TITLE
feat: soft delete + trash/restore for trouble_files

### DIFF
--- a/crates/alc-core/src/models.rs
+++ b/crates/alc-core/src/models.rs
@@ -1650,6 +1650,7 @@ pub struct TroubleFile {
     pub size_bytes: i64,
     pub storage_key: String,
     pub created_at: DateTime<Utc>,
+    pub deleted_at: Option<DateTime<Utc>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, FromRow, TS)]

--- a/crates/alc-core/src/repository/trouble_files.rs
+++ b/crates/alc-core/src/repository/trouble_files.rs
@@ -39,7 +39,15 @@ pub trait TroubleFilesRepository: Send + Sync {
         task_id: Uuid,
     ) -> Result<Vec<TroubleFile>, sqlx::Error>;
 
+    async fn list_trash(
+        &self,
+        tenant_id: Uuid,
+        ticket_id: Uuid,
+    ) -> Result<Vec<TroubleFile>, sqlx::Error>;
+
     async fn get(&self, tenant_id: Uuid, id: Uuid) -> Result<Option<TroubleFile>, sqlx::Error>;
 
-    async fn delete(&self, tenant_id: Uuid, id: Uuid) -> Result<bool, sqlx::Error>;
+    async fn soft_delete(&self, tenant_id: Uuid, id: Uuid) -> Result<bool, sqlx::Error>;
+
+    async fn restore(&self, tenant_id: Uuid, id: Uuid) -> Result<bool, sqlx::Error>;
 }

--- a/crates/alc-trouble/src/files.rs
+++ b/crates/alc-trouble/src/files.rs
@@ -20,8 +20,10 @@ where
             "/trouble/tickets/{ticket_id}/files",
             post(upload_file).get(list_files),
         )
+        .route("/trouble/tickets/{ticket_id}/files/trash", get(list_trash))
         .route("/trouble/files/{file_id}", delete(delete_file))
         .route("/trouble/files/{file_id}/download", get(download_file))
+        .route("/trouble/files/{file_id}/restore", post(restore_file))
 }
 
 async fn upload_file(
@@ -103,6 +105,22 @@ async fn list_files(
     Ok(Json(files))
 }
 
+async fn list_trash(
+    State(state): State<TroubleState>,
+    tenant: axum::Extension<TenantId>,
+    Path(ticket_id): Path<Uuid>,
+) -> Result<Json<Vec<TroubleFile>>, StatusCode> {
+    let files = state
+        .trouble_files
+        .list_trash(tenant.0 .0, ticket_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("list_trash error: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+    Ok(Json(files))
+}
+
 async fn download_file(
     State(state): State<TroubleState>,
     tenant: axum::Extension<TenantId>,
@@ -147,10 +165,30 @@ async fn delete_file(
 ) -> Result<StatusCode, StatusCode> {
     let deleted = state
         .trouble_files
-        .delete(tenant.0 .0, file_id)
+        .soft_delete(tenant.0 .0, file_id)
         .await
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
     if deleted {
+        Ok(StatusCode::NO_CONTENT)
+    } else {
+        Err(StatusCode::NOT_FOUND)
+    }
+}
+
+async fn restore_file(
+    State(state): State<TroubleState>,
+    tenant: axum::Extension<TenantId>,
+    Path(file_id): Path<Uuid>,
+) -> Result<StatusCode, StatusCode> {
+    let restored = state
+        .trouble_files
+        .restore(tenant.0 .0, file_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("restore_file error: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+    if restored {
         Ok(StatusCode::NO_CONTENT)
     } else {
         Err(StatusCode::NOT_FOUND)

--- a/crates/alc-trouble/src/repo/trouble_files.rs
+++ b/crates/alc-trouble/src/repo/trouble_files.rs
@@ -78,7 +78,7 @@ impl TroubleFilesRepository for PgTroubleFilesRepository {
     ) -> Result<Vec<TroubleFile>, sqlx::Error> {
         let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
         sqlx::query_as::<_, TroubleFile>(
-            "SELECT * FROM trouble_files WHERE ticket_id = $1 AND tenant_id = $2 ORDER BY created_at",
+            "SELECT * FROM trouble_files WHERE ticket_id = $1 AND tenant_id = $2 AND deleted_at IS NULL ORDER BY created_at",
         )
         .bind(ticket_id)
         .bind(tenant_id)
@@ -93,9 +93,24 @@ impl TroubleFilesRepository for PgTroubleFilesRepository {
     ) -> Result<Vec<TroubleFile>, sqlx::Error> {
         let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
         sqlx::query_as::<_, TroubleFile>(
-            "SELECT * FROM trouble_files WHERE task_id = $1 AND tenant_id = $2 ORDER BY created_at",
+            "SELECT * FROM trouble_files WHERE task_id = $1 AND tenant_id = $2 AND deleted_at IS NULL ORDER BY created_at",
         )
         .bind(task_id)
+        .bind(tenant_id)
+        .fetch_all(&mut *tc.conn)
+        .await
+    }
+
+    async fn list_trash(
+        &self,
+        tenant_id: Uuid,
+        ticket_id: Uuid,
+    ) -> Result<Vec<TroubleFile>, sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        sqlx::query_as::<_, TroubleFile>(
+            "SELECT * FROM trouble_files WHERE ticket_id = $1 AND tenant_id = $2 AND deleted_at IS NOT NULL ORDER BY deleted_at DESC",
+        )
+        .bind(ticket_id)
         .bind(tenant_id)
         .fetch_all(&mut *tc.conn)
         .await
@@ -112,13 +127,27 @@ impl TroubleFilesRepository for PgTroubleFilesRepository {
         .await
     }
 
-    async fn delete(&self, tenant_id: Uuid, id: Uuid) -> Result<bool, sqlx::Error> {
+    async fn soft_delete(&self, tenant_id: Uuid, id: Uuid) -> Result<bool, sqlx::Error> {
         let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
-        let result = sqlx::query("DELETE FROM trouble_files WHERE id = $1 AND tenant_id = $2")
-            .bind(id)
-            .bind(tenant_id)
-            .execute(&mut *tc.conn)
-            .await?;
+        let result = sqlx::query(
+            "UPDATE trouble_files SET deleted_at = now() WHERE id = $1 AND tenant_id = $2 AND deleted_at IS NULL",
+        )
+        .bind(id)
+        .bind(tenant_id)
+        .execute(&mut *tc.conn)
+        .await?;
+        Ok(result.rows_affected() > 0)
+    }
+
+    async fn restore(&self, tenant_id: Uuid, id: Uuid) -> Result<bool, sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        let result = sqlx::query(
+            "UPDATE trouble_files SET deleted_at = NULL WHERE id = $1 AND tenant_id = $2 AND deleted_at IS NOT NULL",
+        )
+        .bind(id)
+        .bind(tenant_id)
+        .execute(&mut *tc.conn)
+        .await?;
         Ok(result.rows_affected() > 0)
     }
 }

--- a/crates/alc-trouble/src/tasks.rs
+++ b/crates/alc-trouble/src/tasks.rs
@@ -343,7 +343,7 @@ async fn delete_task_file(
 ) -> Result<StatusCode, StatusCode> {
     let deleted = state
         .trouble_files
-        .delete(tenant.0 .0, file_id)
+        .soft_delete(tenant.0 .0, file_id)
         .await
         .map_err(|e| {
             tracing::error!("delete_task_file error: {e}");

--- a/migrations/085_create_trouble_tables.sql
+++ b/migrations/085_create_trouble_tables.sql
@@ -84,10 +84,12 @@ CREATE TABLE alc_api.trouble_files (
     content_type TEXT NOT NULL DEFAULT 'application/octet-stream',
     size_bytes BIGINT NOT NULL DEFAULT 0,
     storage_key TEXT NOT NULL,
-    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    deleted_at TIMESTAMPTZ
 );
 
 CREATE INDEX idx_trouble_files_ticket ON alc_api.trouble_files(ticket_id);
+CREATE INDEX idx_trouble_files_deleted ON alc_api.trouble_files(deleted_at) WHERE deleted_at IS NOT NULL;
 
 -- ステータス変更履歴
 CREATE TABLE alc_api.trouble_status_history (

--- a/tests/mock_helpers/repos_e.rs
+++ b/tests/mock_helpers/repos_e.rs
@@ -305,6 +305,9 @@ impl TroubleFilesRepository for MockTroubleFilesRepository {
 
     async fn restore(&self, _tenant_id: Uuid, _id: Uuid) -> Result<bool, sqlx::Error> {
         check_fail!(self);
+        if self.delete_returns_false.load(Ordering::SeqCst) {
+            return Ok(false);
+        }
         Ok(true)
     }
 }

--- a/tests/mock_helpers/repos_e.rs
+++ b/tests/mock_helpers/repos_e.rs
@@ -218,6 +218,7 @@ impl TroubleFilesRepository for MockTroubleFilesRepository {
             size_bytes,
             storage_key: storage_key.to_string(),
             created_at: Utc::now(),
+            deleted_at: None,
         })
     }
 
@@ -242,6 +243,7 @@ impl TroubleFilesRepository for MockTroubleFilesRepository {
             size_bytes,
             storage_key: storage_key.to_string(),
             created_at: Utc::now(),
+            deleted_at: None,
         })
     }
 
@@ -263,6 +265,15 @@ impl TroubleFilesRepository for MockTroubleFilesRepository {
         Ok(vec![])
     }
 
+    async fn list_trash(
+        &self,
+        _tenant_id: Uuid,
+        _ticket_id: Uuid,
+    ) -> Result<Vec<TroubleFile>, sqlx::Error> {
+        check_fail!(self);
+        Ok(vec![])
+    }
+
     async fn get(&self, tenant_id: Uuid, id: Uuid) -> Result<Option<TroubleFile>, sqlx::Error> {
         check_fail!(self);
         if self.return_some.load(Ordering::SeqCst) {
@@ -277,17 +288,23 @@ impl TroubleFilesRepository for MockTroubleFilesRepository {
                 size_bytes: 5,
                 storage_key: key,
                 created_at: Utc::now(),
+                deleted_at: None,
             }))
         } else {
             Ok(None)
         }
     }
 
-    async fn delete(&self, _tenant_id: Uuid, _id: Uuid) -> Result<bool, sqlx::Error> {
+    async fn soft_delete(&self, _tenant_id: Uuid, _id: Uuid) -> Result<bool, sqlx::Error> {
         check_fail!(self);
         if self.delete_returns_false.load(Ordering::SeqCst) {
             return Ok(false);
         }
+        Ok(true)
+    }
+
+    async fn restore(&self, _tenant_id: Uuid, _id: Uuid) -> Result<bool, sqlx::Error> {
+        check_fail!(self);
         Ok(true)
     }
 }

--- a/tests/mock_tests/mock_trouble_files_test.rs
+++ b/tests/mock_tests/mock_trouble_files_test.rs
@@ -387,6 +387,92 @@ async fn upload_file_db_error_after_upload() {
 }
 
 // ===========================================================================
+// GET /api/trouble/tickets/{ticket_id}/files/trash -- list_trash
+// ===========================================================================
+
+#[tokio::test]
+async fn list_trash_success() {
+    let (base, auth) = setup().await;
+    let ticket_id = Uuid::new_v4();
+    let res = client()
+        .get(format!(
+            "{base}/api/trouble/tickets/{ticket_id}/files/trash"
+        ))
+        .header("Authorization", &auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+}
+
+#[tokio::test]
+async fn list_trash_db_error() {
+    let (base, auth) = setup_failing_files().await;
+    let ticket_id = Uuid::new_v4();
+    let res = client()
+        .get(format!(
+            "{base}/api/trouble/tickets/{ticket_id}/files/trash"
+        ))
+        .header("Authorization", &auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}
+
+// ===========================================================================
+// POST /api/trouble/files/{file_id}/restore -- restore_file
+// ===========================================================================
+
+#[tokio::test]
+async fn restore_file_success() {
+    let (base, auth) = setup().await;
+    let file_id = Uuid::new_v4();
+    let res = client()
+        .post(format!("{base}/api/trouble/files/{file_id}/restore"))
+        .header("Authorization", &auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 204);
+}
+
+#[tokio::test]
+async fn restore_file_not_found() {
+    let mock = Arc::new(MockTroubleFilesRepository::default());
+    mock.delete_returns_false
+        .store(true, std::sync::atomic::Ordering::SeqCst);
+    let mut state = crate::mock_helpers::app_state::setup_mock_app_state();
+    let tenant_id = Uuid::new_v4();
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    state.trouble_files = mock;
+    let base = crate::common::spawn_test_server(state).await;
+    let auth = format!("Bearer {jwt}");
+
+    let file_id = Uuid::new_v4();
+    let res = client()
+        .post(format!("{base}/api/trouble/files/{file_id}/restore"))
+        .header("Authorization", &auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 404);
+}
+
+#[tokio::test]
+async fn restore_file_db_error() {
+    let (base, auth) = setup_failing_files().await;
+    let file_id = Uuid::new_v4();
+    let res = client()
+        .post(format!("{base}/api/trouble/files/{file_id}/restore"))
+        .header("Authorization", &auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}
+
+// ===========================================================================
 // Download file — storage download error (key not in storage)
 // ===========================================================================
 

--- a/tests/trouble_test.rs
+++ b/tests/trouble_test.rs
@@ -593,7 +593,7 @@ async fn test_trouble_file_metadata_crud() {
         .unwrap();
     assert_eq!(res.status(), 200);
 
-    // Delete file
+    // Delete file (soft delete)
     let res = client
         .delete(format!("{base_url}/api/trouble/files/{file_id}"))
         .header("Authorization", &auth)
@@ -601,6 +601,71 @@ async fn test_trouble_file_metadata_crud() {
         .await
         .unwrap();
     assert_eq!(res.status(), 204);
+
+    // List files (0 — soft deleted files are hidden)
+    let res = client
+        .get(format!("{base_url}/api/trouble/tickets/{ticket_id}/files"))
+        .header("Authorization", &auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    let files: Vec<Value> = res.json().await.unwrap();
+    assert_eq!(
+        files.len(),
+        0,
+        "soft deleted file should not appear in list"
+    );
+
+    // List trash (1 — soft deleted file appears here)
+    let res = client
+        .get(format!(
+            "{base_url}/api/trouble/tickets/{ticket_id}/files/trash"
+        ))
+        .header("Authorization", &auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    let trash: Vec<Value> = res.json().await.unwrap();
+    assert_eq!(trash.len(), 1, "trash should contain 1 file");
+    assert!(
+        trash[0]["deleted_at"].as_str().is_some(),
+        "deleted_at should be set"
+    );
+
+    // Restore file
+    let res = client
+        .post(format!("{base_url}/api/trouble/files/{file_id}/restore"))
+        .header("Authorization", &auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 204);
+
+    // List files (1 — restored)
+    let res = client
+        .get(format!("{base_url}/api/trouble/tickets/{ticket_id}/files"))
+        .header("Authorization", &auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    let files: Vec<Value> = res.json().await.unwrap();
+    assert_eq!(files.len(), 1, "restored file should appear in list");
+
+    // Trash empty after restore
+    let res = client
+        .get(format!(
+            "{base_url}/api/trouble/tickets/{ticket_id}/files/trash"
+        ))
+        .header("Authorization", &auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    let trash: Vec<Value> = res.json().await.unwrap();
+    assert_eq!(trash.len(), 0, "trash should be empty after restore");
 }
 
 // ============================================================


### PR DESCRIPTION
## Summary
- trouble_files に deleted_at カラム追加
- DELETE → ソフトデリート（deleted_at を設定）
- POST /trouble/files/{id}/restore で復元
- GET /trouble/tickets/{id}/files/trash でゴミ箱一覧
- 30日間の復元期間

## Test plan
- [x] cargo check pass
- [x] 全9 integration test pass (ローカル)
- [ ] CI check