### PR TITLE
fix: rewrite secret-audit.yml without Python heredoc

### DIFF
--- a/.github/workflows/secret-audit.yml
+++ b/.github/workflows/secret-audit.yml
@@ -21,35 +21,21 @@ jobs:
       - uses: google-github-actions/setup-gcloud@v2
 
       - name: Collect referenced secrets
-        id: refs
         run: |
           {
-            for s in $(gcloud run services list --project=$PROJECT --region=$REGION --format='value(metadata.name)'); do
-              gcloud run services describe "$s" --region=$REGION --project=$PROJECT --format=json \
-                | python3 -c 'import json,sys
-d=json.load(sys.stdin)
-for c in d.get("spec",{}).get("template",{}).get("spec",{}).get("containers",[]):
-    for e in c.get("env",[]):
-        ref=e.get("valueFrom",{}).get("secretKeyRef",{})
-        if ref.get("name"): print(ref["name"])'
+            for s in $(gcloud run services list --project=$PROJECT --region=$REGION --format='value(metadata.name)' 2>/dev/null); do
+              gcloud run services describe "$s" --region=$REGION --project=$PROJECT \
+                --format='value(spec.template.spec.containers[].env[].valueFrom.secretKeyRef.name)' 2>/dev/null
             done
-            for j in $(gcloud run jobs list --project=$PROJECT --region=$REGION --format='value(metadata.name)'); do
-              gcloud run jobs describe "$j" --region=$REGION --project=$PROJECT --format=json \
-                | python3 -c 'import json,sys
-d=json.load(sys.stdin)
-for c in d.get("spec",{}).get("template",{}).get("spec",{}).get("template",{}).get("spec",{}).get("containers",[]):
-    for e in c.get("env",[]):
-        ref=e.get("valueFrom",{}).get("secretKeyRef",{})
-        if ref.get("name"): print(ref["name"])'
+            for j in $(gcloud run jobs list --project=$PROJECT --region=$REGION --format='value(metadata.name)' 2>/dev/null); do
+              gcloud run jobs describe "$j" --region=$REGION --project=$PROJECT \
+                --format='value(spec.template.spec.template.spec.containers[].env[].valueFrom.secretKeyRef.name)' 2>/dev/null
             done
             for f in $(gcloud functions list --project=$PROJECT --regions=$REGION --format='value(name)' 2>/dev/null); do
-              gcloud functions describe "$f" --region=$REGION --project=$PROJECT --format=json \
-                | python3 -c 'import json,sys
-d=json.load(sys.stdin)
-for e in d.get("secretEnvironmentVariables",[]) + d.get("secretVolumes",[]):
-    if e.get("secret"): print(e["secret"])'
+              gcloud functions describe "$f" --region=$REGION --project=$PROJECT \
+                --format='value(secretEnvironmentVariables[].secret,secretVolumes[].secret)' 2>/dev/null
             done
-          } | sort -u > referenced.txt
+          } | tr ';' '\n' | sed '/^$/d' | sort -u > referenced.txt
           echo "Referenced secrets ($(wc -l < referenced.txt)):"
           cat referenced.txt
 
@@ -75,21 +61,14 @@ for e in d.get("secretEnvironmentVariables",[]) + d.get("secretVolumes",[]):
 
           echo "Confirmed unused (no ref + no access in 30d): $(wc -l < unused.txt)"
           cat unused.txt
-          echo "count=$(wc -l < unused.txt)" >> $GITHUB_OUTPUT
+          echo "count=$(wc -l < unused.txt)" >> "$GITHUB_OUTPUT"
 
       - name: Write finding to Cloud Logging
         if: steps.unused.outputs.count != '0'
         run: |
-          payload=$(python3 -c "
-import json
-with open('unused.txt') as f:
-    secrets = [l.strip() for l in f if l.strip()]
-print(json.dumps({
-    'finding': 'unused_secrets',
-    'count': len(secrets),
-    'secrets': secrets,
-    'note': 'not referenced by Cloud Run/Jobs/Functions and no AccessSecretVersion in past 30 days (audit log enabled 2026-04-19)'
-}))")
+          secrets_json=$(awk 'NF{printf "\"%s\",", $0}' unused.txt | sed 's/,$//')
+          count=$(wc -l < unused.txt | tr -d ' ')
+          payload="{\"finding\":\"unused_secrets\",\"count\":${count},\"secrets\":[${secrets_json}],\"note\":\"not referenced by Cloud Run/Jobs/Functions and no AccessSecretVersion in past 30 days (audit log enabled 2026-04-19)\"}"
           echo "$payload"
           gcloud logging write secret-audit "$payload" \
             --payload-type=json \
@@ -98,13 +77,15 @@ print(json.dumps({
 
       - name: Summary
         run: |
-          echo "## Secret Manager audit" >> $GITHUB_STEP_SUMMARY
-          echo "- Referenced: $(wc -l < referenced.txt)" >> $GITHUB_STEP_SUMMARY
-          echo "- Not referenced: $(wc -l < not-referenced.txt)" >> $GITHUB_STEP_SUMMARY
-          echo "- Confirmed unused (both static + 30d audit): ${{ steps.unused.outputs.count }}" >> $GITHUB_STEP_SUMMARY
-          if [ -s unused.txt ]; then
-            echo "### Unused secrets" >> $GITHUB_STEP_SUMMARY
-            echo '```' >> $GITHUB_STEP_SUMMARY
-            cat unused.txt >> $GITHUB_STEP_SUMMARY
-            echo '```' >> $GITHUB_STEP_SUMMARY
-          fi
+          {
+            echo "## Secret Manager audit"
+            echo "- Referenced: $(wc -l < referenced.txt)"
+            echo "- Not referenced: $(wc -l < not-referenced.txt)"
+            echo "- Confirmed unused (static + 30d audit): ${{ steps.unused.outputs.count }}"
+            if [ -s unused.txt ]; then
+              echo "### Unused secrets"
+              echo '```'
+              cat unused.txt
+              echo '```'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- Fixes Invalid workflow file #L30 caused by Python heredoc breaking YAML block-scalar indentation
- Rewrote using gcloud --format='value(...)' selectors only

## Test plan
- [ ] Manual run via workflow_dispatch after merge
- [ ] Verify Job Summary displays counts