### PR TITLE
test(notify): 100% unit coverage for LineClient + local CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,6 +201,7 @@ dependencies = [
  "hmac",
  "jsonwebtoken",
  "reqwest",
+ "rsa",
  "serde",
  "serde_json",
  "sha2",
@@ -209,6 +210,7 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
+ "wiremock",
 ]
 
 [[package]]

--- a/coverage_100.toml
+++ b/coverage_100.toml
@@ -287,3 +287,9 @@ type = "combined"
 path = "crates/alc-trouble/src/repo/trouble_workflow.rs"
 type = "combined"
 
+
+# --- alc-notify ---
+
+[[files]]
+path = "crates/alc-notify/src/clients/line.rs"
+type = "unit"

--- a/crates/alc-notify/Cargo.toml
+++ b/crates/alc-notify/Cargo.toml
@@ -23,3 +23,8 @@ thiserror = "2"
 tokio = { version = "1", features = ["sync", "time"] }
 tracing = "0.1"
 uuid = { version = "1", features = ["v4", "serde"] }
+
+[dev-dependencies]
+rsa = "0.9"
+tokio = { version = "1", features = ["full", "test-util"] }
+wiremock = "0.6"

--- a/crates/alc-notify/examples/line_token_issue.rs
+++ b/crates/alc-notify/examples/line_token_issue.rs
@@ -1,0 +1,106 @@
+//! LINE channel access token v2.1 発行を local から検証する CLI。
+//!
+//! 使い方:
+//! ```bash
+//! export LINE_CHANNEL_ID=1234567890
+//! export LINE_KEY_ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+//! export LINE_PRIVATE_KEY_PATH=/path/to/private.pem   # PKCS#1 or PKCS#8 PEM
+//! cargo run -p alc-notify --example line_token_issue
+//! ```
+//!
+//! 追加で `--push USER_ID "text"` を渡すと、発行したトークンで push まで試す。
+//!
+//! Exit code:
+//!   0 = success
+//!   1 = failure (エラー本文を stderr に出す)
+//!
+//! DB には触らない。秘密鍵は手元の PEM を使うので、
+//! 本番 Secret Manager からコピーしてきて試すこと。
+
+use alc_notify::clients::line::{LineClient, LineConfig};
+use std::env;
+use std::fs;
+use std::process::ExitCode;
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    let channel_id = match env::var("LINE_CHANNEL_ID") {
+        Ok(v) => v,
+        Err(_) => {
+            eprintln!("LINE_CHANNEL_ID が設定されていません");
+            return ExitCode::from(2);
+        }
+    };
+    let key_id = match env::var("LINE_KEY_ID") {
+        Ok(v) => v,
+        Err(_) => {
+            eprintln!("LINE_KEY_ID が設定されていません");
+            return ExitCode::from(2);
+        }
+    };
+    let pk_path = match env::var("LINE_PRIVATE_KEY_PATH") {
+        Ok(v) => v,
+        Err(_) => {
+            eprintln!("LINE_PRIVATE_KEY_PATH が設定されていません");
+            return ExitCode::from(2);
+        }
+    };
+    let private_key = match fs::read_to_string(&pk_path) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("PEM 読み込み失敗 ({pk_path}): {e}");
+            return ExitCode::from(2);
+        }
+    };
+
+    let config = LineConfig {
+        channel_id,
+        channel_secret: env::var("LINE_CHANNEL_SECRET").unwrap_or_default(),
+        key_id,
+        private_key,
+    };
+
+    let client = LineClient::new();
+
+    println!("→ LINE oauth2/v2.1/token を呼び出し中...");
+    let token = match client.get_access_token(&config).await {
+        Ok(t) => {
+            println!(
+                "✓ access_token 発行成功 (先頭 20 文字): {}...",
+                &t[..t.len().min(20)]
+            );
+            t
+        }
+        Err(e) => {
+            eprintln!("✗ token 発行失敗: {e}");
+            return ExitCode::from(1);
+        }
+    };
+
+    // オプション: --push USER_ID "text"
+    let args: Vec<String> = env::args().collect();
+    if let Some(pos) = args.iter().position(|a| a == "--push") {
+        let user_id = match args.get(pos + 1) {
+            Some(v) => v.as_str(),
+            None => {
+                eprintln!("--push には USER_ID を続けて指定してください");
+                return ExitCode::from(2);
+            }
+        };
+        let text = args
+            .get(pos + 2)
+            .map(|s| s.as_str())
+            .unwrap_or("test from line_token_issue");
+        println!("→ push_text to {user_id}");
+        match client.push_text(&config, user_id, text).await {
+            Ok(()) => println!("✓ push 成功"),
+            Err(e) => {
+                eprintln!("✗ push 失敗: {e}");
+                return ExitCode::from(1);
+            }
+        }
+    }
+
+    let _ = token; // unused if --push not given
+    ExitCode::SUCCESS
+}

--- a/crates/alc-notify/src/clients/line.rs
+++ b/crates/alc-notify/src/clients/line.rs
@@ -8,7 +8,8 @@ use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
 use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
 
-const TOKEN_ENDPOINT: &str = "https://api.line.me/oauth2/v2.1/token";
+const PROD_TOKEN_ENDPOINT: &str = "https://api.line.me/oauth2/v2.1/token";
+const PROD_PUSH_ENDPOINT: &str = "https://api.line.me/v2/bot/message/push";
 
 #[derive(Debug, thiserror::Error)]
 pub enum LineError {
@@ -31,14 +32,14 @@ pub struct LineConfig {
     pub private_key: String, // PEM format
 }
 
-#[derive(Debug, Serialize)]
-struct JwtClaims {
-    iss: String,
-    sub: String,
-    aud: String,
-    exp: u64,
-    token_exp: u64,
-    token_type: String,
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct JwtClaims {
+    pub iss: String,
+    pub sub: String,
+    pub aud: String,
+    pub exp: u64,
+    pub token_exp: u64,
+    pub token_type: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -53,9 +54,33 @@ struct CachedToken {
     expires_at: u64,
 }
 
+/// 指定された private key (PEM) と channel_id/key_id で LINE 向け JWT assertion を生成する。
+///
+/// - `exp`       — JWT assertion の有効期限。UNIX 秒 (max now+30分)
+/// - `token_exp` — 発行される access token の有効期間、**秒数** (max 30日 = 2592000)
+pub(crate) fn build_jwt_assertion(config: &LineConfig, now: u64) -> Result<String, LineError> {
+    let claims = JwtClaims {
+        iss: config.channel_id.clone(),
+        sub: config.channel_id.clone(),
+        aud: "https://api.line.me/".to_string(),
+        exp: now + 1800,
+        token_exp: 60 * 60 * 24 * 30,
+        token_type: "Bearer".to_string(),
+    };
+
+    let mut header = Header::new(Algorithm::RS256);
+    header.kid = Some(config.key_id.clone());
+    header.typ = Some("JWT".to_string());
+
+    let key = EncodingKey::from_rsa_pem(config.private_key.as_bytes())?;
+    Ok(encode(&header, &claims, &key)?)
+}
+
 pub struct LineClient {
     client: reqwest::Client,
     cache: Arc<RwLock<Option<CachedToken>>>,
+    token_endpoint: String,
+    push_endpoint: String,
 }
 
 impl Default for LineClient {
@@ -66,9 +91,18 @@ impl Default for LineClient {
 
 impl LineClient {
     pub fn new() -> Self {
+        Self::with_endpoints(
+            PROD_TOKEN_ENDPOINT.to_string(),
+            PROD_PUSH_ENDPOINT.to_string(),
+        )
+    }
+
+    pub fn with_endpoints(token_endpoint: String, push_endpoint: String) -> Self {
         Self {
             client: reqwest::Client::new(),
             cache: Arc::new(RwLock::new(None)),
+            token_endpoint,
+            push_endpoint,
         }
     }
 
@@ -87,27 +121,12 @@ impl LineClient {
             }
         }
 
-        // JWT 生成
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap()
             .as_secs();
 
-        let claims = JwtClaims {
-            iss: config.channel_id.clone(),
-            sub: config.channel_id.clone(),
-            aud: "https://api.line.me/".to_string(),
-            exp: now + 1800, // JWT assertion の有効期限、UNIX 秒 (max 30分)
-            token_exp: 60 * 60 * 24 * 30, // access token の有効期間、秒数 (max 30日)
-            token_type: "Bearer".to_string(),
-        };
-
-        let mut header = Header::new(Algorithm::RS256);
-        header.kid = Some(config.key_id.clone());
-        header.typ = Some("JWT".to_string());
-
-        let key = EncodingKey::from_rsa_pem(config.private_key.as_bytes())?;
-        let jwt = encode(&header, &claims, &key)?;
+        let jwt = build_jwt_assertion(config, now)?;
 
         // トークン交換
         let params = [
@@ -121,7 +140,7 @@ impl LineClient {
 
         let resp = self
             .client
-            .post(TOKEN_ENDPOINT)
+            .post(&self.token_endpoint)
             .form(&params)
             .send()
             .await?;
@@ -170,7 +189,7 @@ impl LineClient {
 
         let resp = self
             .client
-            .post("https://api.line.me/v2/bot/message/push")
+            .post(&self.push_endpoint)
             .header("Authorization", format!("Bearer {}", access_token))
             .json(&body)
             .send()
@@ -184,5 +203,347 @@ impl LineClient {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jsonwebtoken::{decode, decode_header, DecodingKey, Validation};
+    use rsa::pkcs1::EncodeRsaPrivateKey;
+    use rsa::pkcs8::EncodePublicKey;
+    use rsa::rand_core::OsRng;
+    use rsa::{RsaPrivateKey, RsaPublicKey};
+    use std::sync::OnceLock;
+    use wiremock::matchers::{body_string_contains, header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    struct TestKey {
+        private_pem: String,
+        public_pem: String,
+    }
+
+    fn test_key() -> &'static TestKey {
+        static KEY: OnceLock<TestKey> = OnceLock::new();
+        KEY.get_or_init(|| {
+            let private = RsaPrivateKey::new(&mut OsRng, 2048).unwrap();
+            let public = RsaPublicKey::from(&private);
+            let private_pem = private
+                .to_pkcs1_pem(rsa::pkcs1::LineEnding::LF)
+                .unwrap()
+                .to_string();
+            let public_pem = public
+                .to_public_key_pem(rsa::pkcs8::LineEnding::LF)
+                .unwrap();
+            TestKey {
+                private_pem,
+                public_pem,
+            }
+        })
+    }
+
+    fn test_config() -> LineConfig {
+        LineConfig {
+            channel_id: "test-channel-id".into(),
+            channel_secret: "test-channel-secret".into(),
+            key_id: "test-key-id".into(),
+            private_key: test_key().private_pem.clone(),
+        }
+    }
+
+    // --- build_jwt_assertion ---
+
+    #[test]
+    fn build_jwt_assertion_sets_line_spec_claims() {
+        let now = 1_700_000_000;
+        let jwt = build_jwt_assertion(&test_config(), now).unwrap();
+
+        // Header
+        let header = decode_header(&jwt).unwrap();
+        assert_eq!(header.alg, Algorithm::RS256);
+        assert_eq!(header.kid.as_deref(), Some("test-key-id"));
+        assert_eq!(header.typ.as_deref(), Some("JWT"));
+
+        // Payload — decode with public key
+        let decoding_key = DecodingKey::from_rsa_pem(test_key().public_pem.as_bytes()).unwrap();
+        let mut validation = Validation::new(Algorithm::RS256);
+        validation.set_audience(&["https://api.line.me/"]);
+        validation.validate_exp = false; // test-fixed time
+        let data = decode::<JwtClaims>(&jwt, &decoding_key, &validation).unwrap();
+        let c = data.claims;
+
+        assert_eq!(c.iss, "test-channel-id");
+        assert_eq!(c.sub, "test-channel-id");
+        assert_eq!(c.aud, "https://api.line.me/");
+        assert_eq!(c.token_type, "Bearer");
+
+        // exp: absolute timestamp, now + 30 min
+        assert_eq!(c.exp, now + 1800);
+
+        // token_exp: duration in seconds, must satisfy LINE's 30s ≤ x ≤ 2592000
+        assert!((30..=2_592_000).contains(&c.token_exp));
+    }
+
+    #[test]
+    fn build_jwt_assertion_rejects_invalid_pem() {
+        let config = LineConfig {
+            channel_id: "x".into(),
+            channel_secret: "x".into(),
+            key_id: "x".into(),
+            private_key: "not a pem".into(),
+        };
+        let err = build_jwt_assertion(&config, 0).unwrap_err();
+        assert!(matches!(err, LineError::Jwt(_)));
+    }
+
+    // --- get_access_token ---
+
+    #[tokio::test]
+    async fn get_access_token_success_caches() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/oauth2/v2.1/token"))
+            .and(body_string_contains("grant_type=client_credentials"))
+            .and(body_string_contains("client_assertion="))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "access_token": "cached-token",
+                "expires_in": 2_592_000u64,
+                "token_type": "Bearer",
+            })))
+            .expect(1) // 2回目はキャッシュで mock 呼ばれない
+            .mount(&server)
+            .await;
+
+        let client = LineClient::with_endpoints(
+            format!("{}/oauth2/v2.1/token", server.uri()),
+            format!("{}/v2/bot/message/push", server.uri()),
+        );
+
+        let t1 = client.get_access_token(&test_config()).await.unwrap();
+        let t2 = client.get_access_token(&test_config()).await.unwrap();
+        assert_eq!(t1, "cached-token");
+        assert_eq!(t2, "cached-token");
+    }
+
+    #[tokio::test]
+    async fn get_access_token_refreshes_expired_cache() {
+        // expires_in=0 → 直後に再呼び出しすると (expires_at > now+60) が false になり、
+        // キャッシュがあっても fall-through して新規発行する
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/oauth2/v2.1/token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "access_token": "short-lived",
+                "expires_in": 0u64,
+                "token_type": "Bearer",
+            })))
+            .expect(2) // キャッシュが期限切れ扱いなので 2 回とも endpoint が呼ばれる
+            .mount(&server)
+            .await;
+
+        let client = LineClient::with_endpoints(
+            format!("{}/oauth2/v2.1/token", server.uri()),
+            "unused".into(),
+        );
+
+        let t1 = client.get_access_token(&test_config()).await.unwrap();
+        let t2 = client.get_access_token(&test_config()).await.unwrap();
+        assert_eq!(t1, "short-lived");
+        assert_eq!(t2, "short-lived");
+    }
+
+    #[tokio::test]
+    async fn get_access_token_400_returns_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/oauth2/v2.1/token"))
+            .respond_with(ResponseTemplate::new(400).set_body_string(
+                r#"{"error":"invalid_client","error_description":"Invalid token_exp"}"#,
+            ))
+            .mount(&server)
+            .await;
+
+        let client = LineClient::with_endpoints(
+            format!("{}/oauth2/v2.1/token", server.uri()),
+            "unused".into(),
+        );
+
+        let err = client.get_access_token(&test_config()).await.unwrap_err();
+        match err {
+            LineError::TokenIssueFailed(body) => assert!(body.contains("invalid_client")),
+            e => panic!("expected TokenIssueFailed, got {e:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn get_access_token_parse_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/oauth2/v2.1/token"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("not json"))
+            .mount(&server)
+            .await;
+
+        let client = LineClient::with_endpoints(
+            format!("{}/oauth2/v2.1/token", server.uri()),
+            "unused".into(),
+        );
+
+        let err = client.get_access_token(&test_config()).await.unwrap_err();
+        match err {
+            LineError::TokenIssueFailed(body) => assert!(body.contains("parse error")),
+            e => panic!("expected TokenIssueFailed parse error, got {e:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn get_access_token_http_error() {
+        // Unreachable URL → reqwest error
+        let client = LineClient::with_endpoints(
+            "http://127.0.0.1:1/oauth2/v2.1/token".into(),
+            "unused".into(),
+        );
+        let err = client.get_access_token(&test_config()).await.unwrap_err();
+        assert!(matches!(err, LineError::Http(_)));
+    }
+
+    #[tokio::test]
+    async fn get_access_token_jwt_error_propagates() {
+        let client = LineClient::with_endpoints("unused".into(), "unused".into());
+        let bad_config = LineConfig {
+            channel_id: "x".into(),
+            channel_secret: "x".into(),
+            key_id: "x".into(),
+            private_key: "not a pem".into(),
+        };
+        let err = client.get_access_token(&bad_config).await.unwrap_err();
+        assert!(matches!(err, LineError::Jwt(_)));
+    }
+
+    // --- push_text ---
+
+    #[tokio::test]
+    async fn push_text_success() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/oauth2/v2.1/token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "access_token": "tok",
+                "expires_in": 86400u64,
+                "token_type": "Bearer",
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/v2/bot/message/push"))
+            .and(header("Authorization", "Bearer tok"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("{}"))
+            .mount(&server)
+            .await;
+
+        let client = LineClient::with_endpoints(
+            format!("{}/oauth2/v2.1/token", server.uri()),
+            format!("{}/v2/bot/message/push", server.uri()),
+        );
+
+        client
+            .push_text(&test_config(), "U123", "hello")
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn push_text_failure_returns_send_failed() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/oauth2/v2.1/token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "access_token": "tok",
+                "expires_in": 86400u64,
+                "token_type": "Bearer",
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/v2/bot/message/push"))
+            .respond_with(ResponseTemplate::new(400).set_body_string("bad request"))
+            .mount(&server)
+            .await;
+
+        let client = LineClient::with_endpoints(
+            format!("{}/oauth2/v2.1/token", server.uri()),
+            format!("{}/v2/bot/message/push", server.uri()),
+        );
+
+        let err = client
+            .push_text(&test_config(), "U123", "hello")
+            .await
+            .unwrap_err();
+        match err {
+            LineError::SendFailed(msg) => {
+                assert!(msg.contains("400"));
+                assert!(msg.contains("bad request"));
+            }
+            e => panic!("expected SendFailed, got {e:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn push_text_http_error_on_push() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/oauth2/v2.1/token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "access_token": "tok",
+                "expires_in": 86400u64,
+                "token_type": "Bearer",
+            })))
+            .mount(&server)
+            .await;
+
+        // push endpoint is unreachable → reqwest error
+        let client = LineClient::with_endpoints(
+            format!("{}/oauth2/v2.1/token", server.uri()),
+            "http://127.0.0.1:1/v2/bot/message/push".into(),
+        );
+        let err = client
+            .push_text(&test_config(), "U123", "hello")
+            .await
+            .unwrap_err();
+        assert!(matches!(err, LineError::Http(_)));
+    }
+
+    // --- LineError Display ---
+
+    #[test]
+    fn line_error_display() {
+        assert_eq!(
+            LineError::TokenIssueFailed("x".into()).to_string(),
+            "Token issue failed: x"
+        );
+        assert_eq!(
+            LineError::SendFailed("y".into()).to_string(),
+            "Send failed: y"
+        );
+    }
+
+    // --- LineClient constructors ---
+
+    #[test]
+    fn new_uses_prod_endpoints() {
+        let client = LineClient::new();
+        assert_eq!(client.token_endpoint, PROD_TOKEN_ENDPOINT);
+        assert_eq!(client.push_endpoint, PROD_PUSH_ENDPOINT);
+    }
+
+    #[test]
+    fn default_matches_new() {
+        let c = LineClient::default();
+        assert_eq!(c.token_endpoint, PROD_TOKEN_ENDPOINT);
+        assert_eq!(c.push_endpoint, PROD_PUSH_ENDPOINT);
     }
 }


### PR DESCRIPTION
Root cause of the LINE push outage (#265 / #266) was a JWT claim shape that no automated test exercised. This PR adds:

### 1. Unit tests — 100% coverage (mocked LINE via wiremock)

- `build_jwt_assertion`: header (alg=RS256, kid, typ=JWT), all claims, `exp` is absolute timestamp, `token_exp` is a **duration** in `[30, 2592000]`. Regression test for the #265 / #266 bug.
- `get_access_token`: success+cache, expired-cache refresh, 400, JSON parse error, HTTP error, JWT error propagation
- `push_text`: success, 4xx, HTTP error
- `LineClient::new` / `default` use prod endpoints
- `LineError` Display

### 2. Local CLI: `cargo run -p alc-notify --example line_token_issue`

Reads `LINE_CHANNEL_ID` / `LINE_KEY_ID` / `LINE_PRIVATE_KEY_PATH` from env and calls the real LINE token endpoint. Optional `--push USER_ID "text"` to try push end-to-end. **No DB, no deploy needed — ~10s iteration loop.**

### 3. Refactor

`LineClient` now accepts `token_endpoint` / `push_endpoint` so tests can point at a wiremock server instead of the hard-coded const.

### 4. Coverage guard

Registers `crates/alc-notify/src/clients/line.rs` in `coverage_100.toml` (unit type). `check_coverage_100.sh` now blocks regressions.

### Verified in prod

With #265+#266 deployed + this PR's refactor kept prod behavior identical, `/test-distribute` at notify.ippoan.org now returns `sent:1, failed:0`.