### PR TITLE
feat(trouble): add GET /trouble/tasks cross-ticket list endpoint

### DIFF
--- a/crates/alc-core/src/repository/mod.rs
+++ b/crates/alc-core/src/repository/mod.rs
@@ -97,7 +97,7 @@ pub use trouble_offices::TroubleOfficesRepository;
 pub use trouble_progress_statuses::TroubleProgressStatusesRepository;
 pub use trouble_schedules::TroubleSchedulesRepository;
 pub use trouble_task_types::TroubleTaskTypesRepository;
-pub use trouble_tasks::TroubleTasksRepository;
+pub use trouble_tasks::{TroubleTasksFilter, TroubleTasksRepository, TroubleTasksSortBy};
 pub use trouble_tickets::TroubleTicketsRepository;
 pub use trouble_workflow::TroubleWorkflowRepository;
 pub use webhook::WebhookRepository;

--- a/crates/alc-core/src/repository/trouble_tasks.rs
+++ b/crates/alc-core/src/repository/trouble_tasks.rs
@@ -1,7 +1,42 @@
 use async_trait::async_trait;
+use chrono::{DateTime, Utc};
 use uuid::Uuid;
 
 use crate::models::{CreateTroubleTask, TroubleTask, UpdateTroubleTask};
+
+#[derive(Debug, Default, Clone)]
+pub struct TroubleTasksFilter {
+    pub ticket_id: Option<Uuid>,
+    pub status: Option<String>,
+    pub task_type: Option<String>,
+    pub assigned_to: Option<Uuid>,
+    pub q: Option<String>,
+    pub due_from: Option<DateTime<Utc>>,
+    pub due_to: Option<DateTime<Utc>>,
+    pub occurred_from: Option<DateTime<Utc>>,
+    pub occurred_to: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum TroubleTasksSortBy {
+    CreatedAt,
+    OccurredAt,
+    DueDate,
+    NextActionDue,
+    Status,
+}
+
+impl TroubleTasksSortBy {
+    pub fn column(self) -> &'static str {
+        match self {
+            Self::CreatedAt => "created_at",
+            Self::OccurredAt => "occurred_at",
+            Self::DueDate => "due_date",
+            Self::NextActionDue => "next_action_due",
+            Self::Status => "status",
+        }
+    }
+}
 
 #[async_trait]
 pub trait TroubleTasksRepository: Send + Sync {
@@ -29,4 +64,20 @@ pub trait TroubleTasksRepository: Send + Sync {
     ) -> Result<Option<TroubleTask>, sqlx::Error>;
 
     async fn delete(&self, tenant_id: Uuid, id: Uuid) -> Result<bool, sqlx::Error>;
+
+    async fn list_all(
+        &self,
+        tenant_id: Uuid,
+        filter: &TroubleTasksFilter,
+        sort_by: TroubleTasksSortBy,
+        sort_desc: bool,
+        limit: i64,
+        offset: i64,
+    ) -> Result<Vec<TroubleTask>, sqlx::Error>;
+
+    async fn count_all(
+        &self,
+        tenant_id: Uuid,
+        filter: &TroubleTasksFilter,
+    ) -> Result<i64, sqlx::Error>;
 }

--- a/crates/alc-trouble/src/repo/trouble_tasks.rs
+++ b/crates/alc-trouble/src/repo/trouble_tasks.rs
@@ -136,4 +136,162 @@ impl TroubleTasksRepository for PgTroubleTasksRepository {
             .await?;
         Ok(result.rows_affected() > 0)
     }
+
+    async fn list_all(
+        &self,
+        tenant_id: Uuid,
+        filter: &TroubleTasksFilter,
+        sort_by: TroubleTasksSortBy,
+        sort_desc: bool,
+        limit: i64,
+        offset: i64,
+    ) -> Result<Vec<TroubleTask>, sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+
+        let (where_sql, next_idx) = build_where_sql(filter);
+        let direction = if sort_desc { "DESC" } else { "ASC" };
+        let sort_col = sort_by.column();
+
+        let list_sql = format!(
+            "SELECT * FROM trouble_tasks WHERE {where_sql} \
+             ORDER BY {sort_col} {direction} NULLS LAST, created_at DESC \
+             LIMIT ${limit_idx} OFFSET ${offset_idx}",
+            limit_idx = next_idx,
+            offset_idx = next_idx + 1,
+        );
+
+        let mut q = sqlx::query_as::<_, TroubleTask>(&list_sql).bind(tenant_id);
+        q = bind_filters(q, filter);
+        q = q.bind(limit).bind(offset);
+        q.fetch_all(&mut *tc.conn).await
+    }
+
+    async fn count_all(
+        &self,
+        tenant_id: Uuid,
+        filter: &TroubleTasksFilter,
+    ) -> Result<i64, sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        let (where_sql, _next_idx) = build_where_sql(filter);
+        let count_sql = format!("SELECT COUNT(*) FROM trouble_tasks WHERE {where_sql}");
+        let mut q = sqlx::query_scalar::<_, i64>(&count_sql).bind(tenant_id);
+        q = bind_filters_scalar(q, filter);
+        q.fetch_one(&mut *tc.conn).await
+    }
+}
+
+/// Build `WHERE` clause and return `(sql, next_param_index)`.
+/// `$1` is reserved for `tenant_id`; filter binds start at `$2`.
+fn build_where_sql(filter: &TroubleTasksFilter) -> (String, u32) {
+    let mut clauses = vec!["tenant_id = $1".to_string()];
+    let mut idx: u32 = 2;
+
+    if filter.ticket_id.is_some() {
+        clauses.push(format!("ticket_id = ${idx}"));
+        idx += 1;
+    }
+    if filter.status.is_some() {
+        clauses.push(format!("status = ${idx}"));
+        idx += 1;
+    }
+    if filter.task_type.is_some() {
+        clauses.push(format!("task_type = ${idx}"));
+        idx += 1;
+    }
+    if filter.assigned_to.is_some() {
+        clauses.push(format!("assigned_to = ${idx}"));
+        idx += 1;
+    }
+    if filter.q.is_some() {
+        clauses.push(format!(
+            "(title ILIKE '%' || ${idx} || '%' OR description ILIKE '%' || ${idx} || '%')"
+        ));
+        idx += 1;
+    }
+    if filter.due_from.is_some() {
+        clauses.push(format!("due_date >= ${idx}"));
+        idx += 1;
+    }
+    if filter.due_to.is_some() {
+        clauses.push(format!("due_date <= ${idx}"));
+        idx += 1;
+    }
+    if filter.occurred_from.is_some() {
+        clauses.push(format!("occurred_at >= ${idx}"));
+        idx += 1;
+    }
+    if filter.occurred_to.is_some() {
+        clauses.push(format!("occurred_at <= ${idx}"));
+        idx += 1;
+    }
+
+    (clauses.join(" AND "), idx)
+}
+
+fn bind_filters<'q>(
+    mut q: sqlx::query::QueryAs<'q, sqlx::Postgres, TroubleTask, sqlx::postgres::PgArguments>,
+    filter: &'q TroubleTasksFilter,
+) -> sqlx::query::QueryAs<'q, sqlx::Postgres, TroubleTask, sqlx::postgres::PgArguments> {
+    if let Some(v) = filter.ticket_id {
+        q = q.bind(v);
+    }
+    if let Some(ref v) = filter.status {
+        q = q.bind(v);
+    }
+    if let Some(ref v) = filter.task_type {
+        q = q.bind(v);
+    }
+    if let Some(v) = filter.assigned_to {
+        q = q.bind(v);
+    }
+    if let Some(ref v) = filter.q {
+        q = q.bind(v);
+    }
+    if let Some(v) = filter.due_from {
+        q = q.bind(v);
+    }
+    if let Some(v) = filter.due_to {
+        q = q.bind(v);
+    }
+    if let Some(v) = filter.occurred_from {
+        q = q.bind(v);
+    }
+    if let Some(v) = filter.occurred_to {
+        q = q.bind(v);
+    }
+    q
+}
+
+fn bind_filters_scalar<'q>(
+    mut q: sqlx::query::QueryScalar<'q, sqlx::Postgres, i64, sqlx::postgres::PgArguments>,
+    filter: &'q TroubleTasksFilter,
+) -> sqlx::query::QueryScalar<'q, sqlx::Postgres, i64, sqlx::postgres::PgArguments> {
+    if let Some(v) = filter.ticket_id {
+        q = q.bind(v);
+    }
+    if let Some(ref v) = filter.status {
+        q = q.bind(v);
+    }
+    if let Some(ref v) = filter.task_type {
+        q = q.bind(v);
+    }
+    if let Some(v) = filter.assigned_to {
+        q = q.bind(v);
+    }
+    if let Some(ref v) = filter.q {
+        q = q.bind(v);
+    }
+    if let Some(v) = filter.due_from {
+        q = q.bind(v);
+    }
+    if let Some(v) = filter.due_to {
+        q = q.bind(v);
+    }
+    if let Some(v) = filter.occurred_from {
+        q = q.bind(v);
+    }
+    if let Some(v) = filter.occurred_to {
+        q = q.bind(v);
+    }
+    q
 }

--- a/crates/alc-trouble/src/tasks.rs
+++ b/crates/alc-trouble/src/tasks.rs
@@ -1,5 +1,5 @@
 use axum::{
-    extract::{Multipart, Path, State},
+    extract::{Multipart, Path, Query, State},
     http::StatusCode,
     routing::{delete, get, post},
     Json, Router,
@@ -9,6 +9,7 @@ use uuid::Uuid;
 use crate::TroubleState;
 use alc_core::auth_middleware::TenantId;
 use alc_core::models::{CreateTroubleTask, TroubleFile, TroubleTask, UpdateTroubleTask};
+use alc_core::repository::trouble_tasks::{TroubleTasksFilter, TroubleTasksSortBy};
 
 const VALID_STATUSES: &[&str] = &["open", "in_progress", "done"];
 
@@ -18,6 +19,7 @@ where
     S: Clone + Send + Sync + 'static,
 {
     Router::new()
+        .route("/trouble/tasks", get(list_all_tasks))
         .route(
             "/trouble/tickets/{ticket_id}/tasks",
             post(create_task).get(list_tasks),
@@ -35,6 +37,94 @@ where
             get(download_task_file),
         )
         .route("/trouble/task-files/{file_id}", delete(delete_task_file))
+}
+
+#[derive(serde::Deserialize, Default)]
+struct ListTasksQuery {
+    ticket_id: Option<Uuid>,
+    status: Option<String>,
+    task_type: Option<String>,
+    assigned_to: Option<Uuid>,
+    q: Option<String>,
+    due_from: Option<chrono::DateTime<chrono::Utc>>,
+    due_to: Option<chrono::DateTime<chrono::Utc>>,
+    occurred_from: Option<chrono::DateTime<chrono::Utc>>,
+    occurred_to: Option<chrono::DateTime<chrono::Utc>>,
+    sort_by: Option<String>,
+    sort_desc: Option<bool>,
+    page: Option<i64>,
+    per_page: Option<i64>,
+}
+
+#[derive(serde::Serialize)]
+struct ListTasksResponse {
+    items: Vec<TroubleTask>,
+    total: i64,
+    page: i64,
+    per_page: i64,
+}
+
+fn parse_sort_by(s: Option<&str>) -> Result<TroubleTasksSortBy, StatusCode> {
+    match s.unwrap_or("created_at") {
+        "created_at" => Ok(TroubleTasksSortBy::CreatedAt),
+        "occurred_at" => Ok(TroubleTasksSortBy::OccurredAt),
+        "due_date" => Ok(TroubleTasksSortBy::DueDate),
+        "next_action_due" => Ok(TroubleTasksSortBy::NextActionDue),
+        "status" => Ok(TroubleTasksSortBy::Status),
+        _ => Err(StatusCode::BAD_REQUEST),
+    }
+}
+
+async fn list_all_tasks(
+    State(state): State<TroubleState>,
+    tenant: axum::Extension<TenantId>,
+    Query(query): Query<ListTasksQuery>,
+) -> Result<Json<ListTasksResponse>, StatusCode> {
+    let sort_by = parse_sort_by(query.sort_by.as_deref())?;
+    let sort_desc = query.sort_desc.unwrap_or(true);
+
+    let per_page = query.per_page.unwrap_or(50).clamp(1, 200);
+    let page = query.page.unwrap_or(1).max(1);
+    let offset = (page - 1) * per_page;
+
+    let filter = TroubleTasksFilter {
+        ticket_id: query.ticket_id,
+        status: query.status,
+        task_type: query.task_type,
+        assigned_to: query.assigned_to,
+        q: query.q,
+        due_from: query.due_from,
+        due_to: query.due_to,
+        occurred_from: query.occurred_from,
+        occurred_to: query.occurred_to,
+    };
+
+    let tenant_id = tenant.0 .0;
+
+    let items = state
+        .trouble_tasks
+        .list_all(tenant_id, &filter, sort_by, sort_desc, per_page, offset)
+        .await
+        .map_err(|e| {
+            tracing::error!("list_all_tasks error: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    let total = state
+        .trouble_tasks
+        .count_all(tenant_id, &filter)
+        .await
+        .map_err(|e| {
+            tracing::error!("count_all_tasks error: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    Ok(Json(ListTasksResponse {
+        items,
+        total,
+        page,
+        per_page,
+    }))
 }
 
 async fn create_task(

--- a/src/db/repository/mod.rs
+++ b/src/db/repository/mod.rs
@@ -14,8 +14,8 @@ pub use alc_core::repository::{
     TenkoSessionRepository, TenkoWebhooksRepository, TimecardRepository,
     TroubleCategoriesRepository, TroubleFilesRepository, TroubleNotificationPrefsRepository,
     TroubleOfficesRepository, TroubleProgressStatusesRepository, TroubleSchedulesRepository,
-    TroubleTaskTypesRepository, TroubleTasksRepository, TroubleTicketsRepository,
-    TroubleWorkflowRepository, WebhookRepository,
+    TroubleTaskTypesRepository, TroubleTasksFilter, TroubleTasksRepository, TroubleTasksSortBy,
+    TroubleTicketsRepository, TroubleWorkflowRepository, WebhookRepository,
 };
 
 // Re-export TenantConn from alc-core

--- a/tests/mock_helpers/repos_e.rs
+++ b/tests/mock_helpers/repos_e.rs
@@ -14,8 +14,8 @@ use rust_alc_api::db::models::{
 use rust_alc_api::db::repository::{
     TroubleCategoriesRepository, TroubleFilesRepository, TroubleNotificationPrefsRepository,
     TroubleOfficesRepository, TroubleProgressStatusesRepository, TroubleSchedulesRepository,
-    TroubleTaskTypesRepository, TroubleTasksRepository, TroubleTicketsRepository,
-    TroubleWorkflowRepository,
+    TroubleTaskTypesRepository, TroubleTasksFilter, TroubleTasksRepository, TroubleTasksSortBy,
+    TroubleTicketsRepository, TroubleWorkflowRepository,
 };
 
 macro_rules! check_fail {
@@ -1036,5 +1036,27 @@ impl TroubleTasksRepository for MockTroubleTasksRepository {
     async fn delete(&self, _tenant_id: Uuid, _id: Uuid) -> Result<bool, sqlx::Error> {
         check_fail!(self);
         Ok(!self.delete_returns_false.swap(false, Ordering::SeqCst))
+    }
+
+    async fn list_all(
+        &self,
+        _tenant_id: Uuid,
+        _filter: &TroubleTasksFilter,
+        _sort_by: TroubleTasksSortBy,
+        _sort_desc: bool,
+        _limit: i64,
+        _offset: i64,
+    ) -> Result<Vec<TroubleTask>, sqlx::Error> {
+        check_fail!(self);
+        Ok(vec![])
+    }
+
+    async fn count_all(
+        &self,
+        _tenant_id: Uuid,
+        _filter: &TroubleTasksFilter,
+    ) -> Result<i64, sqlx::Error> {
+        check_fail!(self);
+        Ok(0)
     }
 }

--- a/tests/trouble_tasks_cross_ticket_test.rs
+++ b/tests/trouble_tasks_cross_ticket_test.rs
@@ -1,0 +1,243 @@
+#[macro_use]
+mod common;
+
+use serde_json::Value;
+
+/// Helper: setup workflow and create a ticket. Returns ticket_id as String.
+async fn create_ticket(base_url: &str, auth: &str, category: &str, person: &str) -> String {
+    let client = reqwest::Client::new();
+    let res = client
+        .post(format!("{base_url}/api/trouble/tickets"))
+        .header("Authorization", auth)
+        .json(&serde_json::json!({
+            "category": category,
+            "person_name": person,
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 201, "ticket create should return 201");
+    let ticket: Value = res.json().await.unwrap();
+    ticket["id"].as_str().unwrap().to_string()
+}
+
+async fn create_task(
+    base_url: &str,
+    auth: &str,
+    ticket_id: &str,
+    body: serde_json::Value,
+) -> Value {
+    let client = reqwest::Client::new();
+    let res = client
+        .post(format!("{base_url}/api/trouble/tickets/{ticket_id}/tasks"))
+        .header("Authorization", auth)
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 201, "task create should return 201");
+    res.json().await.unwrap()
+}
+
+#[tokio::test]
+async fn test_list_all_tasks_cross_ticket() {
+    test_group!("trouble tasks 横断一覧");
+    test_case!(
+        "2チケット×3タスクで全件取得・フィルタ・ページング・ソートを検証",
+        {
+            let state = common::setup_app_state().await;
+            let base_url = common::spawn_test_server(state.clone()).await;
+            let tenant_id =
+                common::create_test_tenant(state.pool(), "Tasks Cross Ticket Tenant").await;
+            let jwt = common::create_test_jwt(tenant_id, "admin");
+            let client = reqwest::Client::new();
+            let auth = format!("Bearer {jwt}");
+
+            // Setup workflow (to allow ticket create with valid initial status)
+            let res = client
+                .post(format!("{base_url}/api/trouble/workflow/setup"))
+                .header("Authorization", &auth)
+                .send()
+                .await
+                .unwrap();
+            assert_eq!(res.status(), 200);
+
+            // Create two tickets
+            let ticket_a = create_ticket(&base_url, &auth, "貨物事故", "ドライバーA").await;
+            let ticket_b = create_ticket(&base_url, &auth, "その他", "ドライバーB").await;
+
+            // Create 3 tasks per ticket (open, in_progress [via create + update], done [create +
+            // update to set status]). We'll just create as "open" and update 2 of them later.
+            let t_a1 = create_task(
+                &base_url,
+                &auth,
+                &ticket_a,
+                serde_json::json!({"title": "修理手配 alpha", "task_type": "修理手配"}),
+            )
+            .await;
+            let t_a2 = create_task(
+                &base_url,
+                &auth,
+                &ticket_a,
+                serde_json::json!({"title": "連絡 beta", "task_type": "連絡"}),
+            )
+            .await;
+            let _t_a3 = create_task(
+                &base_url,
+                &auth,
+                &ticket_a,
+                serde_json::json!({"title": "報告 gamma", "task_type": "報告"}),
+            )
+            .await;
+            let _t_b1 = create_task(
+                &base_url,
+                &auth,
+                &ticket_b,
+                serde_json::json!({"title": "修理手配 delta", "task_type": "修理手配"}),
+            )
+            .await;
+            let _t_b2 = create_task(
+                &base_url,
+                &auth,
+                &ticket_b,
+                serde_json::json!({"title": "連絡 epsilon", "task_type": "連絡"}),
+            )
+            .await;
+            let _t_b3 = create_task(
+                &base_url,
+                &auth,
+                &ticket_b,
+                serde_json::json!({"title": "報告 zeta", "task_type": "報告"}),
+            )
+            .await;
+
+            // Update t_a1 → in_progress, t_a2 → done
+            let t_a1_id = t_a1["id"].as_str().unwrap();
+            let t_a2_id = t_a2["id"].as_str().unwrap();
+            let res = client
+                .put(format!("{base_url}/api/trouble/tasks/{t_a1_id}"))
+                .header("Authorization", &auth)
+                .json(&serde_json::json!({"status": "in_progress"}))
+                .send()
+                .await
+                .unwrap();
+            assert_eq!(res.status(), 200);
+            let res = client
+                .put(format!("{base_url}/api/trouble/tasks/{t_a2_id}"))
+                .header("Authorization", &auth)
+                .json(&serde_json::json!({"status": "done"}))
+                .send()
+                .await
+                .unwrap();
+            assert_eq!(res.status(), 200);
+
+            // Default list: all 6 returned, sorted created_at desc by default.
+            let res = client
+                .get(format!("{base_url}/api/trouble/tasks"))
+                .header("Authorization", &auth)
+                .send()
+                .await
+                .unwrap();
+            assert_eq!(res.status(), 200);
+            let body: Value = res.json().await.unwrap();
+            assert_eq!(body["total"].as_i64().unwrap(), 6, "total should be 6");
+            assert_eq!(
+                body["items"].as_array().unwrap().len(),
+                6,
+                "items should have 6 tasks"
+            );
+            assert_eq!(body["page"].as_i64().unwrap(), 1);
+            assert_eq!(body["per_page"].as_i64().unwrap(), 50);
+
+            // Filter by status=open → 4 tasks (6 - 1 in_progress - 1 done)
+            let res = client
+                .get(format!("{base_url}/api/trouble/tasks?status=open"))
+                .header("Authorization", &auth)
+                .send()
+                .await
+                .unwrap();
+            assert_eq!(res.status(), 200);
+            let body: Value = res.json().await.unwrap();
+            assert_eq!(body["total"].as_i64().unwrap(), 4);
+            for item in body["items"].as_array().unwrap() {
+                assert_eq!(item["status"], "open");
+            }
+
+            // Filter by ticket_id → 3 tasks
+            let res = client
+                .get(format!("{base_url}/api/trouble/tasks?ticket_id={ticket_a}"))
+                .header("Authorization", &auth)
+                .send()
+                .await
+                .unwrap();
+            assert_eq!(res.status(), 200);
+            let body: Value = res.json().await.unwrap();
+            assert_eq!(body["total"].as_i64().unwrap(), 3);
+            for item in body["items"].as_array().unwrap() {
+                assert_eq!(item["ticket_id"], ticket_a);
+            }
+
+            // Filter by q (title ILIKE) → "beta" matches only t_a2
+            let res = client
+                .get(format!("{base_url}/api/trouble/tasks?q=beta"))
+                .header("Authorization", &auth)
+                .send()
+                .await
+                .unwrap();
+            assert_eq!(res.status(), 200);
+            let body: Value = res.json().await.unwrap();
+            assert_eq!(body["total"].as_i64().unwrap(), 1);
+            assert!(body["items"][0]["title"].as_str().unwrap().contains("beta"));
+
+            // Pagination: per_page=2, page=2 → 2 items, total still 6
+            let res = client
+                .get(format!("{base_url}/api/trouble/tasks?per_page=2&page=2"))
+                .header("Authorization", &auth)
+                .send()
+                .await
+                .unwrap();
+            assert_eq!(res.status(), 200);
+            let body: Value = res.json().await.unwrap();
+            assert_eq!(body["total"].as_i64().unwrap(), 6);
+            assert_eq!(body["items"].as_array().unwrap().len(), 2);
+            assert_eq!(body["page"].as_i64().unwrap(), 2);
+            assert_eq!(body["per_page"].as_i64().unwrap(), 2);
+
+            // Unknown sort_by → 400
+            let res = client
+                .get(format!("{base_url}/api/trouble/tasks?sort_by=bogus_column"))
+                .header("Authorization", &auth)
+                .send()
+                .await
+                .unwrap();
+            assert_eq!(res.status(), 400);
+
+            // Sort by status (ASC) → first items should be "done" (d < i < o alphabetically)
+            let res = client
+                .get(format!(
+                    "{base_url}/api/trouble/tasks?sort_by=status&sort_desc=false"
+                ))
+                .header("Authorization", &auth)
+                .send()
+                .await
+                .unwrap();
+            assert_eq!(res.status(), 200);
+            let body: Value = res.json().await.unwrap();
+            let statuses: Vec<&str> = body["items"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|v| v["status"].as_str().unwrap())
+                .collect();
+            assert_eq!(statuses.first().copied(), Some("done"));
+
+            // Missing auth → 401
+            let res = reqwest::Client::new()
+                .get(format!("{base_url}/api/trouble/tasks"))
+                .send()
+                .await
+                .unwrap();
+            assert_eq!(res.status(), 401);
+        }
+    );
+}


### PR DESCRIPTION
## Summary

- `trouble_tasks` を ticket 横断で一覧するエンドポイント (nuxt-trouble 側の 状況管理 ページ用)
- filter: ticket_id / status / task_type / assigned_to / q / due_from,to / occurred_from,to
- sort: created_at / occurred_at / due_date / next_action_due / status (asc/desc)
- pagination: page + per_page (1..200, default 50)
- Unknown sort_by → 400
- ORDER BY NULLS LAST + created_at DESC tiebreaker for stable paging
- 既存 `GET /trouble/tickets/{id}/tasks` への影響なし (route order で両立)

## Test plan

- [x] `cargo check --all`, `cargo clippy -p alc-trouble -p alc-core` OK
- [x] integration test `trouble_tasks_cross_ticket_test.rs` 追加 (filter/q/pagination/400/auth)

Frontend companion PR: ippoan/nuxt-trouble