### PR TITLE
ci: add daily Artifact Registry size audit

### DIFF
--- a/.github/workflows/ar-size-audit.yml
+++ b/.github/workflows/ar-size-audit.yml
@@ -1,0 +1,56 @@
+name: Artifact Registry size audit
+
+on:
+  schedule:
+    - cron: '0 19 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  snapshot:
+    runs-on: ubuntu-latest
+    env:
+      PROJECT: cloudsql-sv
+      REGION: asia-northeast1
+    steps:
+      - uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+      - uses: google-github-actions/setup-gcloud@v2
+
+      - name: Collect repository sizes
+        run: |
+          gcloud artifacts repositories list \
+            --project=$PROJECT --location=$REGION \
+            --format='value(name.basename(),format,mode,sizeBytes)' > repos.tsv
+          echo "=== Current AR state ==="
+          awk -F'\t' '{ printf "%-30s %-6s %-20s %10.1f MB\n", $1, $2, $3, $4/1024/1024 }' repos.tsv
+          echo "=== Total ==="
+          awk -F'\t' '{ s += $4 } END { printf "%.1f MB (%.2f GB)\n", s/1024/1024, s/1024/1024/1024 }' repos.tsv
+
+      - name: Write snapshot to Cloud Logging
+        run: |
+          payload=$(awk -F'\t' 'BEGIN{printf "{\"finding\":\"ar_size_snapshot\",\"repos\":["}
+                                NR>1{printf ","}
+                                {printf "{\"name\":\"%s\",\"format\":\"%s\",\"mode\":\"%s\",\"size_bytes\":%d,\"size_mb\":%.1f}", $1, $2, $3, $4, $4/1024/1024}
+                                END{printf "],\"total_mb\":%.1f}", total/1024/1024}
+                                {total += $4}' repos.tsv)
+          echo "$payload" | python3 -m json.tool
+          gcloud logging write ar-size-audit "$payload" \
+            --payload-type=json \
+            --severity=WARNING \
+            --project=$PROJECT
+
+      - name: Summary
+        run: |
+          {
+            echo "## Artifact Registry daily snapshot"
+            echo ""
+            echo "| Repository | Format | Mode | Size |"
+            echo "|---|---|---|---|"
+            awk -F'\t' '{ printf "| %s | %s | %s | %.1f MB |\n", $1, $2, $3, $4/1024/1024 }' repos.tsv
+            echo ""
+            echo "**Total**: $(awk -F'\t' '{ s += $4 } END { printf "%.2f GB", s/1024/1024/1024 }' repos.tsv)"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- Daily workflow (04:00 JST) that snapshots all AR repo sizes and writes to Cloud Logging
- Alert 'Artifact Registry - daily size snapshot' fires on every entry → email sent daily regardless of size

## Related out-of-repo changes
- Applied cleanup policy to `ghcr` remote-repo (keep latest 10 per package + delete >30 days)
- Deleted legacy `alc-app` repo (1.1 GB, 435 unused images from pre-CI deploy.sh era)
- Created alert policy `Artifact Registry - daily size snapshot` (email to m.tama.ramu@gmail.com)

## Test plan
- [ ] Manual run via workflow_dispatch after merge
- [ ] Confirm email arrives with size snapshot
- [ ] Over 30 days, observe `ghcr` size trending down