### PR TITLE
ci(secret-audit): tolerate missing IAM perms + surface warnings

### DIFF
--- a/.github/workflows/secret-audit.yml
+++ b/.github/workflows/secret-audit.yml
@@ -23,8 +23,21 @@ jobs:
       - name: Collect referenced secrets
         run: |
           set -o pipefail
+
+          list_or_warn() {
+            local label=$1; shift
+            local out rc=0
+            out=$("$@") || rc=$?
+            if [ $rc -ne 0 ]; then
+              echo "WARN: $label failed (exit $rc) — skipping" >&2
+              return 0
+            fi
+            printf '%s\n' "$out"
+          }
+
           {
-            for s in $(gcloud run services list --project=$PROJECT --region=$REGION --format='value(metadata.name)'); do
+            for s in $(list_or_warn "gcloud run services list" \
+                         gcloud run services list --project=$PROJECT --region=$REGION --format='value(metadata.name)'); do
               gcloud run services describe "$s" --region=$REGION --project=$PROJECT \
                 --flatten='spec.template.spec.containers[].env[]' \
                 --format='value(spec.template.spec.containers.env.valueFrom.secretKeyRef.name)'
@@ -32,7 +45,8 @@ jobs:
                 --flatten='spec.template.spec.volumes[]' \
                 --format='value(spec.template.spec.volumes.secret.secretName)'
             done
-            for j in $(gcloud run jobs list --project=$PROJECT --region=$REGION --format='value(metadata.name)'); do
+            for j in $(list_or_warn "gcloud run jobs list" \
+                         gcloud run jobs list --project=$PROJECT --region=$REGION --format='value(metadata.name)'); do
               gcloud run jobs describe "$j" --region=$REGION --project=$PROJECT \
                 --flatten='spec.template.spec.template.spec.containers[].env[]' \
                 --format='value(spec.template.spec.template.spec.containers.env.valueFrom.secretKeyRef.name)'
@@ -40,7 +54,8 @@ jobs:
                 --flatten='spec.template.spec.template.spec.volumes[]' \
                 --format='value(spec.template.spec.template.spec.volumes.secret.secretName)'
             done
-            for f in $(gcloud functions list --project=$PROJECT --regions=$REGION --format='value(name)'); do
+            for f in $(list_or_warn "gcloud functions list" \
+                         gcloud functions list --project=$PROJECT --regions=$REGION --format='value(name)'); do
               gcloud functions describe "$f" --region=$REGION --project=$PROJECT \
                 --flatten='secretEnvironmentVariables[]' \
                 --format='value(secretEnvironmentVariables.secret)'
@@ -64,10 +79,16 @@ jobs:
           : > unused.txt
           while read s; do
             [ -z "$s" ] && continue
-            n=$(gcloud logging read \
-              "protoPayload.serviceName=\"secretmanager.googleapis.com\" AND protoPayload.methodName=~\".*AccessSecretVersion$\" AND protoPayload.resourceName=~\"secrets/$s(/|$)\"" \
-              --project=$PROJECT --freshness=30d --limit=1 \
-              --format='value(timestamp)' 2>/dev/null | wc -l)
+            rc=0
+            out=$(gcloud logging read \
+                "protoPayload.serviceName=\"secretmanager.googleapis.com\" AND protoPayload.methodName=~\".*AccessSecretVersion$\" AND protoPayload.resourceName=~\"secrets/$s(/|$)\"" \
+                --project=$PROJECT --freshness=30d --limit=1 \
+                --format='value(timestamp)') || rc=$?
+            if [ $rc -ne 0 ]; then
+              echo "WARN: gcloud logging read failed for $s (exit $rc) — skipping unused check" >&2
+              continue
+            fi
+            n=$(printf '%s' "$out" | grep -c . || true)
             if [ "$n" = "0" ]; then
               echo "$s" >> unused.txt
             fi


### PR DESCRIPTION
昨日の cron が失敗していた Secret Manager audit を修正。

## 根本原因
`staging-deploy@cloudsql-sv.iam.gserviceaccount.com` SA に `roles/logging.viewer` と `roles/cloudfunctions.viewer` が欠落。PR #257 で `set -o pipefail` を追加したため、`gcloud logging read` の silent failure がステップを exit 1 で落とすようになっていた。

## 対応
- **IAM (out-of-band 付与済み)**: `roles/cloudfunctions.viewer` + `roles/logging.viewer` を staging-deploy SA に付与
- **workflow 堅牢化**:
  - `gcloud ... list` 3 箇所を `list_or_warn` ヘルパーでラップ。失敗時は WARN を出して空リストで続行
  - `gcloud logging read` は exit code を明示チェック、失敗時は `continue` でスキップ（unused 判定保留 = false positive 回避）
  - `2>/dev/null` を廃止して stderr を拾えるようにし、`| wc -l` を `grep -c .` に変更（gcloud 警告混入の防止）

## 失敗 run
https://github.com/ippoan/rust-alc-api/actions/runs/24684501421