### PR TITLE
ci(secret-audit): fix spec scan with --flatten, add volumes + pipefail

### DIFF
--- a/.github/workflows/secret-audit.yml
+++ b/.github/workflows/secret-audit.yml
@@ -22,26 +22,40 @@ jobs:
 
       - name: Collect referenced secrets
         run: |
+          set -o pipefail
           {
-            for s in $(gcloud run services list --project=$PROJECT --region=$REGION --format='value(metadata.name)' 2>/dev/null); do
+            for s in $(gcloud run services list --project=$PROJECT --region=$REGION --format='value(metadata.name)'); do
               gcloud run services describe "$s" --region=$REGION --project=$PROJECT \
-                --format='value(spec.template.spec.containers[].env[].valueFrom.secretKeyRef.name)' 2>/dev/null
+                --flatten='spec.template.spec.containers[].env[]' \
+                --format='value(spec.template.spec.containers.env.valueFrom.secretKeyRef.name)'
+              gcloud run services describe "$s" --region=$REGION --project=$PROJECT \
+                --flatten='spec.template.spec.volumes[]' \
+                --format='value(spec.template.spec.volumes.secret.secretName)'
             done
-            for j in $(gcloud run jobs list --project=$PROJECT --region=$REGION --format='value(metadata.name)' 2>/dev/null); do
+            for j in $(gcloud run jobs list --project=$PROJECT --region=$REGION --format='value(metadata.name)'); do
               gcloud run jobs describe "$j" --region=$REGION --project=$PROJECT \
-                --format='value(spec.template.spec.template.spec.containers[].env[].valueFrom.secretKeyRef.name)' 2>/dev/null
+                --flatten='spec.template.spec.template.spec.containers[].env[]' \
+                --format='value(spec.template.spec.template.spec.containers.env.valueFrom.secretKeyRef.name)'
+              gcloud run jobs describe "$j" --region=$REGION --project=$PROJECT \
+                --flatten='spec.template.spec.template.spec.volumes[]' \
+                --format='value(spec.template.spec.template.spec.volumes.secret.secretName)'
             done
-            for f in $(gcloud functions list --project=$PROJECT --regions=$REGION --format='value(name)' 2>/dev/null); do
+            for f in $(gcloud functions list --project=$PROJECT --regions=$REGION --format='value(name)'); do
               gcloud functions describe "$f" --region=$REGION --project=$PROJECT \
-                --format='value(secretEnvironmentVariables[].secret,secretVolumes[].secret)' 2>/dev/null
+                --flatten='secretEnvironmentVariables[]' \
+                --format='value(secretEnvironmentVariables.secret)'
+              gcloud functions describe "$f" --region=$REGION --project=$PROJECT \
+                --flatten='secretVolumes[]' \
+                --format='value(secretVolumes.secret)'
             done
-          } | tr ';' '\n' | sed '/^$/d' | sort -u > referenced.txt
+          } | sed '/^$/d' | sort -u > referenced.txt
           echo "Referenced secrets ($(wc -l < referenced.txt)):"
           cat referenced.txt
 
       - name: Find unused secrets
         id: unused
         run: |
+          set -o pipefail
           gcloud secrets list --project=$PROJECT --format='value(name.basename())' | sort -u > all.txt
           comm -23 all.txt referenced.txt > not-referenced.txt
           echo "Not in Cloud Run/Jobs/Functions spec ($(wc -l < not-referenced.txt)):"


### PR DESCRIPTION
### Problem
The audit's spec scan produced Python-list-like strings (`[None, None, 'JWT_SECRET', ...]`) instead of per-line secret names because `value()` with double `[]` doesn't flatten nested arrays. As a result, 21 actively-used secrets (`GOOGLE_REDIRECT_URI` on postgres-prod, `trouble-r2-*` / `rust-logi-*` / `alc-app-database-url` / ... on rust-alc-api services, etc.) were falsely flagged as unused.

Separately, the first run of the corrected audit also surfaced that `staging-deploy` SA lacked `roles/secretmanager.viewer` — fixed out-of-band today (`gcloud projects add-iam-policy-binding --role=roles/secretmanager.viewer`).

### Changes
- Use `--flatten` instead of double `[]` for Cloud Run services/jobs (env secretKeyRef + volumes.secret.secretName) and Cloud Functions (secretEnvironmentVariables / secretVolumes).
- Drop the now-unneeded `tr ';' '\n'` post-processing.
- Add `set -o pipefail` to both steps so future regressions fail loudly instead of silently producing empty results.
- Remove `2>/dev/null` from the describe loops so stderr surfaces in the workflow log.

### Verification
Locally validated `--flatten` against postgres-prod / rust-alc-api / rust-alc-api-{trouble,carins} — all referenced secrets now emit cleanly per line. With the combined fix (IAM + query), the legitimate unused list drops from a false 21 to a much smaller set. Remaining runtime-fetched secrets like `GMAIL_APP_PASSWORD` will still false-positive until the 30-day audit-log window fills naturally (~2026-05-19).