### PR TITLE
fix(lineworks): deserialize nextCursor (camelCase) in users pagination

### DIFF
--- a/crates/alc-notify/src/clients/lineworks.rs
+++ b/crates/alc-notify/src/clients/lineworks.rs
@@ -125,7 +125,8 @@ struct UserName {
 
 #[derive(Debug, Deserialize)]
 struct ResponseMetaData {
-    cursor: Option<String>,
+    #[serde(rename = "nextCursor")]
+    next_cursor: Option<String>,
 }
 
 /// マルチテナント対応の LINE WORKS Bot クライアント
@@ -328,12 +329,61 @@ impl LineworksBotClient {
                 }
             }
 
-            cursor = body.response_meta_data.and_then(|m| m.cursor);
+            cursor = body.response_meta_data.and_then(|m| m.next_cursor);
             if cursor.is_none() {
                 break;
             }
         }
 
         Ok(members)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn response_meta_data_parses_next_cursor_from_camelcase() {
+        let json = r#"{"nextCursor":"A3ST6cnnk0ALxM4u2_cvHtrNaZtBs4Bt3gGIWAjzdJ8="}"#;
+        let md: ResponseMetaData = serde_json::from_str(json).expect("deserialize");
+        assert_eq!(
+            md.next_cursor.as_deref(),
+            Some("A3ST6cnnk0ALxM4u2_cvHtrNaZtBs4Bt3gGIWAjzdJ8=")
+        );
+    }
+
+    #[test]
+    fn response_meta_data_ignores_legacy_cursor_field_name() {
+        // Regression: the prior impl used `cursor:` which silently parsed nothing
+        // from real LINE WORKS responses, capping results at one page.
+        let json = r#"{"cursor":"should-not-match"}"#;
+        let md: ResponseMetaData = serde_json::from_str(json).expect("deserialize");
+        assert_eq!(md.next_cursor, None);
+    }
+
+    #[test]
+    fn users_response_parses_next_page_shape() {
+        let json = r#"{
+            "users": [
+                {"userId": "u1", "userName": {"lastName": "田中", "firstName": "太郎"}, "email": "t@x.com"}
+            ],
+            "responseMetaData": {"nextCursor": "abc"}
+        }"#;
+        let body: UsersResponse = serde_json::from_str(json).expect("deserialize");
+        assert_eq!(body.users.as_ref().map(|u| u.len()), Some(1));
+        assert_eq!(
+            body.response_meta_data
+                .and_then(|m| m.next_cursor)
+                .as_deref(),
+            Some("abc")
+        );
+    }
+
+    #[test]
+    fn users_response_parses_final_page_without_cursor() {
+        let json = r#"{"users": [], "responseMetaData": {}}"#;
+        let body: UsersResponse = serde_json::from_str(json).expect("deserialize");
+        assert!(body.response_meta_data.unwrap().next_cursor.is_none());
     }
 }


### PR DESCRIPTION
## Problem

`/admin/notify` LINE WORKS タブで **100 人目以降が表示されない**。対象組織は 187 名だが UI には 100 名しか出ず 87 名が欠落。

## Root cause

`alc_notify::clients::lineworks::ResponseMetaData.cursor: Option<String>` が LINE WORKS API の `nextCursor` と field 名が違うため (serde rename 無し) 常に `None` → pagination ループが 1 ページ目 (デフォルト 100 件) で即 break。

直接 curl で確認:
```
{"nextCursor":"A3ST6cnnk0ALxM4u2_cvHtrNaZtBs4Bt3gGIWAjzdJ8="}
```

## Fix

`ResponseMetaData.cursor` → `next_cursor` に rename + `#[serde(rename = "nextCursor")]`。呼び出し 1 箇所も追従。

## Tests

4 unit tests (cargo test -p alc-notify --lib で local pass 確認):
- 正常系 (camelCase parse)
- 旧実装名 `cursor` は拾わない (回帰ガード)
- users 配列 + nextCursor 込みのフルレスポンス
- 最終ページ (nextCursor 欠落)

## 関連

直前の PR #275 (decrypt PEM normalize) で LINE WORKS 連携が稼働開始して、このバグが見えた。tag 後 v0.0.51 で本番反映後、187 名全員見えるはず。