### PR TITLE
fix(dtako): default scrape date in JST, not Cloud Run UTC

### DIFF
--- a/crates/alc-dtako/src/dtako_scraper.rs
+++ b/crates/alc-dtako/src/dtako_scraper.rs
@@ -128,13 +128,14 @@ async fn trigger_scrape(
         ));
     }
 
+    let jst = chrono::FixedOffset::east_opt(9 * 3600).unwrap();
     let target_date_str = req.start_date.unwrap_or_else(|| {
-        (chrono::Local::now() - chrono::Duration::days(1))
+        (chrono::Utc::now().with_timezone(&jst) - chrono::Duration::days(1))
             .format("%Y-%m-%d")
             .to_string()
     });
     let target_date = NaiveDate::parse_from_str(&target_date_str, "%Y-%m-%d")
-        .unwrap_or_else(|_| chrono::Local::now().date_naive());
+        .unwrap_or_else(|_| chrono::Utc::now().with_timezone(&jst).date_naive());
     let tid = tenant_id.0;
     let dtako_scraper = state.dtako_scraper.clone();
 


### PR DESCRIPTION
## Summary

- `crates/alc-dtako/src/dtako_scraper.rs` の `target_date` フォールバックが `chrono::Local::now()` を使っており、Cloud Run (TZ 未設定 → UTC) では JST 00:00〜08:59 の呼び出しで「昨日」が 1 日ズレる
- 明示的に `FixedOffset::east_opt(9 * 3600)` で JST に寄せる

## Why

ユーザー報告: 2026-04-24 01:01 JST の cron 実行で `target_date = 2026-04-22` が記録された（期待は 2026-04-23）。

- 01:01 JST = 16:01 UTC on 2026-04-23
- `Local::now()` on Cloud Run → `2026-04-23` → `- 1day` = `2026-04-22` (= おととい from JST 視点)

この PR は `crates/alc-dtako` 側の記録ロジック。scraper 本体 (`dtako-scraper` リポジトリ) 側も同じ罠があり、別 PR で修正する。

## Test plan

- [ ] CI pass
- [ ] staging 反映後、手動 POST で `start_date` 省略 → 履歴テーブルで `target_date = 昨日 JST` を確認
- [ ] 翌朝の cron で通知メール件名に「昨日」が入ることを確認