### PR TITLE
feat(internal): add /api/internal/lineworks routes for auth-worker proxy

### DIFF
--- a/crates/alc-core/src/auth_jwt.rs
+++ b/crates/alc-core/src/auth_jwt.rs
@@ -268,11 +268,12 @@ mod tests {
             use jsonwebtoken::{encode as jwt_encode, EncodingKey, Header};
             let secret = JwtSecret("test-secret-key-256-bits-long!!!".to_string());
             let now = Utc::now();
+            // jsonwebtoken のデフォルト leeway は 60s なので、それを超える過去にする
             let expired = InternalClaims {
                 iss: "auth-worker".to_string(),
                 aud: INTERNAL_AUD.to_string(),
-                iat: (now - Duration::seconds(120)).timestamp(),
-                exp: (now - Duration::seconds(60)).timestamp(),
+                iat: (now - Duration::seconds(7200)).timestamp(),
+                exp: (now - Duration::seconds(3600)).timestamp(),
             };
             let token = jwt_encode(
                 &Header::new(Algorithm::HS256),

--- a/crates/alc-core/src/auth_jwt.rs
+++ b/crates/alc-core/src/auth_jwt.rs
@@ -71,6 +71,59 @@ pub fn verify_access_token(
     Ok(token_data.claims)
 }
 
+/// 内部 API 用 JWT のクレーム (auth-worker → rust-alc-api 間の callback で使用)
+///
+/// 通常のユーザー JWT (`AppClaims`) と区別するため `aud = "alc-api-internal"` を強制する。
+/// `JWT_SECRET` (HS256) は両者で共有しているため、aud で用途分離しないと
+/// auth-worker が発行した内部 JWT がうっかり require_jwt 経路で受け入れられかねない。
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct InternalClaims {
+    pub iss: String,
+    pub aud: String,
+    pub iat: i64,
+    pub exp: i64,
+}
+
+/// 内部 API 用 JWT を発行 (主に rust-alc-api 内テストや CLI から auth-worker 用 JWT を生成する用途)
+pub fn create_internal_token(
+    secret: &JwtSecret,
+    iss: &str,
+    ttl_seconds: i64,
+) -> Result<String, jsonwebtoken::errors::Error> {
+    let now = Utc::now();
+    let claims = InternalClaims {
+        iss: iss.to_string(),
+        aud: INTERNAL_AUD.to_string(),
+        iat: now.timestamp(),
+        exp: (now + Duration::seconds(ttl_seconds)).timestamp(),
+    };
+    encode(
+        &Header::new(Algorithm::HS256),
+        &claims,
+        &EncodingKey::from_secret(secret.0.as_bytes()),
+    )
+}
+
+/// 内部 API 用 JWT を検証
+pub fn verify_internal_token(
+    token: &str,
+    secret: &JwtSecret,
+) -> Result<InternalClaims, jsonwebtoken::errors::Error> {
+    let mut validation = Validation::new(Algorithm::HS256);
+    validation.validate_exp = true;
+    validation.set_audience(&[INTERNAL_AUD]);
+
+    let token_data = decode::<InternalClaims>(
+        token,
+        &DecodingKey::from_secret(secret.0.as_bytes()),
+        &validation,
+    )?;
+
+    Ok(token_data.claims)
+}
+
+pub const INTERNAL_AUD: &str = "alc-api-internal";
+
 /// Refresh token を生成し、(raw_token, hash) を返す
 pub fn create_refresh_token() -> (String, String) {
     let raw = format!("rt_{}", Uuid::new_v4().simple());
@@ -139,6 +192,95 @@ mod tests {
 
             let token = create_access_token(&user, &secret, Some("test-slug".to_string())).unwrap();
             assert!(verify_access_token(&token, &wrong_secret).is_err());
+        });
+    }
+
+    #[test]
+    fn test_create_and_verify_internal_token() {
+        test_group!("内部JWT");
+        test_case!(
+            "内部トークンの生成と検証 (aud=alc-api-internal)",
+            {
+                let secret = JwtSecret("test-internal-secret-256-bits!!!".to_string());
+                let token = create_internal_token(&secret, "auth-worker", 60).unwrap();
+                let claims = verify_internal_token(&token, &secret).unwrap();
+                assert_eq!(claims.iss, "auth-worker");
+                assert_eq!(claims.aud, INTERNAL_AUD);
+            }
+        );
+    }
+
+    #[test]
+    fn test_internal_token_rejects_user_token() {
+        test_group!("内部JWT");
+        test_case!(
+            "ユーザートークンは内部検証で拒否される (aud 不一致)",
+            {
+                let user = test_user();
+                let secret = JwtSecret("shared-secret-key-256-bits-long!".to_string());
+                let user_token = create_access_token(&user, &secret, None).unwrap();
+                assert!(verify_internal_token(&user_token, &secret).is_err());
+            }
+        );
+    }
+
+    #[test]
+    fn test_user_token_rejects_internal_token() {
+        test_group!("内部JWT");
+        test_case!(
+            "内部トークンはユーザー検証で拒否される (Claims 不一致)",
+            {
+                let secret = JwtSecret("shared-secret-key-256-bits-long!".to_string());
+                let internal = create_internal_token(&secret, "auth-worker", 60).unwrap();
+                // AppClaims に sub/email/tenant_id 等が無いので decode 失敗
+                assert!(verify_access_token(&internal, &secret).is_err());
+            }
+        );
+    }
+
+    #[test]
+    fn test_internal_token_wrong_aud_rejected() {
+        test_group!("内部JWT");
+        test_case!("間違った aud は拒否される", {
+            use jsonwebtoken::{encode as jwt_encode, EncodingKey, Header};
+            let secret = JwtSecret("test-secret-key-256-bits-long!!!".to_string());
+            let now = Utc::now();
+            let bad = InternalClaims {
+                iss: "auth-worker".to_string(),
+                aud: "wrong-aud".to_string(),
+                iat: now.timestamp(),
+                exp: (now + Duration::seconds(60)).timestamp(),
+            };
+            let token = jwt_encode(
+                &Header::new(Algorithm::HS256),
+                &bad,
+                &EncodingKey::from_secret(secret.0.as_bytes()),
+            )
+            .unwrap();
+            assert!(verify_internal_token(&token, &secret).is_err());
+        });
+    }
+
+    #[test]
+    fn test_internal_token_expired_rejected() {
+        test_group!("内部JWT");
+        test_case!("期限切れの内部トークンは拒否される", {
+            use jsonwebtoken::{encode as jwt_encode, EncodingKey, Header};
+            let secret = JwtSecret("test-secret-key-256-bits-long!!!".to_string());
+            let now = Utc::now();
+            let expired = InternalClaims {
+                iss: "auth-worker".to_string(),
+                aud: INTERNAL_AUD.to_string(),
+                iat: (now - Duration::seconds(120)).timestamp(),
+                exp: (now - Duration::seconds(60)).timestamp(),
+            };
+            let token = jwt_encode(
+                &Header::new(Algorithm::HS256),
+                &expired,
+                &EncodingKey::from_secret(secret.0.as_bytes()),
+            )
+            .unwrap();
+            assert!(verify_internal_token(&token, &secret).is_err());
         });
     }
 

--- a/crates/alc-core/src/auth_middleware.rs
+++ b/crates/alc-core/src/auth_middleware.rs
@@ -3,7 +3,7 @@ pub use crate::middleware::{AuthUser, TenantId};
 use axum::{extract::Request, http::StatusCode, middleware::Next, response::Response, Extension};
 use uuid::Uuid;
 
-use crate::auth_jwt::{verify_access_token, JwtSecret};
+use crate::auth_jwt::{verify_access_token, verify_internal_token, JwtSecret};
 
 /// JWT 必須ミドルウェア — 管理ページ用
 ///
@@ -69,6 +69,25 @@ pub async fn require_tenant(
         .ok_or(StatusCode::UNAUTHORIZED)?;
 
     req.extensions_mut().insert(TenantId(tenant_id));
+    Ok(next.run(req).await)
+}
+
+/// 内部 API 用 JWT 検証ミドルウェア
+///
+/// `Authorization: Bearer <jwt>` を要求し、`aud == "alc-api-internal"` を強制する。
+/// auth-worker が LINE WORKS webhook を受け取って rust-alc-api に転送する際の
+/// `/api/internal/*` ルート保護に使う。通常のユーザー JWT (`AppClaims`) は
+/// `aud` を持たないため弾かれる。
+pub async fn require_internal_jwt(
+    Extension(jwt_secret): Extension<JwtSecret>,
+    req: Request,
+    next: Next,
+) -> Result<Response, StatusCode> {
+    let token = extract_bearer_token(&req).ok_or(StatusCode::UNAUTHORIZED)?;
+    verify_internal_token(token, &jwt_secret).map_err(|e| {
+        tracing::warn!("internal JWT verification failed: {e}");
+        StatusCode::UNAUTHORIZED
+    })?;
     Ok(next.run(req).await)
 }
 
@@ -211,6 +230,81 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::OK);
         let body = axum::body::to_bytes(resp.into_body(), 1024).await.unwrap();
         assert_eq!(String::from_utf8_lossy(&body), "test@example.com:admin");
+    }
+
+    fn app_internal_jwt() -> Router {
+        Router::new()
+            .route("/i", get(echo_ok))
+            .layer(axum_middleware::from_fn(require_internal_jwt))
+            .layer(Extension(JwtSecret(
+                "test-internal-secret-256-bits!!!".to_string(),
+            )))
+    }
+
+    async fn echo_ok() -> &'static str {
+        "ok"
+    }
+
+    #[tokio::test]
+    async fn internal_jwt_ok() {
+        use crate::auth_jwt::create_internal_token;
+        let secret = JwtSecret("test-internal-secret-256-bits!!!".to_string());
+        let token = create_internal_token(&secret, "auth-worker", 60).unwrap();
+        let resp = send(
+            app_internal_jwt(),
+            req_with_headers("/i", &[("Authorization", &format!("Bearer {token}"))]),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn internal_jwt_missing_header() {
+        let resp = send(app_internal_jwt(), req("/i")).await;
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn internal_jwt_user_token_rejected() {
+        // ユーザー JWT は aud を持たないので拒否されること
+        use crate::auth_jwt::create_access_token;
+        use crate::models::User;
+        let secret = JwtSecret("test-internal-secret-256-bits!!!".to_string());
+        let user = User {
+            id: Uuid::new_v4(),
+            tenant_id: Uuid::new_v4(),
+            google_sub: Some("g".to_string()),
+            lineworks_id: None,
+            line_user_id: None,
+            email: "u@e.com".to_string(),
+            name: "u".to_string(),
+            role: "admin".to_string(),
+            username: None,
+            password_hash: None,
+            refresh_token_hash: None,
+            refresh_token_expires_at: None,
+            created_at: chrono::Utc::now(),
+        };
+        let token = create_access_token(&user, &secret, None).unwrap();
+        let resp = send(
+            app_internal_jwt(),
+            req_with_headers("/i", &[("Authorization", &format!("Bearer {token}"))]),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn internal_jwt_wrong_secret_rejected() {
+        use crate::auth_jwt::create_internal_token;
+        let other = JwtSecret("different-secret-key-256-bits!!".to_string());
+        let token = create_internal_token(&other, "auth-worker", 60).unwrap();
+        let resp = send(
+            app_internal_jwt(),
+            req_with_headers("/i", &[("Authorization", &format!("Bearer {token}"))]),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
     }
 
     #[tokio::test]

--- a/crates/alc-notify/src/lineworks_channels.rs
+++ b/crates/alc-notify/src/lineworks_channels.rs
@@ -37,11 +37,31 @@ pub fn tenant_router() -> Router<AppState> {
 }
 
 /// Public (認証なし) ルート群。LINE WORKS Developers Console から callback URL として登録される。
+///
+/// **段階移行中**: 新しい callback は auth-worker 側 (`https://auth.ippoan.org/lineworks/webhook/{bot_id}`)
+/// で受け、HMAC 検証 + 復号 + イベント抽出を行ってから [`internal_router`] にイベントだけを転送する。
+/// 旧 callback URL を切替えるまでは両方が生きている。
 pub fn public_router() -> Router<AppState> {
     Router::new().route(
         "/notify/lineworks/webhook/{bot_id}",
         post(handle_webhook_route),
     )
+}
+
+/// Internal (auth-worker 専用) ルート群。`require_internal_jwt` 配下に nest される想定。
+///
+/// auth-worker (Cloudflare Workers) が LINE WORKS webhook を edge で受け、
+/// HMAC 検証 + 復号 + イベント抽出を済ませた後、本ルートに転送する。
+///
+/// - `GET  /api/internal/lineworks/bot-secret/{bot_id}` — bot_secret_encrypted を返す (復号は auth-worker)
+/// - `POST /api/internal/lineworks/event` — 検証済みイベントを受け取って upsert/mark_left
+pub fn internal_router() -> Router<AppState> {
+    Router::new()
+        .route(
+            "/internal/lineworks/bot-secret/{bot_id}",
+            get(get_bot_secret_internal),
+        )
+        .route("/internal/lineworks/event", post(receive_event_internal))
 }
 
 fn internal_error(msg: &str) -> (StatusCode, Json<serde_json::Value>) {
@@ -295,6 +315,114 @@ pub async fn handle_webhook(
                 })?;
         }
         // message 等のその他イベントは無視 (200 OK)
+        _ => {}
+    }
+
+    Ok(Json(WebhookResponse { ok: true }))
+}
+
+// ---------- internal: GET bot-secret ----------
+
+#[derive(Debug, Serialize)]
+pub struct BotSecretEncryptedResponse {
+    pub bot_secret_encrypted: String,
+}
+
+async fn get_bot_secret_internal(
+    State(state): State<AppState>,
+    Path(bot_id): Path<String>,
+) -> Result<Json<BotSecretEncryptedResponse>, (StatusCode, Json<serde_json::Value>)> {
+    let cfg = state
+        .lineworks_channels
+        .lookup_bot_config_for_webhook(&bot_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("lookup_bot_config_for_webhook (internal): {e}");
+            internal_error("lookup_failed")
+        })?
+        .ok_or((
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({"error": "bot_not_found"})),
+        ))?;
+
+    let bot_secret_encrypted = cfg.bot_secret_encrypted.ok_or((
+        StatusCode::NOT_FOUND,
+        Json(serde_json::json!({"error": "bot_secret_not_configured"})),
+    ))?;
+
+    Ok(Json(BotSecretEncryptedResponse {
+        bot_secret_encrypted,
+    }))
+}
+
+// ---------- internal: POST event ----------
+
+#[derive(Debug, Deserialize)]
+pub struct InternalEventBody {
+    pub bot_id: String,
+    pub event_type: String,
+    pub channel_id: Option<String>,
+    pub channel_type: Option<String>,
+    pub title: Option<String>,
+}
+
+async fn receive_event_internal(
+    State(state): State<AppState>,
+    Json(body): Json<InternalEventBody>,
+) -> Result<Json<WebhookResponse>, (StatusCode, Json<serde_json::Value>)> {
+    process_internal_event(&state, body).await
+}
+
+/// Public testable core。`receive_event_internal` から委譲される。
+pub async fn process_internal_event(
+    state: &AppState,
+    body: InternalEventBody,
+) -> Result<Json<WebhookResponse>, (StatusCode, Json<serde_json::Value>)> {
+    let cfg = state
+        .lineworks_channels
+        .lookup_bot_config_for_webhook(&body.bot_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("lookup_bot_config_for_webhook (event): {e}");
+            internal_error("lookup_failed")
+        })?
+        .ok_or((
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({"error": "bot_not_found"})),
+        ))?;
+
+    let channel_id = match body.channel_id {
+        Some(c) => c,
+        None => return Ok(Json(WebhookResponse { ok: true })),
+    };
+
+    match body.event_type.as_str() {
+        "join" | "joined" => {
+            state
+                .lineworks_channels
+                .upsert_joined(
+                    cfg.tenant_id,
+                    cfg.id,
+                    &channel_id,
+                    body.channel_type.as_deref(),
+                    body.title.as_deref(),
+                )
+                .await
+                .map_err(|e| {
+                    tracing::error!("upsert_joined (internal): {e}");
+                    internal_error("upsert_failed")
+                })?;
+        }
+        "leave" | "left" => {
+            state
+                .lineworks_channels
+                .mark_left(cfg.tenant_id, cfg.id, &channel_id)
+                .await
+                .map_err(|e| {
+                    tracing::error!("mark_left (internal): {e}");
+                    internal_error("mark_left_failed")
+                })?;
+        }
         _ => {}
     }
 

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -66,7 +66,7 @@ pub use alc_trouble::workflow as trouble_workflow;
 
 use axum::{middleware as axum_middleware, Router};
 
-use crate::middleware::auth::{require_jwt, require_tenant};
+use crate::middleware::auth::{require_internal_jwt, require_jwt, require_tenant};
 use crate::AppState;
 
 pub fn router() -> Router<AppState> {
@@ -80,6 +80,11 @@ pub fn router() -> Router<AppState> {
         .merge(members::router())
         .merge(api_tokens::router())
         .layer(axum_middleware::from_fn(require_jwt));
+
+    // 内部 API ルート (auth-worker 等の信頼できる呼び出し元のみ、aud=alc-api-internal)
+    let internal_protected = Router::new()
+        .merge(notify_lineworks_channels::internal_router())
+        .layer(axum_middleware::from_fn(require_internal_jwt));
 
     // テナント対応ルート (JWT or X-Tenant-ID)
     let tenant_protected = Router::new()
@@ -155,5 +160,6 @@ pub fn router() -> Router<AppState> {
     Router::new()
         .merge(public_routes)
         .merge(jwt_protected)
+        .merge(internal_protected)
         .merge(tenant_protected)
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -480,6 +480,13 @@ pub fn create_test_jwt(tenant_id: Uuid, role: &str) -> String {
     create_access_token(&user, &secret, None).expect("Failed to create test JWT")
 }
 
+/// 内部 API 用のテスト JWT を発行 (aud=alc-api-internal)
+pub fn create_test_internal_jwt() -> String {
+    let secret = JwtSecret(TEST_JWT_SECRET.to_string());
+    rust_alc_api::auth::jwt::create_internal_token(&secret, "test-auth-worker", 60)
+        .expect("Failed to create test internal JWT")
+}
+
 /// dtako テスト用の最小 ZIP (KUDGURI.csv + KUDGIVT.csv) を生成
 pub fn create_test_dtako_zip() -> Vec<u8> {
     create_test_dtako_zip_with_unko_no(1001)

--- a/tests/mock_helpers/repos_d.rs
+++ b/tests/mock_helpers/repos_d.rs
@@ -1,4 +1,5 @@
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Mutex;
 
 use uuid::Uuid;
 
@@ -25,12 +26,22 @@ macro_rules! check_fail {
 
 pub struct MockLineworksChannelsRepository {
     pub fail_next: AtomicBool,
+    /// `lookup_bot_config_for_webhook` の戻り値を注入できる。
+    /// `None` なら従来通り bot_not_found 相当 (`Ok(None)`) を返す。
+    pub bot_config: Mutex<Option<BotConfigForWebhook>>,
+    /// `upsert_joined` の呼び出し回数 (テスト assertion 用)
+    pub upsert_joined_calls: std::sync::atomic::AtomicUsize,
+    /// `mark_left` の呼び出し回数 (テスト assertion 用)
+    pub mark_left_calls: std::sync::atomic::AtomicUsize,
 }
 
 impl Default for MockLineworksChannelsRepository {
     fn default() -> Self {
         Self {
             fail_next: AtomicBool::new(false),
+            bot_config: Mutex::new(None),
+            upsert_joined_calls: std::sync::atomic::AtomicUsize::new(0),
+            mark_left_calls: std::sync::atomic::AtomicUsize::new(0),
         }
     }
 }
@@ -73,6 +84,8 @@ impl LineworksChannelsRepository for MockLineworksChannelsRepository {
         _title: Option<&str>,
     ) -> Result<LineworksChannel, sqlx::Error> {
         check_fail!(self);
+        self.upsert_joined_calls
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
         Ok(mock_lineworks_channel(tenant_id))
     }
     async fn mark_left(
@@ -82,6 +95,8 @@ impl LineworksChannelsRepository for MockLineworksChannelsRepository {
         _channel_id: &str,
     ) -> Result<(), sqlx::Error> {
         check_fail!(self);
+        self.mark_left_calls
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
         Ok(())
     }
     async fn delete(&self, _tenant_id: Uuid, _id: Uuid) -> Result<(), sqlx::Error> {
@@ -93,7 +108,7 @@ impl LineworksChannelsRepository for MockLineworksChannelsRepository {
         _bot_id: &str,
     ) -> Result<Option<BotConfigForWebhook>, sqlx::Error> {
         check_fail!(self);
-        Ok(None)
+        Ok(self.bot_config.lock().unwrap().clone())
     }
 }
 

--- a/tests/mock_misc/main.rs
+++ b/tests/mock_misc/main.rs
@@ -23,6 +23,8 @@ mod mock_employees_test;
 mod mock_guidance_records_test;
 #[path = "../mock_tests/mock_health_test.rs"]
 mod mock_health_test;
+#[path = "../mock_tests/mock_lineworks_internal_test.rs"]
+mod mock_lineworks_internal_test;
 #[path = "../mock_tests/mock_measurements_test.rs"]
 mod mock_measurements_test;
 #[path = "../mock_tests/mock_members_test.rs"]

--- a/tests/mock_tests/mock_lineworks_internal_test.rs
+++ b/tests/mock_tests/mock_lineworks_internal_test.rs
@@ -1,0 +1,366 @@
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+use serde_json::Value;
+use uuid::Uuid;
+
+use rust_alc_api::db::repository::lineworks_channels::BotConfigForWebhook;
+
+use crate::mock_helpers::app_state::setup_mock_app_state;
+use crate::mock_helpers::MockLineworksChannelsRepository;
+
+fn install_mock(
+    state: &mut rust_alc_api::AppState,
+    cfg: Option<BotConfigForWebhook>,
+) -> Arc<MockLineworksChannelsRepository> {
+    let mock = Arc::new(MockLineworksChannelsRepository::default());
+    *mock.bot_config.lock().unwrap() = cfg;
+    state.lineworks_channels = mock.clone();
+    mock
+}
+
+fn sample_bot_cfg() -> BotConfigForWebhook {
+    BotConfigForWebhook {
+        id: Uuid::new_v4(),
+        tenant_id: Uuid::new_v4(),
+        bot_secret_encrypted: Some("aGVsbG8=".to_string()),
+    }
+}
+
+// ============================================================
+// GET /api/internal/lineworks/bot-secret/{bot_id}
+// ============================================================
+
+#[tokio::test]
+async fn test_get_bot_secret_success() {
+    test_group!("Internal: get_bot_secret success");
+    test_case!("登録済み bot は暗号化済み bot_secret を返す", {
+        let _guard = crate::common::ENV_LOCK.lock().unwrap();
+        std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        let mut state = setup_mock_app_state();
+        let _mock = install_mock(&mut state, Some(sample_bot_cfg()));
+        let base_url = crate::common::spawn_test_server(state).await;
+
+        let jwt = crate::common::create_test_internal_jwt();
+        let res = reqwest::Client::new()
+            .get(format!(
+                "{base_url}/api/internal/lineworks/bot-secret/test-bot"
+            ))
+            .header("Authorization", format!("Bearer {jwt}"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(res.status(), 200);
+        let body: Value = res.json().await.unwrap();
+        assert_eq!(body["bot_secret_encrypted"], "aGVsbG8=");
+    });
+}
+
+#[tokio::test]
+async fn test_get_bot_secret_not_found() {
+    test_group!("Internal: get_bot_secret not found");
+    test_case!("未登録 bot_id は 404", {
+        let _guard = crate::common::ENV_LOCK.lock().unwrap();
+        std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        let mut state = setup_mock_app_state();
+        let _mock = install_mock(&mut state, None);
+        let base_url = crate::common::spawn_test_server(state).await;
+
+        let jwt = crate::common::create_test_internal_jwt();
+        let res = reqwest::Client::new()
+            .get(format!("{base_url}/api/internal/lineworks/bot-secret/none"))
+            .header("Authorization", format!("Bearer {jwt}"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(res.status(), 404);
+    });
+}
+
+#[tokio::test]
+async fn test_get_bot_secret_no_secret_configured() {
+    test_group!("Internal: get_bot_secret no secret");
+    test_case!(
+        "bot 自体は存在するが bot_secret 未設定なら 404",
+        {
+            let _guard = crate::common::ENV_LOCK.lock().unwrap();
+            std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+            let mut state = setup_mock_app_state();
+            let mut cfg = sample_bot_cfg();
+            cfg.bot_secret_encrypted = None;
+            let _mock = install_mock(&mut state, Some(cfg));
+            let base_url = crate::common::spawn_test_server(state).await;
+
+            let jwt = crate::common::create_test_internal_jwt();
+            let res = reqwest::Client::new()
+                .get(format!("{base_url}/api/internal/lineworks/bot-secret/x"))
+                .header("Authorization", format!("Bearer {jwt}"))
+                .send()
+                .await
+                .unwrap();
+            assert_eq!(res.status(), 404);
+        }
+    );
+}
+
+#[tokio::test]
+async fn test_get_bot_secret_unauthorized_without_jwt() {
+    test_group!("Internal: get_bot_secret no auth");
+    test_case!("Authorization ヘッダー無しは 401", {
+        let _guard = crate::common::ENV_LOCK.lock().unwrap();
+        std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        let mut state = setup_mock_app_state();
+        let _mock = install_mock(&mut state, Some(sample_bot_cfg()));
+        let base_url = crate::common::spawn_test_server(state).await;
+
+        let res = reqwest::Client::new()
+            .get(format!("{base_url}/api/internal/lineworks/bot-secret/x"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(res.status(), 401);
+    });
+}
+
+#[tokio::test]
+async fn test_get_bot_secret_user_jwt_rejected() {
+    test_group!("Internal: get_bot_secret user JWT");
+    test_case!("ユーザー JWT (aud 無し) は 401", {
+        let _guard = crate::common::ENV_LOCK.lock().unwrap();
+        std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        let mut state = setup_mock_app_state();
+        let _mock = install_mock(&mut state, Some(sample_bot_cfg()));
+        let base_url = crate::common::spawn_test_server(state).await;
+
+        let user_jwt = crate::common::create_test_jwt(Uuid::new_v4(), "admin");
+        let res = reqwest::Client::new()
+            .get(format!("{base_url}/api/internal/lineworks/bot-secret/x"))
+            .header("Authorization", format!("Bearer {user_jwt}"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(res.status(), 401);
+    });
+}
+
+#[tokio::test]
+async fn test_get_bot_secret_db_error() {
+    test_group!("Internal: get_bot_secret DB error");
+    test_case!("lookup 失敗時は 500", {
+        let _guard = crate::common::ENV_LOCK.lock().unwrap();
+        std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        let mut state = setup_mock_app_state();
+        let mock = install_mock(&mut state, Some(sample_bot_cfg()));
+        mock.fail_next.store(true, Ordering::SeqCst);
+        let base_url = crate::common::spawn_test_server(state).await;
+
+        let jwt = crate::common::create_test_internal_jwt();
+        let res = reqwest::Client::new()
+            .get(format!("{base_url}/api/internal/lineworks/bot-secret/x"))
+            .header("Authorization", format!("Bearer {jwt}"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(res.status(), 500);
+    });
+}
+
+// ============================================================
+// POST /api/internal/lineworks/event
+// ============================================================
+
+async fn post_event(base_url: &str, jwt: &str, body: Value) -> reqwest::Response {
+    reqwest::Client::new()
+        .post(format!("{base_url}/api/internal/lineworks/event"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .json(&body)
+        .send()
+        .await
+        .unwrap()
+}
+
+#[tokio::test]
+async fn test_event_joined_calls_upsert() {
+    test_group!("Internal: event joined");
+    test_case!("joined イベントで upsert_joined が呼ばれる", {
+        let _guard = crate::common::ENV_LOCK.lock().unwrap();
+        std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        let mut state = setup_mock_app_state();
+        let mock = install_mock(&mut state, Some(sample_bot_cfg()));
+        let base_url = crate::common::spawn_test_server(state).await;
+
+        let jwt = crate::common::create_test_internal_jwt();
+        let res = post_event(
+            &base_url,
+            &jwt,
+            serde_json::json!({
+                "bot_id": "bot-1",
+                "event_type": "joined",
+                "channel_id": "ch-1",
+                "channel_type": "group",
+                "title": "テスト"
+            }),
+        )
+        .await;
+        assert_eq!(res.status(), 200);
+        assert_eq!(mock.upsert_joined_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(mock.mark_left_calls.load(Ordering::SeqCst), 0);
+    });
+}
+
+#[tokio::test]
+async fn test_event_left_calls_mark_left() {
+    test_group!("Internal: event left");
+    test_case!("left イベントで mark_left が呼ばれる", {
+        let _guard = crate::common::ENV_LOCK.lock().unwrap();
+        std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        let mut state = setup_mock_app_state();
+        let mock = install_mock(&mut state, Some(sample_bot_cfg()));
+        let base_url = crate::common::spawn_test_server(state).await;
+
+        let jwt = crate::common::create_test_internal_jwt();
+        let res = post_event(
+            &base_url,
+            &jwt,
+            serde_json::json!({
+                "bot_id": "bot-1",
+                "event_type": "left",
+                "channel_id": "ch-1"
+            }),
+        )
+        .await;
+        assert_eq!(res.status(), 200);
+        assert_eq!(mock.mark_left_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(mock.upsert_joined_calls.load(Ordering::SeqCst), 0);
+    });
+}
+
+#[tokio::test]
+async fn test_event_unknown_type_ignored() {
+    test_group!("Internal: event unknown type");
+    test_case!("未知の event_type は無視されて 200", {
+        let _guard = crate::common::ENV_LOCK.lock().unwrap();
+        std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        let mut state = setup_mock_app_state();
+        let mock = install_mock(&mut state, Some(sample_bot_cfg()));
+        let base_url = crate::common::spawn_test_server(state).await;
+
+        let jwt = crate::common::create_test_internal_jwt();
+        let res = post_event(
+            &base_url,
+            &jwt,
+            serde_json::json!({
+                "bot_id": "bot-1",
+                "event_type": "message",
+                "channel_id": "ch-1"
+            }),
+        )
+        .await;
+        assert_eq!(res.status(), 200);
+        assert_eq!(mock.upsert_joined_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(mock.mark_left_calls.load(Ordering::SeqCst), 0);
+    });
+}
+
+#[tokio::test]
+async fn test_event_no_channel_id_skipped() {
+    test_group!("Internal: event no channel_id");
+    test_case!(
+        "channel_id 無しは upsert/mark_left 共に呼ばずに 200",
+        {
+            let _guard = crate::common::ENV_LOCK.lock().unwrap();
+            std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+            let mut state = setup_mock_app_state();
+            let mock = install_mock(&mut state, Some(sample_bot_cfg()));
+            let base_url = crate::common::spawn_test_server(state).await;
+
+            let jwt = crate::common::create_test_internal_jwt();
+            let res = post_event(
+                &base_url,
+                &jwt,
+                serde_json::json!({
+                    "bot_id": "bot-1",
+                    "event_type": "joined"
+                }),
+            )
+            .await;
+            assert_eq!(res.status(), 200);
+            assert_eq!(mock.upsert_joined_calls.load(Ordering::SeqCst), 0);
+        }
+    );
+}
+
+#[tokio::test]
+async fn test_event_bot_not_found() {
+    test_group!("Internal: event bot not found");
+    test_case!("未登録 bot_id は 404", {
+        let _guard = crate::common::ENV_LOCK.lock().unwrap();
+        std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        let mut state = setup_mock_app_state();
+        let _mock = install_mock(&mut state, None);
+        let base_url = crate::common::spawn_test_server(state).await;
+
+        let jwt = crate::common::create_test_internal_jwt();
+        let res = post_event(
+            &base_url,
+            &jwt,
+            serde_json::json!({
+                "bot_id": "missing",
+                "event_type": "joined",
+                "channel_id": "ch-1"
+            }),
+        )
+        .await;
+        assert_eq!(res.status(), 404);
+    });
+}
+
+#[tokio::test]
+async fn test_event_unauthorized() {
+    test_group!("Internal: event unauthorized");
+    test_case!("JWT 無しは 401", {
+        let _guard = crate::common::ENV_LOCK.lock().unwrap();
+        std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        let mut state = setup_mock_app_state();
+        let _mock = install_mock(&mut state, Some(sample_bot_cfg()));
+        let base_url = crate::common::spawn_test_server(state).await;
+
+        let res = reqwest::Client::new()
+            .post(format!("{base_url}/api/internal/lineworks/event"))
+            .json(&serde_json::json!({
+                "bot_id": "bot-1",
+                "event_type": "joined",
+                "channel_id": "ch-1"
+            }))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(res.status(), 401);
+    });
+}
+
+#[tokio::test]
+async fn test_event_lookup_db_error() {
+    test_group!("Internal: event DB error");
+    test_case!("lookup 失敗時は 500", {
+        let _guard = crate::common::ENV_LOCK.lock().unwrap();
+        std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        let mut state = setup_mock_app_state();
+        let mock = install_mock(&mut state, Some(sample_bot_cfg()));
+        mock.fail_next.store(true, Ordering::SeqCst);
+        let base_url = crate::common::spawn_test_server(state).await;
+
+        let jwt = crate::common::create_test_internal_jwt();
+        let res = post_event(
+            &base_url,
+            &jwt,
+            serde_json::json!({
+                "bot_id": "bot-1",
+                "event_type": "joined",
+                "channel_id": "ch-1"
+            }),
+        )
+        .await;
+        assert_eq!(res.status(), 500);
+    });
+}


### PR DESCRIPTION
## Summary

LINE WORKS callback を rust-alc-api から auth-worker (Cloudflare Workers) へ移設するための **Step 1**: backend 側に internal route を追加。HMAC 検証 + 復号は将来 auth-worker 側で行い、検証済みのイベントだけを JWT 認証付き internal route で本サービスに転送する形に変更する。

旧 public_router (\`/api/notify/lineworks/webhook/{bot_id}\`) は段階移行のため当面残置。auth-worker 側 (DO + handler) 実装後の Step 6 で削除する。

## 変更内容

- **auth_jwt**: \`InternalClaims\` + \`create_internal_token\` + \`verify_internal_token\` 追加。\`aud=alc-api-internal\` で通常ユーザー JWT と用途分離。
- **auth_middleware**: \`require_internal_jwt\` 追加。aud 不一致は 401。
- **lineworks_channels**: \`internal_router()\` 追加
  - \`GET /api/internal/lineworks/bot-secret/{bot_id}\` — 暗号化済み bot_secret を返す (復号は auth-worker 側)
  - \`POST /api/internal/lineworks/event\` — 検証済みの joined/left イベントを upsert_joined / mark_left に流す
- **routes/mod.rs**: internal_router を \`require_internal_jwt\` 配下で nest
- **tests**: 内部 JWT のユニットテスト 4 + mock_lineworks_internal_test.rs で internal 経路の成功/失敗 11 ケース

## 今後の Step

1. ✅ 本 PR (Step 1)
2. auth-worker に Durable Object 経由の webhook handler 実装 (bot_secret キャッシュ + event 再送キュー)
3. staging で実 LINE WORKS bot 切替検証
4. nuxt-notify lineworks-groups.vue の URL ハードコード差し替え
5. 本番 callback URL 切替 + 過渡期 1〜2 日
6. rust-alc-api public_router 削除

## Test plan

- [x] cargo fmt
- [x] cargo check --tests (pre-existing warning のみ)
- [ ] CI: unit-tests + integration-tests (mock_lineworks_internal_test.rs 11 cases)
- [ ] CI: 100% coverage 既存ファイルのリグレッション無し
- [ ] staging deploy 通過 (本 PR は機能追加のみで callback URL 変更なし)