### PR TITLE
feat(carins): add car inspection history by CarId endpoint

### DIFF
--- a/crates/alc-carins/src/car_inspections.rs
+++ b/crates/alc-carins/src/car_inspections.rs
@@ -22,6 +22,10 @@ where
             "/car-inspections/vehicle-categories",
             get(vehicle_categories),
         )
+        .route(
+            "/car-inspections/by-car/{car_id}/history",
+            get(list_history),
+        )
         .route("/car-inspections/{id}", get(get_by_id))
 }
 
@@ -42,6 +46,25 @@ async fn list_current(
         .await
         .map_err(|e| {
             tracing::error!("list_current failed: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    Ok(Json(ListResponse {
+        car_inspections: rows,
+    }))
+}
+
+async fn list_history(
+    State(state): State<CarinsState>,
+    Extension(tenant_id): Extension<TenantId>,
+    Path(car_id): Path<String>,
+) -> Result<Json<ListResponse>, StatusCode> {
+    let rows = state
+        .car_inspections
+        .list_by_car_id(tenant_id.0, &car_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("list_by_car_id failed: {e}");
             StatusCode::INTERNAL_SERVER_ERROR
         })?;
 

--- a/crates/alc-carins/src/carins_files.rs
+++ b/crates/alc-carins/src/carins_files.rs
@@ -637,6 +637,13 @@ mod tests {
         ) -> Result<Option<serde_json::Value>, sqlx::Error> {
             Ok(None)
         }
+        async fn list_by_car_id(
+            &self,
+            _: Uuid,
+            _: &str,
+        ) -> Result<Vec<serde_json::Value>, sqlx::Error> {
+            Ok(vec![])
+        }
         async fn vehicle_categories(
             &self,
             _: Uuid,

--- a/crates/alc-carins/src/repo/car_inspections.rs
+++ b/crates/alc-carins/src/repo/car_inspections.rs
@@ -112,6 +112,50 @@ impl CarInspectionRepository for PgCarInspectionRepository {
         Ok(row.map(|r| r.0))
     }
 
+    async fn list_by_car_id(
+        &self,
+        tenant_id: Uuid,
+        car_id: &str,
+    ) -> Result<Vec<serde_json::Value>, sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        let rows = sqlx::query_as::<_, (serde_json::Value,)>(
+            r#"
+            SELECT to_jsonb(sub) FROM (
+                SELECT
+                    ci.*,
+                    (SELECT uuid::text FROM car_inspection_files_b
+                     WHERE tenant_id = ci.tenant_id
+                       AND "ElectCertMgNo" = ci."ElectCertMgNo"
+                       AND "GrantdateE" = ci."GrantdateE"
+                       AND "GrantdateY" = ci."GrantdateY"
+                       AND "GrantdateM" = ci."GrantdateM"
+                       AND "GrantdateD" = ci."GrantdateD"
+                       AND type = 'application/pdf'
+                       AND deleted_at IS NULL
+                     ORDER BY created_at DESC LIMIT 1) as "pdfUuid",
+                    (SELECT uuid::text FROM car_inspection_files_a
+                     WHERE tenant_id = ci.tenant_id
+                       AND "ElectCertMgNo" = ci."ElectCertMgNo"
+                       AND "GrantdateE" = ci."GrantdateE"
+                       AND "GrantdateY" = ci."GrantdateY"
+                       AND "GrantdateM" = ci."GrantdateM"
+                       AND "GrantdateD" = ci."GrantdateD"
+                       AND type = 'application/json'
+                       AND deleted_at IS NULL
+                     ORDER BY created_at DESC LIMIT 1) as "jsonUuid"
+                FROM car_inspection ci
+                WHERE ci."CarId" = $1
+                ORDER BY ci."TwodimensionCodeInfoValidPeriodExpirdate" DESC,
+                         ci.created_at DESC
+            ) sub
+            "#,
+        )
+        .bind(car_id)
+        .fetch_all(&mut *tc.conn)
+        .await?;
+        Ok(rows.into_iter().map(|r| r.0).collect())
+    }
+
     async fn vehicle_categories(&self, tenant_id: Uuid) -> Result<VehicleCategories, sqlx::Error> {
         let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
         sqlx::query_as::<_, VehicleCategories>(

--- a/crates/alc-core/src/repository/car_inspections.rs
+++ b/crates/alc-core/src/repository/car_inspections.rs
@@ -56,6 +56,13 @@ pub trait CarInspectionRepository: Send + Sync {
         id: i32,
     ) -> Result<Option<serde_json::Value>, sqlx::Error>;
 
+    /// CarId で同一車両の車検証履歴一覧 (新→旧順、pdfUuid/jsonUuid 付き)
+    async fn list_by_car_id(
+        &self,
+        tenant_id: Uuid,
+        car_id: &str,
+    ) -> Result<Vec<serde_json::Value>, sqlx::Error>;
+
     /// 車両カテゴリ一覧
     async fn vehicle_categories(&self, tenant_id: Uuid) -> Result<VehicleCategories, sqlx::Error>;
 

--- a/tests/mock_helpers/repos_a.rs
+++ b/tests/mock_helpers/repos_a.rs
@@ -532,6 +532,15 @@ impl CarInspectionRepository for MockCarInspectionRepository {
         Ok(None)
     }
 
+    async fn list_by_car_id(
+        &self,
+        _tenant_id: Uuid,
+        _car_id: &str,
+    ) -> Result<Vec<serde_json::Value>, sqlx::Error> {
+        check_fail!(self);
+        Ok(vec![])
+    }
+
     async fn vehicle_categories(&self, _tenant_id: Uuid) -> Result<VehicleCategories, sqlx::Error> {
         check_fail!(self);
         Ok(VehicleCategories {

--- a/tests/mock_tests/mock_car_inspections_test.rs
+++ b/tests/mock_tests/mock_car_inspections_test.rs
@@ -66,6 +66,35 @@ impl CarInspectionRepository for SuccessMockCarInspectionRepository {
         Ok(Some(serde_json::json!({"id": id, "CarId": "ABC-123"})))
     }
 
+    async fn list_by_car_id(
+        &self,
+        _tenant_id: Uuid,
+        car_id: &str,
+    ) -> Result<Vec<serde_json::Value>, sqlx::Error> {
+        if self.fail_next.swap(false, Ordering::SeqCst) {
+            return Err(sqlx::Error::RowNotFound);
+        }
+        if car_id == "NONEXISTENT" {
+            return Ok(vec![]);
+        }
+        Ok(vec![
+            serde_json::json!({
+                "id": 10,
+                "CarId": car_id,
+                "TwodimensionCodeInfoValidPeriodExpirdate": "270401",
+                "pdfUuid": "11111111-1111-1111-1111-111111111111",
+                "jsonUuid": null,
+            }),
+            serde_json::json!({
+                "id": 9,
+                "CarId": car_id,
+                "TwodimensionCodeInfoValidPeriodExpirdate": "250401",
+                "pdfUuid": null,
+                "jsonUuid": "22222222-2222-2222-2222-222222222222",
+            }),
+        ])
+    }
+
     async fn vehicle_categories(&self, _tenant_id: Uuid) -> Result<VehicleCategories, sqlx::Error> {
         if self.fail_next.swap(false, Ordering::SeqCst) {
             return Err(sqlx::Error::RowNotFound);
@@ -401,4 +430,101 @@ async fn test_get_by_id_db_error() {
         .await
         .unwrap();
     assert_eq!(res.status(), 500);
+}
+
+// ============================================================
+// list_history: GET /api/car-inspections/by-car/{car_id}/history
+// ============================================================
+
+#[tokio::test]
+async fn test_list_history_success() {
+    let mock = Arc::new(SuccessMockCarInspectionRepository::new());
+    let (base_url, jwt) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!(
+            "{base_url}/api/car-inspections/by-car/ABC-123/history"
+        ))
+        .header("Authorization", auth(&jwt))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+
+    let body: Value = res.json().await.unwrap();
+    let inspections = body["carInspections"].as_array().unwrap();
+    assert_eq!(inspections.len(), 2);
+    // 新→旧の順
+    assert_eq!(inspections[0]["id"], 10);
+    assert_eq!(
+        inspections[0]["TwodimensionCodeInfoValidPeriodExpirdate"],
+        "270401"
+    );
+    assert_eq!(inspections[1]["id"], 9);
+    // pdfUuid/jsonUuid が含まれる
+    assert_eq!(
+        inspections[0]["pdfUuid"],
+        "11111111-1111-1111-1111-111111111111"
+    );
+    assert_eq!(
+        inspections[1]["jsonUuid"],
+        "22222222-2222-2222-2222-222222222222"
+    );
+}
+
+#[tokio::test]
+async fn test_list_history_empty() {
+    let mock = Arc::new(SuccessMockCarInspectionRepository::new());
+    let (base_url, jwt) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!(
+            "{base_url}/api/car-inspections/by-car/NONEXISTENT/history"
+        ))
+        .header("Authorization", auth(&jwt))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+
+    let body: Value = res.json().await.unwrap();
+    let inspections = body["carInspections"].as_array().unwrap();
+    assert!(inspections.is_empty());
+}
+
+#[tokio::test]
+async fn test_list_history_db_error() {
+    let mock = Arc::new(crate::mock_helpers::MockCarInspectionRepository::default());
+    mock.fail_next.store(true, Ordering::SeqCst);
+    let (base_url, jwt) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .get(format!(
+            "{base_url}/api/car-inspections/by-car/ABC-123/history"
+        ))
+        .header("Authorization", auth(&jwt))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}
+
+#[tokio::test]
+async fn test_list_history_unauthorized() {
+    let mock = Arc::new(SuccessMockCarInspectionRepository::new());
+    let (base_url, _jwt) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    // JWT なし → 401 (テナント未解決)
+    let res = client
+        .get(format!(
+            "{base_url}/api/car-inspections/by-car/ABC-123/history"
+        ))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 401);
 }


### PR DESCRIPTION
## Summary
- Adds `GET /api/car-inspections/by-car/{car_id}/history` returning all inspections for a CarId, ordered by expiration desc
- Joins pdfUuid/jsonUuid from car_inspection_files_a/b, same shape as /current
- Adds mock tests for success, empty, db error, unauthorized

## Why
Frontend currently only sees the latest inspection per vehicle (DISTINCT ON CarId in /current). Past inspections exist in the DB but no UI can reach them. nuxt-pwa-carins will expand list rows to show history via this endpoint.

## Test plan
- [ ] CI unit-tests + integration-tests pass
- [ ] Staging: `curl /api/car-inspections/by-car/<CarId>/history` returns list
- [ ] nuxt-pwa-carins PR wires this up