### PR TITLE
test: verify gateway disk cache hit after crate_universe split

### DIFF
--- a/crates/gateway/BUILD.bazel
+++ b/crates/gateway/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_test")
 load("@crates_gateway//:defs.bzl", "all_crate_deps")
 
 # Shadow workspace package path for all_crate_deps() resolution.
+# See bazel/workspaces/gateway/ for the dedicated crate_universe.
 _PKG = "bazel/workspaces/gateway/crates/gateway"
 
 rust_binary(


### PR DESCRIPTION
## Summary
- cache-warm (bazel-gateway) が main で成功済み
- この PR で Build gateway の disk cache hit 率を検証
- BUILD.bazel にコメント追加のみ (Bazel target に影響なし)

## 検証ポイント
- [ ] Build gateway: `disk cache hit` が 422/631 前後であること
- [ ] Build gateway: Critical Path が ~1s 以下であること (全キャッシュヒット)

🤖 Generated with [Claude Code](https://claude.com/claude-code)