### PR TITLE
feat: add storage verification after R2 upload

### DIFF
--- a/crates/alc-carins/Cargo.toml
+++ b/crates/alc-carins/Cargo.toml
@@ -15,6 +15,7 @@ serde_json = "1"
 tracing = "0.1"
 ts-rs = { version = "10", features = ["chrono-impl", "uuid-impl", "serde-json-impl"] }
 uuid = { version = "1", features = ["v4", "serde"] }
+tokio = { version = "1", features = ["rt"] }
 pdf-extract = "0.7"
 regex = "1"
 

--- a/crates/alc-carins/src/carins_files.rs
+++ b/crates/alc-carins/src/carins_files.rs
@@ -54,6 +54,8 @@ async fn list_files(
             StatusCode::INTERNAL_SERVER_ERROR
         })?;
 
+    spawn_verify_unverified(&state, tenant_id.0, &rows);
+
     Ok(Json(ListResponse { files: rows }))
 }
 
@@ -69,6 +71,8 @@ async fn list_recent(
             tracing::error!("list_recent failed: {e}");
             StatusCode::INTERNAL_SERVER_ERROR
         })?;
+
+    spawn_verify_unverified(&state, tenant_id.0, &rows);
 
     Ok(Json(ListResponse { files: rows }))
 }
@@ -196,6 +200,23 @@ async fn create_file(
             StatusCode::INTERNAL_SERVER_ERROR
         })?;
 
+    // Verify the uploaded object actually exists in storage
+    let verified = match state.storage.exists(&gcs_key).await {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!("storage exists check failed: {e}");
+            false
+        }
+    };
+    if !verified {
+        tracing::error!(
+            "storage verification failed: object not found after upload (bucket={}, key={})",
+            state.storage.bucket(),
+            gcs_key
+        );
+        return Err(StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
     let row = state
         .carins_files
         .create_file(
@@ -211,6 +232,15 @@ async fn create_file(
             tracing::error!("create_file DB insert failed: {e}");
             StatusCode::INTERNAL_SERVER_ERROR
         })?;
+
+    // Mark as verified in DB
+    if let Err(e) = state
+        .carins_files
+        .update_storage_verified(tenant_id.0, &row.uuid, true)
+        .await
+    {
+        tracing::warn!("update_storage_verified failed: {e}");
+    }
 
     // 車検証ファイル自動パース (JSON / PDF) — エラーはログのみ
     let parse_result = match body.file_type.as_str() {
@@ -473,6 +503,49 @@ async fn restore_file(
     }
 
     Ok(StatusCode::NO_CONTENT)
+}
+
+/// Spawn a background task to verify unverified files (storage_verified IS NULL).
+/// Called once per list request — files get checked and DB updated.
+fn spawn_verify_unverified(state: &CarinsState, tenant_id: Uuid, rows: &[FileRow]) {
+    let unverified: Vec<(String, Option<String>)> = rows
+        .iter()
+        .filter(|r| r.storage_verified.is_none() && r.s3_key.is_some())
+        .map(|r| (r.uuid.clone(), r.s3_key.clone()))
+        .collect();
+
+    if unverified.is_empty() {
+        return;
+    }
+
+    let storage = state.storage.clone();
+    let repo = state.carins_files.clone();
+    tokio::spawn(async move {
+        for (uuid, s3_key) in unverified {
+            let key = match s3_key {
+                Some(k) => k,
+                None => continue,
+            };
+            let verified = match storage.exists(&key).await {
+                Ok(v) => v,
+                Err(e) => {
+                    tracing::warn!("verify check failed for {uuid}: {e}");
+                    continue;
+                }
+            };
+            if let Err(e) = repo
+                .update_storage_verified(tenant_id, &uuid, verified)
+                .await
+            {
+                tracing::warn!("update_storage_verified failed for {uuid}: {e}");
+            }
+            if !verified {
+                tracing::warn!(
+                    "storage verification: file {uuid} not found in storage (key={key})"
+                );
+            }
+        }
+    });
 }
 
 #[cfg(test)]

--- a/crates/alc-carins/src/repo/carins_files.rs
+++ b/crates/alc-carins/src/repo/carins_files.rs
@@ -14,7 +14,8 @@ const FILE_SELECT: &str = r#"
     NULL as blob, s3_key, storage_class,
     to_char(last_accessed_at, 'YYYY-MM-DD"T"HH24:MI:SS"Z"') as last_accessed_at,
     access_count_weekly, access_count_total,
-    to_char(promoted_to_standard_at, 'YYYY-MM-DD"T"HH24:MI:SS"Z"') as promoted_to_standard_at
+    to_char(promoted_to_standard_at, 'YYYY-MM-DD"T"HH24:MI:SS"Z"') as promoted_to_standard_at,
+    storage_verified
 "#;
 
 const FILE_SELECT_F: &str = r#"
@@ -24,7 +25,8 @@ const FILE_SELECT_F: &str = r#"
     NULL as blob, f.s3_key, f.storage_class,
     to_char(f.last_accessed_at, 'YYYY-MM-DD"T"HH24:MI:SS"Z"') as last_accessed_at,
     f.access_count_weekly, f.access_count_total,
-    to_char(f.promoted_to_standard_at, 'YYYY-MM-DD"T"HH24:MI:SS"Z"') as promoted_to_standard_at
+    to_char(f.promoted_to_standard_at, 'YYYY-MM-DD"T"HH24:MI:SS"Z"') as promoted_to_standard_at,
+    f.storage_verified
 "#;
 
 pub struct PgCarinsFilesRepository {
@@ -106,7 +108,8 @@ impl CarinsFilesRepository for PgCarinsFilesRepository {
              blob, s3_key, storage_class, \
              to_char(last_accessed_at, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') as last_accessed_at, \
              access_count_weekly, access_count_total, \
-             to_char(promoted_to_standard_at, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') as promoted_to_standard_at \
+             to_char(promoted_to_standard_at, 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"') as promoted_to_standard_at, \
+             storage_verified \
              FROM files WHERE uuid = $1::uuid",
         )
         .bind(uuid)
@@ -157,5 +160,20 @@ impl CarinsFilesRepository for PgCarinsFilesRepository {
             .execute(&mut *tc.conn)
             .await?;
         Ok(result.rows_affected() > 0)
+    }
+
+    async fn update_storage_verified(
+        &self,
+        tenant_id: Uuid,
+        uuid: &str,
+        verified: bool,
+    ) -> Result<(), sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        sqlx::query("UPDATE files SET storage_verified = $1 WHERE uuid = $2::uuid")
+            .bind(verified)
+            .bind(uuid)
+            .execute(&mut *tc.conn)
+            .await?;
+        Ok(())
     }
 }

--- a/crates/alc-core/src/repository/carins_files.rs
+++ b/crates/alc-core/src/repository/carins_files.rs
@@ -19,6 +19,7 @@ pub struct FileRow {
     pub access_count_weekly: Option<i32>,
     pub access_count_total: Option<i32>,
     pub promoted_to_standard_at: Option<String>,
+    pub storage_verified: Option<bool>,
 }
 
 #[async_trait]
@@ -57,4 +58,12 @@ pub trait CarinsFilesRepository: Send + Sync {
 
     /// Restore soft-deleted file. Returns true if a row was affected.
     async fn restore_file(&self, tenant_id: Uuid, uuid: &str) -> Result<bool, sqlx::Error>;
+
+    /// Update storage_verified flag for a file.
+    async fn update_storage_verified(
+        &self,
+        tenant_id: Uuid,
+        uuid: &str,
+        verified: bool,
+    ) -> Result<(), sqlx::Error>;
 }

--- a/crates/alc-core/src/storage.rs
+++ b/crates/alc-core/src/storage.rs
@@ -22,6 +22,9 @@ pub trait StorageBackend: Send + Sync {
     /// Download file and return the bytes.
     async fn download(&self, key: &str) -> Result<Vec<u8>, StorageError>;
 
+    /// Check if an object exists in storage (HEAD request).
+    async fn exists(&self, key: &str) -> Result<bool, StorageError>;
+
     /// Extract the object key from a public URL.
     fn extract_key(&self, url: &str) -> Option<String>;
 

--- a/crates/alc-storage/src/gcs.rs
+++ b/crates/alc-storage/src/gcs.rs
@@ -66,6 +66,25 @@ impl StorageBackend for GcsBackend {
         format!("https://storage.googleapis.com/{}/{}", self.bucket, key)
     }
 
+    async fn exists(&self, key: &str) -> Result<bool, StorageError> {
+        let token = self.get_access_token().await?;
+        let encoded_key = key.replace('/', "%2F");
+        let url = format!(
+            "https://storage.googleapis.com/storage/v1/b/{}/o/{}",
+            self.bucket, encoded_key
+        );
+
+        let resp = self
+            .client
+            .get(&url)
+            .bearer_auth(&token)
+            .send()
+            .await
+            .map_err(|e| StorageError::Upload(format!("GCS head: {e}")))?;
+
+        Ok(resp.status().is_success())
+    }
+
     async fn download(&self, key: &str) -> Result<Vec<u8>, StorageError> {
         let token = self.get_access_token().await?;
         // GCS JSON API requires URL-encoded object name (slashes → %2F)

--- a/crates/alc-storage/src/r2.rs
+++ b/crates/alc-storage/src/r2.rs
@@ -75,6 +75,15 @@ impl StorageBackend for R2Backend {
         format!("{}/{}", self.public_url_base, key)
     }
 
+    async fn exists(&self, key: &str) -> Result<bool, StorageError> {
+        match self.bucket.head_object(key).await {
+            Ok(_) => Ok(true),
+            Err(s3::error::S3Error::HttpFailWithBody(404, _))
+            | Err(s3::error::S3Error::HttpFail) => Ok(false),
+            Err(e) => Err(StorageError::Upload(format!("R2 head: {e}"))),
+        }
+    }
+
     async fn download(&self, key: &str) -> Result<Vec<u8>, StorageError> {
         let response = self
             .bucket

--- a/migrations/094_add_storage_verified.sql
+++ b/migrations/094_add_storage_verified.sql
@@ -1,0 +1,9 @@
+-- storage_verified: NULL=未確認, true=R2に存在確認済み, false=R2に存在しない
+ALTER TABLE files ADD COLUMN IF NOT EXISTS storage_verified BOOLEAN DEFAULT NULL;
+
+-- 既存ファイル: s3_key がある場合は verified=true とみなす（移行済みデータ）
+-- s3_key が NULL の場合は blob に格納されているため verified=true
+UPDATE files SET storage_verified = true WHERE storage_verified IS NULL;
+
+-- GRANT (alc_api_app ロールに権限付与)
+GRANT SELECT, INSERT, UPDATE, DELETE ON files TO alc_api_app;

--- a/src/archive/test_helpers.rs
+++ b/src/archive/test_helpers.rs
@@ -45,6 +45,10 @@ impl StorageBackend for TestStorage {
         format!("https://test-storage/{}", key)
     }
 
+    async fn exists(&self, key: &str) -> Result<bool, StorageError> {
+        Ok(self.files.lock().unwrap().contains_key(key))
+    }
+
     async fn download(&self, key: &str) -> Result<Vec<u8>, StorageError> {
         self.files
             .lock()

--- a/src/archive/test_helpers.rs
+++ b/src/archive/test_helpers.rs
@@ -102,6 +102,14 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_storage_exists() {
+        let s = TestStorage::new();
+        assert!(!s.exists("missing").await.unwrap());
+        s.upload("k", b"data", "text/plain").await.unwrap();
+        assert!(s.exists("k").await.unwrap());
+    }
+
+    #[tokio::test]
     async fn test_storage_download_not_found() {
         let s = TestStorage::new();
         assert!(s.download("missing").await.is_err());

--- a/tests/common/mock_storage.rs
+++ b/tests/common/mock_storage.rs
@@ -49,6 +49,10 @@ impl StorageBackend for MockStorage {
         format!("https://mock-storage/{}/{}", self.bucket_name, key)
     }
 
+    async fn exists(&self, key: &str) -> Result<bool, StorageError> {
+        Ok(self.files.lock().unwrap().contains_key(key))
+    }
+
     async fn download(&self, key: &str) -> Result<Vec<u8>, StorageError> {
         self.files
             .lock()

--- a/tests/mock_helpers/repos_a.rs
+++ b/tests/mock_helpers/repos_a.rs
@@ -690,6 +690,7 @@ impl CarinsFilesRepository for MockCarinsFilesRepository {
             access_count_weekly: None,
             access_count_total: None,
             promoted_to_standard_at: None,
+            storage_verified: Some(true),
         })
     }
 
@@ -701,6 +702,16 @@ impl CarinsFilesRepository for MockCarinsFilesRepository {
     async fn restore_file(&self, _tenant_id: Uuid, _uuid: &str) -> Result<bool, sqlx::Error> {
         check_fail!(self);
         Ok(*self.return_affected.lock().unwrap())
+    }
+
+    async fn update_storage_verified(
+        &self,
+        _tenant_id: Uuid,
+        _uuid: &str,
+        _verified: bool,
+    ) -> Result<(), sqlx::Error> {
+        check_fail!(self);
+        Ok(())
     }
 }
 

--- a/tests/mock_tests/mock_carins_files_test.rs
+++ b/tests/mock_tests/mock_carins_files_test.rs
@@ -38,6 +38,7 @@ fn make_file_row(uuid: &str, s3_key: Option<&str>, blob: Option<&str>) -> FileRo
         access_count_weekly: None,
         access_count_total: None,
         promoted_to_standard_at: None,
+        storage_verified: Some(true),
     }
 }
 


### PR DESCRIPTION
R2がPUT時に権限外バケットへ200を返しデータが保存されない問題への対策。upload後にHEADで存在確認し、DBにverifiedフラグを記録。未確認ファイルは一覧取得時にバックグラウンドで再確認。