### PR TITLE
perf: switch to -c fastbuild — 44% critical path reduction (#217)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -2,6 +2,3 @@
 build --incompatible_strict_action_env
 build --action_env=PATH
 build --jobs=auto
-
-# Use LLD for faster linking (~10% build time reduction)
-build --@rules_rust//rust/settings:extra_rustc_flag=-Clink-arg=-fuse-ld=lld

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,15 +80,13 @@ jobs:
           - { name: trouble, targets: "//crates/trouble-api" }
     steps:
       - uses: actions/checkout@v4
-      - name: Install LLD
-        run: sudo apt-get install -y lld
       - uses: ippoan/setup-bazel@main
         with:
           disk-cache: "bazel-${{ matrix.name }}"
           external-cache: true
           repository-cache: true
       - name: Build (Bazel)
-        run: bazel build -c opt ${{ matrix.targets }}
+        run: bazel build -c fastbuild --strip=always ${{ matrix.targets }}
 
   cache-cleanup:
     name: Cache Cleanup
@@ -329,9 +327,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install LLD
-        run: sudo apt-get install -y lld
-
       - uses: ippoan/setup-bazel@main
         with:
           disk-cache: "bazel-${{ matrix.name }}"
@@ -341,7 +336,7 @@ jobs:
           r2-secret-access-key: ${{ secrets.BAZEL_R2_SECRET_ACCESS_KEY }}
 
       - name: Build (Bazel)
-        run: bazel build -c opt ${{ matrix.targets }}
+        run: bazel build -c fastbuild --strip=always ${{ matrix.targets }}
 
       - name: Prepare Docker context
         run: |


### PR DESCRIPTION
## Summary
- Switch Bazel build from `-c opt` to `-c fastbuild --strip=always`
- Remove redundant LLD flags (rustc 1.92 uses rust-lld by default)
- Remove `Install LLD` CI step

## Benchmark (local, 3 worktrees, cold build)

| Mode | Elapsed | Critical Path |
|------|---------|--------------|
| `-c opt` | 183s | 128s |
| **`-c fastbuild`** | **126s** | **72s (-44%)** |

## Trade-off
- No LLVM optimization (`-O0` instead of `-O2`)
- Binary not optimized for runtime speed
- Acceptable for this API server (I/O bound, not CPU bound)

Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)