### PR TITLE
fix: use extra_rustc_flag for LLD instead of --linkopt (#217)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -3,6 +3,5 @@ build --incompatible_strict_action_env
 build --action_env=PATH
 build --jobs=auto
 
-# CI config (disk_cache is managed by ippoan/setup-bazel + R2)
-# Note: --strip and --linkopt are passed directly in CI build commands
-# to avoid cache invalidation from --config flag changes
+# Use LLD for faster linking (~10% build time reduction)
+build --@rules_rust//rust/settings:extra_rustc_flag=-Clink-arg=-fuse-ld=lld

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
           external-cache: true
           repository-cache: true
       - name: Build (Bazel)
-        run: bazel build -c opt --linkopt=-fuse-ld=lld ${{ matrix.targets }}
+        run: bazel build -c opt ${{ matrix.targets }}
 
   cache-cleanup:
     name: Cache Cleanup
@@ -341,7 +341,7 @@ jobs:
           r2-secret-access-key: ${{ secrets.BAZEL_R2_SECRET_ACCESS_KEY }}
 
       - name: Build (Bazel)
-        run: bazel build -c opt --linkopt=-fuse-ld=lld ${{ matrix.targets }}
+        run: bazel build -c opt ${{ matrix.targets }}
 
       - name: Prepare Docker context
         run: |


### PR DESCRIPTION
## Summary
- Replace `--linkopt=-fuse-ld=lld` with `extra_rustc_flag=-Clink-arg=-fuse-ld=lld` in `.bazelrc`
- `--linkopt` changes C++ toolchain config hash → invalidates entire Bazel cache
- `extra_rustc_flag` only affects rust actions → cache compatible

## Benchmark (local, `bazel build -c opt //:rust-alc-api`)

| Method | Elapsed | Critical Path | Cache OK |
|--------|---------|---------------|----------|
| No LLD | 104.0s | 90.75s | ✅ |
| `extra_rustc_flag` LLD | 93.8s | 86.65s | ✅ |
| `--linkopt` LLD | N/A | N/A | ❌ cross-config |

## Test plan
- [x] Local: `bazel clean` → build → rebuild confirms cache hit (0.1s)
- [ ] CI: cache-warm on main → PR build should see cache hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)