### PR TITLE
feat(bot-admin): export bot_configs JSON for developers

### DIFF
--- a/crates/alc-core/src/repository/bot_admin.rs
+++ b/crates/alc-core/src/repository/bot_admin.rs
@@ -15,6 +15,33 @@ pub struct BotConfigWithSecrets {
     pub enabled: bool,
 }
 
+/// テナント情報 (Bot Config export 用、staging import と互換のシェイプ)
+#[derive(Debug, Clone, sqlx::FromRow, serde::Serialize)]
+pub struct TenantInfoForExport {
+    pub id: Uuid,
+    pub name: String,
+    pub slug: Option<String>,
+    pub email_domain: Option<String>,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+}
+
+/// bot_configs 行 (export 用、暗号化のまま全フィールド)
+#[derive(Debug, Clone, sqlx::FromRow, serde::Serialize)]
+pub struct BotConfigExportRow {
+    pub id: Uuid,
+    pub tenant_id: Uuid,
+    pub provider: String,
+    pub name: String,
+    pub client_id: String,
+    pub client_secret_encrypted: String,
+    pub service_account: String,
+    pub private_key_encrypted: String,
+    pub bot_id: String,
+    pub enabled: bool,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub updated_at: chrono::DateTime<chrono::Utc>,
+}
+
 /// bot_configs 行 (secret 列を除外した公開用)
 #[derive(Debug, sqlx::FromRow)]
 pub struct BotConfigRow {
@@ -87,4 +114,16 @@ pub trait BotAdminRepository: Send + Sync {
 
     /// bot_config を削除
     async fn delete_config(&self, tenant_id: Uuid, id: Uuid) -> Result<(), sqlx::Error>;
+
+    /// 指定テナントの基本情報を取得 (Bot Config export 用、tenants は RLS なしで OK)
+    async fn get_tenant_for_export(
+        &self,
+        tenant_id: Uuid,
+    ) -> Result<Option<TenantInfoForExport>, sqlx::Error>;
+
+    /// 指定テナントの全 bot_configs を export 用に取得 (暗号化フィールド含む)
+    async fn list_configs_for_export(
+        &self,
+        tenant_id: Uuid,
+    ) -> Result<Vec<BotConfigExportRow>, sqlx::Error>;
 }

--- a/crates/alc-misc/src/bot_admin.rs
+++ b/crates/alc-misc/src/bot_admin.rs
@@ -103,10 +103,7 @@ async fn export_configs(
     Query(params): Query<ExportQuery>,
 ) -> Result<Json<serde_json::Value>, StatusCode> {
     if !is_developer_email(&auth_user.email) {
-        tracing::warn!(
-            "bot_configs export refused for non-developer: {}",
-            auth_user.email
-        );
+        tracing::warn!("export refused: {}", auth_user.email);
         return Err(StatusCode::FORBIDDEN);
     }
 
@@ -216,6 +213,26 @@ mod tests {
             assert!(is_developer_email("m.tama.ramu@gmail.com"));
             assert!(!is_developer_email(""));
         });
+    }
+
+    #[test]
+    fn restores_previous_value_from_some() {
+        // Pre-set DEVELOPER_EMAILS so with_env's `prev` is Some(_) and the
+        // restore path takes the `Some(v) => set_var(...)` branch.
+        let _g = ENV_LOCK.lock().unwrap();
+        std::env::set_var("DEVELOPER_EMAILS", "preset@example.com");
+        drop(_g);
+
+        with_env(Some("temp@example.com"), || {
+            assert!(is_developer_email("temp@example.com"));
+        });
+
+        let _g = ENV_LOCK.lock().unwrap();
+        assert_eq!(
+            std::env::var("DEVELOPER_EMAILS").ok().as_deref(),
+            Some("preset@example.com")
+        );
+        std::env::remove_var("DEVELOPER_EMAILS");
     }
 }
 

--- a/crates/alc-misc/src/bot_admin.rs
+++ b/crates/alc-misc/src/bot_admin.rs
@@ -5,7 +5,7 @@ use axum::{
     routing::{delete, get, post},
     Extension, Json, Router,
 };
-use chrono::{DateTime, Utc};
+use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use ts_rs::TS;
@@ -14,7 +14,6 @@ use uuid::Uuid;
 use alc_core::auth_lineworks::normalize_pem_newlines;
 use alc_core::auth_middleware::AuthUser;
 use alc_core::repository::bot_admin::BotConfigRow;
-use alc_core::tenant::TenantConn;
 use alc_core::AppState;
 
 #[derive(Debug, Serialize, TS)]
@@ -88,31 +87,6 @@ struct ExportQuery {
     tenant_id: Uuid,
 }
 
-#[derive(Debug, Serialize, sqlx::FromRow)]
-struct ExportTenant {
-    id: Uuid,
-    name: String,
-    slug: Option<String>,
-    email_domain: Option<String>,
-    created_at: DateTime<Utc>,
-}
-
-#[derive(Debug, Serialize, sqlx::FromRow)]
-struct ExportBotConfig {
-    id: Uuid,
-    tenant_id: Uuid,
-    provider: String,
-    name: String,
-    client_id: String,
-    client_secret_encrypted: String,
-    service_account: String,
-    private_key_encrypted: String,
-    bot_id: String,
-    enabled: bool,
-    created_at: DateTime<Utc>,
-    updated_at: DateTime<Utc>,
-}
-
 /// `DEVELOPER_EMAILS` env var (comma-separated) のいずれかと一致するか判定。
 /// 大文字小文字無視 / 空エントリ無視。env が未設定なら常に false (export 不可)。
 pub(crate) fn is_developer_email(email: &str) -> bool {
@@ -136,42 +110,26 @@ async fn export_configs(
         return Err(StatusCode::FORBIDDEN);
     }
 
-    let pool = state.pool();
     let tid = params.tenant_id;
 
-    let tenant = sqlx::query_as::<_, ExportTenant>(
-        "SELECT id, name, slug, email_domain, created_at FROM tenants WHERE id = $1",
-    )
-    .bind(tid)
-    .fetch_optional(pool)
-    .await
-    .map_err(|e| {
-        tracing::error!("Failed to fetch tenant for export: {e}");
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?
-    .ok_or(StatusCode::NOT_FOUND)?;
-
-    let mut tc = TenantConn::acquire(pool, &tid.to_string())
+    let tenant = state
+        .bot_admin
+        .get_tenant_for_export(tid)
         .await
         .map_err(|e| {
-            tracing::error!("Failed to set tenant context for export: {e}");
+            tracing::error!("Failed to fetch tenant for export: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?
+        .ok_or(StatusCode::NOT_FOUND)?;
+
+    let bot_configs = state
+        .bot_admin
+        .list_configs_for_export(tid)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to fetch bot_configs for export: {e}");
             StatusCode::INTERNAL_SERVER_ERROR
         })?;
-
-    let bot_configs = sqlx::query_as::<_, ExportBotConfig>(
-        r#"
-        SELECT id, tenant_id, provider, name, client_id, client_secret_encrypted,
-               service_account, private_key_encrypted, bot_id, enabled, created_at, updated_at
-        FROM bot_configs
-        ORDER BY name
-        "#,
-    )
-    .fetch_all(&mut *tc.conn)
-    .await
-    .map_err(|e| {
-        tracing::error!("Failed to fetch bot_configs for export: {e}");
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?;
 
     Ok(Json(json!({
         "version": 1,

--- a/crates/alc-misc/src/bot_admin.rs
+++ b/crates/alc-misc/src/bot_admin.rs
@@ -1,17 +1,20 @@
 /// Bot Config 管理 REST API
 use axum::{
-    extract::{Path, State},
+    extract::{Path, Query, State},
     http::StatusCode,
     routing::{delete, get, post},
     Extension, Json, Router,
 };
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use serde_json::json;
 use ts_rs::TS;
 use uuid::Uuid;
 
 use alc_core::auth_lineworks::normalize_pem_newlines;
 use alc_core::auth_middleware::AuthUser;
 use alc_core::repository::bot_admin::BotConfigRow;
+use alc_core::tenant::TenantConn;
 use alc_core::AppState;
 
 #[derive(Debug, Serialize, TS)]
@@ -72,7 +75,190 @@ pub fn router() -> Router<AppState> {
         .route("/admin/bot/configs", get(list_configs))
         .route("/admin/bot/configs", post(upsert_config))
         .route("/admin/bot/configs", delete(delete_config))
+        .route("/admin/bot/configs/export", get(export_configs))
         .route("/admin/bot/configs/{id}/secrets", get(get_config_secrets))
+}
+
+// ---------------------------------------------------------------------------
+// Developer-only export (Bot Config dump compatible with /api/staging/import)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct ExportQuery {
+    tenant_id: Uuid,
+}
+
+#[derive(Debug, Serialize, sqlx::FromRow)]
+struct ExportTenant {
+    id: Uuid,
+    name: String,
+    slug: Option<String>,
+    email_domain: Option<String>,
+    created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Serialize, sqlx::FromRow)]
+struct ExportBotConfig {
+    id: Uuid,
+    tenant_id: Uuid,
+    provider: String,
+    name: String,
+    client_id: String,
+    client_secret_encrypted: String,
+    service_account: String,
+    private_key_encrypted: String,
+    bot_id: String,
+    enabled: bool,
+    created_at: DateTime<Utc>,
+    updated_at: DateTime<Utc>,
+}
+
+/// `DEVELOPER_EMAILS` env var (comma-separated) のいずれかと一致するか判定。
+/// 大文字小文字無視 / 空エントリ無視。env が未設定なら常に false (export 不可)。
+pub(crate) fn is_developer_email(email: &str) -> bool {
+    let allowlist = std::env::var("DEVELOPER_EMAILS").unwrap_or_default();
+    allowlist
+        .split(',')
+        .map(str::trim)
+        .any(|entry| !entry.is_empty() && entry.eq_ignore_ascii_case(email))
+}
+
+async fn export_configs(
+    State(state): State<AppState>,
+    Extension(auth_user): Extension<AuthUser>,
+    Query(params): Query<ExportQuery>,
+) -> Result<Json<serde_json::Value>, StatusCode> {
+    if !is_developer_email(&auth_user.email) {
+        tracing::warn!(
+            "bot_configs export refused for non-developer: {}",
+            auth_user.email
+        );
+        return Err(StatusCode::FORBIDDEN);
+    }
+
+    let pool = state.pool();
+    let tid = params.tenant_id;
+
+    let tenant = sqlx::query_as::<_, ExportTenant>(
+        "SELECT id, name, slug, email_domain, created_at FROM tenants WHERE id = $1",
+    )
+    .bind(tid)
+    .fetch_optional(pool)
+    .await
+    .map_err(|e| {
+        tracing::error!("Failed to fetch tenant for export: {e}");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?
+    .ok_or(StatusCode::NOT_FOUND)?;
+
+    let mut tc = TenantConn::acquire(pool, &tid.to_string())
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to set tenant context for export: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    let bot_configs = sqlx::query_as::<_, ExportBotConfig>(
+        r#"
+        SELECT id, tenant_id, provider, name, client_id, client_secret_encrypted,
+               service_account, private_key_encrypted, bot_id, enabled, created_at, updated_at
+        FROM bot_configs
+        ORDER BY name
+        "#,
+    )
+    .fetch_all(&mut *tc.conn)
+    .await
+    .map_err(|e| {
+        tracing::error!("Failed to fetch bot_configs for export: {e}");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    Ok(Json(json!({
+        "version": 1,
+        "exported_at": Utc::now().to_rfc3339(),
+        "tenant_id": tid.to_string(),
+        "data": {
+            "tenant": tenant,
+            "users": [],
+            "employees": [],
+            "devices": [],
+            "tenko_schedules": [],
+            "webhook_configs": [],
+            "tenant_allowed_emails": [],
+            "sso_provider_configs": [],
+            "tenko_call_numbers": [],
+            "tenko_call_drivers": [],
+            "bot_configs": bot_configs,
+            "notify_line_configs": [],
+            "notify_recipients": []
+        }
+    })))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_developer_email;
+    use std::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn with_env<F: FnOnce()>(value: Option<&str>, body: F) {
+        let _g = ENV_LOCK.lock().unwrap();
+        let prev = std::env::var("DEVELOPER_EMAILS").ok();
+        match value {
+            Some(v) => std::env::set_var("DEVELOPER_EMAILS", v),
+            None => std::env::remove_var("DEVELOPER_EMAILS"),
+        }
+        body();
+        match prev {
+            Some(v) => std::env::set_var("DEVELOPER_EMAILS", v),
+            None => std::env::remove_var("DEVELOPER_EMAILS"),
+        }
+    }
+
+    #[test]
+    fn rejects_when_env_unset() {
+        with_env(None, || {
+            assert!(!is_developer_email("m.tama.ramu@gmail.com"));
+        });
+    }
+
+    #[test]
+    fn rejects_when_env_empty() {
+        with_env(Some(""), || {
+            assert!(!is_developer_email("m.tama.ramu@gmail.com"));
+        });
+    }
+
+    #[test]
+    fn accepts_single_match_case_insensitive() {
+        with_env(Some("m.tama.ramu@gmail.com"), || {
+            assert!(is_developer_email("m.tama.ramu@gmail.com"));
+            assert!(is_developer_email("M.Tama.Ramu@Gmail.com"));
+            assert!(!is_developer_email("attacker@example.com"));
+        });
+    }
+
+    #[test]
+    fn accepts_csv_with_whitespace() {
+        with_env(
+            Some(" foo@example.com , m.tama.ramu@gmail.com ,bar@x"),
+            || {
+                assert!(is_developer_email("foo@example.com"));
+                assert!(is_developer_email("m.tama.ramu@gmail.com"));
+                assert!(is_developer_email("bar@x"));
+                assert!(!is_developer_email("baz@x"));
+            },
+        );
+    }
+
+    #[test]
+    fn ignores_empty_csv_entries() {
+        with_env(Some(",,,m.tama.ramu@gmail.com,,"), || {
+            assert!(is_developer_email("m.tama.ramu@gmail.com"));
+            assert!(!is_developer_email(""));
+        });
+    }
 }
 
 async fn list_configs(

--- a/crates/alc-misc/src/repo/bot_admin.rs
+++ b/crates/alc-misc/src/repo/bot_admin.rs
@@ -152,4 +152,33 @@ impl BotAdminRepository for PgBotAdminRepository {
             .await?;
         Ok(())
     }
+
+    async fn get_tenant_for_export(
+        &self,
+        tenant_id: Uuid,
+    ) -> Result<Option<TenantInfoForExport>, sqlx::Error> {
+        sqlx::query_as::<_, TenantInfoForExport>(
+            "SELECT id, name, slug, email_domain, created_at FROM tenants WHERE id = $1",
+        )
+        .bind(tenant_id)
+        .fetch_optional(&self.pool)
+        .await
+    }
+
+    async fn list_configs_for_export(
+        &self,
+        tenant_id: Uuid,
+    ) -> Result<Vec<BotConfigExportRow>, sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        sqlx::query_as::<_, BotConfigExportRow>(
+            r#"
+            SELECT id, tenant_id, provider, name, client_id, client_secret_encrypted,
+                   service_account, private_key_encrypted, bot_id, enabled, created_at, updated_at
+            FROM bot_configs
+            ORDER BY name
+            "#,
+        )
+        .fetch_all(&mut *tc.conn)
+        .await
+    }
 }

--- a/tests/mock_helpers/repos_a.rs
+++ b/tests/mock_helpers/repos_a.rs
@@ -7,7 +7,7 @@ use rust_alc_api::db::models::DtakologRow;
 use rust_alc_api::db::models::*;
 use rust_alc_api::db::repository::auth::{AuthRepository, SsoConfigRow};
 use rust_alc_api::db::repository::bot_admin::{
-    BotAdminRepository, BotConfigRow, BotConfigWithSecrets,
+    BotAdminRepository, BotConfigExportRow, BotConfigRow, BotConfigWithSecrets, TenantInfoForExport,
 };
 use rust_alc_api::db::repository::car_inspections::{
     CarInspectionFile, CarInspectionRepository, VehicleCategories,
@@ -384,6 +384,10 @@ impl AuthRepository for MockAuthRepository {
 pub struct MockBotAdminRepository {
     pub fail_next: AtomicBool,
     pub return_config_with_secrets: std::sync::Mutex<Option<BotConfigWithSecrets>>,
+    pub return_tenant_for_export: std::sync::Mutex<Option<TenantInfoForExport>>,
+    pub return_configs_for_export: std::sync::Mutex<Vec<BotConfigExportRow>>,
+    pub fail_tenant_for_export: AtomicBool,
+    pub fail_configs_for_export: AtomicBool,
 }
 
 impl Default for MockBotAdminRepository {
@@ -391,6 +395,10 @@ impl Default for MockBotAdminRepository {
         Self {
             fail_next: AtomicBool::new(false),
             return_config_with_secrets: std::sync::Mutex::new(None),
+            return_tenant_for_export: std::sync::Mutex::new(None),
+            return_configs_for_export: std::sync::Mutex::new(Vec::new()),
+            fail_tenant_for_export: AtomicBool::new(false),
+            fail_configs_for_export: AtomicBool::new(false),
         }
     }
 }
@@ -485,6 +493,26 @@ impl BotAdminRepository for MockBotAdminRepository {
     async fn delete_config(&self, _tenant_id: Uuid, _id: Uuid) -> Result<(), sqlx::Error> {
         check_fail!(self);
         Ok(())
+    }
+
+    async fn get_tenant_for_export(
+        &self,
+        _tenant_id: Uuid,
+    ) -> Result<Option<TenantInfoForExport>, sqlx::Error> {
+        if self.fail_tenant_for_export.swap(false, Ordering::SeqCst) {
+            return Err(sqlx::Error::RowNotFound);
+        }
+        Ok(self.return_tenant_for_export.lock().unwrap().clone())
+    }
+
+    async fn list_configs_for_export(
+        &self,
+        _tenant_id: Uuid,
+    ) -> Result<Vec<BotConfigExportRow>, sqlx::Error> {
+        if self.fail_configs_for_export.swap(false, Ordering::SeqCst) {
+            return Err(sqlx::Error::RowNotFound);
+        }
+        Ok(self.return_configs_for_export.lock().unwrap().clone())
     }
 }
 

--- a/tests/mock_tests/mock_bot_admin_test.rs
+++ b/tests/mock_tests/mock_bot_admin_test.rs
@@ -991,3 +991,249 @@ async fn test_get_config_secrets_missing_env_var() {
         }
     });
 }
+
+// ============================================================
+// GET /admin/bot/configs/export — developer-only
+// ============================================================
+
+fn dev_email() -> &'static str {
+    "m.tama.ramu@gmail.com"
+}
+
+fn set_dev_emails(value: &str) -> Option<String> {
+    let prev = std::env::var("DEVELOPER_EMAILS").ok();
+    std::env::set_var("DEVELOPER_EMAILS", value);
+    prev
+}
+
+fn restore_dev_emails(prev: Option<String>) {
+    match prev {
+        Some(v) => std::env::set_var("DEVELOPER_EMAILS", v),
+        None => std::env::remove_var("DEVELOPER_EMAILS"),
+    }
+}
+
+#[tokio::test]
+async fn test_export_configs_success() {
+    test_group!("Bot Admin: export_configs success");
+    test_case!("developer email + tenant + 1 config", {
+        let _guard = crate::common::ENV_LOCK.lock().unwrap();
+        std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        let prev = set_dev_emails(dev_email());
+
+        let mock = Arc::new(MockBotAdminRepository::default());
+        let tenant_id = Uuid::new_v4();
+        *mock.return_tenant_for_export.lock().unwrap() = Some(
+            rust_alc_api::db::repository::bot_admin::TenantInfoForExport {
+                id: tenant_id,
+                name: "テナント大石".to_string(),
+                slug: Some("ohishi".to_string()),
+                email_domain: None,
+                created_at: chrono::Utc::now(),
+            },
+        );
+        *mock.return_configs_for_export.lock().unwrap() = vec![
+            rust_alc_api::db::repository::bot_admin::BotConfigExportRow {
+                id: Uuid::new_v4(),
+                tenant_id,
+                provider: "lineworks".to_string(),
+                name: "test bot".to_string(),
+                client_id: "cid".to_string(),
+                client_secret_encrypted: "enc-secret".to_string(),
+                service_account: "sa@example".to_string(),
+                private_key_encrypted: "enc-pk".to_string(),
+                bot_id: "8977068".to_string(),
+                enabled: true,
+                created_at: chrono::Utc::now(),
+                updated_at: chrono::Utc::now(),
+            },
+        ];
+
+        let mut state = setup_mock_app_state();
+        state.bot_admin = mock;
+        let base_url = crate::common::spawn_test_server(state).await;
+
+        let dev_jwt = crate::common::create_test_jwt_for_user(
+            Uuid::new_v4(),
+            tenant_id,
+            dev_email(),
+            "admin",
+        );
+        let client = reqwest::Client::new();
+
+        let res = client
+            .get(format!(
+                "{base_url}/api/admin/bot/configs/export?tenant_id={tenant_id}"
+            ))
+            .header("Authorization", format!("Bearer {dev_jwt}"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(res.status(), 200);
+        let body: Value = res.json().await.unwrap();
+        assert_eq!(body["version"], 1);
+        assert_eq!(body["tenant_id"], tenant_id.to_string());
+        assert_eq!(body["data"]["tenant"]["slug"], "ohishi");
+        assert_eq!(body["data"]["bot_configs"].as_array().unwrap().len(), 1);
+        assert_eq!(body["data"]["bot_configs"][0]["bot_id"], "8977068");
+        assert_eq!(
+            body["data"]["bot_configs"][0]["client_secret_encrypted"],
+            "enc-secret"
+        );
+        assert_eq!(body["data"]["users"].as_array().unwrap().len(), 0);
+
+        restore_dev_emails(prev);
+    });
+}
+
+#[tokio::test]
+async fn test_export_configs_forbidden_for_non_developer() {
+    test_group!("Bot Admin: export_configs forbidden");
+    test_case!("DEVELOPER_EMAILS に含まれない user は 403", {
+        let _guard = crate::common::ENV_LOCK.lock().unwrap();
+        std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        let prev = set_dev_emails(dev_email());
+
+        let mock = Arc::new(MockBotAdminRepository::default());
+        let mut state = setup_mock_app_state();
+        state.bot_admin = mock;
+        let base_url = crate::common::spawn_test_server(state).await;
+
+        let tenant_id = Uuid::new_v4();
+        let attacker_jwt = crate::common::create_test_jwt_for_user(
+            Uuid::new_v4(),
+            tenant_id,
+            "attacker@example.com",
+            "admin",
+        );
+        let client = reqwest::Client::new();
+        let res = client
+            .get(format!(
+                "{base_url}/api/admin/bot/configs/export?tenant_id={tenant_id}"
+            ))
+            .header("Authorization", format!("Bearer {attacker_jwt}"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(res.status(), 403);
+
+        restore_dev_emails(prev);
+    });
+}
+
+#[tokio::test]
+async fn test_export_configs_tenant_not_found() {
+    test_group!("Bot Admin: export_configs tenant not found");
+    test_case!("テナントが存在しない場合は 404", {
+        let _guard = crate::common::ENV_LOCK.lock().unwrap();
+        std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        let prev = set_dev_emails(dev_email());
+
+        let mock = Arc::new(MockBotAdminRepository::default());
+        // return_tenant_for_export はデフォルト None → handler 側で NOT_FOUND
+        let mut state = setup_mock_app_state();
+        state.bot_admin = mock;
+        let base_url = crate::common::spawn_test_server(state).await;
+
+        let tenant_id = Uuid::new_v4();
+        let dev_jwt = crate::common::create_test_jwt_for_user(
+            Uuid::new_v4(),
+            tenant_id,
+            dev_email(),
+            "admin",
+        );
+        let client = reqwest::Client::new();
+        let res = client
+            .get(format!(
+                "{base_url}/api/admin/bot/configs/export?tenant_id={tenant_id}"
+            ))
+            .header("Authorization", format!("Bearer {dev_jwt}"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(res.status(), 404);
+
+        restore_dev_emails(prev);
+    });
+}
+
+#[tokio::test]
+async fn test_export_configs_tenant_db_error() {
+    test_group!("Bot Admin: export_configs tenant DB error");
+    test_case!("tenant 取得時の DB エラーで 500", {
+        let _guard = crate::common::ENV_LOCK.lock().unwrap();
+        std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        let prev = set_dev_emails(dev_email());
+
+        let mock = Arc::new(MockBotAdminRepository::default());
+        mock.fail_tenant_for_export.store(true, Ordering::SeqCst);
+        let mut state = setup_mock_app_state();
+        state.bot_admin = mock;
+        let base_url = crate::common::spawn_test_server(state).await;
+
+        let tenant_id = Uuid::new_v4();
+        let dev_jwt = crate::common::create_test_jwt_for_user(
+            Uuid::new_v4(),
+            tenant_id,
+            dev_email(),
+            "admin",
+        );
+        let client = reqwest::Client::new();
+        let res = client
+            .get(format!(
+                "{base_url}/api/admin/bot/configs/export?tenant_id={tenant_id}"
+            ))
+            .header("Authorization", format!("Bearer {dev_jwt}"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(res.status(), 500);
+
+        restore_dev_emails(prev);
+    });
+}
+
+#[tokio::test]
+async fn test_export_configs_configs_db_error() {
+    test_group!("Bot Admin: export_configs configs DB error");
+    test_case!("bot_configs 取得時の DB エラーで 500", {
+        let _guard = crate::common::ENV_LOCK.lock().unwrap();
+        std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        let prev = set_dev_emails(dev_email());
+
+        let mock = Arc::new(MockBotAdminRepository::default());
+        let tenant_id = Uuid::new_v4();
+        *mock.return_tenant_for_export.lock().unwrap() = Some(
+            rust_alc_api::db::repository::bot_admin::TenantInfoForExport {
+                id: tenant_id,
+                name: "T".to_string(),
+                slug: None,
+                email_domain: None,
+                created_at: chrono::Utc::now(),
+            },
+        );
+        mock.fail_configs_for_export.store(true, Ordering::SeqCst);
+        let mut state = setup_mock_app_state();
+        state.bot_admin = mock;
+        let base_url = crate::common::spawn_test_server(state).await;
+
+        let dev_jwt = crate::common::create_test_jwt_for_user(
+            Uuid::new_v4(),
+            tenant_id,
+            dev_email(),
+            "admin",
+        );
+        let client = reqwest::Client::new();
+        let res = client
+            .get(format!(
+                "{base_url}/api/admin/bot/configs/export?tenant_id={tenant_id}"
+            ))
+            .header("Authorization", format!("Bearer {dev_jwt}"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(res.status(), 500);
+
+        restore_dev_emails(prev);
+    });
+}


### PR DESCRIPTION
本番 alc-api に開発者専用の bot_configs export エンドポイントを追加。

## Summary
- `GET /api/admin/bot/configs/export?tenant_id=<uuid>` を新設
- 認証: `DEVELOPER_EMAILS` env (CSV) の email allowlist のみ通す
- レスポンス形式は既存 `/api/staging/export` と同じシェイプ — staging 側で `POST /api/staging/import` にそのまま貼って復元できる
- 暗号化 secrets は暗号化のままダンプ (import 側で同じ key で復号)
- 5 unit tests (DEVELOPER_EMAILS allowlist パースの境界ケース)

## Why
本番には export 機能がなく、Bot Config を staging で再現するには手動再入力が必要だった。本機能でそのギャップを埋める。テナント全体の export ではないので Bot Config 以外の本番データは出さない。

## Test plan
- [x] `cargo test -p alc-misc --lib bot_admin` 通過 (allowlist 5 ケース)
- [ ] CI: ci.yml + integration tests 通過
- [ ] staging deploy 後、staging Cloud Run で \`DEVELOPER_EMAILS=m.tama.ramu@gmail.com\` を設定して 200 returnable か確認
- [ ] 本番デプロイ後、\`auth.ippoan.org/admin/sso\` から JSON DL → staging で \`/api/staging/import\` に貼って bot_configs が復元できるか E2E