### PR TITLE
ci: add Secret Manager audit workflow

### DIFF
--- a/.github/workflows/secret-audit.yml
+++ b/.github/workflows/secret-audit.yml
@@ -1,0 +1,110 @@
+name: Secret Manager audit
+
+on:
+  schedule:
+    - cron: '0 18 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  unused-check:
+    runs-on: ubuntu-latest
+    env:
+      PROJECT: cloudsql-sv
+      REGION: asia-northeast1
+    steps:
+      - uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+      - uses: google-github-actions/setup-gcloud@v2
+
+      - name: Collect referenced secrets
+        id: refs
+        run: |
+          {
+            for s in $(gcloud run services list --project=$PROJECT --region=$REGION --format='value(metadata.name)'); do
+              gcloud run services describe "$s" --region=$REGION --project=$PROJECT --format=json \
+                | python3 -c 'import json,sys
+d=json.load(sys.stdin)
+for c in d.get("spec",{}).get("template",{}).get("spec",{}).get("containers",[]):
+    for e in c.get("env",[]):
+        ref=e.get("valueFrom",{}).get("secretKeyRef",{})
+        if ref.get("name"): print(ref["name"])'
+            done
+            for j in $(gcloud run jobs list --project=$PROJECT --region=$REGION --format='value(metadata.name)'); do
+              gcloud run jobs describe "$j" --region=$REGION --project=$PROJECT --format=json \
+                | python3 -c 'import json,sys
+d=json.load(sys.stdin)
+for c in d.get("spec",{}).get("template",{}).get("spec",{}).get("template",{}).get("spec",{}).get("containers",[]):
+    for e in c.get("env",[]):
+        ref=e.get("valueFrom",{}).get("secretKeyRef",{})
+        if ref.get("name"): print(ref["name"])'
+            done
+            for f in $(gcloud functions list --project=$PROJECT --regions=$REGION --format='value(name)' 2>/dev/null); do
+              gcloud functions describe "$f" --region=$REGION --project=$PROJECT --format=json \
+                | python3 -c 'import json,sys
+d=json.load(sys.stdin)
+for e in d.get("secretEnvironmentVariables",[]) + d.get("secretVolumes",[]):
+    if e.get("secret"): print(e["secret"])'
+            done
+          } | sort -u > referenced.txt
+          echo "Referenced secrets ($(wc -l < referenced.txt)):"
+          cat referenced.txt
+
+      - name: Find unused secrets
+        id: unused
+        run: |
+          gcloud secrets list --project=$PROJECT --format='value(name.basename())' | sort -u > all.txt
+          comm -23 all.txt referenced.txt > not-referenced.txt
+          echo "Not in Cloud Run/Jobs/Functions spec ($(wc -l < not-referenced.txt)):"
+          cat not-referenced.txt
+
+          : > unused.txt
+          while read s; do
+            [ -z "$s" ] && continue
+            n=$(gcloud logging read \
+              "protoPayload.serviceName=\"secretmanager.googleapis.com\" AND protoPayload.methodName=~\".*AccessSecretVersion$\" AND protoPayload.resourceName=~\"secrets/$s(/|$)\"" \
+              --project=$PROJECT --freshness=30d --limit=1 \
+              --format='value(timestamp)' 2>/dev/null | wc -l)
+            if [ "$n" = "0" ]; then
+              echo "$s" >> unused.txt
+            fi
+          done < not-referenced.txt
+
+          echo "Confirmed unused (no ref + no access in 30d): $(wc -l < unused.txt)"
+          cat unused.txt
+          echo "count=$(wc -l < unused.txt)" >> $GITHUB_OUTPUT
+
+      - name: Write finding to Cloud Logging
+        if: steps.unused.outputs.count != '0'
+        run: |
+          payload=$(python3 -c "
+import json
+with open('unused.txt') as f:
+    secrets = [l.strip() for l in f if l.strip()]
+print(json.dumps({
+    'finding': 'unused_secrets',
+    'count': len(secrets),
+    'secrets': secrets,
+    'note': 'not referenced by Cloud Run/Jobs/Functions and no AccessSecretVersion in past 30 days (audit log enabled 2026-04-19)'
+}))")
+          echo "$payload"
+          gcloud logging write secret-audit "$payload" \
+            --payload-type=json \
+            --severity=ERROR \
+            --project=$PROJECT
+
+      - name: Summary
+        run: |
+          echo "## Secret Manager audit" >> $GITHUB_STEP_SUMMARY
+          echo "- Referenced: $(wc -l < referenced.txt)" >> $GITHUB_STEP_SUMMARY
+          echo "- Not referenced: $(wc -l < not-referenced.txt)" >> $GITHUB_STEP_SUMMARY
+          echo "- Confirmed unused (both static + 30d audit): ${{ steps.unused.outputs.count }}" >> $GITHUB_STEP_SUMMARY
+          if [ -s unused.txt ]; then
+            echo "### Unused secrets" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            cat unused.txt >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+          fi


### PR DESCRIPTION
## Summary
- Daily scheduled workflow (03:00 JST) that detects unused Secret Manager secrets via 2-source cross-verification
- Static analysis: not referenced by any Cloud Run service/job/function
- Audit log: no AccessSecretVersion event in past 30 days
- Findings written to Cloud Logging stream secret-audit (severity ERROR) → picked up by the 'Secret Manager - unused secrets detected' alert policy (email)

## Related out-of-repo changes
- Enabled secretmanager.googleapis.com Data Access audit logs (ADMIN_READ + DATA_READ + DATA_WRITE) in cloudsql-sv project
- Created 3 Cloud Monitoring alert policies (log-based, email to m.tama.ramu@gmail.com):
  - Secret Manager - access error: any Secret Manager API error
  - Secret Manager - version added: every AddSecretVersion
  - Secret Manager - unused secrets detected: findings from this workflow

## Test plan
- [ ] Manual run via workflow_dispatch
- [ ] Verify job summary lists secrets
- [ ] Confirm no unused secrets reported (since Tier A already disabled)
- [ ] After 30 days, re-run to verify audit log accumulation works