### PR TITLE
fix(dtako): derive drivers from dtako_operations, not employees master

### DIFF
--- a/crates/alc-dtako/src/dtako_drivers.rs
+++ b/crates/alc-dtako/src/dtako_drivers.rs
@@ -18,11 +18,10 @@ async fn list_drivers(
 ) -> Result<Json<Vec<Driver>>, StatusCode> {
     let tenant_id = tenant.0 .0;
 
-    let drivers = state
-        .dtako_drivers
-        .list(tenant_id)
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let drivers = state.dtako_drivers.list(tenant_id).await.map_err(|e| {
+        tracing::error!("list_drivers failed: {e:?}");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
 
     Ok(Json(drivers))
 }

--- a/crates/alc-dtako/src/repo/dtako_drivers.rs
+++ b/crates/alc-dtako/src/repo/dtako_drivers.rs
@@ -21,7 +21,11 @@ impl DtakoDriversRepository for PgDtakoDriversRepository {
     async fn list(&self, tenant_id: Uuid) -> Result<Vec<Driver>, sqlx::Error> {
         let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
         sqlx::query_as::<_, Driver>(
-            "SELECT id, tenant_id, driver_cd, name FROM alc_api.employees WHERE driver_cd IS NOT NULL AND deleted_at IS NULL ORDER BY driver_cd",
+            "SELECT DISTINCT e.id, e.tenant_id, e.driver_cd, e.name AS driver_name \
+             FROM alc_api.employees e \
+             INNER JOIN alc_api.dtako_operations op ON op.driver_id = e.id \
+             WHERE e.deleted_at IS NULL \
+             ORDER BY e.driver_cd",
         )
         .fetch_all(&mut *tc.conn)
         .await


### PR DESCRIPTION
## Summary

- `/api/drivers` が 500 Internal Server Error になっていたバグ修正に加え、データソース設計を見直し
- **drivers** (デジタコ登録運転者) と **employees** (社員マスタ) は別概念とし、drivers は rust-alc-api の dtako データから抽出する設計に変更
- SQL を `alc_api.employees` 単独から `INNER JOIN alc_api.dtako_operations` に変更 (dtako に実在する driver のみ返す)
- エラーハンドリングに `tracing::error!` を追加し、今後 sqlx エラーが Cloud Run ログから追えるように

## Root cause (500 の直接原因)

- `alc_core::repository::dtako_drivers::Driver` struct の field `driver_name` に対し、旧 SQL は column `name` を返していた → sqlx::FromRow mapping 失敗
- `#[serde(rename)]` は JSON 出力専用で sqlx には効かない
- handler の `.map_err(|_| INTERNAL_SERVER_ERROR)` が詳細を握り潰していたためログにも出ず発見が遅れた (2026-03-31 の alc-core 抽出以来 3 週間潜在、dtako-admin が 2026-04-23 PR #17 で apiBase を rust-alc-api に戻したタイミングで顕在化)

## Design note

employees は Google OAuth / LINE WORKS 等で登録する社員マスタ。drivers はデジタコから入ってくる運転者データで、source of truth は dtako_operations 等。両者の混同を避けるため、/api/drivers は dtako 由来の driver_id に出現する employees のみ返すようにした。

将来的に drivers 専用テーブル (`alc_api.dtako_drivers`) に分離し、drivers → employees 昇格 API を追加する予定 (別 PR)。

## psql 事前確認

tenant `ohishiunyusouko` で旧クエリ (employees 単独) と新クエリ (INNER JOIN) どちらも 118 行で一致。カラム `driver_name` も意図通り返る。

## Test plan

- [ ] CI 緑
- [ ] v0.0.52 tag 後、dtako.ippoan.org で /api/drivers が 200 OK + 運転者リスト表示
- [ ] Cloud Run ログに `list_drivers failed` が出ていないこと