### PR TITLE
feat(trouble): add person_is_external flag for non-employee parties

### DIFF
--- a/crates/alc-core/src/models.rs
+++ b/crates/alc-core/src/models.rs
@@ -1502,6 +1502,7 @@ pub struct TroubleTicket {
     pub department: String,
     pub person_name: String,
     pub person_id: Option<Uuid>,
+    pub person_is_external: bool,
     pub registration_number: String,
     pub location: String,
     pub description: String,
@@ -1546,6 +1547,8 @@ pub struct CreateTroubleTicket {
         deserialize_with = "crate::serde_helpers::empty_string_as_none_uuid"
     )]
     pub person_id: Option<Uuid>,
+    #[serde(default)]
+    pub person_is_external: Option<bool>,
     pub registration_number: Option<String>,
     pub location: Option<String>,
     pub description: Option<String>,
@@ -1587,6 +1590,8 @@ pub struct UpdateTroubleTicket {
         deserialize_with = "crate::serde_helpers::empty_string_as_none_uuid"
     )]
     pub person_id: Option<Uuid>,
+    #[serde(default)]
+    pub person_is_external: Option<bool>,
     #[serde(
         default,
         deserialize_with = "crate::serde_helpers::empty_string_as_none_option_string"

--- a/crates/alc-trouble/src/repo/trouble_tickets.rs
+++ b/crates/alc-trouble/src/repo/trouble_tickets.rs
@@ -36,7 +36,7 @@ impl TroubleTicketsRepository for PgTroubleTicketsRepository {
                 tenant_id, category, title,
                 occurred_at, occurred_date,
                 company_name, office_name, department,
-                person_name, person_id,
+                person_name, person_id, person_is_external,
                 registration_number,
                 location, description,
                 status_id, assigned_to,
@@ -48,18 +48,18 @@ impl TroubleTicketsRepository for PgTroubleTicketsRepository {
                 $1, $2, COALESCE($3, ''),
                 $4, $5,
                 COALESCE($6, ''), COALESCE($7, ''), COALESCE($8, ''),
-                COALESCE($9, ''), $10,
-                COALESCE($11, ''),
-                COALESCE($12, ''), COALESCE($13, ''),
-                $14, $15,
-                $16, $17, $18,
-                COALESCE($19, ''), COALESCE($20, ''),
-                COALESCE($21, '{}'::jsonb), $22, $23
+                COALESCE($9, ''), $10, COALESCE($11, false),
+                COALESCE($12, ''),
+                COALESCE($13, ''), COALESCE($14, ''),
+                $15, $16,
+                $17, $18, $19,
+                COALESCE($20, ''), COALESCE($21, ''),
+                COALESCE($22, '{}'::jsonb), $23, $24
             )
             RETURNING id, tenant_id, ticket_no, category, title,
                 occurred_at, occurred_date,
                 company_name, office_name, department,
-                person_name, person_id,
+                person_name, person_id, person_is_external,
                 registration_number,
                 location, description,
                 status_id, assigned_to,
@@ -82,6 +82,7 @@ impl TroubleTicketsRepository for PgTroubleTicketsRepository {
         .bind(&input.department)
         .bind(&input.person_name)
         .bind(input.person_id)
+        .bind(input.person_is_external)
         .bind(&input.registration_number)
         .bind(&input.location)
         .bind(&input.description)
@@ -162,7 +163,7 @@ impl TroubleTicketsRepository for PgTroubleTicketsRepository {
             r#"SELECT id, tenant_id, ticket_no, category, title,
                 occurred_at, occurred_date,
                 company_name, office_name, department,
-                person_name, person_id,
+                person_name, person_id, person_is_external,
                 registration_number,
                 location, description,
                 status_id, assigned_to,
@@ -234,7 +235,7 @@ impl TroubleTicketsRepository for PgTroubleTicketsRepository {
             r#"SELECT id, tenant_id, ticket_no, category, title,
                 occurred_at, occurred_date,
                 company_name, office_name, department,
-                person_name, person_id,
+                person_name, person_id, person_is_external,
                 registration_number,
                 location, description,
                 status_id, assigned_to,
@@ -272,28 +273,29 @@ impl TroubleTicketsRepository for PgTroubleTicketsRepository {
                 department = COALESCE($9, department),
                 person_name = COALESCE($10, person_name),
                 person_id = COALESCE($11, person_id),
-                location = COALESCE($12, location),
-                description = COALESCE($13, description),
-                assigned_to = COALESCE($14, assigned_to),
-                progress_notes = COALESCE($15, progress_notes),
-                allowance = COALESCE($16, allowance),
-                damage_amount = COALESCE($17, damage_amount),
-                compensation_amount = COALESCE($18, compensation_amount),
-                confirmation_notice = COALESCE($19, confirmation_notice),
-                disciplinary_content = COALESCE($20, disciplinary_content),
-                disciplinary_action = COALESCE($21, disciplinary_action),
-                road_service_cost = COALESCE($22, road_service_cost),
-                counterparty = COALESCE($23, counterparty),
-                counterparty_insurance = COALESCE($24, counterparty_insurance),
-                custom_fields = COALESCE($25, custom_fields),
-                due_date = COALESCE($26, due_date),
-                registration_number = CASE WHEN $27 THEN $28 ELSE registration_number END,
+                person_is_external = COALESCE($12, person_is_external),
+                location = COALESCE($13, location),
+                description = COALESCE($14, description),
+                assigned_to = COALESCE($15, assigned_to),
+                progress_notes = COALESCE($16, progress_notes),
+                allowance = COALESCE($17, allowance),
+                damage_amount = COALESCE($18, damage_amount),
+                compensation_amount = COALESCE($19, compensation_amount),
+                confirmation_notice = COALESCE($20, confirmation_notice),
+                disciplinary_content = COALESCE($21, disciplinary_content),
+                disciplinary_action = COALESCE($22, disciplinary_action),
+                road_service_cost = COALESCE($23, road_service_cost),
+                counterparty = COALESCE($24, counterparty),
+                counterparty_insurance = COALESCE($25, counterparty_insurance),
+                custom_fields = COALESCE($26, custom_fields),
+                due_date = COALESCE($27, due_date),
+                registration_number = CASE WHEN $28 THEN $29 ELSE registration_number END,
                 updated_at = NOW()
             WHERE id = $1 AND tenant_id = $2 AND deleted_at IS NULL
             RETURNING id, tenant_id, ticket_no, category, title,
                 occurred_at, occurred_date,
                 company_name, office_name, department,
-                person_name, person_id,
+                person_name, person_id, person_is_external,
                 registration_number,
                 location, description,
                 status_id, assigned_to,
@@ -316,6 +318,7 @@ impl TroubleTicketsRepository for PgTroubleTicketsRepository {
         .bind(&input.department)
         .bind(&input.person_name)
         .bind(input.person_id)
+        .bind(input.person_is_external)
         .bind(&input.location)
         .bind(&input.description)
         .bind(input.assigned_to)
@@ -369,7 +372,7 @@ impl TroubleTicketsRepository for PgTroubleTicketsRepository {
             RETURNING id, tenant_id, ticket_no, category, title,
                 occurred_at, occurred_date,
                 company_name, office_name, department,
-                person_name, person_id,
+                person_name, person_id, person_is_external,
                 registration_number,
                 location, description,
                 status_id, assigned_to,

--- a/migrations/101_add_person_is_external.sql
+++ b/migrations/101_add_person_is_external.sql
@@ -1,0 +1,5 @@
+-- Mark tickets whose person_name is an external party (not in employee master).
+-- When true, the UI should render person_name as free-text input and skip the
+-- "unlinked employee" warning/auto-linking flow.
+ALTER TABLE alc_api.trouble_tickets
+    ADD COLUMN person_is_external BOOLEAN NOT NULL DEFAULT FALSE;

--- a/tests/mock_helpers/repos_e.rs
+++ b/tests/mock_helpers/repos_e.rs
@@ -62,6 +62,7 @@ fn mock_ticket(tenant_id: Uuid) -> TroubleTicket {
         department: "第1運行課".to_string(),
         person_name: "テスト太郎".to_string(),
         person_id: None,
+        person_is_external: false,
         registration_number: "".to_string(),
         location: "".to_string(),
         description: "test description".to_string(),


### PR DESCRIPTION
## Summary

- `trouble_tickets` に `person_is_external BOOLEAN NOT NULL DEFAULT FALSE` を追加
- `TroubleTicket` / `CreateTroubleTicket` / `UpdateTroubleTicket` に反映（作成・更新は `Option<bool>` で後方互換）
- Repo の INSERT / UPDATE / SELECT / RETURNING を更新

## Why

外部運転手や相手方など、従業員マスタに永遠に存在しない当事者を「未リンク」(person_id=null) と区別するため。フロントエンドの nuxt-trouble 側で:

- 一覧の「未リンク従業員」警告色（琥珀色）を外部フラグが立った行ではスキップ
- 編集フォームの 氏名 フィールドを USelect ↔ UInput（free text）で切替
- 名前一致による person_id 自動 back-fill を外部フラグ時はスキップ

## Follow-up (nuxt-trouble side PR)

この PR が staging にデプロイされたあと、nuxt-trouble で ts-bindings を sync して UI を追加する別 PR を出します。

## Test plan

- [ ] CI で migrate-test (splinter / RLS) 通過
- [ ] staging 自動デプロイ後、API が person_is_external を返す / 受け付けることを確認
- [ ] 既存レガシーデータ (person_id=null, person_is_external=false) は変わらず一覧で警告色