### PR TITLE
feat(members): add /api/members alias for nuxt-dtako-admin

### DIFF
--- a/crates/alc-core/src/repository/tenant_users.rs
+++ b/crates/alc-core/src/repository/tenant_users.rs
@@ -31,4 +31,17 @@ pub trait TenantUsersRepository: Send + Sync {
     async fn delete_invitation(&self, tenant_id: Uuid, id: Uuid) -> Result<(), sqlx::Error>;
 
     async fn delete_user(&self, tenant_id: Uuid, id: Uuid) -> Result<(), sqlx::Error>;
+
+    /// email を条件に users.role / tenant_allowed_emails.role を更新する。
+    /// いずれかの行を更新できたら true、どちらも該当なしなら false。
+    async fn update_role_by_email(
+        &self,
+        tenant_id: Uuid,
+        email: &str,
+        role: &str,
+    ) -> Result<bool, sqlx::Error>;
+
+    /// email を条件に users / tenant_allowed_emails から削除する。
+    /// いずれかから削除できたら true、どちらも該当なしなら false。
+    async fn delete_by_email(&self, tenant_id: Uuid, email: &str) -> Result<bool, sqlx::Error>;
 }

--- a/crates/alc-misc/src/lib.rs
+++ b/crates/alc-misc/src/lib.rs
@@ -8,6 +8,7 @@ pub mod guidance_records;
 pub mod health;
 pub mod items;
 pub mod measurements;
+pub mod members;
 pub mod repo;
 pub mod sso_admin;
 pub mod staging;

--- a/crates/alc-misc/src/members.rs
+++ b/crates/alc-misc/src/members.rs
@@ -1,0 +1,199 @@
+//! nuxt-dtako-admin 向け `/api/members` 系エンドポイント。
+//!
+//! 既存 `/admin/users` (auth-worker admin UI 用) が返す
+//! `{ users: [...] }` 形式とは別の、フラットな `TenantMember[]` を
+//! frontend に返すための alias layer。
+//! 既存の `TenantUsersRepository` を再利用する。
+
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    routing::{get, patch},
+    Extension, Json, Router,
+};
+use serde::{Deserialize, Serialize};
+
+use alc_core::auth_middleware::AuthUser;
+use alc_core::AppState;
+
+/// frontend (nuxt-dtako-admin) が期待する共通形。
+/// 登録済みユーザーと未承諾の招待 (tenant_allowed_emails) を同じ形で返す。
+#[derive(Debug, Serialize)]
+struct TenantMember {
+    email: String,
+    role: String,
+    created_at: chrono::DateTime<chrono::Utc>,
+}
+
+#[derive(Debug, Deserialize)]
+struct InviteRequest {
+    email: String,
+    role: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct UpdateRoleRequest {
+    role: String,
+}
+
+/// frontend から送られてくる role を受け付ける集合。
+/// DB 側は text でゆるいので、`member` などの frontend 固有値もそのまま保存する。
+fn is_allowed_role(role: &str) -> bool {
+    matches!(role, "admin" | "viewer" | "member")
+}
+
+pub fn router() -> Router<AppState> {
+    Router::new()
+        .route("/members", get(list_members).post(invite_member))
+        .route(
+            "/members/{email}",
+            patch(update_member_role).delete(delete_member),
+        )
+}
+
+/// GET /members — 登録済みユーザー + 未承諾の招待をマージしたフラット配列。
+async fn list_members(
+    State(state): State<AppState>,
+    Extension(auth_user): Extension<AuthUser>,
+) -> Result<Json<Vec<TenantMember>>, StatusCode> {
+    if auth_user.role != "admin" {
+        return Err(StatusCode::FORBIDDEN);
+    }
+
+    let users = state
+        .tenant_users
+        .list_users(auth_user.tenant_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to list users: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    let invitations = state
+        .tenant_users
+        .list_invitations(auth_user.tenant_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to list invitations: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    let mut members: Vec<TenantMember> = users
+        .into_iter()
+        .map(|u| TenantMember {
+            email: u.email,
+            role: u.role,
+            created_at: u.created_at,
+        })
+        .collect();
+
+    // 既にユーザー登録済みの email は招待側から除外 (重複排除)
+    let registered: std::collections::HashSet<String> =
+        members.iter().map(|m| m.email.clone()).collect();
+
+    for inv in invitations {
+        if !registered.contains(&inv.email) {
+            members.push(TenantMember {
+                email: inv.email,
+                role: inv.role,
+                created_at: inv.created_at,
+            });
+        }
+    }
+
+    Ok(Json(members))
+}
+
+/// POST /members — 招待 (`tenant_allowed_emails` への upsert) を行い、
+/// TenantMember 形で返す。
+async fn invite_member(
+    State(state): State<AppState>,
+    Extension(auth_user): Extension<AuthUser>,
+    Json(body): Json<InviteRequest>,
+) -> Result<Json<TenantMember>, StatusCode> {
+    if auth_user.role != "admin" {
+        return Err(StatusCode::FORBIDDEN);
+    }
+
+    let role = body.role.unwrap_or_else(|| "member".to_string());
+    if !is_allowed_role(&role) {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+
+    let invitation = state
+        .tenant_users
+        .invite_user(auth_user.tenant_id, &body.email, &role)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to invite member: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    Ok(Json(TenantMember {
+        email: invitation.email,
+        role: invitation.role,
+        created_at: invitation.created_at,
+    }))
+}
+
+/// PATCH /members/{email} — email 単位で role を更新する。
+/// 登録済みユーザー / 招待どちらの行も更新対象になる。
+async fn update_member_role(
+    State(state): State<AppState>,
+    Extension(auth_user): Extension<AuthUser>,
+    Path(email): Path<String>,
+    Json(body): Json<UpdateRoleRequest>,
+) -> Result<StatusCode, StatusCode> {
+    if auth_user.role != "admin" {
+        return Err(StatusCode::FORBIDDEN);
+    }
+    if !is_allowed_role(&body.role) {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+
+    let found = state
+        .tenant_users
+        .update_role_by_email(auth_user.tenant_id, &email, &body.role)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to update member role: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    if !found {
+        return Err(StatusCode::NOT_FOUND);
+    }
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// DELETE /members/{email} — email 単位で削除する。
+async fn delete_member(
+    State(state): State<AppState>,
+    Extension(auth_user): Extension<AuthUser>,
+    Path(email): Path<String>,
+) -> Result<StatusCode, StatusCode> {
+    if auth_user.role != "admin" {
+        return Err(StatusCode::FORBIDDEN);
+    }
+
+    // 自分自身は削除不可
+    if email == auth_user.email {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+
+    let found = state
+        .tenant_users
+        .delete_by_email(auth_user.tenant_id, &email)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to delete member: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    if !found {
+        return Err(StatusCode::NOT_FOUND);
+    }
+
+    Ok(StatusCode::NO_CONTENT)
+}

--- a/crates/alc-misc/src/repo/tenant_users.rs
+++ b/crates/alc-misc/src/repo/tenant_users.rs
@@ -79,4 +79,42 @@ impl TenantUsersRepository for PgTenantUsersRepository {
             .await?;
         Ok(())
     }
+
+    async fn update_role_by_email(
+        &self,
+        tenant_id: Uuid,
+        email: &str,
+        role: &str,
+    ) -> Result<bool, sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        let users_affected = sqlx::query("UPDATE users SET role = $1 WHERE email = $2")
+            .bind(role)
+            .bind(email)
+            .execute(&mut *tc.conn)
+            .await?
+            .rows_affected();
+        let invites_affected =
+            sqlx::query("UPDATE tenant_allowed_emails SET role = $1 WHERE email = $2")
+                .bind(role)
+                .bind(email)
+                .execute(&mut *tc.conn)
+                .await?
+                .rows_affected();
+        Ok(users_affected + invites_affected > 0)
+    }
+
+    async fn delete_by_email(&self, tenant_id: Uuid, email: &str) -> Result<bool, sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        let users_affected = sqlx::query("DELETE FROM users WHERE email = $1")
+            .bind(email)
+            .execute(&mut *tc.conn)
+            .await?
+            .rows_affected();
+        let invites_affected = sqlx::query("DELETE FROM tenant_allowed_emails WHERE email = $1")
+            .bind(email)
+            .execute(&mut *tc.conn)
+            .await?
+            .rows_affected();
+        Ok(users_affected + invites_affected > 0)
+    }
 }

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -27,6 +27,7 @@ pub use alc_misc::guidance_records;
 pub use alc_misc::health;
 pub use alc_misc::items;
 pub use alc_misc::measurements;
+pub use alc_misc::members;
 pub use alc_misc::sso_admin;
 pub use alc_misc::staging;
 pub use alc_misc::tenant_users;
@@ -74,6 +75,7 @@ pub fn router() -> Router<AppState> {
         .merge(sso_admin::router())
         .merge(bot_admin::router())
         .merge(tenant_users::router())
+        .merge(members::router())
         .layer(axum_middleware::from_fn(require_jwt));
 
     // テナント対応ルート (JWT or X-Tenant-ID)

--- a/tests/mock_helpers/repos_c.rs
+++ b/tests/mock_helpers/repos_c.rs
@@ -185,6 +185,10 @@ impl SsoAdminRepository for MockSsoAdminRepository {
 pub struct MockTenantUsersRepository {
     pub fail_next: AtomicBool,
     pub users: std::sync::Mutex<Vec<UserRow>>,
+    pub invitations: std::sync::Mutex<Vec<TenantAllowedEmail>>,
+    /// update_role_by_email / delete_by_email の戻り値を切り替える。
+    /// true で「対象あり」扱い、false で「見つからず」扱い。
+    pub found_by_email: AtomicBool,
 }
 
 impl Default for MockTenantUsersRepository {
@@ -192,6 +196,8 @@ impl Default for MockTenantUsersRepository {
         Self {
             fail_next: AtomicBool::new(false),
             users: std::sync::Mutex::new(vec![]),
+            invitations: std::sync::Mutex::new(vec![]),
+            found_by_email: AtomicBool::new(true),
         }
     }
 }
@@ -208,7 +214,7 @@ impl TenantUsersRepository for MockTenantUsersRepository {
         _tenant_id: Uuid,
     ) -> Result<Vec<TenantAllowedEmail>, sqlx::Error> {
         check_fail!(self);
-        Ok(vec![])
+        Ok(self.invitations.lock().unwrap().clone())
     }
 
     async fn invite_user(
@@ -235,6 +241,21 @@ impl TenantUsersRepository for MockTenantUsersRepository {
     async fn delete_user(&self, _tenant_id: Uuid, _id: Uuid) -> Result<(), sqlx::Error> {
         check_fail!(self);
         Ok(())
+    }
+
+    async fn update_role_by_email(
+        &self,
+        _tenant_id: Uuid,
+        _email: &str,
+        _role: &str,
+    ) -> Result<bool, sqlx::Error> {
+        check_fail!(self);
+        Ok(self.found_by_email.load(Ordering::SeqCst))
+    }
+
+    async fn delete_by_email(&self, _tenant_id: Uuid, _email: &str) -> Result<bool, sqlx::Error> {
+        check_fail!(self);
+        Ok(self.found_by_email.load(Ordering::SeqCst))
     }
 }
 

--- a/tests/mock_misc/main.rs
+++ b/tests/mock_misc/main.rs
@@ -23,6 +23,8 @@ mod mock_guidance_records_test;
 mod mock_health_test;
 #[path = "../mock_tests/mock_measurements_test.rs"]
 mod mock_measurements_test;
+#[path = "../mock_tests/mock_members_test.rs"]
+mod mock_members_test;
 #[path = "../mock_tests/mock_sso_admin_test.rs"]
 mod mock_sso_admin_test;
 #[path = "../mock_tests/mock_tenant_users_test.rs"]

--- a/tests/mock_tests/mock_members_test.rs
+++ b/tests/mock_tests/mock_members_test.rs
@@ -1,0 +1,450 @@
+//! Mock-based tests for `/api/members` alias endpoints.
+//!
+//! 既存 tenant_users 実装を再利用し、frontend (nuxt-dtako-admin) が期待する
+//! フラットな `TenantMember[]` / email キーの PATCH・DELETE を提供する。
+
+use rust_alc_api::db::repository::tenant_users::UserRow;
+use serde_json::json;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use uuid::Uuid;
+
+use crate::mock_helpers::MockTenantUsersRepository;
+
+async fn setup_admin() -> (String, String) {
+    let state = crate::mock_helpers::app_state::setup_mock_app_state();
+    let tenant_id = Uuid::new_v4();
+    let base_url = crate::common::spawn_test_server(state).await;
+    let jwt = crate::common::create_test_jwt_for_user(
+        Uuid::new_v4(),
+        tenant_id,
+        "admin@example.com",
+        "admin",
+    );
+    (base_url, format!("Bearer {jwt}"))
+}
+
+async fn setup_viewer() -> (String, String) {
+    let state = crate::mock_helpers::app_state::setup_mock_app_state();
+    let tenant_id = Uuid::new_v4();
+    let base_url = crate::common::spawn_test_server(state).await;
+    let jwt = crate::common::create_test_jwt(tenant_id, "viewer");
+    (base_url, format!("Bearer {jwt}"))
+}
+
+/// Prepare a state with fail_next=true on tenant_users, admin JWT.
+async fn setup_failing_admin() -> (String, String) {
+    let mock = Arc::new(MockTenantUsersRepository::default());
+    mock.fail_next.store(true, Ordering::SeqCst);
+    let mut state = crate::mock_helpers::app_state::setup_mock_app_state();
+    state.tenant_users = mock;
+    let tenant_id = Uuid::new_v4();
+    let base_url = crate::common::spawn_test_server(state).await;
+    let jwt = crate::common::create_test_jwt_for_user(
+        Uuid::new_v4(),
+        tenant_id,
+        "admin@example.com",
+        "admin",
+    );
+    (base_url, format!("Bearer {jwt}"))
+}
+
+/// Prepare a state with found_by_email=false (for 404 paths), admin JWT.
+async fn setup_admin_not_found() -> (String, String) {
+    let mock = Arc::new(MockTenantUsersRepository::default());
+    mock.found_by_email.store(false, Ordering::SeqCst);
+    let mut state = crate::mock_helpers::app_state::setup_mock_app_state();
+    state.tenant_users = mock;
+    let tenant_id = Uuid::new_v4();
+    let base_url = crate::common::spawn_test_server(state).await;
+    let jwt = crate::common::create_test_jwt_for_user(
+        Uuid::new_v4(),
+        tenant_id,
+        "admin@example.com",
+        "admin",
+    );
+    (base_url, format!("Bearer {jwt}"))
+}
+
+// =========================================================================
+// GET /api/members
+// =========================================================================
+
+#[tokio::test]
+async fn test_list_members_success_empty() {
+    let (base_url, auth) = setup_admin().await;
+    let client = reqwest::Client::new();
+    let res = client
+        .get(format!("{base_url}/api/members"))
+        .header("Authorization", &auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert!(body.is_array());
+    assert_eq!(body.as_array().unwrap().len(), 0);
+}
+
+#[tokio::test]
+async fn test_list_members_merges_users_and_invitations() {
+    let mock = Arc::new(MockTenantUsersRepository::default());
+    mock.users.lock().unwrap().push(UserRow {
+        id: Uuid::new_v4(),
+        email: "alice@example.com".to_string(),
+        name: "Alice".to_string(),
+        role: "admin".to_string(),
+        created_at: chrono::Utc::now(),
+    });
+    mock.invitations
+        .lock()
+        .unwrap()
+        .push(alc_core::models::TenantAllowedEmail {
+            id: Uuid::new_v4(),
+            tenant_id: Uuid::new_v4(),
+            email: "bob@example.com".to_string(),
+            role: "viewer".to_string(),
+            created_at: chrono::Utc::now(),
+        });
+    // 重複 email (users 側と同じ) — 除外される
+    mock.invitations
+        .lock()
+        .unwrap()
+        .push(alc_core::models::TenantAllowedEmail {
+            id: Uuid::new_v4(),
+            tenant_id: Uuid::new_v4(),
+            email: "alice@example.com".to_string(),
+            role: "viewer".to_string(),
+            created_at: chrono::Utc::now(),
+        });
+    let mut state = crate::mock_helpers::app_state::setup_mock_app_state();
+    state.tenant_users = mock;
+    let tenant_id = Uuid::new_v4();
+    let base_url = crate::common::spawn_test_server(state).await;
+    let jwt = crate::common::create_test_jwt_for_user(
+        Uuid::new_v4(),
+        tenant_id,
+        "admin@example.com",
+        "admin",
+    );
+    let auth = format!("Bearer {jwt}");
+
+    let client = reqwest::Client::new();
+    let res = client
+        .get(format!("{base_url}/api/members"))
+        .header("Authorization", &auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    let body: serde_json::Value = res.json().await.unwrap();
+    let arr = body.as_array().unwrap();
+    assert_eq!(arr.len(), 2);
+    let emails: Vec<String> = arr
+        .iter()
+        .map(|v| v["email"].as_str().unwrap().to_string())
+        .collect();
+    assert!(emails.contains(&"alice@example.com".to_string()));
+    assert!(emails.contains(&"bob@example.com".to_string()));
+}
+
+#[tokio::test]
+async fn test_list_members_forbidden_for_viewer() {
+    let (base_url, auth) = setup_viewer().await;
+    let client = reqwest::Client::new();
+    let res = client
+        .get(format!("{base_url}/api/members"))
+        .header("Authorization", &auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 403);
+}
+
+#[tokio::test]
+async fn test_list_members_unauthorized() {
+    let state = crate::mock_helpers::app_state::setup_mock_app_state();
+    let base_url = crate::common::spawn_test_server(state).await;
+    let client = reqwest::Client::new();
+    let res = client
+        .get(format!("{base_url}/api/members"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 401);
+}
+
+#[tokio::test]
+async fn test_list_members_db_error_on_users() {
+    let (base_url, auth) = setup_failing_admin().await;
+    let client = reqwest::Client::new();
+    let res = client
+        .get(format!("{base_url}/api/members"))
+        .header("Authorization", &auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}
+
+// =========================================================================
+// POST /api/members  (invite)
+// =========================================================================
+
+#[tokio::test]
+async fn test_invite_member_success_default_role() {
+    let (base_url, auth) = setup_admin().await;
+    let client = reqwest::Client::new();
+    let res = client
+        .post(format!("{base_url}/api/members"))
+        .header("Authorization", &auth)
+        .json(&json!({ "email": "new@example.com" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(body["email"], "new@example.com");
+    assert_eq!(body["role"], "member");
+}
+
+#[tokio::test]
+async fn test_invite_member_success_explicit_admin() {
+    let (base_url, auth) = setup_admin().await;
+    let client = reqwest::Client::new();
+    let res = client
+        .post(format!("{base_url}/api/members"))
+        .header("Authorization", &auth)
+        .json(&json!({ "email": "x@example.com", "role": "admin" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+}
+
+#[tokio::test]
+async fn test_invite_member_bad_role() {
+    let (base_url, auth) = setup_admin().await;
+    let client = reqwest::Client::new();
+    let res = client
+        .post(format!("{base_url}/api/members"))
+        .header("Authorization", &auth)
+        .json(&json!({ "email": "x@example.com", "role": "god" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 400);
+}
+
+#[tokio::test]
+async fn test_invite_member_forbidden_for_viewer() {
+    let (base_url, auth) = setup_viewer().await;
+    let client = reqwest::Client::new();
+    let res = client
+        .post(format!("{base_url}/api/members"))
+        .header("Authorization", &auth)
+        .json(&json!({ "email": "x@example.com" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 403);
+}
+
+#[tokio::test]
+async fn test_invite_member_unauthorized() {
+    let state = crate::mock_helpers::app_state::setup_mock_app_state();
+    let base_url = crate::common::spawn_test_server(state).await;
+    let client = reqwest::Client::new();
+    let res = client
+        .post(format!("{base_url}/api/members"))
+        .json(&json!({ "email": "x@example.com" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 401);
+}
+
+#[tokio::test]
+async fn test_invite_member_db_error() {
+    let (base_url, auth) = setup_failing_admin().await;
+    let client = reqwest::Client::new();
+    let res = client
+        .post(format!("{base_url}/api/members"))
+        .header("Authorization", &auth)
+        .json(&json!({ "email": "x@example.com" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}
+
+// =========================================================================
+// PATCH /api/members/{email}
+// =========================================================================
+
+#[tokio::test]
+async fn test_update_role_success() {
+    let (base_url, auth) = setup_admin().await;
+    let client = reqwest::Client::new();
+    let res = client
+        .patch(format!("{base_url}/api/members/foo@example.com"))
+        .header("Authorization", &auth)
+        .json(&json!({ "role": "viewer" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 204);
+}
+
+#[tokio::test]
+async fn test_update_role_not_found() {
+    let (base_url, auth) = setup_admin_not_found().await;
+    let client = reqwest::Client::new();
+    let res = client
+        .patch(format!("{base_url}/api/members/none@example.com"))
+        .header("Authorization", &auth)
+        .json(&json!({ "role": "viewer" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 404);
+}
+
+#[tokio::test]
+async fn test_update_role_bad_role() {
+    let (base_url, auth) = setup_admin().await;
+    let client = reqwest::Client::new();
+    let res = client
+        .patch(format!("{base_url}/api/members/foo@example.com"))
+        .header("Authorization", &auth)
+        .json(&json!({ "role": "nope" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 400);
+}
+
+#[tokio::test]
+async fn test_update_role_forbidden_for_viewer() {
+    let (base_url, auth) = setup_viewer().await;
+    let client = reqwest::Client::new();
+    let res = client
+        .patch(format!("{base_url}/api/members/foo@example.com"))
+        .header("Authorization", &auth)
+        .json(&json!({ "role": "admin" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 403);
+}
+
+#[tokio::test]
+async fn test_update_role_unauthorized() {
+    let state = crate::mock_helpers::app_state::setup_mock_app_state();
+    let base_url = crate::common::spawn_test_server(state).await;
+    let client = reqwest::Client::new();
+    let res = client
+        .patch(format!("{base_url}/api/members/foo@example.com"))
+        .json(&json!({ "role": "admin" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 401);
+}
+
+#[tokio::test]
+async fn test_update_role_db_error() {
+    let (base_url, auth) = setup_failing_admin().await;
+    let client = reqwest::Client::new();
+    let res = client
+        .patch(format!("{base_url}/api/members/foo@example.com"))
+        .header("Authorization", &auth)
+        .json(&json!({ "role": "admin" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}
+
+// =========================================================================
+// DELETE /api/members/{email}
+// =========================================================================
+
+#[tokio::test]
+async fn test_delete_member_success() {
+    let (base_url, auth) = setup_admin().await;
+    let client = reqwest::Client::new();
+    let res = client
+        .delete(format!("{base_url}/api/members/foo@example.com"))
+        .header("Authorization", &auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 204);
+}
+
+#[tokio::test]
+async fn test_delete_member_not_found() {
+    let (base_url, auth) = setup_admin_not_found().await;
+    let client = reqwest::Client::new();
+    let res = client
+        .delete(format!("{base_url}/api/members/foo@example.com"))
+        .header("Authorization", &auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 404);
+}
+
+#[tokio::test]
+async fn test_delete_member_self_rejected() {
+    let (base_url, auth) = setup_admin().await;
+    let client = reqwest::Client::new();
+    // setup_admin は email = admin@example.com で JWT 発行済み
+    let res = client
+        .delete(format!("{base_url}/api/members/admin@example.com"))
+        .header("Authorization", &auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 400);
+}
+
+#[tokio::test]
+async fn test_delete_member_forbidden_for_viewer() {
+    let (base_url, auth) = setup_viewer().await;
+    let client = reqwest::Client::new();
+    let res = client
+        .delete(format!("{base_url}/api/members/foo@example.com"))
+        .header("Authorization", &auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 403);
+}
+
+#[tokio::test]
+async fn test_delete_member_unauthorized() {
+    let state = crate::mock_helpers::app_state::setup_mock_app_state();
+    let base_url = crate::common::spawn_test_server(state).await;
+    let client = reqwest::Client::new();
+    let res = client
+        .delete(format!("{base_url}/api/members/foo@example.com"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 401);
+}
+
+#[tokio::test]
+async fn test_delete_member_db_error() {
+    let (base_url, auth) = setup_failing_admin().await;
+    let client = reqwest::Client::new();
+    let res = client
+        .delete(format!("{base_url}/api/members/foo@example.com"))
+        .header("Authorization", &auth)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+}


### PR DESCRIPTION
前回プラン A-PR1 相当。nuxt-dtako-admin の pages/members.vue が呼ぶ `/api/members` 系 (404) を解消する。

## 背景

nuxt-dtako-admin frontend は以下を呼ぶ:
- `GET /api/members` → TenantMember[]
- `POST /api/members` body `{ email, role? }` → TenantMember
- `PATCH /api/members/{email}` body `{ role }` → void
- `DELETE /api/members/{email}` → void

rust-alc-api 側は `/admin/users` (`{ users: [...] }` 包み、UUID キー) しか実装していなかった。薄い alias では済まないため、email キー + TenantMember 形の新エンドポイントを新設する。

## 変更点

### 新エンドポイント (jwt_protected、admin 必須)

- `GET /api/members` — 登録済み users + 未承諾 tenant_allowed_emails をマージしたフラット配列 (重複 email は users 側を優先)
- `POST /api/members` — invite upsert、戻り値は TenantMember 形
- `PATCH /api/members/{email}` — email で users.role / tenant_allowed_emails.role を一括更新。対象なし時 404
- `DELETE /api/members/{email}` — email で users / tenant_allowed_emails の両方から削除。自分自身削除は 400、対象なし時 404

### 新 repository メソッド

`TenantUsersRepository` trait に追加:
- `update_role_by_email(tenant_id, email, role) -> Result<bool, sqlx::Error>`
- `delete_by_email(tenant_id, email) -> Result<bool, sqlx::Error>`

PG 実装は `users` と `tenant_allowed_emails` を連続で叩き、`rows_affected` の合計 > 0 を返す。

### role 許容セット

`admin | viewer | member` (frontend の USelect options `[admin, member]` に合わせ、`member` を許容)。既存 `/admin/users/invite` は従来通り `admin | viewer` のみで変更なし。

## テスト

`tests/mock_tests/mock_members_test.rs` で 18 ケース:
- GET: success (空/users+invitations マージ/重複排除) / 403 / 401 / 500
- POST: success (default role=member) / success (explicit admin) / 400 (bad role) / 403 / 401 / 500
- PATCH: success (204) / 404 / 400 (bad role) / 403 / 401 / 500
- DELETE: success (204) / 404 / 400 (self) / 403 / 401 / 500

## 非対象

- A-PR2 (`/api/api-tokens` 新規実装) は別 PR
- auth-worker の `/admin/users` UI は従来のまま
- `coverage_100.toml` 登録は CI の coverage artifact を見て別 PR で追加判断

## Test plan

- [x] `cargo check --tests` (PR 作成前にローカル検証済み)
- [ ] CI: unit-tests / integration-tests / migrate-test
- [ ] staging auto-deploy pass