### PR TITLE
feat(secret-audit): write daily summary with active version count

### DIFF
--- a/.github/workflows/secret-audit.yml
+++ b/.github/workflows/secret-audit.yml
@@ -98,12 +98,39 @@ jobs:
           cat unused.txt
           echo "count=$(wc -l < unused.txt)" >> "$GITHUB_OUTPUT"
 
+      - name: Count active versions
+        id: versions
+        run: |
+          set -o pipefail
+          active=$(while read s; do
+            [ -z "$s" ] && continue
+            gcloud secrets versions list "$s" --project=$PROJECT \
+              --filter='state=ENABLED' --format='value(name)' 2>/dev/null | wc -l
+          done < all.txt | awk '{s+=$1} END {print s+0}')
+          echo "active=$active" >> "$GITHUB_OUTPUT"
+          echo "Active versions: $active"
+
+      - name: Write daily summary to Cloud Logging
+        run: |
+          active=${{ steps.versions.outputs.active }}
+          secrets_total=$(wc -l < all.txt | tr -d ' ')
+          referenced=$(wc -l < referenced.txt | tr -d ' ')
+          not_ref=$(wc -l < not-referenced.txt | tr -d ' ')
+          unused=${{ steps.unused.outputs.count }}
+          monthly_usd=$(awk -v a=$active 'BEGIN{printf "%.2f", a*0.06}')
+          payload="{\"finding\":\"audit_summary\",\"secrets_total\":${secrets_total},\"active_versions\":${active},\"referenced\":${referenced},\"not_referenced\":${not_ref},\"confirmed_unused\":${unused},\"monthly_usd_estimate\":${monthly_usd}}"
+          echo "$payload"
+          gcloud logging write secret-audit-summary "$payload" \
+            --payload-type=json \
+            --severity=NOTICE \
+            --project=$PROJECT
+
       - name: Write finding to Cloud Logging
         if: steps.unused.outputs.count != '0'
         run: |
           secrets_json=$(awk 'NF{printf "\"%s\",", $0}' unused.txt | sed 's/,$//')
           count=$(wc -l < unused.txt | tr -d ' ')
-          payload="{\"finding\":\"unused_secrets\",\"count\":${count},\"secrets\":[${secrets_json}],\"note\":\"not referenced by Cloud Run/Jobs/Functions and no AccessSecretVersion in past 30 days (audit log enabled 2026-04-19)\"}"
+          payload="{\"finding\":\"unused_secrets\",\"count\":${count},\"active_versions\":${{ steps.versions.outputs.active }},\"secrets\":[${secrets_json}],\"note\":\"not referenced by Cloud Run/Jobs/Functions and no AccessSecretVersion in past 30 days (audit log enabled 2026-04-19)\"}"
           echo "$payload"
           gcloud logging write secret-audit "$payload" \
             --payload-type=json \
@@ -114,6 +141,8 @@ jobs:
         run: |
           {
             echo "## Secret Manager audit"
+            echo "- Secrets total: $(wc -l < all.txt)"
+            echo "- Active versions: ${{ steps.versions.outputs.active }}"
             echo "- Referenced: $(wc -l < referenced.txt)"
             echo "- Not referenced: $(wc -l < not-referenced.txt)"
             echo "- Confirmed unused (static + 30d audit): ${{ steps.unused.outputs.count }}"


### PR DESCRIPTION
## 概要
毎日の email 日報で active version 数 + Secret Manager 月額見積を確認できるように。

## 変更
- workflow に `Count active versions` + `Write daily summary` ステップ追加
- 新 log stream `secret-audit-summary` に severity=NOTICE で毎日 1 件書込
- payload: secrets_total / active_versions / referenced / not_referenced / confirmed_unused / monthly_usd_estimate
- 既存の `unused_secrets` payload にも `active_versions` フィールドを追加
- GitHub step summary にも active versions 表示

## 別途対応
この PR マージ後、Cloud Monitoring に `secret-audit-summary` 用の alert policy を新設する (email 配信)。workflow 自体は alert なしでも log は出るので、先にデータを貯めてから alert 設定でも OK。

## 参考
現在 active=21 → 月 $1.26 = ¥190 程度 (¥150/$)