### PR TITLE
feat(lineworks): remove public webhook route (auth-worker takes over)

### DIFF
--- a/crates/alc-notify/src/lineworks_channels.rs
+++ b/crates/alc-notify/src/lineworks_channels.rs
@@ -6,14 +6,11 @@
 
 use axum::{
     extract::{Path, State},
-    http::{HeaderMap, StatusCode},
+    http::StatusCode,
     routing::{delete, get, post},
     Extension, Json, Router,
 };
-use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
-use hmac::{Hmac, Mac};
 use serde::{Deserialize, Serialize};
-use sha2::Sha256;
 use uuid::Uuid;
 
 use alc_core::auth_lineworks::decrypt_secret;
@@ -22,8 +19,6 @@ use alc_core::repository::lineworks_channels::LineworksChannel;
 use alc_core::AppState;
 
 use crate::clients::lineworks::{LineworksBotClient, LineworksBotConfig};
-
-type HmacSha256 = Hmac<Sha256>;
 
 /// Admin (require_tenant) ルート群。
 pub fn tenant_router() -> Router<AppState> {
@@ -34,18 +29,6 @@ pub fn tenant_router() -> Router<AppState> {
             "/notify/lineworks/channels/{id}/test-send",
             post(test_send_channel),
         )
-}
-
-/// Public (認証なし) ルート群。LINE WORKS Developers Console から callback URL として登録される。
-///
-/// **段階移行中**: 新しい callback は auth-worker 側 (`https://auth.ippoan.org/lineworks/webhook/{bot_id}`)
-/// で受け、HMAC 検証 + 復号 + イベント抽出を行ってから [`internal_router`] にイベントだけを転送する。
-/// 旧 callback URL を切替えるまでは両方が生きている。
-pub fn public_router() -> Router<AppState> {
-    Router::new().route(
-        "/notify/lineworks/webhook/{bot_id}",
-        post(handle_webhook_route),
-    )
 }
 
 /// Internal (auth-worker 専用) ルート群。`require_internal_jwt` 配下に nest される想定。
@@ -189,136 +172,11 @@ async fn test_send_channel(
     Ok(Json(serde_json::json!({"ok": true})))
 }
 
-// ---------- webhook (public) ----------
-
-#[derive(Debug, Deserialize)]
-pub struct WebhookEvent {
-    #[serde(rename = "type")]
-    pub event_type: String,
-    pub source: Option<WebhookSource>,
-}
-
-#[derive(Debug, Deserialize)]
-pub struct WebhookSource {
-    #[serde(rename = "channelId")]
-    pub channel_id: Option<String>,
-    #[serde(rename = "channelType")]
-    pub channel_type: Option<String>,
-    pub title: Option<String>,
-}
+// ---------- shared response shape ----------
 
 #[derive(Debug, Serialize)]
 pub struct WebhookResponse {
     pub ok: bool,
-}
-
-async fn handle_webhook_route(
-    State(state): State<AppState>,
-    Path(bot_id): Path<String>,
-    headers: HeaderMap,
-    body: axum::body::Bytes,
-) -> Result<Json<WebhookResponse>, (StatusCode, Json<serde_json::Value>)> {
-    handle_webhook(&state, &bot_id, &headers, &body).await
-}
-
-/// Public testable core. handler は HeaderMap/Body をこの関数に委譲する。
-pub async fn handle_webhook(
-    state: &AppState,
-    bot_id: &str,
-    headers: &HeaderMap,
-    body: &[u8],
-) -> Result<Json<WebhookResponse>, (StatusCode, Json<serde_json::Value>)> {
-    let cfg = state
-        .lineworks_channels
-        .lookup_bot_config_for_webhook(bot_id)
-        .await
-        .map_err(|e| {
-            tracing::error!("lookup_bot_config_for_webhook: {e}");
-            internal_error("lookup_failed")
-        })?
-        .ok_or((
-            StatusCode::NOT_FOUND,
-            Json(serde_json::json!({"error": "bot_not_found"})),
-        ))?;
-
-    let bot_secret_encrypted = cfg.bot_secret_encrypted.ok_or((
-        StatusCode::UNAUTHORIZED,
-        Json(serde_json::json!({"error": "bot_secret_not_configured"})),
-    ))?;
-
-    let key = encryption_key()?;
-    let bot_secret = decrypt_secret(&bot_secret_encrypted, &key).map_err(|e| {
-        tracing::error!("decrypt bot_secret: {e}");
-        internal_error("decrypt_failed")
-    })?;
-
-    // X-WORKS-Signature: base64(HMAC-SHA256(bot_secret, raw_body))
-    let signature_b64 = headers
-        .get("x-works-signature")
-        .and_then(|v| v.to_str().ok())
-        .ok_or((
-            StatusCode::UNAUTHORIZED,
-            Json(serde_json::json!({"error": "missing_signature"})),
-        ))?;
-
-    if !verify_signature(&bot_secret, body, signature_b64) {
-        return Err((
-            StatusCode::UNAUTHORIZED,
-            Json(serde_json::json!({"error": "signature_mismatch"})),
-        ));
-    }
-
-    let event: WebhookEvent = serde_json::from_slice(body).map_err(|e| {
-        tracing::error!("parse webhook event: {e}");
-        (
-            StatusCode::BAD_REQUEST,
-            Json(serde_json::json!({"error": "invalid_payload"})),
-        )
-    })?;
-
-    let source = event.source.unwrap_or(WebhookSource {
-        channel_id: None,
-        channel_type: None,
-        title: None,
-    });
-    let channel_id = match source.channel_id {
-        Some(c) => c,
-        // Source 無しイベント (e.g. bot メッセージ) は無視
-        None => return Ok(Json(WebhookResponse { ok: true })),
-    };
-
-    match event.event_type.as_str() {
-        "join" | "joined" => {
-            state
-                .lineworks_channels
-                .upsert_joined(
-                    cfg.tenant_id,
-                    cfg.id,
-                    &channel_id,
-                    source.channel_type.as_deref(),
-                    source.title.as_deref(),
-                )
-                .await
-                .map_err(|e| {
-                    tracing::error!("upsert_joined: {e}");
-                    internal_error("upsert_failed")
-                })?;
-        }
-        "leave" | "left" => {
-            state
-                .lineworks_channels
-                .mark_left(cfg.tenant_id, cfg.id, &channel_id)
-                .await
-                .map_err(|e| {
-                    tracing::error!("mark_left: {e}");
-                    internal_error("mark_left_failed")
-                })?;
-        }
-        // message 等のその他イベントは無視 (200 OK)
-        _ => {}
-    }
-
-    Ok(Json(WebhookResponse { ok: true }))
 }
 
 // ---------- internal: GET bot-secret ----------
@@ -427,97 +285,4 @@ pub async fn process_internal_event(
     }
 
     Ok(Json(WebhookResponse { ok: true }))
-}
-
-/// HMAC-SHA256(bot_secret, body) の base64 と signature_b64 が一致するか定数時間比較。
-pub(crate) fn verify_signature(bot_secret: &str, body: &[u8], signature_b64: &str) -> bool {
-    let mut mac = match HmacSha256::new_from_slice(bot_secret.as_bytes()) {
-        Ok(m) => m,
-        Err(_) => return false,
-    };
-    mac.update(body);
-    let expected = mac.finalize().into_bytes();
-    let provided = match BASE64.decode(signature_b64) {
-        Ok(v) => v,
-        Err(_) => return false,
-    };
-    if provided.len() != expected.len() {
-        return false;
-    }
-    // 定数時間比較
-    let mut diff: u8 = 0;
-    for (a, b) in expected.iter().zip(provided.iter()) {
-        diff |= a ^ b;
-    }
-    diff == 0
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn sign(secret: &str, body: &[u8]) -> String {
-        let mut mac = HmacSha256::new_from_slice(secret.as_bytes()).unwrap();
-        mac.update(body);
-        BASE64.encode(mac.finalize().into_bytes())
-    }
-
-    #[test]
-    fn verify_signature_accepts_matching_hmac() {
-        let secret = "topsecret";
-        let body = br#"{"hello":"world"}"#;
-        let sig = sign(secret, body);
-        assert!(verify_signature(secret, body, &sig));
-    }
-
-    #[test]
-    fn verify_signature_rejects_wrong_secret() {
-        let body = br#"{"hello":"world"}"#;
-        let sig = sign("right", body);
-        assert!(!verify_signature("wrong", body, &sig));
-    }
-
-    #[test]
-    fn verify_signature_rejects_tampered_body() {
-        let secret = "topsecret";
-        let original = br#"{"hello":"world"}"#;
-        let tampered = br#"{"hello":"WORLD"}"#;
-        let sig = sign(secret, original);
-        assert!(!verify_signature(secret, tampered, &sig));
-    }
-
-    #[test]
-    fn verify_signature_rejects_invalid_base64() {
-        let secret = "topsecret";
-        let body = b"x";
-        assert!(!verify_signature(secret, body, "!!!not-base64!!!"));
-    }
-
-    #[test]
-    fn verify_signature_rejects_wrong_length_signature() {
-        let secret = "topsecret";
-        let body = b"x";
-        // valid base64 but decoded to 3 bytes (HMAC is 32)
-        assert!(!verify_signature(secret, body, "AAAA"));
-    }
-
-    #[test]
-    fn webhook_event_parses_join_with_source() {
-        let json =
-            r#"{"type":"joined","source":{"channelId":"ch1","channelType":"group","title":"T"}}"#;
-        let ev: WebhookEvent = serde_json::from_str(json).unwrap();
-        assert_eq!(ev.event_type, "joined");
-        let s = ev.source.unwrap();
-        assert_eq!(s.channel_id.as_deref(), Some("ch1"));
-        assert_eq!(s.channel_type.as_deref(), Some("group"));
-        assert_eq!(s.title.as_deref(), Some("T"));
-    }
-
-    #[test]
-    fn webhook_event_accepts_missing_source() {
-        let json = r#"{"type":"message"}"#;
-        let ev: WebhookEvent = serde_json::from_str(json).unwrap();
-        assert_eq!(ev.event_type, "message");
-        assert!(ev.source.is_none());
-    }
 }

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -152,7 +152,6 @@ pub fn router() -> Router<AppState> {
         .merge(devices::public_router())
         .merge(staging::router())
         .merge(notify_line_webhook::public_router())
-        .merge(notify_lineworks_channels::public_router())
         .merge(notify_read_tracker::public_router())
         .merge(access_requests::public_router())
         .merge(trouble_schedules::fire_router());


### PR DESCRIPTION
## Summary

LINE WORKS callback 移設の **Step 6**: rust-alc-api 側の旧 public webhook route (\`POST /api/notify/lineworks/webhook/{bot_id}\`) を削除。

LINE WORKS Developers Console 側で本番 (auth.ippoan.org) と staging (auth-staging.ippoan.org) どちらも auth-worker URL に切替済み。staging E2E (joined/left/message) 全パターン検証通過しており、これ以上 backend に public 入口を残す理由が無いため deep defense として削除する。

## 関連 PR (移設 step 1-5)
- ippoan/rust-alc-api#289 (Step 1: internal route 追加)
- ippoan/auth-worker#83 (Step 2: DO + handler)
- ippoan/nuxt-notify#28 (Step 4: 表示 URL 切替)
- LINE WORKS Console + auth-worker secret 投入 (Step 3+5: 実 Bot E2E ✅)

## 削除内容

\`crates/alc-notify/src/lineworks_channels.rs\`:
- \`public_router()\` 関数
- \`handle_webhook_route\` / \`handle_webhook\`
- \`WebhookEvent\` / \`WebhookSource\` 構造体 (handle_webhook 専用)
- \`verify_signature()\` + 関連 unit tests 7 ケース
- 不要 import: HeaderMap, hmac::{Hmac, Mac}, sha2::Sha256, base64::BASE64

\`src/routes/mod.rs\`:
- \`public_routes\` の \`.merge(notify_lineworks_channels::public_router())\` 行

## 残置

- \`WebhookResponse\` (internal route の戻り値で使用)
- \`internal_router()\` (\`/api/internal/lineworks/{bot-secret/{bot_id},event}\`)
- \`tenant_router()\` (admin CRUD)
- \`decrypt_secret\` 経路 (\`test_send_channel\` で使用)

## staging E2E 検証 (Step 3 で実施済み)

- ✅ 正しい署名 webhook → 200 + \`queued: true\`
- ✅ 不正署名 → 401 \`signature_mismatch\`
- ✅ joined イベント → \`lineworks_channels\` 行追加
- ✅ leave イベント → \`active=false\` (mark_left)
- ✅ message 等の未知イベント → 200 ignored

## 効果

backend (Cloud Run) は LINE WORKS callback の public 入口を持たなくなる。今後 Cloud Run ingress を internal-only に絞れる (別 PR)。

## Test plan

- [x] cargo fmt + cargo check --tests (pre-existing warning のみ)
- [ ] CI: 全テスト
- [ ] CI: 100% coverage 既存ファイルのリグレッション無し (削除のみで純減)
- [ ] staging deploy 通過 → 本番デプロイ後に LINE WORKS の callback が **新 URL に来ていることを再確認** (旧 URL を叩くと 404 になる)