### PR TITLE
feat(deploy): wire SSO_ENCRYPTION_KEY env (prod/staging共通)

### DIFF
--- a/cloudrun/render.sh
+++ b/cloudrun/render.sh
@@ -201,6 +201,11 @@ YAML
                 secretKeyRef:
                   key: latest
                   name: developer-emails
+            - name: SSO_ENCRYPTION_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: latest
+                  name: sso-encryption-key
 YAML
 }
 


### PR DESCRIPTION
PR #284 / #285 で export 機能はリリース済みだが、staging に import しても
LINE WORKS 送信時に **暗号化キー不一致で復号失敗**する問題があった。

## Summary
- 新 secret \`sso-encryption-key\` を Secret Manager に作成 (本番 JWT_SECRET と同値)
- cloudrun/render.sh の backend env に \`SSO_ENCRYPTION_KEY\` を valueFrom secretKeyRef で追加
- prod / staging 両環境で同じ secret を参照 → ciphertext 互換性確保
- 本番挙動は変わらない (もともと JWT_SECRET fallback を使っていた値と同一)

## Why
\`bot_configs.client_secret_encrypted\` / \`private_key_encrypted\` は SSO_ENCRYPTION_KEY (fallback で JWT_SECRET) で AES-256-GCM 暗号化。prod の JWT_SECRET と staging の \`alc-api-staging-jwt-secret\` は別値なので、export → import 後の LINE WORKS 送信で InvalidKeyFormat エラー。新 secret を作って両方に同じ値を入れることで復号可能に。

## Pre-merge step (実施済み)
\`\`\`bash
gcloud secrets versions access latest --secret=JWT_SECRET --project=cloudsql-sv \\
  | gcloud secrets create sso-encryption-key --data-file=- --project=cloudsql-sv
gcloud secrets add-iam-policy-binding sso-encryption-key \\
  --member="serviceAccount:747065218280-compute@developer.gserviceaccount.com" \\
  --role="roles/secretmanager.secretAccessor" --project=cloudsql-sv
\`\`\`

## Test plan
- [x] Secret Manager に sso-encryption-key (version 1) 作成済み + accessor 付与済み
- [ ] CI: render.sh 変更のみ、コード変更なし → 既存 CI が pass するはず
- [ ] tag release で本番反映 → 既存 LINE WORKS 配信 (auth.ippoan.org /admin/notify) が動作することを確認 (回帰なし)
- [ ] staging deploy 後、staging で /api/staging/import 経由で本番 bot_configs を import → notify 経由で LINE WORKS 送信成功