### PR TITLE
fix(lineworks): auto-normalize escaped newlines in decrypted PEM

### DIFF
--- a/crates/alc-core/src/auth_lineworks.rs
+++ b/crates/alc-core/src/auth_lineworks.rs
@@ -220,6 +220,33 @@ pub fn decrypt_secret(ciphertext_b64: &str, key_material: &str) -> Result<String
     String::from_utf8(plaintext.to_vec()).map_err(|e| format!("UTF-8 error: {e}"))
 }
 
+/// Decrypt a PEM-shaped secret (RSA private key), normalizing legacy rows whose
+/// plaintext contains literal `\n` escape sequences instead of real 0x0A newlines.
+///
+/// jsonwebtoken's `EncodingKey::from_rsa_pem` rejects PEM with escaped newlines
+/// as `InvalidKeyFormat`. Some historical writers JSON-escaped the key once too
+/// many and persisted the escaped form. Callers that feed the plaintext to a
+/// PEM parser should use this helper so those rows keep working without requiring
+/// the tenant to re-upload the key.
+///
+/// Normalization is idempotent and safe: it replaces `\\n` with `\n` only when
+/// real newlines are absent, so already-correct PEM plaintext passes through
+/// unchanged.
+pub fn decrypt_pem_secret(ciphertext_b64: &str, key_material: &str) -> Result<String, String> {
+    let plaintext = decrypt_secret(ciphertext_b64, key_material)?;
+    Ok(normalize_pem_newlines(plaintext))
+}
+
+/// Replace literal `\n` sequences with real newlines when the input has none.
+/// Exposed for reuse in other storage paths that keep a decrypted PEM.
+pub fn normalize_pem_newlines(s: String) -> String {
+    if s.contains("\\n") && !s.contains('\n') {
+        s.replace("\\n", "\n")
+    } else {
+        s
+    }
+}
+
 /// Build LINE WORKS authorize URL
 pub fn authorize_url(client_id: &str, redirect_uri: &str, state: &str) -> String {
     format!(
@@ -235,6 +262,59 @@ pub fn authorize_url(client_id: &str, redirect_uri: &str, state: &str) -> String
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn normalize_pem_newlines_fixes_escaped_input() {
+        let escaped =
+            "-----BEGIN PRIVATE KEY-----\\nMIIE...\\n-----END PRIVATE KEY-----".to_string();
+        let fixed = normalize_pem_newlines(escaped);
+        assert!(fixed.contains('\n'), "should have real newlines");
+        assert!(!fixed.contains("\\n"), "should not have literal \\n");
+        assert_eq!(fixed.lines().count(), 3);
+    }
+
+    #[test]
+    fn normalize_pem_newlines_passes_valid_pem_unchanged() {
+        let valid = "-----BEGIN PRIVATE KEY-----\nMIIE...\n-----END PRIVATE KEY-----".to_string();
+        let expected = valid.clone();
+        assert_eq!(normalize_pem_newlines(valid), expected);
+    }
+
+    #[test]
+    fn normalize_pem_newlines_leaves_mixed_input_alone() {
+        // Real newlines present → don't touch (could be legitimate inside PEM body)
+        let mixed = "-----BEGIN PRIVATE KEY-----\nAB\\nCD\n-----END PRIVATE KEY-----".to_string();
+        let out = normalize_pem_newlines(mixed.clone());
+        assert_eq!(out, mixed);
+    }
+
+    #[test]
+    fn decrypt_pem_secret_normalizes_escaped_plaintext() {
+        let key_material = "test-key-material-32chars!!!";
+        // Encrypt a PEM string that contains literal \n (the bug)
+        let escaped_pem =
+            "-----BEGIN PRIVATE KEY-----\\nABC\\n-----END PRIVATE KEY-----".to_string();
+        let ciphertext = encrypt_secret(&escaped_pem, key_material).expect("encrypt");
+        let decrypted = decrypt_pem_secret(&ciphertext, key_material).expect("decrypt");
+        assert!(decrypted.contains('\n'));
+        assert!(!decrypted.contains("\\n"));
+        assert_eq!(decrypted.lines().count(), 3);
+    }
+
+    #[test]
+    fn decrypt_pem_secret_passes_through_valid_pem() {
+        let key_material = "another-32-byte-test-key-!!!!!";
+        let valid_pem = "-----BEGIN PRIVATE KEY-----\nABC\n-----END PRIVATE KEY-----".to_string();
+        let ciphertext = encrypt_secret(&valid_pem, key_material).expect("encrypt");
+        let decrypted = decrypt_pem_secret(&ciphertext, key_material).expect("decrypt");
+        assert_eq!(decrypted, valid_pem);
+    }
+
+    #[test]
+    fn decrypt_pem_secret_propagates_decrypt_errors() {
+        let result = decrypt_pem_secret("not-base64!!", "key");
+        assert!(result.is_err());
+    }
 
     #[test]
     fn test_display_name_full() {

--- a/crates/alc-misc/src/bot_admin.rs
+++ b/crates/alc-misc/src/bot_admin.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 use ts_rs::TS;
 use uuid::Uuid;
 
+use alc_core::auth_lineworks::normalize_pem_newlines;
 use alc_core::auth_middleware::AuthUser;
 use alc_core::repository::bot_admin::BotConfigRow;
 use alc_core::AppState;
@@ -241,10 +242,12 @@ async fn get_config_secrets(
         tracing::error!("Failed to decrypt client_secret: {e}");
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
-    let private_key = decrypt_secret(&row.private_key_encrypted, &key).map_err(|e| {
-        tracing::error!("Failed to decrypt private_key: {e}");
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?;
+    let private_key = decrypt_secret(&row.private_key_encrypted, &key)
+        .map(normalize_pem_newlines)
+        .map_err(|e| {
+            tracing::error!("Failed to decrypt private_key: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
 
     Ok(Json(BotConfigSecretsResponse {
         client_id: row.client_id,

--- a/crates/alc-notify/src/distribute.rs
+++ b/crates/alc-notify/src/distribute.rs
@@ -8,7 +8,7 @@ use axum::{
 };
 use uuid::Uuid;
 
-use alc_core::auth_lineworks::decrypt_secret;
+use alc_core::auth_lineworks::{decrypt_pem_secret, decrypt_secret};
 use alc_core::auth_middleware::TenantId;
 use alc_core::AppState;
 
@@ -53,8 +53,8 @@ async fn resolve_line_config(state: &AppState, tenant_id: Uuid) -> Result<LineCo
     let private_key_enc = config
         .private_key_encrypted
         .ok_or_else(|| "LINE config missing private_key".to_string())?;
-    let private_key =
-        decrypt_secret(&private_key_enc, &key).map_err(|e| format!("decrypt private_key: {e}"))?;
+    let private_key = decrypt_pem_secret(&private_key_enc, &key)
+        .map_err(|e| format!("decrypt private_key: {e}"))?;
 
     Ok(LineConfig {
         channel_id: config.channel_id,
@@ -89,7 +89,7 @@ async fn resolve_lineworks_config(
     let key = encryption_key().map_err(|_| "Encryption key not set".to_string())?;
     let client_secret = decrypt_secret(&full.client_secret_encrypted, &key)
         .map_err(|e| format!("decrypt client_secret: {e}"))?;
-    let private_key = decrypt_secret(&full.private_key_encrypted, &key)
+    let private_key = decrypt_pem_secret(&full.private_key_encrypted, &key)
         .map_err(|e| format!("decrypt private_key: {e}"))?;
 
     Ok((

--- a/crates/alc-notify/src/lineworks_directory.rs
+++ b/crates/alc-notify/src/lineworks_directory.rs
@@ -9,7 +9,7 @@ use axum::{extract::State, http::StatusCode, Extension, Json, Router};
 use serde::Serialize;
 use std::collections::HashSet;
 
-use alc_core::auth_lineworks::decrypt_secret;
+use alc_core::auth_lineworks::{decrypt_pem_secret, decrypt_secret};
 use alc_core::auth_middleware::TenantId;
 use alc_core::AppState;
 
@@ -83,7 +83,7 @@ async fn list_users(
         tracing::error!("decrypt client_secret: {e}");
         internal_error("decrypt_failed")
     })?;
-    let private_key = decrypt_secret(&full.private_key_encrypted, &key).map_err(|e| {
+    let private_key = decrypt_pem_secret(&full.private_key_encrypted, &key).map_err(|e| {
         tracing::error!("decrypt private_key: {e}");
         internal_error("decrypt_failed")
     })?;

--- a/crates/alc-trouble/src/notifier.rs
+++ b/crates/alc-trouble/src/notifier.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use uuid::Uuid;
 
-use alc_core::auth_lineworks::decrypt_secret;
+use alc_core::auth_lineworks::{decrypt_pem_secret, decrypt_secret};
 use alc_core::repository::bot_admin::BotAdminRepository;
 use alc_notify::clients::lineworks::{LineworksBotClient, LineworksBotConfig};
 
@@ -48,7 +48,7 @@ pub async fn resolve_lineworks_config(
     let key = encryption_key()?;
     let client_secret = decrypt_secret(&full.client_secret_encrypted, &key)
         .map_err(|e| format!("decrypt client_secret: {e}"))?;
-    let private_key = decrypt_secret(&full.private_key_encrypted, &key)
+    let private_key = decrypt_pem_secret(&full.private_key_encrypted, &key)
         .map_err(|e| format!("decrypt private_key: {e}"))?;
 
     Ok((


### PR DESCRIPTION
## Problem

Legacy `bot_configs` rows had their LINE WORKS Service Account private key persisted with literal `\n` sequences instead of real `0x0A` newlines. `jsonwebtoken::EncodingKey::from_rsa_pem` rejects escaped PEM as `InvalidKeyFormat`, causing:

- **502** on `GET /api/notify/lineworks/users` (what triggered this investigation)
- Silent failures on trouble notifications and notify distribute for all LINE WORKS tenants for weeks

## Root cause

Decrypted plaintext is literally `-----BEGIN PRIVATE KEY-----\\nABC\\n-----END PRIVATE KEY-----` (one long line containing literal backslash-n pairs). RSA PEM parser needs real newlines.

## Fix

Add `decrypt_pem_secret` helper in `alc_core::auth_lineworks` that wraps `decrypt_secret` and normalizes escaped newlines. Idempotent: passes through correct PEM unchanged (only replaces `\\n` → `\n` when real newlines are absent).

Apply at every private_key decrypt site:
- `alc-notify/src/lineworks_directory.rs` (/notify/lineworks/users)
- `alc-notify/src/distribute.rs` (LINE + LINE WORKS both paths)
- `alc-trouble/src/notifier.rs` (trouble LINE WORKS notifier)
- `alc-misc/src/bot_admin.rs` (bot config edit-form secrets)

## Tests

5 unit tests in `alc_core::auth_lineworks::tests`: escape fix, valid PEM passthrough, mixed input preservation, encrypt+decrypt roundtrip (both variants), error propagation.

## Deployment

- Prod DB row for affected tenant already normalized via one-off admin fix (separate action)
- This code deploy is defense-in-depth: future legacy-escape writes (or new ones from the edit UI) are auto-healed on read
- tag-release after merge → Cloud Run prod deploy