### PR TITLE
fix: R2 exists() status code check + reset verified

### DIFF
--- a/crates/alc-storage/src/r2.rs
+++ b/crates/alc-storage/src/r2.rs
@@ -77,7 +77,7 @@ impl StorageBackend for R2Backend {
 
     async fn exists(&self, key: &str) -> Result<bool, StorageError> {
         match self.bucket.head_object(key).await {
-            Ok(_) => Ok(true),
+            Ok((_, status)) => Ok((200..300).contains(&status)),
             Err(s3::error::S3Error::HttpFailWithBody(404, _))
             | Err(s3::error::S3Error::HttpFail) => Ok(false),
             Err(e) => Err(StorageError::Upload(format!("R2 head: {e}"))),

--- a/migrations/096_reset_storage_verified_all.sql
+++ b/migrations/096_reset_storage_verified_all.sql
@@ -1,0 +1,17 @@
+-- Reset ALL storage_verified to NULL for re-verification.
+-- Previous verification used a buggy exists() that ignored HTTP status codes,
+-- so some files were incorrectly marked as verified.
+-- This runs as SECURITY DEFINER function to bypass RLS.
+CREATE OR REPLACE FUNCTION reset_storage_verified_all()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = alc_api
+AS $$
+BEGIN
+    UPDATE files SET storage_verified = NULL;
+END;
+$$;
+
+SELECT reset_storage_verified_all();
+DROP FUNCTION reset_storage_verified_all();


### PR DESCRIPTION
rust-s3 head_objectが404でもOk返す問題修正 + SECURITY DEFINER でRLSバイパスして全件NULLリセット