### PR TITLE
fix(notify): token_exp is a duration, not a unix timestamp

### DIFF
--- a/crates/alc-notify/src/clients/line.rs
+++ b/crates/alc-notify/src/clients/line.rs
@@ -97,8 +97,8 @@ impl LineClient {
             iss: config.channel_id.clone(),
             sub: config.channel_id.clone(),
             aud: "https://api.line.me/".to_string(),
-            exp: now + 1800,                    // JWT assertion の有効期限 (max 30分)
-            token_exp: now + 60 * 60 * 24 * 30, // 発行 access token の有効期限 (max 30日)
+            exp: now + 1800, // JWT assertion の有効期限、UNIX 秒 (max 30分)
+            token_exp: 60 * 60 * 24 * 30, // access token の有効期間、秒数 (max 30日)
             token_type: "Bearer".to_string(),
         };
 


### PR DESCRIPTION
Follow-up to #265.

Previous fix set `token_exp = now + 30d`, producing a huge number that LINE rejected as `"Invalid token_exp"`. Per LINE's channel access token v2.1 spec:

- `exp` — JWT assertion expiry, **UNIX timestamp (seconds)**
- `token_exp` — issued access token **lifetime in seconds** (max 2592000 = 30d)

Fixed to use `60 * 60 * 24 * 30` (30d as a duration).

Refs: https://developers.line.biz/en/docs/messaging-api/generate-json-web-token/

Verified against prod logs which showed `{"error":"invalid_client","error_description":"Invalid token_exp"}` after PR #265 was deployed.