### PR TITLE
feat(trouble): accept registration_number on create/update ticket

### DIFF
--- a/crates/alc-core/src/models.rs
+++ b/crates/alc-core/src/models.rs
@@ -1548,6 +1548,7 @@ pub struct CreateTroubleTicket {
     )]
     pub person_id: Option<Uuid>,
     pub vehicle_number: Option<String>,
+    pub registration_number: Option<String>,
     pub location: Option<String>,
     pub description: Option<String>,
     #[serde(
@@ -1589,6 +1590,7 @@ pub struct UpdateTroubleTicket {
     )]
     pub person_id: Option<Uuid>,
     pub vehicle_number: Option<String>,
+    pub registration_number: Option<String>,
     pub location: Option<String>,
     pub description: Option<String>,
     #[serde(

--- a/crates/alc-trouble/src/repo/trouble_tickets.rs
+++ b/crates/alc-trouble/src/repo/trouble_tickets.rs
@@ -37,6 +37,7 @@ impl TroubleTicketsRepository for PgTroubleTicketsRepository {
                 occurred_at, occurred_date,
                 company_name, office_name, department,
                 person_name, person_id, vehicle_number,
+                registration_number,
                 location, description,
                 status_id, assigned_to,
                 damage_amount, compensation_amount, road_service_cost,
@@ -48,11 +49,12 @@ impl TroubleTicketsRepository for PgTroubleTicketsRepository {
                 $4, $5,
                 COALESCE($6, ''), COALESCE($7, ''), COALESCE($8, ''),
                 COALESCE($9, ''), $10, COALESCE($11, ''),
-                COALESCE($12, ''), COALESCE($13, ''),
-                $14, $15,
-                $16, $17, $18,
-                COALESCE($19, ''), COALESCE($20, ''),
-                COALESCE($21, '{}'::jsonb), $22, $23
+                COALESCE($12, ''),
+                COALESCE($13, ''), COALESCE($14, ''),
+                $15, $16,
+                $17, $18, $19,
+                COALESCE($20, ''), COALESCE($21, ''),
+                COALESCE($22, '{}'::jsonb), $23, $24
             )
             RETURNING id, tenant_id, ticket_no, category, title,
                 occurred_at, occurred_date,
@@ -81,6 +83,7 @@ impl TroubleTicketsRepository for PgTroubleTicketsRepository {
         .bind(&input.person_name)
         .bind(input.person_id)
         .bind(&input.vehicle_number)
+        .bind(&input.registration_number)
         .bind(&input.location)
         .bind(&input.description)
         .bind(initial_status_id)
@@ -282,6 +285,7 @@ impl TroubleTicketsRepository for PgTroubleTicketsRepository {
                 counterparty_insurance = COALESCE($25, counterparty_insurance),
                 custom_fields = COALESCE($26, custom_fields),
                 due_date = COALESCE($27, due_date),
+                registration_number = COALESCE($28, registration_number),
                 updated_at = NOW()
             WHERE id = $1 AND tenant_id = $2 AND deleted_at IS NULL
             RETURNING id, tenant_id, ticket_no, category, title,
@@ -326,6 +330,7 @@ impl TroubleTicketsRepository for PgTroubleTicketsRepository {
         .bind(&input.counterparty_insurance)
         .bind(&input.custom_fields)
         .bind(input.due_date)
+        .bind(&input.registration_number)
         .fetch_optional(&mut *tc.conn)
         .await
     }

--- a/tests/trouble_test.rs
+++ b/tests/trouble_test.rs
@@ -123,7 +123,8 @@ async fn test_trouble_ticket_crud() {
                     "category": "貨物事故",
                     "title": "テスト事故報告",
                     "person_name": "テスト太郎",
-                    "description": "テスト説明"
+                    "description": "テスト説明",
+                    "registration_number": "品川300あ1234"
                 }))
                 .send()
                 .await
@@ -133,6 +134,7 @@ async fn test_trouble_ticket_crud() {
             let ticket_id = ticket["id"].as_str().unwrap();
             assert_eq!(ticket["category"], "貨物事故");
             assert_eq!(ticket["person_name"], "テスト太郎");
+            assert_eq!(ticket["registration_number"], "品川300あ1234");
 
             // GET /api/trouble/tickets → total >= 1
             let res = client
@@ -161,7 +163,8 @@ async fn test_trouble_ticket_crud() {
                 .put(format!("{base_url}/api/trouble/tickets/{ticket_id}"))
                 .header("Authorization", &auth)
                 .json(&serde_json::json!({
-                    "progress_notes": "対応中"
+                    "progress_notes": "対応中",
+                    "registration_number": "横浜500さ5678"
                 }))
                 .send()
                 .await
@@ -169,6 +172,7 @@ async fn test_trouble_ticket_crud() {
             assert_eq!(res.status(), 200);
             let updated: Value = res.json().await.unwrap();
             assert_eq!(updated["progress_notes"], "対応中");
+            assert_eq!(updated["registration_number"], "横浜500さ5678");
 
             // DELETE /api/trouble/tickets/{id} → 204
             let res = client


### PR DESCRIPTION
## Summary
- `registration_number` は migration 086 で既に追加されていたが、`CreateTroubleTicket` / `UpdateTroubleTicket` 構造体に欠けており API 経由で保存不可だった
- Create/Update 両方に `Option<String>` フィールド追加 + INSERT/UPDATE SQL を対応
- nuxt-trouble 側の車検証マスタ連携 (別 PR) と組み合わせて使う

## Test plan
- [x] `cargo test -p alc-core --lib export_bindings` で ts-rs 再生成
- [x] 既存 CRUD integration test に registration_number の POST/PUT ラウンドトリップを追加
- [ ] CI 上で全テスト + カバレッジ pass