### PR TITLE
feat(bot-admin): add bot_secret upsert/get for LINE WORKS webhook (PR 2/3)

### DIFF
--- a/crates/alc-core/src/repository/bot_admin.rs
+++ b/crates/alc-core/src/repository/bot_admin.rs
@@ -13,6 +13,9 @@ pub struct BotConfigWithSecrets {
     pub private_key_encrypted: String,
     pub bot_id: String,
     pub enabled: bool,
+    /// LINE WORKS Bot webhook 署名検証用 (X-WORKS-Signature HMAC key)。
+    /// migration 102 で追加。未設定時は webhook が常に 401 を返す。
+    pub bot_secret_encrypted: Option<String>,
 }
 
 /// テナント情報 (Bot Config export 用、staging import と互換のシェイプ)
@@ -38,6 +41,8 @@ pub struct BotConfigExportRow {
     pub private_key_encrypted: String,
     pub bot_id: String,
     pub enabled: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bot_secret_encrypted: Option<String>,
     pub created_at: chrono::DateTime<chrono::Utc>,
     pub updated_at: chrono::DateTime<chrono::Utc>,
 }
@@ -79,6 +84,14 @@ pub trait BotAdminRepository: Send + Sync {
 
     /// private_key_encrypted 更新
     async fn update_private_key(
+        &self,
+        tenant_id: Uuid,
+        id: Uuid,
+        encrypted: &str,
+    ) -> Result<(), sqlx::Error>;
+
+    /// bot_secret_encrypted 更新 (LINE WORKS Bot webhook 署名検証用)
+    async fn update_bot_secret(
         &self,
         tenant_id: Uuid,
         id: Uuid,

--- a/crates/alc-misc/src/bot_admin.rs
+++ b/crates/alc-misc/src/bot_admin.rs
@@ -62,6 +62,8 @@ struct UpsertRequest {
     private_key: Option<String>,
     bot_id: String,
     enabled: Option<bool>,
+    /// LINE WORKS Bot webhook 署名検証用 (X-WORKS-Signature HMAC key)
+    bot_secret: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -300,6 +302,16 @@ async fn upsert_config(
                     .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
             }
         }
+        if let Some(ref bs) = body.bot_secret {
+            if !bs.is_empty() {
+                let encrypted = encrypt_secret(bs, &key).expect("AES-256-GCM encrypt infallible");
+                state
+                    .bot_admin
+                    .update_bot_secret(tenant_id, id, &encrypted)
+                    .await
+                    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+            }
+        }
 
         state
             .bot_admin
@@ -321,7 +333,7 @@ async fn upsert_config(
         let encrypted_pk = encrypt_secret(body.private_key.as_deref().unwrap_or(""), &key)
             .expect("AES-256-GCM encrypt infallible");
 
-        state
+        let created = state
             .bot_admin
             .create_config(
                 tenant_id,
@@ -334,7 +346,22 @@ async fn upsert_config(
                 &body.bot_id,
                 enabled,
             )
-            .await
+            .await;
+
+        if let Ok(ref row) = created {
+            if let Some(ref bs) = body.bot_secret {
+                if !bs.is_empty() {
+                    let encrypted =
+                        encrypt_secret(bs, &key).expect("AES-256-GCM encrypt infallible");
+                    state
+                        .bot_admin
+                        .update_bot_secret(tenant_id, row.id, &encrypted)
+                        .await
+                        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+                }
+            }
+        }
+        created
     };
 
     row.map(BotConfigResponse::from).map(Json).map_err(|e| {
@@ -374,6 +401,8 @@ struct BotConfigSecretsResponse {
     service_account: String,
     private_key: String,
     bot_id: String,
+    /// LINE WORKS Bot webhook 署名検証用 (未設定なら空文字)
+    bot_secret: String,
 }
 
 async fn get_config_secrets(
@@ -410,12 +439,21 @@ async fn get_config_secrets(
             StatusCode::INTERNAL_SERVER_ERROR
         })?;
 
+    let bot_secret = match row.bot_secret_encrypted {
+        Some(ref enc) => decrypt_secret(enc, &key).map_err(|e| {
+            tracing::error!("Failed to decrypt bot_secret: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?,
+        None => String::new(),
+    };
+
     Ok(Json(BotConfigSecretsResponse {
         client_id: row.client_id,
         client_secret,
         service_account: row.service_account,
         private_key,
         bot_id: row.bot_id,
+        bot_secret,
     }))
 }
 

--- a/crates/alc-misc/src/bot_admin.rs
+++ b/crates/alc-misc/src/bot_admin.rs
@@ -302,15 +302,13 @@ async fn upsert_config(
                     .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
             }
         }
-        if let Some(ref bs) = body.bot_secret {
-            if !bs.is_empty() {
-                let encrypted = encrypt_secret(bs, &key).expect("AES-256-GCM encrypt infallible");
-                state
-                    .bot_admin
-                    .update_bot_secret(tenant_id, id, &encrypted)
-                    .await
-                    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-            }
+        if let Some(bs) = body.bot_secret.as_deref().filter(|s| !s.is_empty()) {
+            let encrypted = encrypt_secret(bs, &key).expect("AES-256-GCM encrypt infallible");
+            state
+                .bot_admin
+                .update_bot_secret(tenant_id, id, &encrypted)
+                .await
+                .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
         }
 
         state
@@ -349,16 +347,13 @@ async fn upsert_config(
             .await;
 
         if let Ok(ref row) = created {
-            if let Some(ref bs) = body.bot_secret {
-                if !bs.is_empty() {
-                    let encrypted =
-                        encrypt_secret(bs, &key).expect("AES-256-GCM encrypt infallible");
-                    state
-                        .bot_admin
-                        .update_bot_secret(tenant_id, row.id, &encrypted)
-                        .await
-                        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-                }
+            if let Some(bs) = body.bot_secret.as_deref().filter(|s| !s.is_empty()) {
+                let encrypted = encrypt_secret(bs, &key).expect("AES-256-GCM encrypt infallible");
+                state
+                    .bot_admin
+                    .update_bot_secret(tenant_id, row.id, &encrypted)
+                    .await
+                    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
             }
         }
         created

--- a/crates/alc-misc/src/repo/bot_admin.rs
+++ b/crates/alc-misc/src/repo/bot_admin.rs
@@ -61,6 +61,21 @@ impl BotAdminRepository for PgBotAdminRepository {
         Ok(())
     }
 
+    async fn update_bot_secret(
+        &self,
+        tenant_id: Uuid,
+        id: Uuid,
+        encrypted: &str,
+    ) -> Result<(), sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        sqlx::query("UPDATE bot_configs SET bot_secret_encrypted = $1 WHERE id = $2")
+            .bind(encrypted)
+            .bind(id)
+            .execute(&mut *tc.conn)
+            .await?;
+        Ok(())
+    }
+
     async fn update_config(
         &self,
         tenant_id: Uuid,
@@ -135,7 +150,8 @@ impl BotAdminRepository for PgBotAdminRepository {
         sqlx::query_as::<_, BotConfigWithSecrets>(
             r#"
             SELECT id, provider, name, client_id, client_secret_encrypted,
-                   service_account, private_key_encrypted, bot_id, enabled
+                   service_account, private_key_encrypted, bot_id, enabled,
+                   bot_secret_encrypted
             FROM bot_configs WHERE id = $1
             "#,
         )
@@ -173,7 +189,8 @@ impl BotAdminRepository for PgBotAdminRepository {
         sqlx::query_as::<_, BotConfigExportRow>(
             r#"
             SELECT id, tenant_id, provider, name, client_id, client_secret_encrypted,
-                   service_account, private_key_encrypted, bot_id, enabled, created_at, updated_at
+                   service_account, private_key_encrypted, bot_id, enabled,
+                   bot_secret_encrypted, created_at, updated_at
             FROM bot_configs
             ORDER BY name
             "#,

--- a/tests/mock_helpers/repos_a.rs
+++ b/tests/mock_helpers/repos_a.rs
@@ -388,6 +388,8 @@ pub struct MockBotAdminRepository {
     pub return_configs_for_export: std::sync::Mutex<Vec<BotConfigExportRow>>,
     pub fail_tenant_for_export: AtomicBool,
     pub fail_configs_for_export: AtomicBool,
+    /// update_bot_secret だけ失敗させたい時に使う (create path で先に create_config 成功させるため)
+    pub fail_update_bot_secret_only: AtomicBool,
 }
 
 impl Default for MockBotAdminRepository {
@@ -399,6 +401,7 @@ impl Default for MockBotAdminRepository {
             return_configs_for_export: std::sync::Mutex::new(Vec::new()),
             fail_tenant_for_export: AtomicBool::new(false),
             fail_configs_for_export: AtomicBool::new(false),
+            fail_update_bot_secret_only: AtomicBool::new(false),
         }
     }
 }
@@ -436,6 +439,12 @@ impl BotAdminRepository for MockBotAdminRepository {
         _id: Uuid,
         _encrypted: &str,
     ) -> Result<(), sqlx::Error> {
+        if self
+            .fail_update_bot_secret_only
+            .swap(false, Ordering::SeqCst)
+        {
+            return Err(sqlx::Error::RowNotFound);
+        }
         check_fail!(self);
         Ok(())
     }

--- a/tests/mock_helpers/repos_a.rs
+++ b/tests/mock_helpers/repos_a.rs
@@ -430,6 +430,16 @@ impl BotAdminRepository for MockBotAdminRepository {
         Ok(())
     }
 
+    async fn update_bot_secret(
+        &self,
+        _tenant_id: Uuid,
+        _id: Uuid,
+        _encrypted: &str,
+    ) -> Result<(), sqlx::Error> {
+        check_fail!(self);
+        Ok(())
+    }
+
     async fn update_config(
         &self,
         _tenant_id: Uuid,

--- a/tests/mock_tests/mock_bot_admin_test.rs
+++ b/tests/mock_tests/mock_bot_admin_test.rs
@@ -431,6 +431,45 @@ async fn test_update_config_with_empty_bot_secret_skipped() {
 }
 
 #[tokio::test]
+async fn test_create_config_with_bot_secret_update_fails() {
+    test_group!("Bot Admin: create_config bot_secret update fails");
+    test_case!(
+        "新規作成は成功するが update_bot_secret が失敗 → 500",
+        {
+            let _guard = crate::common::ENV_LOCK.lock().unwrap();
+            std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+            // create_config は成功させ、update_bot_secret だけを失敗させる
+            let mock = Arc::new(MockBotAdminRepository::default());
+            mock.fail_update_bot_secret_only
+                .store(true, Ordering::SeqCst);
+            let mut state = setup_mock_app_state();
+            state.bot_admin = mock;
+            let base_url = crate::common::spawn_test_server(state).await;
+
+            let tenant_id = Uuid::new_v4();
+            let admin_jwt = crate::common::create_test_jwt(tenant_id, "admin");
+            let client = reqwest::Client::new();
+
+            let res = client
+                .post(format!("{base_url}/api/admin/bot/configs"))
+                .header("Authorization", format!("Bearer {admin_jwt}"))
+                .json(&serde_json::json!({
+                    "name": "Bot",
+                    "client_id": "cid",
+                    "service_account": "sa",
+                    "bot_id": "bid",
+                    "bot_secret": "will-fail",
+                }))
+                .send()
+                .await
+                .unwrap();
+            assert_eq!(res.status(), 500);
+        }
+    );
+}
+
+#[tokio::test]
 async fn test_update_bot_secret_db_error() {
     test_group!("Bot Admin: update_bot_secret DB error");
     test_case!("update_bot_secret 失敗時に 500", {

--- a/tests/mock_tests/mock_bot_admin_test.rs
+++ b/tests/mock_tests/mock_bot_admin_test.rs
@@ -690,6 +690,7 @@ async fn test_get_config_secrets_success() {
                 service_account: "sa@test.com".to_string(),
                 private_key_encrypted: encrypted_pk,
                 bot_id: "bot-123".to_string(),
+                bot_secret_encrypted: None,
                 enabled: true,
             });
 
@@ -832,6 +833,7 @@ async fn test_get_config_secrets_decrypt_error() {
             private_key_encrypted: "also-bad".to_string(),
             bot_id: "b".to_string(),
             enabled: true,
+            bot_secret_encrypted: None,
         });
 
         let mut state = setup_mock_app_state();
@@ -878,6 +880,7 @@ async fn test_get_config_secrets_short_ciphertext() {
             private_key_encrypted: STANDARD.encode(b"short"),
             bot_id: "b".to_string(),
             enabled: true,
+            bot_secret_encrypted: None,
         });
 
         let mut state = setup_mock_app_state();
@@ -925,6 +928,7 @@ async fn test_get_config_secrets_private_key_decrypt_error() {
                 private_key_encrypted: "not-valid-base64!!!".to_string(),
                 bot_id: "b".to_string(),
                 enabled: true,
+                bot_secret_encrypted: None,
             });
 
             let mut state = setup_mock_app_state();
@@ -1044,6 +1048,7 @@ async fn test_export_configs_success() {
                 private_key_encrypted: "enc-pk".to_string(),
                 bot_id: "8977068".to_string(),
                 enabled: true,
+                bot_secret_encrypted: None,
                 created_at: chrono::Utc::now(),
                 updated_at: chrono::Utc::now(),
             },

--- a/tests/mock_tests/mock_bot_admin_test.rs
+++ b/tests/mock_tests/mock_bot_admin_test.rs
@@ -322,6 +322,153 @@ async fn test_update_config_with_secrets() {
 }
 
 #[tokio::test]
+async fn test_create_config_with_bot_secret() {
+    test_group!("Bot Admin: create_config with bot_secret");
+    test_case!(
+        "新規作成時に bot_secret を渡すと update_bot_secret が呼ばれる",
+        {
+            let _guard = crate::common::ENV_LOCK.lock().unwrap();
+            std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+            let mock = Arc::new(MockBotAdminRepository::default());
+            let mut state = setup_mock_app_state();
+            state.bot_admin = mock;
+            let base_url = crate::common::spawn_test_server(state).await;
+
+            let tenant_id = Uuid::new_v4();
+            let admin_jwt = crate::common::create_test_jwt(tenant_id, "admin");
+            let client = reqwest::Client::new();
+
+            let res = client
+                .post(format!("{base_url}/api/admin/bot/configs"))
+                .header("Authorization", format!("Bearer {admin_jwt}"))
+                .json(&serde_json::json!({
+                    "name": "Bot",
+                    "client_id": "cid",
+                    "service_account": "sa",
+                    "bot_id": "bid",
+                    "bot_secret": "webhook-secret-123",
+                }))
+                .send()
+                .await
+                .unwrap();
+            assert_eq!(res.status(), 200);
+        }
+    );
+}
+
+#[tokio::test]
+async fn test_update_config_with_bot_secret() {
+    test_group!("Bot Admin: update_config with bot_secret");
+    test_case!(
+        "更新時に bot_secret を渡すと update_bot_secret が呼ばれる",
+        {
+            let _guard = crate::common::ENV_LOCK.lock().unwrap();
+            std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+            let mock = Arc::new(MockBotAdminRepository::default());
+            let mut state = setup_mock_app_state();
+            state.bot_admin = mock;
+            let base_url = crate::common::spawn_test_server(state).await;
+
+            let tenant_id = Uuid::new_v4();
+            let admin_jwt = crate::common::create_test_jwt(tenant_id, "admin");
+            let client = reqwest::Client::new();
+
+            let existing_id = Uuid::new_v4();
+            let res = client
+                .post(format!("{base_url}/api/admin/bot/configs"))
+                .header("Authorization", format!("Bearer {admin_jwt}"))
+                .json(&serde_json::json!({
+                    "id": existing_id.to_string(),
+                    "name": "Bot",
+                    "client_id": "cid",
+                    "service_account": "sa",
+                    "bot_id": "bid",
+                    "bot_secret": "rotated-secret",
+                }))
+                .send()
+                .await
+                .unwrap();
+            assert_eq!(res.status(), 200);
+        }
+    );
+}
+
+#[tokio::test]
+async fn test_update_config_with_empty_bot_secret_skipped() {
+    test_group!("Bot Admin: update_config empty bot_secret");
+    test_case!("空文字の bot_secret は更新スキップ", {
+        let _guard = crate::common::ENV_LOCK.lock().unwrap();
+        std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+        let mock = Arc::new(MockBotAdminRepository::default());
+        let mut state = setup_mock_app_state();
+        state.bot_admin = mock;
+        let base_url = crate::common::spawn_test_server(state).await;
+
+        let tenant_id = Uuid::new_v4();
+        let admin_jwt = crate::common::create_test_jwt(tenant_id, "admin");
+        let client = reqwest::Client::new();
+
+        let existing_id = Uuid::new_v4();
+        let res = client
+            .post(format!("{base_url}/api/admin/bot/configs"))
+            .header("Authorization", format!("Bearer {admin_jwt}"))
+            .json(&serde_json::json!({
+                "id": existing_id.to_string(),
+                "name": "Bot",
+                "client_id": "cid",
+                "service_account": "sa",
+                "bot_id": "bid",
+                "bot_secret": "",
+            }))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(res.status(), 200);
+    });
+}
+
+#[tokio::test]
+async fn test_update_bot_secret_db_error() {
+    test_group!("Bot Admin: update_bot_secret DB error");
+    test_case!("update_bot_secret 失敗時に 500", {
+        let _guard = crate::common::ENV_LOCK.lock().unwrap();
+        std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+        // fail_next を 1 回だけ true → 最初の呼び出しが失敗。
+        // update_config よりも先に update_bot_secret が呼ばれることを期待。
+        let mock = Arc::new(MockBotAdminRepository::default());
+        mock.fail_next.store(true, Ordering::SeqCst);
+        let mut state = setup_mock_app_state();
+        state.bot_admin = mock;
+        let base_url = crate::common::spawn_test_server(state).await;
+
+        let tenant_id = Uuid::new_v4();
+        let admin_jwt = crate::common::create_test_jwt(tenant_id, "admin");
+        let client = reqwest::Client::new();
+
+        let existing_id = Uuid::new_v4();
+        let res = client
+            .post(format!("{base_url}/api/admin/bot/configs"))
+            .header("Authorization", format!("Bearer {admin_jwt}"))
+            .json(&serde_json::json!({
+                "id": existing_id.to_string(),
+                "name": "Bot",
+                "client_id": "cid",
+                "service_account": "sa",
+                "bot_id": "bid",
+                "bot_secret": "any-secret",
+            }))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(res.status(), 500);
+    });
+}
+
+#[tokio::test]
 async fn test_update_config_with_empty_secrets() {
     test_group!("Bot Admin: update_config empty secrets");
     test_case!(
@@ -717,10 +864,106 @@ async fn test_get_config_secrets_success() {
             assert_eq!(body["service_account"], "sa@test.com");
             assert_eq!(body["private_key"], "my-private-key");
             assert_eq!(body["bot_id"], "bot-123");
+            // bot_secret_encrypted: None → bot_secret は空文字
+            assert_eq!(body["bot_secret"], "");
 
             std::env::remove_var("SSO_ENCRYPTION_KEY");
         }
     );
+}
+
+#[tokio::test]
+async fn test_get_config_secrets_with_bot_secret() {
+    test_group!("Bot Admin: get_config_secrets bot_secret 復号");
+    test_case!("bot_secret_encrypted=Some の場合は復号して返す", {
+        let _guard = crate::common::ENV_LOCK.lock().unwrap();
+        let key = "test-encryption-key-bot-secret";
+        std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", key);
+
+        let config_id = Uuid::new_v4();
+        let mock = Arc::new(MockBotAdminRepository::default());
+        *mock.return_config_with_secrets.lock().unwrap() = Some(BotConfigWithSecrets {
+            id: config_id,
+            provider: "lineworks".to_string(),
+            name: "Bot With Secret".to_string(),
+            client_id: "cid".to_string(),
+            client_secret_encrypted: test_encrypt("cs", key),
+            service_account: "sa".to_string(),
+            private_key_encrypted: test_encrypt("pk", key),
+            bot_id: "b".to_string(),
+            enabled: true,
+            bot_secret_encrypted: Some(test_encrypt("my-bot-secret", key)),
+        });
+
+        let mut state = setup_mock_app_state();
+        state.bot_admin = mock;
+        let base_url = crate::common::spawn_test_server(state).await;
+
+        let tenant_id = Uuid::new_v4();
+        let admin_jwt = crate::common::create_test_jwt(tenant_id, "admin");
+        let client = reqwest::Client::new();
+
+        let res = client
+            .get(format!(
+                "{base_url}/api/admin/bot/configs/{config_id}/secrets"
+            ))
+            .header("Authorization", format!("Bearer {admin_jwt}"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(res.status(), 200);
+        let body: Value = res.json().await.unwrap();
+        assert_eq!(body["bot_secret"], "my-bot-secret");
+
+        std::env::remove_var("SSO_ENCRYPTION_KEY");
+    });
+}
+
+#[tokio::test]
+async fn test_get_config_secrets_bot_secret_decrypt_error() {
+    test_group!("Bot Admin: get_config_secrets bot_secret 復号失敗");
+    test_case!("bot_secret_encrypted が不正な base64 の場合 500", {
+        let _guard = crate::common::ENV_LOCK.lock().unwrap();
+        let key = "test-key-bot-secret-fail";
+        std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", key);
+
+        let config_id = Uuid::new_v4();
+        let mock = Arc::new(MockBotAdminRepository::default());
+        *mock.return_config_with_secrets.lock().unwrap() = Some(BotConfigWithSecrets {
+            id: config_id,
+            provider: "lineworks".to_string(),
+            name: "Bot".to_string(),
+            client_id: "cid".to_string(),
+            client_secret_encrypted: test_encrypt("cs", key),
+            service_account: "sa".to_string(),
+            private_key_encrypted: test_encrypt("pk", key),
+            bot_id: "b".to_string(),
+            enabled: true,
+            bot_secret_encrypted: Some("not-valid-base64!!!".to_string()),
+        });
+
+        let mut state = setup_mock_app_state();
+        state.bot_admin = mock;
+        let base_url = crate::common::spawn_test_server(state).await;
+
+        let tenant_id = Uuid::new_v4();
+        let admin_jwt = crate::common::create_test_jwt(tenant_id, "admin");
+        let client = reqwest::Client::new();
+
+        let res = client
+            .get(format!(
+                "{base_url}/api/admin/bot/configs/{config_id}/secrets"
+            ))
+            .header("Authorization", format!("Bearer {admin_jwt}"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(res.status(), 500);
+
+        std::env::remove_var("SSO_ENCRYPTION_KEY");
+    });
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

PR #2/3 of LINE WORKS group feature. [PR #287](#287) added \`bot_configs.bot_secret_encrypted\` column + \`lineworks_channels\` webhook handler. このPRで bot_admin 管理 API から bot_secret を保存/取得できるようにする。

### 含む変更

- **alc-core BotAdminRepository**:
  - \`BotConfigWithSecrets\` / \`BotConfigExportRow\` に \`bot_secret_encrypted: Option<String>\`
  - \`update_bot_secret(tenant_id, id, encrypted)\` trait method 追加

- **alc-misc PgBotAdminRepository**:
  - \`update_bot_secret\` SQL 実装
  - \`get_config_with_secrets\` / \`list_configs_for_export\` SELECT に \`bot_secret_encrypted\` 追加

- **alc-misc bot_admin handler**:
  - \`UpsertRequest.bot_secret: Option<String>\` 追加 (空文字スキップ、新規/更新両対応)
  - \`BotConfigSecretsResponse.bot_secret: String\` 追加 (未設定なら空文字)
  - \`get_config_secrets\` で bot_secret 復号して返す

- **mock_helpers/mock_tests**: 既存 BotConfigWithSecrets/ExportRow リテラルに \`bot_secret_encrypted: None\` フィールド追加

### 動作影響

- bot_secret を保存できるようになる → PR #1 の webhook が初めて 200 を返せる
- 既存 bot_configs 行の bot_secret_encrypted は NULL のまま (空文字 upsert で skip)
- ts-rs export: BotConfigSecretsResponse.bot_secret 追加 (フロントは optional 扱い)

## Test plan

- [x] cargo build --tests pass (BotConfigWithSecrets/ExportRow E0063 解消)
- [x] cargo fmt 適用
- [ ] CI: 全 mock-X jobs SUCCESS (PR #287 で axum 0.8 path syntax 直したのでこちらは静か)
- [ ] staging 自動デプロイで bot_admin /admin/bot/configs/{id}/secrets が bot_secret を返すこと

次は PR #3 (nuxt-notify /lineworks-groups page)。