### PR TITLE
Revert: GHCR direct pull (not supported by services replace)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,7 @@ env:
   REGION: asia-northeast1
   PROJECT: cloudsql-sv
   REPO: ghcr.io/ippoan/rust-alc-api
+  AR_PREFIX: asia-northeast1-docker.pkg.dev/cloudsql-sv/ghcr
 
 jobs:
   # ---------------------------------------------------------------------------
@@ -147,17 +148,17 @@ jobs:
 
       - name: Run migrations
         run: |
-          IMAGE="${{ env.REPO }}:${{ inputs.image_sha }}"
+          AR_IMAGE="${{ env.AR_PREFIX }}/${{ env.REPO }}:${{ inputs.image_sha }}"
           JOB_NAME="rust-alc-api-migrate"
 
           if gcloud run jobs describe $JOB_NAME --region ${{ env.REGION }} --project ${{ env.PROJECT }} &>/dev/null; then
             gcloud run jobs update $JOB_NAME \
               --region ${{ env.REGION }} --project ${{ env.PROJECT }} \
-              --image "$IMAGE"
+              --image "$AR_IMAGE"
           else
             gcloud run jobs create $JOB_NAME \
               --region ${{ env.REGION }} --project ${{ env.PROJECT }} \
-              --image "$IMAGE" \
+              --image "$AR_IMAGE" \
               --set-secrets "DATABASE_URL=alc-app-database-url:latest" \
               --command "migrate" \
               --memory 512Mi --task-timeout 120s --max-retries 0
@@ -204,7 +205,7 @@ jobs:
 
           if [ "${DEPLOY_ENV}" = "staging" ]; then
             STAGING_URL="${{ vars.STAGING_API_URL }}"
-            DB_IMAGE="${{ env.REPO }}-staging-db:latest"
+            DB_IMAGE="${{ env.AR_PREFIX }}/${{ env.REPO }}-staging-db:latest"
             RENDER_ARGS="${RENDER_ARGS} --staging-url ${STAGING_URL} --db-image ${DB_IMAGE}"
           fi
 
@@ -362,8 +363,8 @@ jobs:
 
       - name: Update archive Job image
         run: |
-          IMAGE="${{ env.REPO }}:${{ inputs.image_sha }}"
+          AR_IMAGE="${{ env.AR_PREFIX }}/${{ env.REPO }}:${{ inputs.image_sha }}"
           gcloud run jobs update rust-alc-api-archive \
             --region ${{ env.REGION }} --project ${{ env.PROJECT }} \
-            --image "$IMAGE"
+            --image "$AR_IMAGE"
           echo "::notice ::Archive Job updated"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -678,7 +678,7 @@ npx playwright test
 ### CI 自動デプロイ
 
 - **rust-alc-api**: PR to main → `ci.yml` の `deploy-staging` ジョブ → Cloud Run staging
-  - Docker イメージは GHCR (`ghcr.io/ippoan/rust-alc-api` 他、public package) に push → Cloud Run が直接 pull
+  - Docker イメージは GHCR に push → Artifact Registry リモートリポジトリ (`asia-northeast1-docker.pkg.dev/cloudsql-sv/ghcr/`) 経由で Cloud Run が pull
 - **alc-app**: PR to main → `test.yml` の `deploy-staging` ジョブ → `wrangler deploy --env staging`
 
 ### Secrets / 環境変数
@@ -688,6 +688,7 @@ npx playwright test
 - `alc-r2-access-key`, `alc-r2-secret-key`, `alc-oauth-state-secret`
 - `carins-r2-access-key`, `carins-r2-secret-key`, `dtako-r2-access-key`, `dtako-r2-secret-key`
 - SA `747065218280-compute@developer.gserviceaccount.com` に `secretmanager.secretAccessor` 付与済み
+- SA `staging-deploy@cloudsql-sv.iam.gserviceaccount.com` に Artifact Registry `artifactregistry.reader` 付与済み
 
 **alc-app staging** (Cloudflare Workers → wrangler.jsonc `env.staging.vars`):
 - `NUXT_PUBLIC_API_BASE`: staging Cloud Run URL

--- a/archive.sh
+++ b/archive.sh
@@ -4,7 +4,8 @@ set -e
 PROJECT_ID="cloudsql-sv"
 REGION="asia-northeast1"
 SERVICE_NAME="rust-alc-api"
-IMAGE="ghcr.io/ippoan/rust-alc-api"
+REPOSITORY="alc-app"
+IMAGE="$REGION-docker.pkg.dev/$PROJECT_ID/$REPOSITORY/$SERVICE_NAME"
 ARCHIVE_JOB_NAME="rust-alc-api-archive"
 
 # Usage: ./archive.sh dtako-archive --dry-run

--- a/cloudrun/render.sh
+++ b/cloudrun/render.sh
@@ -30,6 +30,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 REPO="ghcr.io/ippoan/rust-alc-api"
+AR_PREFIX="asia-northeast1-docker.pkg.dev/cloudsql-sv/ghcr"
 REGION="asia-northeast1"
 
 # ---------------------------------------------------------------------------
@@ -49,13 +50,13 @@ if [[ "$ENV" == "staging" ]]; then
   SERVICE_NAME="rust-alc-api-staging${SUFFIX}"
   # Gateway has no sidecar, so use the production image directly
   if [[ "$SERVICE" == "gateway" ]]; then
-    IMAGE="${REPO}${SUFFIX}:${IMAGE_SHA}"
+    IMAGE="${AR_PREFIX}/${REPO}${SUFFIX}:${IMAGE_SHA}"
   else
-    IMAGE="${REPO}${SUFFIX}-staging:${IMAGE_SHA}"
+    IMAGE="${AR_PREFIX}/${REPO}${SUFFIX}-staging:${IMAGE_SHA}"
   fi
 else
   SERVICE_NAME="rust-alc-api${SUFFIX}"
-  IMAGE="${REPO}${SUFFIX}:${IMAGE_SHA}"
+  IMAGE="${AR_PREFIX}/${REPO}${SUFFIX}:${IMAGE_SHA}"
 fi
 
 # ---------------------------------------------------------------------------

--- a/deploy.sh
+++ b/deploy.sh
@@ -4,13 +4,14 @@ set -e
 PROJECT_ID="cloudsql-sv"
 REGION="asia-northeast1"
 SERVICE_NAME="rust-alc-api"
-IMAGE="ghcr.io/ippoan/rust-alc-api"
+REPOSITORY="alc-app"
+IMAGE="$REGION-docker.pkg.dev/$PROJECT_ID/$REPOSITORY/$SERVICE_NAME"
 MIGRATION_JOB_NAME="rust-alc-api-migrate"
 
 echo "=== Building Docker image ==="
 docker build -t $IMAGE:latest .
 
-echo "=== Pushing to GHCR ==="
+echo "=== Pushing to Artifact Registry ==="
 docker push $IMAGE:latest
 
 echo "=== Running migrations via Cloud Run Jobs ==="


### PR DESCRIPTION
## Why revert
PR #253 tried to remove the Artifact Registry remote-repository proxy and have Cloud Run pull directly from ghcr.io. However, `gcloud run services replace` (used by render.sh + deploy.yml) rejects `ghcr.io/...` images with:

```
ERROR: spec.template.spec.containers[0].image: Expected an image path like [host/]repo-path[:tag], where host is one of [region.]gcr.io, [region-]docker.pkg.dev or docker.io but obtained ghcr.io/...
```

The AR remote-repository IS the Google-recommended workaround for this restriction (confirmed via GCP docs and web search).

## Effect
Restores the working AR remote-repo flow. Staging/production deploy path returns to normal.

## Next step (separate PR)
Set a cleanup policy on the AR `ghcr` remote repository to cap cached-image retention — this reduces the ¥116/month AR cost without breaking the deploy pipeline.