### PR TITLE
fix(notify): wire NOTIFY_FRONTEND_URL env var (read-redirect target)

### DIFF
--- a/cloudrun/render.sh
+++ b/cloudrun/render.sh
@@ -102,6 +102,8 @@ emit_env_backend() {
               value: "${ENV_DTAKO_R2_BUCKET:-ohishi-dtako}"
             - name: NOTIFY_R2_BUCKET
               value: "$( [[ "$ENV" == "staging" ]] && echo "notify-files-staging" || echo "notify-files" )"
+            - name: NOTIFY_FRONTEND_URL
+              value: "$( [[ "$ENV" == "staging" ]] && echo "https://notify-staging.ippoan.org" || echo "https://notify.ippoan.org" )"
             - name: SCRAPER_URL
               value: "${ENV_SCRAPER_URL:?ENV_SCRAPER_URL not set (GitHub vars.SCRAPER_URL)}"
             - name: FCM_PROJECT_ID


### PR DESCRIPTION
## 問題

\`read_tracker\` (\`/api/notify/read/{token}\`) は LINE/LW メッセージ内の
「詳細を見る」リンクをクリックされた際、\`NOTIFY_FRONTEND_URL\` 環境変数を読んで
\`{frontend_url}/documents/{document_id}\` へ 302 リダイレクトする
([crates/alc-notify/src/read_tracker.rs:34-36](crates/alc-notify/src/read_tracker.rs#L34-L36))。

しかし staging/prod の Cloud Run どちらにも \`NOTIFY_FRONTEND_URL\` が設定されていなかったため、
デフォルト値 \`https://notify.example.com\` (DNS 解決不能) に飛んでいて、
配信メッセージの「詳細を見る」リンクが機能していなかった。

## 修正

\`cloudrun/render.sh\` の backend env vars に \`NOTIFY_FRONTEND_URL\` を追加:

- staging: \`https://notify-staging.ippoan.org\`
- production: \`https://notify.ippoan.org\`

既存の \`NOTIFY_R2_BUCKET\` / \`STAGING_MODE\` と同じ三項演算 (\`[[ \"\$ENV\" == \"staging\" ]] && ... || ...\`) で振り分け。

## 検証

\`\`\`
\$ ENV_SCRAPER_URL=https://example.com bash cloudrun/render.sh backend production v0.0.50 | grep -A1 NOTIFY_FRONTEND_URL
            - name: NOTIFY_FRONTEND_URL
              value: \"https://notify.ippoan.org\"

\$ ENV_SCRAPER_URL=https://example.com bash cloudrun/render.sh backend staging v0.0.50 --staging-url x --db-image y | grep -A1 NOTIFY_FRONTEND_URL
            - name: NOTIFY_FRONTEND_URL
              value: \"https://notify-staging.ippoan.org\"
\`\`\`

## 関連 PR
- nuxt-notify ippoan/nuxt-notify#41 で \`/documents/[id]\` ページを新規追加。
  両方マージ → staging 自動デプロイ → 本番タグ release で「詳細を見る」リンクが完動する。

## 備考
- nuxt-notify のデプロイは PR merge → CI auto-deploy
- 本 PR は merge 後さらに \`/tag-release patch\` で本番反映が必要 (タグ駆動デプロイ)