### PR TITLE
fix(deploy): scope ENV_SCRAPER_URL check to backend/dtako only

### DIFF
--- a/cloudrun/render.sh
+++ b/cloudrun/render.sh
@@ -20,7 +20,10 @@ IMAGE_SHA="${3:?Usage: render.sh <service> <environment> <image_sha>}"
 shift 3
 
 # Required env vars (fed from GitHub Actions `vars.*`)
-: "${ENV_SCRAPER_URL:?ENV_SCRAPER_URL not set (expected GitHub vars.SCRAPER_URL)}"
+# Only the services that actually emit SCRAPER_URL need the var
+if [[ "$SERVICE" == "backend" || "$SERVICE" == "dtako" ]]; then
+  : "${ENV_SCRAPER_URL:?ENV_SCRAPER_URL not set (expected GitHub vars.SCRAPER_URL)}"
+fi
 
 STAGING_URL=""
 DB_IMAGE=""


### PR DESCRIPTION
## Summary

PR #281 のフォローアップ。gateway deploy ジョブで `render.sh` を呼んだ時に ENV_SCRAPER_URL 未設定でこけた (`Deploy gateway` step failed)。

- gateway/tenko/carins/trouble の YAML は SCRAPER_URL を emit しないので、必須チェックは backend/dtako のみに限定する
- gateway の Render step 側に env を追加する手もあるが、本当に必要なサービスだけ validation する方が意図が明確

## Test plan

- [x] `bash cloudrun/render.sh gateway production abc123` (ENV_SCRAPER_URL 未設定) → exit 0
- [x] `bash cloudrun/render.sh backend production abc123` (未設定) → exit 1
- [x] `bash cloudrun/render.sh dtako production abc123` (未設定) → exit 1
- [x] `ENV_SCRAPER_URL=x bash cloudrun/render.sh backend production abc123` → exit 0
- [ ] CI: Deploy gateway job pass