### PR TITLE
feat(tenants): short_id for email ingest

### DIFF
--- a/crates/alc-auth/src/lib.rs
+++ b/crates/alc-auth/src/lib.rs
@@ -68,8 +68,13 @@ pub struct UserResponse {
     pub email: String,
     pub name: String,
     pub tenant_id: Uuid,
+    /// 廃止予定。`tenants.slug` (NULL のことが多い)。
+    /// 新しいフロントは `tenant_short_id` を使う。
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tenant_slug: Option<String>,
+    /// `tenants.short_id` (8 文字 hex、UNIQUE、NOT NULL)。
+    /// メール ingest や URL 生成で使う。
+    pub tenant_short_id: String,
     pub role: String,
 }
 
@@ -187,6 +192,11 @@ async fn issue_tokens_for_google_claims(
         .get_tenant_slug(user.tenant_id)
         .await
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let short_id = repo
+        .get_tenant_short_id(user.tenant_id)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+        .ok_or(StatusCode::INTERNAL_SERVER_ERROR)?;
 
     let access_token = create_access_token(&user, jwt_secret, slug.clone())
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
@@ -209,6 +219,7 @@ async fn issue_tokens_for_google_claims(
             name: user.name,
             tenant_id: user.tenant_id,
             tenant_slug: slug,
+            tenant_short_id: short_id,
             role: user.role,
         },
     }))
@@ -259,15 +270,28 @@ async fn refresh_token(
 
 // --- Me ---
 
-async fn me(Extension(auth_user): Extension<AuthUser>) -> Json<UserResponse> {
-    Json(UserResponse {
+async fn me(
+    State(state): State<AppState>,
+    Extension(auth_user): Extension<AuthUser>,
+) -> Result<Json<UserResponse>, StatusCode> {
+    // tenant_short_id は JWT に入れていないので毎回 DB から引く (NOT NULL なので
+    // 必ずある。Lookup 1 回 = ms 単位で済むので /auth/me には無視できるコスト)。
+    let short_id = state
+        .auth
+        .get_tenant_short_id(auth_user.tenant_id)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+        .ok_or(StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    Ok(Json(UserResponse {
         id: auth_user.user_id,
         email: auth_user.email,
         name: auth_user.name,
         tenant_id: auth_user.tenant_id,
         tenant_slug: auth_user.tenant_slug,
+        tenant_short_id: short_id,
         role: auth_user.role,
-    })
+    }))
 }
 
 // --- Logout ---
@@ -1216,6 +1240,12 @@ async fn password_login(
         .get_tenant_slug(user.tenant_id)
         .await
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let short_id = state
+        .auth
+        .get_tenant_short_id(user.tenant_id)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+        .ok_or(StatusCode::INTERNAL_SERVER_ERROR)?;
 
     let access_token = create_access_token(&user, &jwt_secret, slug.clone())
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
@@ -1239,6 +1269,7 @@ async fn password_login(
             name: user.name,
             tenant_id: user.tenant_id,
             tenant_slug: slug,
+            tenant_short_id: short_id,
             role: user.role,
         },
     }))

--- a/crates/alc-core/src/models.rs
+++ b/crates/alc-core/src/models.rs
@@ -12,6 +12,8 @@ pub struct Tenant {
     pub name: String,
     pub slug: Option<String>,
     pub email_domain: Option<String>,
+    /// メール ingest 等で使う 8 文字 hex の短縮 ID。NOT NULL + UNIQUE。
+    pub short_id: String,
     pub created_at: DateTime<Utc>,
 }
 

--- a/crates/alc-core/src/repo/auth.rs
+++ b/crates/alc-core/src/repo/auth.rs
@@ -83,19 +83,43 @@ impl AuthRepository for PgAuthRepository {
     }
 
     async fn create_tenant_with_domain(&self, email_domain: &str) -> Result<Tenant, sqlx::Error> {
-        sqlx::query_as::<_, Tenant>(
-            "INSERT INTO tenants (name, email_domain) VALUES ($1, $1) RETURNING *",
-        )
-        .bind(email_domain)
-        .fetch_one(&self.pool)
-        .await
+        // short_id 衝突は DB の UNIQUE 制約で弾かれるので、UNIQUE 違反だけ
+        // 補足して再試行する。DEFAULT 式が gen_random_uuid() なので、
+        // 同じ短縮ID が連続して降ってくる確率は実質ゼロ (4B 中 1)。
+        for _ in 0..16 {
+            let result = sqlx::query_as::<_, Tenant>(
+                "INSERT INTO tenants (name, email_domain) VALUES ($1, $1) RETURNING *",
+            )
+            .bind(email_domain)
+            .fetch_one(&self.pool)
+            .await;
+            match result {
+                Ok(t) => return Ok(t),
+                Err(sqlx::Error::Database(e)) if e.is_unique_violation() => continue,
+                Err(e) => return Err(e),
+            }
+        }
+        Err(sqlx::Error::Configuration(
+            "could not insert tenant: 16 short_id collisions in a row".into(),
+        ))
     }
 
     async fn create_tenant_by_name(&self, name: &str) -> Result<Tenant, sqlx::Error> {
-        sqlx::query_as::<_, Tenant>("INSERT INTO tenants (name) VALUES ($1) RETURNING *")
-            .bind(name)
-            .fetch_one(&self.pool)
-            .await
+        for _ in 0..16 {
+            let result =
+                sqlx::query_as::<_, Tenant>("INSERT INTO tenants (name) VALUES ($1) RETURNING *")
+                    .bind(name)
+                    .fetch_one(&self.pool)
+                    .await;
+            match result {
+                Ok(t) => return Ok(t),
+                Err(sqlx::Error::Database(e)) if e.is_unique_violation() => continue,
+                Err(e) => return Err(e),
+            }
+        }
+        Err(sqlx::Error::Configuration(
+            "could not insert tenant: 16 short_id collisions in a row".into(),
+        ))
     }
 
     async fn get_tenant_by_id(&self, id: Uuid) -> Result<Option<Tenant>, sqlx::Error> {
@@ -111,6 +135,13 @@ impl AuthRepository for PgAuthRepository {
             .fetch_optional(&self.pool)
             .await
             .map(|opt| opt.flatten())
+    }
+
+    async fn get_tenant_short_id(&self, tenant_id: Uuid) -> Result<Option<String>, sqlx::Error> {
+        sqlx::query_scalar::<_, String>("SELECT short_id FROM tenants WHERE id = $1")
+            .bind(tenant_id)
+            .fetch_optional(&self.pool)
+            .await
     }
 
     async fn create_user_google(

--- a/crates/alc-core/src/repository/auth.rs
+++ b/crates/alc-core/src/repository/auth.rs
@@ -54,6 +54,9 @@ pub trait AuthRepository: Send + Sync {
 
     async fn get_tenant_slug(&self, tenant_id: Uuid) -> Result<Option<String>, sqlx::Error>;
 
+    /// `tenants.short_id` (8 文字 hex、NOT NULL)。tenant_id が存在しない時のみ None。
+    async fn get_tenant_short_id(&self, tenant_id: Uuid) -> Result<Option<String>, sqlx::Error>;
+
     // --- User creation ---
 
     #[allow(clippy::too_many_arguments)]

--- a/crates/alc-notify/src/ingest.rs
+++ b/crates/alc-notify/src/ingest.rs
@@ -1,12 +1,12 @@
-//! Email Worker からの ingest エンドポイント (X-Worker-Secret 認証 + tenant_slug 解決)
+//! Email Worker からの ingest エンドポイント (X-Worker-Secret 認証 + tenant_short_id 解決)
 //!
 //! Cloudflare Email Worker が受信したメールを JSON で POST してくる。
 //! 添付ファイルは base64 で送られ、各ファイルは notify_documents の 1 行に分解される。
 //! 同一メールに含まれる添付は同じ email_message_id でグルーピングされる。
 //!
 //! 認証は **shared secret** 1 個 (`NOTIFY_WORKER_SECRET`) で Worker ⇄ backend 経路を
-//! 守る。テナント特定は body の `tenant_slug` を `tenants.slug` で引いて行う。
-//! 旧 `notify_ingest_keys` テーブル + Cloudflare KV namespace 方式は廃止済み。
+//! 守る。テナント特定は body の `tenant_short_id` を `tenants.short_id` (UNIQUE)
+//! で引いて行う。旧 `notify_ingest_keys` テーブル + Cloudflare KV namespace 方式は廃止済み。
 
 use axum::{extract::State, http::StatusCode, Json, Router};
 use base64::Engine;
@@ -21,9 +21,9 @@ pub fn public_router() -> Router<AppState> {
 
 #[derive(serde::Deserialize)]
 pub struct IngestRequest {
-    /// テナント識別子 (`tenants.slug`)。Worker がメール宛先 `tenant-{slug}@...`
-    /// から抽出して送ってくる。
-    pub tenant_slug: String,
+    /// テナント識別子 (`tenants.short_id`)。Worker がメール宛先 `tenant-{short_id}@...`
+    /// から抽出して送ってくる。`short_id` は 8 文字 hex (UNIQUE)。
+    pub tenant_short_id: String,
     pub from: Option<String>,
     pub subject: Option<String>,
     pub body_text: Option<String>,
@@ -71,19 +71,19 @@ async fn handle_ingest(
         return Err(StatusCode::UNAUTHORIZED);
     }
 
-    // 2. tenant_slug → tenant_id 解決
-    let slug = payload.tenant_slug.trim();
-    if slug.is_empty() {
+    // 2. tenant_short_id → tenant_id 解決
+    let short_id = payload.tenant_short_id.trim();
+    if short_id.is_empty() {
         return Err(StatusCode::BAD_REQUEST);
     }
 
     let pool = state.pool();
-    let tenant_id: Option<Uuid> = sqlx::query_scalar("SELECT id FROM tenants WHERE slug = $1")
-        .bind(slug)
+    let tenant_id: Option<Uuid> = sqlx::query_scalar("SELECT id FROM tenants WHERE short_id = $1")
+        .bind(short_id)
         .fetch_optional(pool)
         .await
         .map_err(|e| {
-            tracing::error!("lookup tenant by slug: {e}");
+            tracing::error!("lookup tenant by short_id: {e}");
             StatusCode::INTERNAL_SERVER_ERROR
         })?;
     let tenant_id = tenant_id.ok_or(StatusCode::NOT_FOUND)?;

--- a/migrations/105_tenant_short_id.sql
+++ b/migrations/105_tenant_short_id.sql
@@ -1,0 +1,42 @@
+-- tenants.short_id : メール ingest や URL で使う 8 文字 hex の短縮 ID
+--
+-- これまで `tenants.slug` を兼用していたが、Google OAuth 自動サインアップで
+-- 作られたテナントは slug が NULL のままで、`tenant-{slug}@notify...` 経路や
+-- /auth/me の tenant_slug が機能していなかった。
+--
+-- short_id は UNIQUE 制約付きで NOT NULL。INSERT 側は衝突したらアプリ側
+-- (create_tenant_with_domain) で再生成する。
+
+ALTER TABLE alc_api.tenants
+    ADD COLUMN short_id TEXT
+    DEFAULT substring(replace(gen_random_uuid()::text, '-', '') FROM 1 FOR 8);
+
+-- 既存テナントを backfill (UNIQUE 制約は後で張るので衝突したら再ループ)。
+DO $backfill$
+DECLARE
+    t RECORD;
+    new_short TEXT;
+    attempts INT;
+BEGIN
+    FOR t IN SELECT id FROM alc_api.tenants WHERE short_id IS NULL LOOP
+        attempts := 0;
+        LOOP
+            new_short := substring(replace(gen_random_uuid()::text, '-', '') FROM 1 FOR 8);
+            EXIT WHEN NOT EXISTS (
+                SELECT 1 FROM alc_api.tenants
+                WHERE short_id = new_short AND id <> t.id
+            );
+            attempts := attempts + 1;
+            IF attempts > 100 THEN
+                RAISE EXCEPTION 'could not generate unique short_id for tenant %', t.id;
+            END IF;
+        END LOOP;
+        UPDATE alc_api.tenants SET short_id = new_short WHERE id = t.id;
+    END LOOP;
+END
+$backfill$;
+
+ALTER TABLE alc_api.tenants ALTER COLUMN short_id SET NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS tenants_short_id_unique
+    ON alc_api.tenants (short_id);

--- a/tests/mock_helpers/repos_a.rs
+++ b/tests/mock_helpers/repos_a.rs
@@ -117,7 +117,10 @@ impl Default for MockAuthRepository {
             return_switch_user: std::sync::Mutex::new(None),
             return_username_user: std::sync::Mutex::new(None),
             return_slug: std::sync::Mutex::new(None),
-            return_short_id: std::sync::Mutex::new(None),
+            // mock のデフォルトを Some にしておくと、google_login 等で
+            // get_tenant_short_id (NOT NULL 期待) を踏む経路が落ちずに済む。
+            // 個別テストで上書きしたければ return_short_id を直接いじる。
+            return_short_id: std::sync::Mutex::new(Some("mockshrt".to_string())),
         }
     }
 }

--- a/tests/mock_helpers/repos_a.rs
+++ b/tests/mock_helpers/repos_a.rs
@@ -95,6 +95,8 @@ pub struct MockAuthRepository {
     pub return_username_user: std::sync::Mutex<Option<User>>,
     /// If Some, get_tenant_slug returns this slug
     pub return_slug: std::sync::Mutex<Option<String>>,
+    /// If Some, get_tenant_short_id returns this short_id
+    pub return_short_id: std::sync::Mutex<Option<String>>,
 }
 
 impl Default for MockAuthRepository {
@@ -115,6 +117,7 @@ impl Default for MockAuthRepository {
             return_switch_user: std::sync::Mutex::new(None),
             return_username_user: std::sync::Mutex::new(None),
             return_slug: std::sync::Mutex::new(None),
+            return_short_id: std::sync::Mutex::new(None),
         }
     }
 }
@@ -178,6 +181,7 @@ impl AuthRepository for MockAuthRepository {
             name: email_domain.to_string(),
             slug: None,
             email_domain: Some(email_domain.to_string()),
+            short_id: format!("{:.8}", tid.simple()),
             created_at: Utc::now(),
         })
     }
@@ -194,6 +198,7 @@ impl AuthRepository for MockAuthRepository {
             name: name.to_string(),
             slug: None,
             email_domain: None,
+            short_id: format!("{:.8}", tid.simple()),
             created_at: Utc::now(),
         })
     }
@@ -206,6 +211,11 @@ impl AuthRepository for MockAuthRepository {
     async fn get_tenant_slug(&self, _tenant_id: Uuid) -> Result<Option<String>, sqlx::Error> {
         check_fail!(self);
         Ok(self.return_slug.lock().unwrap().clone())
+    }
+
+    async fn get_tenant_short_id(&self, _tenant_id: Uuid) -> Result<Option<String>, sqlx::Error> {
+        check_fail!(self);
+        Ok(self.return_short_id.lock().unwrap().clone())
     }
 
     async fn create_user_google(

--- a/tests/mock_tests/mock_auth_test.rs
+++ b/tests/mock_tests/mock_auth_test.rs
@@ -160,6 +160,7 @@ async fn test_google_login_new_user_via_email_domain() {
         name: "Domain Tenant".to_string(),
         slug: Some("domain-tenant".to_string()),
         email_domain: Some("example.com".to_string()),
+        short_id: "abcd1234".to_string(),
         created_at: chrono::Utc::now(),
     });
 
@@ -467,6 +468,7 @@ async fn test_my_orgs_success() {
         name: "Test Org".to_string(),
         slug: Some("test-org".to_string()),
         email_domain: None,
+        short_id: "deadbeef".to_string(),
         created_at: chrono::Utc::now(),
     });
 


### PR DESCRIPTION
Google OAuth 自動サインアップで作られたテナントは `slug` が NULL のままなので、`tenant-{slug}@notify.ippoan.org` の経路や /auth/me の `tenant_slug` が空になるケースがあった (= 受信用メールアドレスが UI に出ない)。

専用の `short_id` カラム (8 文字 hex、UNIQUE、NOT NULL) を追加し、メール ingest 経路はこちらに切り替える。`slug` は既存ユースケースのため残す。

## What changes

- migration 105: `tenants.short_id` 追加。DEFAULT で 8 文字 hex 生成、既存行は backfill (衝突時再ループ)、NOT NULL + UNIQUE。
- `Tenant` struct + `AuthRepository::get_tenant_short_id` を追加。
- `create_tenant_with_domain` / `create_tenant_by_name` は UNIQUE 違反を 16 回まで再試行 (UUID v4 prefix が同じ確率は 4B 中 1)。
- `crates/alc-notify/src/ingest.rs`: body field `tenant_slug` → `tenant_short_id`、lookup を `tenants.short_id` に。
- `UserResponse` に `tenant_short_id: String` (NOT NULL) 追加。/auth/me + google login + password login が返却。
- `tenant_slug` は廃止予定として skip_serializing_if=none で残す。

## Follow-up

- nuxt-notify Worker: `tenant_short_id` 送信 + tenant-${shortid}@... 抽出
- nuxt-notify settings.vue: `me.tenant_short_id` を読む

## Test plan

- [ ] CI green
- [ ] staging deploy 後 `/api/auth/me` が tenant_short_id を返す
- [ ] tenant 自動作成 (Google 新規) でも /settings に受信用アドレスが出る