### PR TITLE
feat(notify): StorageBackend::delete + email ingest migration

### DIFF
--- a/crates/alc-core/src/storage.rs
+++ b/crates/alc-core/src/storage.rs
@@ -25,6 +25,9 @@ pub trait StorageBackend: Send + Sync {
     /// Check if an object exists in storage (HEAD request).
     async fn exists(&self, key: &str) -> Result<bool, StorageError>;
 
+    /// Delete an object. Returns Ok(()) even if the object did not exist (idempotent).
+    async fn delete(&self, key: &str) -> Result<(), StorageError>;
+
     /// Extract the object key from a public URL.
     fn extract_key(&self, url: &str) -> Option<String>;
 

--- a/crates/alc-storage/src/gcs.rs
+++ b/crates/alc-storage/src/gcs.rs
@@ -110,6 +110,32 @@ impl StorageBackend for GcsBackend {
         Ok(bytes.to_vec())
     }
 
+    async fn delete(&self, key: &str) -> Result<(), StorageError> {
+        let token = self.get_access_token().await?;
+        let encoded_key = key.replace('/', "%2F");
+        let url = format!(
+            "https://storage.googleapis.com/storage/v1/b/{}/o/{}",
+            self.bucket, encoded_key
+        );
+
+        let resp = self
+            .client
+            .delete(&url)
+            .bearer_auth(&token)
+            .send()
+            .await
+            .map_err(|e| StorageError::Upload(format!("GCS delete: {e}")))?;
+
+        let status = resp.status();
+        if !status.is_success() && status.as_u16() != 404 {
+            return Err(StorageError::Upload(format!(
+                "GCS delete status {}",
+                status
+            )));
+        }
+        Ok(())
+    }
+
     fn extract_key(&self, url: &str) -> Option<String> {
         let prefix = format!("https://storage.googleapis.com/{}/", self.bucket);
         url.strip_prefix(&prefix).map(|s| s.to_string())

--- a/crates/alc-storage/src/r2.rs
+++ b/crates/alc-storage/src/r2.rs
@@ -103,6 +103,26 @@ impl StorageBackend for R2Backend {
         Ok(response.to_vec())
     }
 
+    async fn delete(&self, key: &str) -> Result<(), StorageError> {
+        let response = self
+            .bucket
+            .delete_object(key)
+            .await
+            .map_err(|e| StorageError::Upload(format!("R2 delete: {e}")))?;
+
+        let status = response.status_code();
+        if !(200..300).contains(&status) && status != 404 {
+            return Err(StorageError::Upload(format!(
+                "R2 delete status {}: {}",
+                status,
+                String::from_utf8_lossy(response.as_slice())
+            )));
+        }
+
+        tracing::info!("R2 delete: bucket={}, key={}", self.bucket_name, key);
+        Ok(())
+    }
+
     fn extract_key(&self, url: &str) -> Option<String> {
         let prefix = format!("{}/", self.public_url_base);
         url.strip_prefix(&prefix).map(|s| s.to_string())

--- a/migrations/103_notify_email_grouping.sql
+++ b/migrations/103_notify_email_grouping.sql
@@ -1,0 +1,21 @@
+-- notify_documents: メール受信用カラム追加
+-- email_message_id: 同一メールに含まれた複数添付をまとめるグルーピングID
+-- source_body_text: メール本文 (プレーンテキスト)
+-- source_received_at: メール受信日時 (Email Worker が記録)
+ALTER TABLE alc_api.notify_documents
+    ADD COLUMN IF NOT EXISTS email_message_id UUID,
+    ADD COLUMN IF NOT EXISTS source_body_text TEXT,
+    ADD COLUMN IF NOT EXISTS source_received_at TIMESTAMPTZ;
+
+CREATE INDEX IF NOT EXISTS idx_notify_documents_email_message_id
+    ON alc_api.notify_documents(tenant_id, email_message_id)
+    WHERE email_message_id IS NOT NULL;
+
+-- notify_deliveries: 「だれが送信を実行したか」を記録
+-- NULL は古い行 (この機能導入前のレコード) または自動配信
+ALTER TABLE alc_api.notify_deliveries
+    ADD COLUMN IF NOT EXISTS triggered_by_user_id UUID REFERENCES alc_api.users(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_notify_deliveries_triggered_by
+    ON alc_api.notify_deliveries(tenant_id, triggered_by_user_id)
+    WHERE triggered_by_user_id IS NOT NULL;

--- a/src/archive/test_helpers.rs
+++ b/src/archive/test_helpers.rs
@@ -136,4 +136,15 @@ mod tests {
         assert_eq!(s.get("c"), None);
         assert_eq!(s.keys().len(), 2);
     }
+
+    #[tokio::test]
+    async fn test_storage_delete() {
+        let s = TestStorage::new();
+        s.upload("k", b"data", "text/plain").await.unwrap();
+        assert!(s.exists("k").await.unwrap());
+        s.delete("k").await.unwrap();
+        assert!(!s.exists("k").await.unwrap());
+        // 存在しないキーの削除は idempotent
+        s.delete("missing").await.unwrap();
+    }
 }

--- a/src/archive/test_helpers.rs
+++ b/src/archive/test_helpers.rs
@@ -58,6 +58,11 @@ impl StorageBackend for TestStorage {
             .ok_or_else(|| StorageError::Upload(format!("not found: {key}")))
     }
 
+    async fn delete(&self, key: &str) -> Result<(), StorageError> {
+        self.files.lock().unwrap().remove(key);
+        Ok(())
+    }
+
     fn extract_key(&self, url: &str) -> Option<String> {
         url.strip_prefix("https://test-storage/")
             .map(|s| s.to_string())

--- a/tests/common/mock_storage.rs
+++ b/tests/common/mock_storage.rs
@@ -62,6 +62,11 @@ impl StorageBackend for MockStorage {
             .ok_or_else(|| StorageError::Upload(format!("Not found: {key}")))
     }
 
+    async fn delete(&self, key: &str) -> Result<(), StorageError> {
+        self.files.lock().unwrap().remove(key);
+        Ok(())
+    }
+
     fn extract_key(&self, url: &str) -> Option<String> {
         let prefix = format!("https://mock-storage/{}/", self.bucket_name);
         url.strip_prefix(&prefix).map(|s| s.to_string())


### PR DESCRIPTION
Phase 2 (メール受信機能) の基盤PR (1/4)。

## Summary
- StorageBackend trait に `async fn delete(&self, key: &str)` を追加
  - R2: `bucket.delete_object()` (404 は idempotent 扱い)
  - GCS: DELETE `/storage/v1/b/{bucket}/o/{key}` (404 idempotent)
  - MockStorage / TestStorage: HashMap.remove
- migration 103_notify_email_grouping.sql:
  - `notify_documents` に `email_message_id UUID`, `source_body_text TEXT`, `source_received_at TIMESTAMPTZ` を追加 (1メール=N行のグルーピング用)
  - `notify_deliveries` に `triggered_by_user_id UUID FK` を追加 (誰が配信を実行したかの記録用)
  - 全列 NULLABLE で既存行の互換性を維持

後続 PR で:
- ingest endpoint (`POST /api/notify/ingest`)
- 受信メール一覧 / 添付管理ルート
- Cloudflare Email Worker
- フロントエンド (`/emails` ページ + 配信履歴 UI)

## Test plan
- [ ] CI: cargo fmt + clippy + unit test (StorageBackend mock の delete 経路)
- [ ] CI: migrate-test (splinter / RLS) で migration 103 が通ること
- [ ] staging deploy で migration 103 が適用されること