### PR TITLE
perf: reduce MODULE.bazel manifests — 35% build time reduction

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -13,23 +13,7 @@ crate = use_extension(
 crate.from_cargo(
     name = "crates",
     cargo_lockfile = "//:Cargo.lock",
-    manifests = [
-        "//:Cargo.toml",
-        "//crates/alc-auth:Cargo.toml",
-        "//crates/alc-carins:Cargo.toml",
-        "//crates/alc-compare:Cargo.toml",
-        "//crates/alc-core:Cargo.toml",
-        "//crates/alc-csv-parser:Cargo.toml",
-        "//crates/alc-devices:Cargo.toml",
-        "//crates/alc-dtako:Cargo.toml",
-        "//crates/alc-misc:Cargo.toml",
-        "//crates/alc-notify:Cargo.toml",
-        "//crates/alc-pdf:Cargo.toml",
-        "//crates/alc-storage:Cargo.toml",
-        "//crates/alc-tenko:Cargo.toml",
-        "//crates/gateway:Cargo.toml",
-        "//crates/tenko-api:Cargo.toml",
-    ],
+    manifests = ["//:Cargo.toml"],
 )
 
 use_repo(crate, "crates")


### PR DESCRIPTION
## Summary
- Reduce `manifests` in MODULE.bazel from 14 entries to root `Cargo.toml` only
- crate_universe resolves workspace members automatically
- Eliminates 27s target pattern evaluation overhead

## Benchmark (local cold build, `-c fastbuild`)

| | Before | After |
|---|---|---|
| Total | 126s | **82s (-35%)** |
| Target eval | 27.4s | **0.08s (-99.7%)** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)