### PR TITLE
chore(tests): clean up per-binary dead_code warnings

### DIFF
--- a/crates/alc-compare/src/lib.rs
+++ b/crates/alc-compare/src/lib.rs
@@ -4345,7 +4345,7 @@ U002,x,x,x,x,x,x,x,x,x,2026/02/02 22:00:00,2026/02/03 06:00:00\n";
             let t = NaiveTime::from_hms_opt(8, 0, 0).unwrap();
             let segs = vec![(dt(2026, 2, 1, 8, 0, 0), dt(2026, 2, 1, 17, 0, 0), d, t)];
             // 7:00はセグメント[8:00, 17:00)の外 → fallback
-            let (wd, st) = find_event_workday(dt(2026, 2, 1, 7, 0, 0), Some(&segs));
+            let (wd, _st) = find_event_workday(dt(2026, 2, 1, 7, 0, 0), Some(&segs));
             assert_eq!(wd, d); // fallbackで最初のセグメント
         });
     }

--- a/crates/alc-dtako/src/dtako_restraint_report.rs
+++ b/crates/alc-dtako/src/dtako_restraint_report.rs
@@ -830,7 +830,6 @@ fn detect_diffs(csv_days: &[CsvDayRow], sys_days: &[SystemDayRow]) -> Vec<DiffIt
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alc_compare::detect_diffs_csv;
 
     // 一瀬　道広 (1026) 2026年2月分 — 日跨ぎ運行（同一日2行）あり
     const CSV_1026: &str = "拘束時間管理表 (2026年 2月分)\n\

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,3 +1,8 @@
+// tests/common は複数の test binary から `#[path = "../common/mod.rs"] mod common;`
+// として include されるため、binary ごとに使う API が違う。ここを許容しないと
+// 単体 binary から見た dead_code / unused_imports 警告が大量に出る。
+#![allow(dead_code, unused_imports)]
+
 #[macro_use]
 pub mod test_macros;
 pub mod mock_storage;

--- a/tests/common/test_macros.rs
+++ b/tests/common/test_macros.rs
@@ -1,3 +1,5 @@
+#![allow(unused_macros)]
+
 #[cfg(coverage)]
 macro_rules! test_case {
     ($desc:expr, $body:expr) => {

--- a/tests/mock_helpers/mod.rs
+++ b/tests/mock_helpers/mod.rs
@@ -4,6 +4,10 @@
 //! 各 mock struct は `fail_next: AtomicBool` を持ち、
 //! true にすると次のメソッド呼び出しで sqlx::Error を返す。
 
+// 複数の test binary から path include される共有モジュール。
+// binary ごとに使う mock / helper が違うので per-binary の未使用警告を許容する。
+#![allow(dead_code, unused_imports)]
+
 #[macro_use]
 mod repos_a;
 #[macro_use]

--- a/tests/mock_tests/mock_carrying_items_test.rs
+++ b/tests/mock_tests/mock_carrying_items_test.rs
@@ -208,13 +208,10 @@ async fn test_list_items_db_error_on_conditions() {
     test_case!(
         "GET /carrying-items returns 500 when list_conditions fails",
         {
-            // Need a mock that succeeds on list() but fails on list_conditions()
-            let tenant_id = Uuid::new_v4();
-            let mock = Arc::new(SuccessMockCarryingItemsRepository::new(tenant_id));
-            // fail_next is consumed by list() — we need a custom approach.
-            // Use a wrapper that fails only on list_conditions.
-            let mock2 = Arc::new(ListConditionsFailMock);
-            let (base_url, jwt, _) = spawn_with_mock(mock2).await;
+            // Use a wrapper that fails only on list_conditions
+            // (SuccessMockCarryingItemsRepository.fail_next is consumed by list()).
+            let mock = Arc::new(ListConditionsFailMock);
+            let (base_url, jwt, _) = spawn_with_mock(mock).await;
             let client = reqwest::Client::new();
 
             let res = client

--- a/tests/mock_tests/mock_dtako_csv_proxy_test.rs
+++ b/tests/mock_tests/mock_dtako_csv_proxy_test.rs
@@ -1,5 +1,3 @@
-use uuid::Uuid;
-
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 

--- a/tests/mock_tests/mock_dtako_drivers_test.rs
+++ b/tests/mock_tests/mock_dtako_drivers_test.rs
@@ -1,5 +1,3 @@
-use uuid::Uuid;
-
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 

--- a/tests/mock_tests/mock_dtako_upload_test.rs
+++ b/tests/mock_tests/mock_dtako_upload_test.rs
@@ -739,7 +739,7 @@ async fn test_dtako_upload_rich_zip_success() {
 #[tokio::test]
 async fn test_dtako_upload_rich_zip_with_employee_id() {
     let employee_id = Uuid::new_v4();
-    let mut mock = MockDtakoUploadRepository::default();
+    let mock = MockDtakoUploadRepository::default();
     *mock.employee_id.lock().unwrap() = Some(employee_id);
 
     let state = setup_with_mock(mock);
@@ -963,7 +963,7 @@ async fn test_dtako_download_success() {
     let zip_key = format!("{}/uploads/{}/test.zip", tenant_id, upload_id);
 
     // Create mock with upload_history that returns a record
-    let mut mock = MockDtakoUploadRepository::default();
+    let mock = MockDtakoUploadRepository::default();
     *mock.upload_history.lock().unwrap() = Some(UploadHistoryRecord {
         tenant_id,
         r2_zip_key: zip_key.clone(),
@@ -1006,7 +1006,7 @@ async fn test_dtako_download_ascii_safe_filename() {
     let upload_id = Uuid::new_v4();
     let zip_key = format!("{}/uploads/{}/test.zip", tenant_id, upload_id);
 
-    let mut mock = MockDtakoUploadRepository::default();
+    let mock = MockDtakoUploadRepository::default();
     // Use a filename with non-ASCII chars (Japanese) that will be filtered
     *mock.upload_history.lock().unwrap() = Some(UploadHistoryRecord {
         tenant_id,
@@ -1049,7 +1049,7 @@ async fn test_dtako_rerun_success() {
     let upload_id = Uuid::new_v4();
     let zip_key = format!("{}/uploads/{}/test.zip", tenant_id, upload_id);
 
-    let mut mock = MockDtakoUploadRepository::default();
+    let mock = MockDtakoUploadRepository::default();
     *mock.upload_history.lock().unwrap() = Some(UploadHistoryRecord {
         tenant_id,
         r2_zip_key: zip_key.clone(),
@@ -1094,7 +1094,7 @@ async fn test_dtako_rerun_rich_zip() {
     let zip_key = format!("{}/uploads/{}/rich.zip", tenant_id, upload_id);
 
     let employee_id = Uuid::new_v4();
-    let mut mock = MockDtakoUploadRepository::default();
+    let mock = MockDtakoUploadRepository::default();
     *mock.upload_history.lock().unwrap() = Some(UploadHistoryRecord {
         tenant_id,
         r2_zip_key: zip_key.clone(),
@@ -1138,7 +1138,7 @@ async fn test_dtako_split_csv_success() {
     let upload_id = Uuid::new_v4();
     let zip_key = format!("{}/uploads/{}/test.zip", tenant_id, upload_id);
 
-    let mut mock = MockDtakoUploadRepository::default();
+    let mock = MockDtakoUploadRepository::default();
     *mock.tenant_and_key.lock().unwrap() = Some(UploadTenantAndKey {
         tenant_id,
         r2_zip_key: zip_key.clone(),
@@ -1175,7 +1175,7 @@ async fn test_dtako_split_csv_all_with_uploads() {
     let upload_id = Uuid::new_v4();
     let zip_key = format!("{}/uploads/{}/test.zip", tenant_id, upload_id);
 
-    let mut mock = MockDtakoUploadRepository::default();
+    let mock = MockDtakoUploadRepository::default();
     *mock.uploads_needing_split.lock().unwrap() = vec![(upload_id, "test.zip".to_string())];
     // split_csv_from_r2 needs get_upload_tenant_and_key
     *mock.tenant_and_key.lock().unwrap() = Some(UploadTenantAndKey {
@@ -1224,7 +1224,7 @@ async fn test_dtako_recalculate_with_operations() {
          {unko_no},2026/03/15,DR01,運転者A,1,2026/03/15 15:00:00,2026/03/15 17:00:00,201,走行,120,50.0\n"
     );
 
-    let mut mock = MockDtakoUploadRepository::default();
+    let mock = MockDtakoUploadRepository::default();
     let dep = Utc.with_ymd_and_hms(2026, 3, 15, 8, 0, 0).unwrap();
     let ret = Utc.with_ymd_and_hms(2026, 3, 15, 17, 0, 0).unwrap();
     *mock.operations.lock().unwrap() = vec![DtakoOpRow {
@@ -1272,7 +1272,7 @@ async fn test_dtako_recalculate_no_kudgivt_error() {
 
     let tenant_id = Uuid::new_v4();
 
-    let mut mock = MockDtakoUploadRepository::default();
+    let mock = MockDtakoUploadRepository::default();
     let dep = Utc.with_ymd_and_hms(2026, 3, 15, 8, 0, 0).unwrap();
     let ret = Utc.with_ymd_and_hms(2026, 3, 15, 17, 0, 0).unwrap();
     *mock.operations.lock().unwrap() = vec![DtakoOpRow {
@@ -1325,7 +1325,7 @@ async fn test_dtako_recalculate_driver_with_data() {
          {unko_no},2026/03/20,DR01,運転者A,1,2026/03/20 13:00:00,2026/03/20 16:00:00,201,走行,180,70.0\n"
     );
 
-    let mut mock = MockDtakoUploadRepository::default();
+    let mock = MockDtakoUploadRepository::default();
     *mock.driver_cd.lock().unwrap() = Some("DR01".to_string());
 
     let dep = Utc.with_ymd_and_hms(2026, 3, 20, 8, 0, 0).unwrap();
@@ -1406,7 +1406,7 @@ async fn test_dtako_recalculate_drivers_batch_with_data() {
     let tenant_id = Uuid::new_v4();
     let driver_id = Uuid::new_v4();
 
-    let mut mock = MockDtakoUploadRepository::default();
+    let mock = MockDtakoUploadRepository::default();
     *mock.driver_cd.lock().unwrap() = Some("DR01".to_string());
 
     let dep = Utc.with_ymd_and_hms(2026, 3, 20, 8, 0, 0).unwrap();
@@ -1484,7 +1484,7 @@ async fn test_dtako_recalculate_with_ferry_data() {
          {unko_no},2026/03/10,DR01,運転者A,1,2026/03/10 14:00:00,2026/03/10 14:30:00,302,休息,30,0\n"
     );
 
-    let mut mock = MockDtakoUploadRepository::default();
+    let mock = MockDtakoUploadRepository::default();
     let dep = Utc.with_ymd_and_hms(2026, 3, 10, 6, 0, 0).unwrap();
     let ret = Utc.with_ymd_and_hms(2026, 3, 10, 15, 0, 0).unwrap();
     // 2nd operation: has ferry data but NO KUDGIVT → covers continue at L382
@@ -1568,7 +1568,7 @@ async fn test_dtako_recalculate_ferry_zero_duration() {
          {unko_no},2026/03/10,DR01,運転者A,1,2026/03/10 08:00:00,2026/03/10 12:00:00,201,走行,240,100.0\n"
     );
 
-    let mut mock = MockDtakoUploadRepository::default();
+    let mock = MockDtakoUploadRepository::default();
     let dep = Utc.with_ymd_and_hms(2026, 3, 10, 8, 0, 0).unwrap();
     let ret = Utc.with_ymd_and_hms(2026, 3, 10, 12, 0, 0).unwrap();
     *mock.operations.lock().unwrap() = vec![DtakoOpRow {
@@ -1628,7 +1628,7 @@ async fn test_dtako_recalculate_ferry_short_cols() {
          {unko_no},2026/03/10,DR01,運転者A,1,2026/03/10 08:00:00,2026/03/10 12:00:00,201,走行,240,100.0\n"
     );
 
-    let mut mock = MockDtakoUploadRepository::default();
+    let mock = MockDtakoUploadRepository::default();
     let dep = Utc.with_ymd_and_hms(2026, 3, 10, 8, 0, 0).unwrap();
     let ret = Utc.with_ymd_and_hms(2026, 3, 10, 12, 0, 0).unwrap();
     *mock.operations.lock().unwrap() = vec![DtakoOpRow {
@@ -1687,7 +1687,7 @@ async fn test_dtako_recalculate_ferry_invalid_datetime() {
          {unko_no},2026/03/10,DR01,運転者A,1,2026/03/10 08:00:00,2026/03/10 12:00:00,201,走行,240,100.0\n"
     );
 
-    let mut mock = MockDtakoUploadRepository::default();
+    let mock = MockDtakoUploadRepository::default();
     let dep = Utc.with_ymd_and_hms(2026, 3, 10, 8, 0, 0).unwrap();
     let ret = Utc.with_ymd_and_hms(2026, 3, 10, 12, 0, 0).unwrap();
     *mock.operations.lock().unwrap() = vec![DtakoOpRow {
@@ -1837,7 +1837,7 @@ async fn test_dtako_recalculate_invalid_month() {
 
 #[tokio::test]
 async fn test_dtako_recalculate_driver_invalid_month() {
-    let mut mock = MockDtakoUploadRepository::default();
+    let mock = MockDtakoUploadRepository::default();
     *mock.driver_cd.lock().unwrap() = Some("DR01".to_string());
 
     let state = setup_with_mock(mock);
@@ -1911,7 +1911,7 @@ async fn test_dtako_recalculate_multiple_operations_with_rest() {
          9002,2026/03/10,DR02,運転者B,1,2026/03/10 09:00:00,2026/03/10 14:00:00,201,走行,300,80.0\n\
          9002,2026/03/10,DR02,運転者B,1,2026/03/10 14:00:00,2026/03/10 15:00:00,204,その他,60,0\n";
 
-    let mut mock = MockDtakoUploadRepository::default();
+    let mock = MockDtakoUploadRepository::default();
 
     let dep1 = Utc.with_ymd_and_hms(2026, 3, 10, 8, 0, 0).unwrap();
     let ret1 = Utc.with_ymd_and_hms(2026, 3, 10, 15, 0, 0).unwrap();
@@ -1984,7 +1984,7 @@ async fn test_dtako_recalculate_with_employee_id_mapped() {
          {unko_no},2026/03/15,DR01,運転者A,1,2026/03/15 08:00:00,2026/03/15 17:00:00,201,走行,540,200.0\n"
     );
 
-    let mut mock = MockDtakoUploadRepository::default();
+    let mock = MockDtakoUploadRepository::default();
     *mock.employee_id.lock().unwrap() = Some(employee_id);
 
     let dep = Utc.with_ymd_and_hms(2026, 3, 15, 8, 0, 0).unwrap();
@@ -2065,7 +2065,7 @@ async fn test_dtako_recalculate_driver_bad_zip_in_storage() {
     let tenant_id = Uuid::new_v4();
     let driver_id = Uuid::new_v4();
 
-    let mut mock = MockDtakoUploadRepository::default();
+    let mock = MockDtakoUploadRepository::default();
     *mock.driver_cd.lock().unwrap() = Some("DR01".to_string());
 
     let dep = Utc.with_ymd_and_hms(2026, 3, 20, 8, 0, 0).unwrap();
@@ -2123,7 +2123,7 @@ async fn test_dtako_recalculate_driver_kudgivt_parse_error_in_zip() {
     let tenant_id = Uuid::new_v4();
     let driver_id = Uuid::new_v4();
 
-    let mut mock = MockDtakoUploadRepository::default();
+    let mock = MockDtakoUploadRepository::default();
     *mock.driver_cd.lock().unwrap() = Some("DR01".to_string());
 
     let dep = Utc.with_ymd_and_hms(2026, 3, 20, 8, 0, 0).unwrap();
@@ -2186,7 +2186,7 @@ async fn test_dtako_recalculate_late_night_work() {
          {unko_no},2026/03/10,DR01,運転者A,1,2026/03/10 20:00:00,2026/03/11 03:00:00,201,走行,420,200.0\n"
     );
 
-    let mut mock = MockDtakoUploadRepository::default();
+    let mock = MockDtakoUploadRepository::default();
     *mock.employee_id.lock().unwrap() = Some(employee_id);
 
     let dep = Utc.with_ymd_and_hms(2026, 3, 10, 20, 0, 0).unwrap();
@@ -2264,7 +2264,7 @@ async fn test_dtako_download_r2_download_failure() {
     let upload_id = Uuid::new_v4();
     let missing_key = format!("{}/uploads/{}/missing.zip", tenant_id, upload_id);
 
-    let mut mock = MockDtakoUploadRepository::default();
+    let mock = MockDtakoUploadRepository::default();
     *mock.upload_history.lock().unwrap() = Some(UploadHistoryRecord {
         tenant_id,
         r2_zip_key: missing_key, // key does NOT exist in storage
@@ -2302,7 +2302,7 @@ async fn test_dtako_rerun_r2_download_failure() {
     let upload_id = Uuid::new_v4();
     let missing_key = format!("{}/uploads/{}/missing.zip", tenant_id, upload_id);
 
-    let mut mock = MockDtakoUploadRepository::default();
+    let mock = MockDtakoUploadRepository::default();
     *mock.upload_history.lock().unwrap() = Some(UploadHistoryRecord {
         tenant_id,
         r2_zip_key: missing_key, // key does NOT exist in storage
@@ -2340,7 +2340,7 @@ async fn test_dtako_rerun_process_zip_failure() {
     let upload_id = Uuid::new_v4();
     let zip_key = format!("{}/uploads/{}/bad.zip", tenant_id, upload_id);
 
-    let mut mock = MockDtakoUploadRepository::default();
+    let mock = MockDtakoUploadRepository::default();
     *mock.upload_history.lock().unwrap() = Some(UploadHistoryRecord {
         tenant_id,
         r2_zip_key: zip_key.clone(),
@@ -2376,7 +2376,7 @@ async fn test_dtako_rerun_process_zip_failure() {
 
 #[tokio::test]
 async fn test_dtako_upload_with_event_classifications_from_db() {
-    let mut mock = MockDtakoUploadRepository::default();
+    let mock = MockDtakoUploadRepository::default();
     // Pre-populate all classification branches
     *mock.event_classifications.lock().unwrap() = vec![
         ("201".to_string(), "drive".to_string()),
@@ -2420,7 +2420,7 @@ async fn test_dtako_split_csv_update_has_kudgivt_failure() {
     let upload_id = Uuid::new_v4();
     let zip_key = format!("{}/uploads/{}/test.zip", tenant_id, upload_id);
 
-    let mut mock = MockDtakoUploadRepository::default();
+    let mock = MockDtakoUploadRepository::default();
     *mock.tenant_and_key.lock().unwrap() = Some(UploadTenantAndKey {
         tenant_id,
         r2_zip_key: zip_key.clone(),
@@ -2499,7 +2499,7 @@ async fn test_dtako_split_csv_all_with_failures() {
     let upload_id1 = Uuid::new_v4();
     let upload_id2 = Uuid::new_v4();
 
-    let mut mock = MockDtakoUploadRepository::default();
+    let mock = MockDtakoUploadRepository::default();
     *mock.uploads_needing_split.lock().unwrap() = vec![
         (upload_id1, "file1.zip".to_string()),
         (upload_id2, "file2.zip".to_string()),
@@ -2536,7 +2536,7 @@ async fn test_dtako_recalculate_kudgivt_parse_error_per_unko() {
     let tenant_id = Uuid::new_v4();
     let unko_no = "PERR01";
 
-    let mut mock = MockDtakoUploadRepository::default();
+    let mock = MockDtakoUploadRepository::default();
     let dep = Utc.with_ymd_and_hms(2026, 3, 15, 8, 0, 0).unwrap();
     let ret = Utc.with_ymd_and_hms(2026, 3, 15, 17, 0, 0).unwrap();
     *mock.operations.lock().unwrap() = vec![DtakoOpRow {
@@ -2705,7 +2705,7 @@ async fn test_dtako_split_csv_non_csv_files_skipped() {
     let upload_id = Uuid::new_v4();
     let zip_key = format!("{}/uploads/{}/mixed.zip", tenant_id, upload_id);
 
-    let mut mock = MockDtakoUploadRepository::default();
+    let mock = MockDtakoUploadRepository::default();
     *mock.tenant_and_key.lock().unwrap() = Some(UploadTenantAndKey {
         tenant_id,
         r2_zip_key: zip_key.clone(),
@@ -2770,7 +2770,7 @@ async fn test_dtako_recalculate_driver_zip_download_error() {
     let tenant_id = Uuid::new_v4();
     let driver_id = Uuid::new_v4();
 
-    let mut mock = MockDtakoUploadRepository::default();
+    let mock = MockDtakoUploadRepository::default();
     *mock.driver_cd.lock().unwrap() = Some("DR01".to_string());
 
     let dep = Utc.with_ymd_and_hms(2026, 3, 20, 8, 0, 0).unwrap();
@@ -2826,7 +2826,7 @@ async fn test_dtako_recalculate_driver_zip_no_kudgivt_inside() {
     let tenant_id = Uuid::new_v4();
     let driver_id = Uuid::new_v4();
 
-    let mut mock = MockDtakoUploadRepository::default();
+    let mock = MockDtakoUploadRepository::default();
     *mock.driver_cd.lock().unwrap() = Some("DR01".to_string());
 
     let dep = Utc.with_ymd_and_hms(2026, 3, 20, 8, 0, 0).unwrap();
@@ -2924,7 +2924,7 @@ async fn test_dtako_recalculate_with_rich_data_progress() {
     let dep = Utc.with_ymd_and_hms(2026, 3, 1, 6, 0, 0).unwrap();
     let ret = Utc.with_ymd_and_hms(2026, 3, 1, 18, 0, 0).unwrap();
 
-    let mut mock = MockDtakoUploadRepository::default();
+    let mock = MockDtakoUploadRepository::default();
     *mock.operations.lock().unwrap() = vec![DtakoOpRow {
         unko_no: "U001".to_string(),
         reading_date: chrono::NaiveDate::from_ymd_opt(2026, 3, 1).unwrap(),

--- a/tests/mock_tests/mock_dtako_work_times_test.rs
+++ b/tests/mock_tests/mock_dtako_work_times_test.rs
@@ -188,7 +188,7 @@ async fn mock_list_work_times_count_db_error() {
 // ---------------------------------------------------------------------------
 #[tokio::test]
 async fn mock_list_work_times_list_db_error() {
-    let (state, mock_wt) = setup().await;
+    let (state, _mock_wt) = setup().await;
     let tenant_id = Uuid::new_v4();
     let jwt = crate::common::create_test_jwt(tenant_id, "admin");
 

--- a/tests/mock_tests/mock_sso_admin_test.rs
+++ b/tests/mock_tests/mock_sso_admin_test.rs
@@ -1,5 +1,3 @@
-use uuid::Uuid;
-
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 

--- a/tests/mock_tests/mock_tenko_records_test.rs
+++ b/tests/mock_tests/mock_tenko_records_test.rs
@@ -1,5 +1,3 @@
-use uuid::Uuid;
-
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 

--- a/tests/mock_tests/mock_tenko_schedules_test.rs
+++ b/tests/mock_tests/mock_tenko_schedules_test.rs
@@ -1,5 +1,3 @@
-use uuid::Uuid;
-
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 


### PR DESCRIPTION
## Summary
- tests/common/mod.rs 等の共有モジュールに `#![allow(dead_code, unused_imports)]` を追加 (binary ごとに使う API 違い由来の警告を許容)
- 使われていない uuid::Uuid import 5 ファイル・不要な `mut` 32 箇所・`_` 付け忘れ 2 箇所などを掃除
- src 側の未使用 `st` 変数・未使用 import `detect_diffs_csv` も同時修正

## Test plan
- [x] cargo check --tests で警告が劇的に減ったことを確認 (worktree ローカル)
- [ ] CI の Tests (各 matrix) が引き続き green