### PR TITLE
revert: run migrations per-test instead of once-per-job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,13 +211,6 @@ jobs:
       - name: Init DB
         run: psql "postgresql://postgres:test@localhost:5432/postgres" -f scripts/init_local_db.sql
 
-      - name: Run migrations (once per job)
-        env:
-          DATABASE_URL: "postgresql://postgres:test@localhost:5432/postgres?options=-c search_path=alc_api"
-          SCCACHE_GHA_ENABLED: "true"
-          RUSTC_WRAPPER: "sccache"
-        run: cargo run --bin migrate
-
       - name: Run tests with coverage
         env:
           SCCACHE_GHA_ENABLED: "true"

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # ローカル開発: make test (DB不要、ユニットのみ)
 # CI はフルテスト + カバレッジリグレッションを保証
 
-.PHONY: test test-file db-up db-down db-migrate itest itest-file cov-check cov-check-unit fmt clippy cov-dl cov-summary cov-not100 cov-file
+.PHONY: test test-file db-up db-down itest itest-file cov-check cov-check-unit fmt clippy cov-dl cov-summary cov-not100 cov-file
 
 # --- ユニットテスト (DB 不要、高速) ---
 
@@ -25,17 +25,13 @@ db-up:
 db-down:
 	docker compose down
 
-# Migrations はテスト前に 1 回だけ適用。テスト自体は migrate を呼ばない。
-db-migrate:
-	source .test-config && DATABASE_URL="$$TEST_DATABASE_URL" cargo run --bin migrate
-
 # --- インテグレーションテスト (DB 必要) ---
 
-itest: db-up db-migrate
+itest: db-up
 	source .test-config && cargo test --test '*'
 	$(MAKE) db-down
 
-# 特定テストファイル: make itest-file T=auth_test (事前に make db-migrate が必要)
+# 特定テストファイル: make itest-file T=auth_test
 itest-file:
 	source .test-config && cargo test --test $(T)
 

--- a/tests/archive_repo_test.rs
+++ b/tests/archive_repo_test.rs
@@ -11,6 +11,10 @@ async fn setup_pool() -> sqlx::PgPool {
         .connect(&url)
         .await
         .expect("Failed to connect to test DB");
+    sqlx::migrate!("./migrations")
+        .run(&pool)
+        .await
+        .expect("Failed to run migrations");
     pool
 }
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -222,6 +222,11 @@ pub async fn setup_app_state() -> AppState {
         .await
         .expect("Failed to connect to test DB");
 
+    sqlx::migrate!("./migrations")
+        .run(&pool)
+        .await
+        .expect("Failed to run migrations");
+
     let storage: Arc<dyn rust_alc_api::storage::StorageBackend> =
         Arc::new(MockStorage::new("test-bucket"));
 
@@ -392,6 +397,11 @@ pub async fn setup_app_state_no_fcm() -> AppState {
         .await
         .expect("Failed to connect to test DB");
 
+    sqlx::migrate!("./migrations")
+        .run(&pool)
+        .await
+        .expect("Failed to run migrations");
+
     let storage: Arc<dyn rust_alc_api::storage::StorageBackend> =
         Arc::new(MockStorage::new("test-bucket"));
 
@@ -413,6 +423,11 @@ pub async fn setup_app_state_failing_fcm() -> AppState {
         .connect(&test_database_url())
         .await
         .expect("Failed to connect to test DB");
+
+    sqlx::migrate!("./migrations")
+        .run(&pool)
+        .await
+        .expect("Failed to run migrations");
 
     let storage: Arc<dyn rust_alc_api::storage::StorageBackend> =
         Arc::new(MockStorage::new("test-bucket"));


### PR DESCRIPTION
## Summary
PR #274 で入れた「Run migrations (once per job)」最適化を revert。真因は race ではなく migration 098 version 衝突だったことが判明 (既に 098→100 rename で解消済み)。

## Why
- sqlx::migrate!() は pg_advisory_lock で並列 call safe
- cargo run --bin migrate は 2min × 7 jobs のコンパイル無駄 (cache-warm に含まれず)
- sqlx-cli に [prebuilt binary が無い](https://github.com/launchbadge/sqlx/issues/1201) ので install-action も結局 compile
- per-test migrate の overhead は ~1s/job で無視できる

## 変更
- tests/common/mod.rs の 3 箇所と tests/archive_repo_test.rs で sqlx::migrate!() 復活
- .github/workflows/ci.yml から Run migrations step 削除
- Makefile の db-migrate target 削除、itest は db-up → test の元構成に戻す

## Test plan
- [ ] CI mock-trouble / mock-misc が green (098 衝突は解消済みなので通るはず)
- [ ] 他 matrix も regression なし
- [ ] CI 時間が PR #274 より短縮