### PR TITLE
refactor(trouble): drop vehicle_number column, unify with registration_number

### DIFF
--- a/crates/alc-core/src/models.rs
+++ b/crates/alc-core/src/models.rs
@@ -1502,7 +1502,6 @@ pub struct TroubleTicket {
     pub department: String,
     pub person_name: String,
     pub person_id: Option<Uuid>,
-    pub vehicle_number: String,
     pub registration_number: String,
     pub location: String,
     pub description: String,
@@ -1547,7 +1546,6 @@ pub struct CreateTroubleTicket {
         deserialize_with = "crate::serde_helpers::empty_string_as_none_uuid"
     )]
     pub person_id: Option<Uuid>,
-    pub vehicle_number: Option<String>,
     pub registration_number: Option<String>,
     pub location: Option<String>,
     pub description: Option<String>,
@@ -1589,7 +1587,6 @@ pub struct UpdateTroubleTicket {
         deserialize_with = "crate::serde_helpers::empty_string_as_none_uuid"
     )]
     pub person_id: Option<Uuid>,
-    pub vehicle_number: Option<String>,
     pub registration_number: Option<String>,
     pub location: Option<String>,
     pub description: Option<String>,

--- a/crates/alc-trouble/src/repo/trouble_tickets.rs
+++ b/crates/alc-trouble/src/repo/trouble_tickets.rs
@@ -36,7 +36,7 @@ impl TroubleTicketsRepository for PgTroubleTicketsRepository {
                 tenant_id, category, title,
                 occurred_at, occurred_date,
                 company_name, office_name, department,
-                person_name, person_id, vehicle_number,
+                person_name, person_id,
                 registration_number,
                 location, description,
                 status_id, assigned_to,
@@ -48,18 +48,18 @@ impl TroubleTicketsRepository for PgTroubleTicketsRepository {
                 $1, $2, COALESCE($3, ''),
                 $4, $5,
                 COALESCE($6, ''), COALESCE($7, ''), COALESCE($8, ''),
-                COALESCE($9, ''), $10, COALESCE($11, ''),
-                COALESCE($12, ''),
-                COALESCE($13, ''), COALESCE($14, ''),
-                $15, $16,
-                $17, $18, $19,
-                COALESCE($20, ''), COALESCE($21, ''),
-                COALESCE($22, '{}'::jsonb), $23, $24
+                COALESCE($9, ''), $10,
+                COALESCE($11, ''),
+                COALESCE($12, ''), COALESCE($13, ''),
+                $14, $15,
+                $16, $17, $18,
+                COALESCE($19, ''), COALESCE($20, ''),
+                COALESCE($21, '{}'::jsonb), $22, $23
             )
             RETURNING id, tenant_id, ticket_no, category, title,
                 occurred_at, occurred_date,
                 company_name, office_name, department,
-                person_name, person_id, vehicle_number,
+                person_name, person_id,
                 registration_number,
                 location, description,
                 status_id, assigned_to,
@@ -82,7 +82,6 @@ impl TroubleTicketsRepository for PgTroubleTicketsRepository {
         .bind(&input.department)
         .bind(&input.person_name)
         .bind(input.person_id)
-        .bind(&input.vehicle_number)
         .bind(&input.registration_number)
         .bind(&input.location)
         .bind(&input.description)
@@ -163,7 +162,7 @@ impl TroubleTicketsRepository for PgTroubleTicketsRepository {
             r#"SELECT id, tenant_id, ticket_no, category, title,
                 occurred_at, occurred_date,
                 company_name, office_name, department,
-                person_name, person_id, vehicle_number,
+                person_name, person_id,
                 registration_number,
                 location, description,
                 status_id, assigned_to,
@@ -235,7 +234,7 @@ impl TroubleTicketsRepository for PgTroubleTicketsRepository {
             r#"SELECT id, tenant_id, ticket_no, category, title,
                 occurred_at, occurred_date,
                 company_name, office_name, department,
-                person_name, person_id, vehicle_number,
+                person_name, person_id,
                 registration_number,
                 location, description,
                 status_id, assigned_to,
@@ -273,29 +272,28 @@ impl TroubleTicketsRepository for PgTroubleTicketsRepository {
                 department = COALESCE($9, department),
                 person_name = COALESCE($10, person_name),
                 person_id = COALESCE($11, person_id),
-                vehicle_number = COALESCE($12, vehicle_number),
-                location = COALESCE($13, location),
-                description = COALESCE($14, description),
-                assigned_to = COALESCE($15, assigned_to),
-                progress_notes = COALESCE($16, progress_notes),
-                allowance = COALESCE($17, allowance),
-                damage_amount = COALESCE($18, damage_amount),
-                compensation_amount = COALESCE($19, compensation_amount),
-                confirmation_notice = COALESCE($20, confirmation_notice),
-                disciplinary_content = COALESCE($21, disciplinary_content),
-                disciplinary_action = COALESCE($22, disciplinary_action),
-                road_service_cost = COALESCE($23, road_service_cost),
-                counterparty = COALESCE($24, counterparty),
-                counterparty_insurance = COALESCE($25, counterparty_insurance),
-                custom_fields = COALESCE($26, custom_fields),
-                due_date = COALESCE($27, due_date),
-                registration_number = COALESCE($28, registration_number),
+                location = COALESCE($12, location),
+                description = COALESCE($13, description),
+                assigned_to = COALESCE($14, assigned_to),
+                progress_notes = COALESCE($15, progress_notes),
+                allowance = COALESCE($16, allowance),
+                damage_amount = COALESCE($17, damage_amount),
+                compensation_amount = COALESCE($18, compensation_amount),
+                confirmation_notice = COALESCE($19, confirmation_notice),
+                disciplinary_content = COALESCE($20, disciplinary_content),
+                disciplinary_action = COALESCE($21, disciplinary_action),
+                road_service_cost = COALESCE($22, road_service_cost),
+                counterparty = COALESCE($23, counterparty),
+                counterparty_insurance = COALESCE($24, counterparty_insurance),
+                custom_fields = COALESCE($25, custom_fields),
+                due_date = COALESCE($26, due_date),
+                registration_number = COALESCE($27, registration_number),
                 updated_at = NOW()
             WHERE id = $1 AND tenant_id = $2 AND deleted_at IS NULL
             RETURNING id, tenant_id, ticket_no, category, title,
                 occurred_at, occurred_date,
                 company_name, office_name, department,
-                person_name, person_id, vehicle_number,
+                person_name, person_id,
                 registration_number,
                 location, description,
                 status_id, assigned_to,
@@ -318,7 +316,6 @@ impl TroubleTicketsRepository for PgTroubleTicketsRepository {
         .bind(&input.department)
         .bind(&input.person_name)
         .bind(input.person_id)
-        .bind(&input.vehicle_number)
         .bind(&input.location)
         .bind(&input.description)
         .bind(input.assigned_to)
@@ -365,7 +362,7 @@ impl TroubleTicketsRepository for PgTroubleTicketsRepository {
             RETURNING id, tenant_id, ticket_no, category, title,
                 occurred_at, occurred_date,
                 company_name, office_name, department,
-                person_name, person_id, vehicle_number,
+                person_name, person_id,
                 registration_number,
                 location, description,
                 status_id, assigned_to,

--- a/crates/alc-trouble/src/tickets.rs
+++ b/crates/alc-trouble/src/tickets.rs
@@ -355,7 +355,7 @@ async fn export_csv(
             t.office_name.clone(),
             t.department.clone(),
             t.person_name.clone(),
-            t.vehicle_number.clone(),
+            t.registration_number.clone(),
             t.category.clone(),
             t.location.clone(),
             t.description.clone(),

--- a/migrations/097_drop_trouble_vehicle_number.sql
+++ b/migrations/097_drop_trouble_vehicle_number.sql
@@ -1,0 +1,4 @@
+-- trouble_tickets.vehicle_number を廃止し、以降 registration_number に一本化する。
+-- prod 全チケットで vehicle_number は空文字、modern な機能 (車検証 lookup / 半角正規化 / q 検索) は
+-- 全て registration_number 側に実装済み。
+ALTER TABLE alc_api.trouble_tickets DROP COLUMN IF EXISTS vehicle_number;

--- a/tests/mock_helpers/repos_e.rs
+++ b/tests/mock_helpers/repos_e.rs
@@ -60,7 +60,6 @@ fn mock_ticket(tenant_id: Uuid) -> TroubleTicket {
         department: "第1運行課".to_string(),
         person_name: "テスト太郎".to_string(),
         person_id: None,
-        vehicle_number: "".to_string(),
         registration_number: "".to_string(),
         location: "".to_string(),
         description: "test description".to_string(),


### PR DESCRIPTION
## Why

`trouble_tickets` に `vehicle_number` (車両番号) と `registration_number` (登録番号) の 2 カラムが共存しており、役割が曖昧だった。

- PR #90 以降 modern な機能 (車検証マスタ lookup / 半角正規化 / q 検索マッチ) は全て `registration_number` 側に実装済み
- **prod 全 8 チケットで `vehicle_number` は空文字**。実データは `registration_number` のみ
- CSV 出力は header「登録番号」なのに値は `t.vehicle_number` を返していた矛盾バグも存在

ユーザー確定方針: `vehicle_number` を値ごと廃止、`registration_number` に統一。

## Changes

- **`migrations/097_drop_trouble_vehicle_number.sql`**: `ALTER TABLE ... DROP COLUMN vehicle_number`
- **crates/alc-core/src/models.rs**: `TroubleTicket` / `CreateTroubleTicket` / `UpdateTroubleTicket` から `vehicle_number` フィールド削除
- **crates/alc-trouble/src/repo/trouble_tickets.rs**: `create` / `list` / `get` / `update` / `update_status` の列リスト + placeholder 番号を詰める
- **crates/alc-trouble/src/tickets.rs**: CSV export で `t.vehicle_number` → `t.registration_number` (header との整合)
- **tests/mock_helpers/repos_e.rs**: mock ticket から `vehicle_number` 削除
- ts-rs bindings は test 実行時に自動再生成 (gitignore 済)

## Data / Compat

- **prod データ影響なし**: 全件 `vehicle_number=''` のため DROP で失われるものは無い
- **staging**: 揮発性 DB で migration 再実行 → 即整合
- **serde**: 未知フィールド silent ignore 仕様のため、既存 frontend が `vehicle_number` を送信しても 400 にならない。Phase B (nuxt-trouble) マージ前の中間状態でも downtime 無し

## Test plan

- [x] `cargo test -p alc-core --lib` (117 pass)
- [x] `bash ~/.claude/skills/migrate-test/scripts/migrate_test.sh` (97 migrations + splinter OK)
- [x] `cargo test --test trouble_test` (10 pass、`test_trouble_ticket_csv_export` / `test_trouble_ticket_search_registration_number_width` 含む)
- [ ] staging 反映後、nuxt-trouble の Phase B PR 作成