### PR TITLE
fix(deploy): inject SCRAPER_URL via GitHub vars (backend + dtako)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -195,6 +195,8 @@ jobs:
         uses: google-github-actions/setup-gcloud@v2
 
       - name: Render and deploy
+        env:
+          ENV_SCRAPER_URL: ${{ vars.SCRAPER_URL }}
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             DEPLOY_ENV="staging"

--- a/cloudrun/render.sh
+++ b/cloudrun/render.sh
@@ -19,6 +19,9 @@ ENV="${2:?Usage: render.sh <service> <environment> <image_sha>}"
 IMAGE_SHA="${3:?Usage: render.sh <service> <environment> <image_sha>}"
 shift 3
 
+# Required env vars (fed from GitHub Actions `vars.*`)
+: "${ENV_SCRAPER_URL:?ENV_SCRAPER_URL not set (expected GitHub vars.SCRAPER_URL)}"
+
 STAGING_URL=""
 DB_IMAGE=""
 while [[ $# -gt 0 ]]; do
@@ -89,6 +92,8 @@ emit_env_backend() {
               value: "${ENV_CARINS_R2_BUCKET:-carins-files}"
             - name: DTAKO_R2_BUCKET
               value: "${ENV_DTAKO_R2_BUCKET:-ohishi-dtako}"
+            - name: SCRAPER_URL
+              value: "${ENV_SCRAPER_URL:?ENV_SCRAPER_URL not set (GitHub vars.SCRAPER_URL)}"
             - name: FCM_PROJECT_ID
               value: "alc-fcm"
             - name: STAGING_MODE
@@ -264,6 +269,8 @@ emit_env_dtako() {
                 secretKeyRef:
                   key: latest
                   name: dtako-r2-secret-key
+            - name: SCRAPER_URL
+              value: "${ENV_SCRAPER_URL:?ENV_SCRAPER_URL not set (GitHub vars.SCRAPER_URL)}"
             - name: RUST_LOG
               value: "dtako_api=info"
 YAML


### PR DESCRIPTION
## Summary

- `rust-alc-api` backend と `-dtako` microservice は `SCRAPER_URL` 未設定時に `http://localhost:8081` にフォールバックするため、現在本番で `/api/scraper/scrape` が 502 (`error sending request for url http://localhost:8081/scrape`)
- 旧 `deploy.sh` の `SCRAPER_URL=...` 設定が microservice 分割時に `cloudrun/render.sh` へ継承されていなかった
- URL をコードにハードコードせず、GitHub Actions repo variable (`vars.SCRAPER_URL`) 経由で `ENV_SCRAPER_URL` として注入する

## 変更点

- `cloudrun/render.sh`
  - 先頭に `: "${ENV_SCRAPER_URL:?...}"` で必須チェック（未設定なら render 時に exit 1）
  - `emit_env_backend()` と `emit_env_dtako()` の両方で `SCRAPER_URL` env var を emit
- `.github/workflows/deploy.yml`
  - `Render and deploy` step に `env: ENV_SCRAPER_URL: ${{ vars.SCRAPER_URL }}` を追加

## GitHub Variables

`vars.SCRAPER_URL = https://dtako-scraper-566bls5vfq-an.a.run.app` を repo 変数として登録済み（`gh variable set` で事前セット）。

## Test plan

- [ ] CI pass
- [ ] staging auto-deploy 後、`https://rust-alc-api-staging-566bls5vfq-an.a.run.app` 側で `SCRAPER_URL` が設定されていることを Cloud Run コンソールで確認
- [ ] production タグリリース後、`dtako.ippoan.org/scraper` で 502 が解消することを確認
- [ ] 変数未設定時は `render.sh` が exit 1 で落ちる (regression guard)

## 補足

`crates/dtako-api/src/main.rs` は現状 `ScraperUrl` Extension を layer していないため、gateway が backend 経由でなく dtako microservice 経由でルーティングを始めると別途バグる可能性あり。現状 gateway は backend 経由なので今回は影響なし（必要になったら別 PR で対応）。