### PR TITLE
feat(auth): expose tenant_slug on /auth/me

### DIFF
--- a/crates/alc-auth/src/lib.rs
+++ b/crates/alc-auth/src/lib.rs
@@ -68,6 +68,8 @@ pub struct UserResponse {
     pub email: String,
     pub name: String,
     pub tenant_id: Uuid,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tenant_slug: Option<String>,
     pub role: String,
 }
 
@@ -186,7 +188,7 @@ async fn issue_tokens_for_google_claims(
         .await
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
-    let access_token = create_access_token(&user, jwt_secret, slug)
+    let access_token = create_access_token(&user, jwt_secret, slug.clone())
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
     let (raw_refresh, refresh_hash) = create_refresh_token();
@@ -206,6 +208,7 @@ async fn issue_tokens_for_google_claims(
             email: user.email,
             name: user.name,
             tenant_id: user.tenant_id,
+            tenant_slug: slug,
             role: user.role,
         },
     }))
@@ -262,6 +265,7 @@ async fn me(Extension(auth_user): Extension<AuthUser>) -> Json<UserResponse> {
         email: auth_user.email,
         name: auth_user.name,
         tenant_id: auth_user.tenant_id,
+        tenant_slug: auth_user.tenant_slug,
         role: auth_user.role,
     })
 }
@@ -1213,7 +1217,7 @@ async fn password_login(
         .await
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
-    let access_token = create_access_token(&user, &jwt_secret, slug)
+    let access_token = create_access_token(&user, &jwt_secret, slug.clone())
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
     let (raw_refresh, refresh_hash) = create_refresh_token();
@@ -1234,6 +1238,7 @@ async fn password_login(
             email: user.email,
             name: user.name,
             tenant_id: user.tenant_id,
+            tenant_slug: slug,
             role: user.role,
         },
     }))

--- a/crates/alc-core/src/auth_middleware.rs
+++ b/crates/alc-core/src/auth_middleware.rs
@@ -26,6 +26,7 @@ pub async fn require_jwt(
         email: claims.email,
         name: claims.name.clone(),
         tenant_id: claims.tenant_id,
+        tenant_slug: claims.org_slug,
         role: claims.role,
     };
 
@@ -53,6 +54,7 @@ pub async fn require_tenant(
             email: claims.email,
             name: claims.name.clone(),
             tenant_id: claims.tenant_id,
+            tenant_slug: claims.org_slug,
             role: claims.role,
         };
         req.extensions_mut().insert(TenantId(claims.tenant_id));
@@ -122,12 +124,19 @@ pub async fn require_tenant_header(mut req: Request, next: Next) -> Result<Respo
         .and_then(|v| v.to_str().ok())
         .map(String::from);
 
+    let tenant_slug = req
+        .headers()
+        .get("X-Tenant-Slug")
+        .and_then(|v| v.to_str().ok())
+        .map(String::from);
+
     if let (Some(user_id), Some(email), Some(role)) = (user_id, email, role) {
         let auth_user = AuthUser {
             user_id,
             email,
             name: String::new(),
             tenant_id,
+            tenant_slug,
             role,
         };
         req.extensions_mut().insert(auth_user);

--- a/crates/alc-core/src/middleware.rs
+++ b/crates/alc-core/src/middleware.rs
@@ -7,6 +7,7 @@ pub struct AuthUser {
     pub email: String,
     pub name: String,
     pub tenant_id: Uuid,
+    pub tenant_slug: Option<String>,
     pub role: String,
 }
 


### PR DESCRIPTION
JWT は org_slug を持っているが AuthUser / UserResponse には露出していなかった。

nuxt-notify settings.vue は `me?.tenant?.slug` を読んで Email 受信設定の `tenant-{slug}@notify.ippoan.org` を組み立てるが、レスポンスにそのフィールドが無いため永遠に空 → 「(テナント情報取得中...)」のままになっていた。

## What changes

- AuthUser に tenant_slug: Option<String> 追加
- 全 middleware (require_jwt / require_tenant / require_tenant_header) が claims.org_slug もしくは X-Tenant-Slug ヘッダーから populate
- UserResponse に tenant_slug: Option<String> 追加 (skip_serializing_if=none)
- /auth/me + google login + password login のレスポンスが tenant_slug を含む

## Follow-up

nuxt-notify settings.vue で `me?.tenant?.slug` → `me?.tenant_slug` に直す PR を別途。

## Test plan

- [ ] CI green
- [ ] staging 自動デプロイ後 `curl /api/auth/me` で tenant_slug が返る