### PR TITLE
ci: use GHCR directly for Cloud Run image pulls

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,6 @@ env:
   REGION: asia-northeast1
   PROJECT: cloudsql-sv
   REPO: ghcr.io/ippoan/rust-alc-api
-  AR_PREFIX: asia-northeast1-docker.pkg.dev/cloudsql-sv/ghcr
 
 jobs:
   # ---------------------------------------------------------------------------
@@ -148,17 +147,17 @@ jobs:
 
       - name: Run migrations
         run: |
-          AR_IMAGE="${{ env.AR_PREFIX }}/${{ env.REPO }}:${{ inputs.image_sha }}"
+          IMAGE="${{ env.REPO }}:${{ inputs.image_sha }}"
           JOB_NAME="rust-alc-api-migrate"
 
           if gcloud run jobs describe $JOB_NAME --region ${{ env.REGION }} --project ${{ env.PROJECT }} &>/dev/null; then
             gcloud run jobs update $JOB_NAME \
               --region ${{ env.REGION }} --project ${{ env.PROJECT }} \
-              --image "$AR_IMAGE"
+              --image "$IMAGE"
           else
             gcloud run jobs create $JOB_NAME \
               --region ${{ env.REGION }} --project ${{ env.PROJECT }} \
-              --image "$AR_IMAGE" \
+              --image "$IMAGE" \
               --set-secrets "DATABASE_URL=alc-app-database-url:latest" \
               --command "migrate" \
               --memory 512Mi --task-timeout 120s --max-retries 0
@@ -205,7 +204,7 @@ jobs:
 
           if [ "${DEPLOY_ENV}" = "staging" ]; then
             STAGING_URL="${{ vars.STAGING_API_URL }}"
-            DB_IMAGE="${{ env.AR_PREFIX }}/${{ env.REPO }}-staging-db:latest"
+            DB_IMAGE="${{ env.REPO }}-staging-db:latest"
             RENDER_ARGS="${RENDER_ARGS} --staging-url ${STAGING_URL} --db-image ${DB_IMAGE}"
           fi
 
@@ -363,8 +362,8 @@ jobs:
 
       - name: Update archive Job image
         run: |
-          AR_IMAGE="${{ env.AR_PREFIX }}/${{ env.REPO }}:${{ inputs.image_sha }}"
+          IMAGE="${{ env.REPO }}:${{ inputs.image_sha }}"
           gcloud run jobs update rust-alc-api-archive \
             --region ${{ env.REGION }} --project ${{ env.PROJECT }} \
-            --image "$AR_IMAGE"
+            --image "$IMAGE"
           echo "::notice ::Archive Job updated"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -678,7 +678,7 @@ npx playwright test
 ### CI 自動デプロイ
 
 - **rust-alc-api**: PR to main → `ci.yml` の `deploy-staging` ジョブ → Cloud Run staging
-  - Docker イメージは GHCR に push → Artifact Registry リモートリポジトリ (`asia-northeast1-docker.pkg.dev/cloudsql-sv/ghcr/`) 経由で Cloud Run が pull
+  - Docker イメージは GHCR (`ghcr.io/ippoan/rust-alc-api` 他、public package) に push → Cloud Run が直接 pull
 - **alc-app**: PR to main → `test.yml` の `deploy-staging` ジョブ → `wrangler deploy --env staging`
 
 ### Secrets / 環境変数
@@ -688,7 +688,6 @@ npx playwright test
 - `alc-r2-access-key`, `alc-r2-secret-key`, `alc-oauth-state-secret`
 - `carins-r2-access-key`, `carins-r2-secret-key`, `dtako-r2-access-key`, `dtako-r2-secret-key`
 - SA `747065218280-compute@developer.gserviceaccount.com` に `secretmanager.secretAccessor` 付与済み
-- SA `staging-deploy@cloudsql-sv.iam.gserviceaccount.com` に Artifact Registry `artifactregistry.reader` 付与済み
 
 **alc-app staging** (Cloudflare Workers → wrangler.jsonc `env.staging.vars`):
 - `NUXT_PUBLIC_API_BASE`: staging Cloud Run URL

--- a/archive.sh
+++ b/archive.sh
@@ -4,8 +4,7 @@ set -e
 PROJECT_ID="cloudsql-sv"
 REGION="asia-northeast1"
 SERVICE_NAME="rust-alc-api"
-REPOSITORY="alc-app"
-IMAGE="$REGION-docker.pkg.dev/$PROJECT_ID/$REPOSITORY/$SERVICE_NAME"
+IMAGE="ghcr.io/ippoan/rust-alc-api"
 ARCHIVE_JOB_NAME="rust-alc-api-archive"
 
 # Usage: ./archive.sh dtako-archive --dry-run

--- a/cloudrun/render.sh
+++ b/cloudrun/render.sh
@@ -30,7 +30,6 @@ while [[ $# -gt 0 ]]; do
 done
 
 REPO="ghcr.io/ippoan/rust-alc-api"
-AR_PREFIX="asia-northeast1-docker.pkg.dev/cloudsql-sv/ghcr"
 REGION="asia-northeast1"
 
 # ---------------------------------------------------------------------------
@@ -50,13 +49,13 @@ if [[ "$ENV" == "staging" ]]; then
   SERVICE_NAME="rust-alc-api-staging${SUFFIX}"
   # Gateway has no sidecar, so use the production image directly
   if [[ "$SERVICE" == "gateway" ]]; then
-    IMAGE="${AR_PREFIX}/${REPO}${SUFFIX}:${IMAGE_SHA}"
+    IMAGE="${REPO}${SUFFIX}:${IMAGE_SHA}"
   else
-    IMAGE="${AR_PREFIX}/${REPO}${SUFFIX}-staging:${IMAGE_SHA}"
+    IMAGE="${REPO}${SUFFIX}-staging:${IMAGE_SHA}"
   fi
 else
   SERVICE_NAME="rust-alc-api${SUFFIX}"
-  IMAGE="${AR_PREFIX}/${REPO}${SUFFIX}:${IMAGE_SHA}"
+  IMAGE="${REPO}${SUFFIX}:${IMAGE_SHA}"
 fi
 
 # ---------------------------------------------------------------------------

--- a/deploy.sh
+++ b/deploy.sh
@@ -4,14 +4,13 @@ set -e
 PROJECT_ID="cloudsql-sv"
 REGION="asia-northeast1"
 SERVICE_NAME="rust-alc-api"
-REPOSITORY="alc-app"
-IMAGE="$REGION-docker.pkg.dev/$PROJECT_ID/$REPOSITORY/$SERVICE_NAME"
+IMAGE="ghcr.io/ippoan/rust-alc-api"
 MIGRATION_JOB_NAME="rust-alc-api-migrate"
 
 echo "=== Building Docker image ==="
 docker build -t $IMAGE:latest .
 
-echo "=== Pushing to Artifact Registry ==="
+echo "=== Pushing to GHCR ==="
 docker push $IMAGE:latest
 
 echo "=== Running migrations via Cloud Run Jobs ==="


### PR DESCRIPTION
## Summary
- Removes Artifact Registry remote-repository proxy (`asia-northeast1-docker.pkg.dev/cloudsql-sv/ghcr/`) from Cloud Run image URLs
- Changes image references in `cloudrun/render.sh` and `.github/workflows/deploy.yml` to pull directly from GHCR (`ghcr.io/ippoan/...`)
- Updates supplementary `deploy.sh`/`archive.sh` and `CLAUDE.md` for consistency
- GHCR packages verified public (anonymous bearer token pull succeeds)

## Effect
- staging deploy (this PR): image URL should start with `ghcr.io/ippoan/rust-alc-api-staging:...`
- Next production tag: will pull from GHCR directly
- AR remote-repo (`ghcr` in asia-northeast1) can be deleted after 2-4 week soak

## Test plan
- [ ] staging Cloud Run `spec.containers[0].image` begins with `ghcr.io/`
- [ ] `/api/health` returns 200 on staging
- [ ] Monitor Cloud Logging for `artifactregistry.googleapis.com` calls → should drop to 0 over the next day