### PR TITLE
feat: accept GOOGLE_DEVICE_CLIENT_ID for Device Flow auth

### DIFF
--- a/crates/alc-core/src/auth_google.rs
+++ b/crates/alc-core/src/auth_google.rs
@@ -394,10 +394,49 @@ mod tests {
     fn test_verifier_new() {
         let v = GoogleTokenVerifier::new("cid".into(), "csec".into());
         assert_eq!(v.client_id(), "cid");
+        assert!(v.extra_client_ids.is_empty());
         assert!(v.test_claims.is_none());
     }
 
+    #[test]
+    fn test_verifier_with_extra_client_ids() {
+        let v = GoogleTokenVerifier::new("cid".into(), "csec".into())
+            .with_extra_client_ids(vec!["device-id".into(), "other-id".into()]);
+        assert_eq!(v.client_id(), "cid");
+        assert_eq!(v.extra_client_ids, vec!["device-id", "other-id"]);
+    }
+
     // --- verify with wiremock ---
+
+    /// extra_client_ids に含まれる audience のトークンも検証が通ること
+    #[tokio::test]
+    async fn test_verify_extra_client_id() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let server = MockServer::start().await;
+        std::env::set_var("GOOGLE_JWKS_URL", format!("{}/jwks", server.uri()));
+
+        let device_client_id = "device-flow-client-id";
+        let key = test_key();
+        let (n, e) = (&key.n, &key.e);
+        // トークンの aud は device_client_id
+        let claims = test_claims(device_client_id);
+        let token = create_test_jwt(&claims, TEST_KID);
+
+        Mock::given(method("GET"))
+            .and(path("/jwks"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(build_jwks_response(&n, &e)))
+            .mount(&server)
+            .await;
+
+        // primary client_id は "web-client-id" だが、extra に device_client_id を含む
+        let verifier = GoogleTokenVerifier::new("web-client-id".into(), "secret".into())
+            .with_extra_client_ids(vec![device_client_id.into()]);
+        let result = verifier.verify(&token).await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().email, "test@example.com");
+
+        std::env::remove_var("GOOGLE_JWKS_URL");
+    }
 
     #[tokio::test]
     async fn test_verify_success() {

--- a/crates/alc-core/src/auth_google.rs
+++ b/crates/alc-core/src/auth_google.rs
@@ -72,6 +72,8 @@ struct GoogleTokenResponse {
 #[derive(Clone)]
 pub struct GoogleTokenVerifier {
     client_id: String,
+    /// 追加で受け入れる Client ID (Device Flow 用など)
+    extra_client_ids: Vec<String>,
     client_secret: String,
     http_client: Client,
     jwks_cache: Arc<RwLock<Option<CachedJwks>>>,
@@ -83,6 +85,7 @@ impl GoogleTokenVerifier {
     pub fn new(client_id: String, client_secret: String) -> Self {
         Self {
             client_id,
+            extra_client_ids: Vec::new(),
             client_secret,
             http_client: Client::new(),
             jwks_cache: Arc::new(RwLock::new(None)),
@@ -90,10 +93,17 @@ impl GoogleTokenVerifier {
         }
     }
 
+    /// 追加の Client ID を受け入れるように設定 (Device Flow 等)
+    pub fn with_extra_client_ids(mut self, ids: Vec<String>) -> Self {
+        self.extra_client_ids = ids;
+        self
+    }
+
     /// テスト用: verify/exchange_code で固定 claims を返す verifier を作成
     pub fn with_test_claims(client_id: String, claims: GoogleClaims) -> Self {
         Self {
             client_id,
+            extra_client_ids: Vec::new(),
             client_secret: String::new(),
             http_client: Client::new(),
             jwks_cache: Arc::new(RwLock::new(None)),
@@ -174,7 +184,11 @@ impl GoogleTokenVerifier {
         // 検証パラメータ
         let mut validation = Validation::new(Algorithm::RS256);
         validation.set_issuer(&[GOOGLE_ISSUER, "accounts.google.com"]);
-        validation.set_audience(&[&self.client_id]);
+        let mut audiences: Vec<&str> = vec![&self.client_id];
+        for id in &self.extra_client_ids {
+            audiences.push(id.as_str());
+        }
+        validation.set_audience(&audiences);
 
         // デコード + 検証
         let token_data =

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,7 +59,16 @@ async fn main() -> anyhow::Result<()> {
     let google_client_secret =
         std::env::var("GOOGLE_CLIENT_SECRET").expect("GOOGLE_CLIENT_SECRET must be set");
 
-    let google_verifier = GoogleTokenVerifier::new(google_client_id, google_client_secret);
+    let extra_client_ids: Vec<String> = std::env::var("GOOGLE_DEVICE_CLIENT_ID")
+        .map(|s| {
+            s.split(',')
+                .map(|id| id.trim().to_string())
+                .filter(|id| !id.is_empty())
+                .collect()
+        })
+        .unwrap_or_default();
+    let google_verifier = GoogleTokenVerifier::new(google_client_id, google_client_secret)
+        .with_extra_client_ids(extra_client_ids);
     let jwt_secret = JwtSecret(jwt_secret);
 
     let pool = PgPoolOptions::new()


### PR DESCRIPTION
smb-watch の Device Flow (TVs and Limited Input devices) の Google id_token を rust-alc-api で受け入れるための変更。GOOGLE_DEVICE_CLIENT_ID 環境変数でカンマ区切りの追加 Client ID を設定可能。