### PR TITLE
feat(notify): R2 presigned URL で配信リンクをログイン不要に + 任意期限

### DIFF
--- a/crates/alc-core/src/repository/notify_deliveries.rs
+++ b/crates/alc-core/src/repository/notify_deliveries.rs
@@ -42,6 +42,8 @@ pub struct NotifyDeliveryWithRecipient {
 pub struct ReadResult {
     pub document_id: Uuid,
     pub tenant_id: Uuid,
+    pub r2_key: String,
+    pub expire_at: chrono::DateTime<chrono::Utc>,
 }
 
 #[async_trait]

--- a/crates/alc-core/src/storage.rs
+++ b/crates/alc-core/src/storage.rs
@@ -33,4 +33,10 @@ pub trait StorageBackend: Send + Sync {
 
     /// Bucket name.
     fn bucket(&self) -> &str;
+
+    /// Generate a presigned GET URL for the given key.
+    ///
+    /// `expiry_seconds` controls how long the signed URL is valid (max 604800 = 7 days for S3 spec).
+    /// The URL grants read access without further authentication; treat it as a bearer token.
+    async fn presign_get(&self, key: &str, expiry_seconds: u32) -> Result<String, StorageError>;
 }

--- a/crates/alc-notify/src/distribute.rs
+++ b/crates/alc-notify/src/distribute.rs
@@ -152,6 +152,10 @@ pub struct DistributeTarget {
 #[derive(serde::Deserialize, Default)]
 pub struct DistributeRequest {
     pub target: Option<DistributeTarget>,
+    /// 配信から何日後に閲覧期限切れにするか (デフォルト 7 日)。
+    /// 指定範囲: 1〜90 (R2 presigned URL 仕様の最大 7 日 (= 604800 秒) を超えても、
+    /// read_tracker が都度 1 時間 presign を発行するので問題なく動く)
+    pub retention_days: Option<i64>,
 }
 
 async fn resolve_target_recipients(
@@ -212,11 +216,14 @@ async fn distribute(
         })?
         .ok_or(StatusCode::NOT_FOUND)?;
 
-    let target = body.and_then(|b| b.0.target).unwrap_or(DistributeTarget {
+    let req = body.map(|b| b.0).unwrap_or_default();
+    let target = req.target.unwrap_or(DistributeTarget {
         all: true,
         group_id: None,
         recipient_ids: Vec::new(),
     });
+    // retention_days: クライアントから来なければ 7 日、来た値は 1〜90 日にクランプ
+    let retention_days: i32 = req.retention_days.unwrap_or(7).clamp(1, 90) as i32;
     let recipients = resolve_target_recipients(&state, tenant_id, &target).await?;
 
     if recipients.is_empty() {
@@ -244,23 +251,38 @@ async fn distribute(
             StatusCode::INTERNAL_SERVER_ERROR
         })?;
 
-    // 「だれが配信したか」を新規 deliveries 行にマーク (best-effort)
-    if let (Some(user_id), false) = (triggered_by, deliveries.is_empty()) {
+    // triggered_by_user_id (best-effort) と expire_at の調整 (default 7d 以外を指定された場合)
+    if !deliveries.is_empty() {
         let ids: Vec<Uuid> = deliveries.iter().map(|d| d.id).collect();
         match TenantConn::acquire(state.pool(), &tenant_id.to_string()).await {
             Ok(mut tc) => {
-                if let Err(e) = sqlx::query(
-                    "UPDATE notify_deliveries SET triggered_by_user_id = $1 WHERE id = ANY($2)",
-                )
-                .bind(user_id)
-                .bind(&ids)
-                .execute(&mut *tc.conn)
-                .await
-                {
-                    tracing::warn!("set triggered_by_user_id: {e}");
+                if let Some(user_id) = triggered_by {
+                    if let Err(e) = sqlx::query(
+                        "UPDATE notify_deliveries SET triggered_by_user_id = $1 WHERE id = ANY($2)",
+                    )
+                    .bind(user_id)
+                    .bind(&ids)
+                    .execute(&mut *tc.conn)
+                    .await
+                    {
+                        tracing::warn!("set triggered_by_user_id: {e}");
+                    }
+                }
+                // 7 日以外なら expire_at を上書き (default は migration で NOW() + 7 days)
+                if retention_days != 7 {
+                    if let Err(e) = sqlx::query(
+                        "UPDATE notify_deliveries SET expire_at = NOW() + make_interval(days => $1) WHERE id = ANY($2)",
+                    )
+                    .bind(retention_days)
+                    .bind(&ids)
+                    .execute(&mut *tc.conn)
+                    .await
+                    {
+                        tracing::warn!("set expire_at: {e}");
+                    }
                 }
             }
-            Err(e) => tracing::warn!("acquire conn for triggered_by: {e}"),
+            Err(e) => tracing::warn!("acquire conn for delivery update: {e}"),
         }
     }
 

--- a/crates/alc-notify/src/read_tracker.rs
+++ b/crates/alc-notify/src/read_tracker.rs
@@ -1,5 +1,11 @@
-//! 既読トラッキング
-//! メッセージ内リンクをクリック → 既読記録 → フロントエンドにリダイレクト
+//! 既読トラッキング + 公開ファイル配信
+//!
+//! メッセージ内リンク `/api/notify/read/{token}` がクリックされると:
+//! 1. mark_delivery_read で既読更新 + r2_key + expire_at を取得
+//! 2. expire_at 経過後なら 410 Gone (リンク失効)
+//! 3. 期限内なら R2 の presigned URL (短期、最大 1 時間) を発行 → 302 redirect
+//!
+//! ログイン不要で LINE WORKS in-app browser から見られる (Google OAuth ブロック回避)。
 
 use axum::{
     extract::{Path, State},
@@ -10,6 +16,13 @@ use axum::{
 use uuid::Uuid;
 
 use alc_core::AppState;
+
+/// presigned URL の有効期間 (秒)。delivery.expire_at までの残期間と
+/// この値の小さい方を採用する。LINE トークから複数回タップしても
+/// 都度新規発行されるので、単一 URL の漏洩耐性を上げる目的。
+const PRESIGN_DEFAULT_SECS: i64 = 3600;
+/// presigned URL の最低秒数 (R2/S3 の最小値に対する安全マージン)
+const PRESIGN_MIN_SECS: i64 = 60;
 
 pub fn public_router() -> Router<AppState> {
     Router::new().route("/notify/read/{token}", axum::routing::get(read_redirect))
@@ -28,20 +41,30 @@ async fn read_redirect(
             StatusCode::INTERNAL_SERVER_ERROR
         })?;
 
-    match result {
-        Some(r) => {
-            // フロントエンドのドキュメント詳細ページにリダイレクト
-            let frontend_url = std::env::var("NOTIFY_FRONTEND_URL")
-                .unwrap_or_else(|_| "https://notify.example.com".into());
-            let redirect_url = format!("{}/documents/{}", frontend_url, r.document_id);
+    let r = result.ok_or(StatusCode::NOT_FOUND)?;
 
-            Ok((StatusCode::FOUND, [(header::LOCATION, redirect_url)]).into_response())
-        }
-        None => {
-            // 既に既読済み or トークン不正 → それでもリダイレクト
-            let frontend_url = std::env::var("NOTIFY_FRONTEND_URL")
-                .unwrap_or_else(|_| "https://notify.example.com".into());
-            Ok((StatusCode::FOUND, [(header::LOCATION, frontend_url)]).into_response())
-        }
+    // 配信単位の絶対期限 (= notify_deliveries.expire_at) を超えたら 410
+    let now = chrono::Utc::now();
+    if r.expire_at <= now {
+        return Err(StatusCode::GONE);
     }
+
+    // 残期間と PRESIGN_DEFAULT_SECS の小さい方を採用 (PRESIGN_MIN_SECS で下限ガード)
+    let remaining = (r.expire_at - now).num_seconds();
+    let presign_secs = remaining.clamp(PRESIGN_MIN_SECS, PRESIGN_DEFAULT_SECS) as u32;
+
+    let storage = state.notify_storage.as_ref().ok_or_else(|| {
+        tracing::error!("notify_storage not configured");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    let presigned_url = storage
+        .presign_get(&r.r2_key, presign_secs)
+        .await
+        .map_err(|e| {
+            tracing::error!("presign_get: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    Ok((StatusCode::FOUND, [(header::LOCATION, presigned_url)]).into_response())
 }

--- a/crates/alc-storage/src/gcs.rs
+++ b/crates/alc-storage/src/gcs.rs
@@ -144,4 +144,10 @@ impl StorageBackend for GcsBackend {
     fn bucket(&self) -> &str {
         &self.bucket
     }
+
+    async fn presign_get(&self, _key: &str, _expiry_seconds: u32) -> Result<String, StorageError> {
+        Err(StorageError::Config(
+            "GCS presign_get not implemented (notify uses R2)".into(),
+        ))
+    }
 }

--- a/crates/alc-storage/src/r2.rs
+++ b/crates/alc-storage/src/r2.rs
@@ -131,4 +131,11 @@ impl StorageBackend for R2Backend {
     fn bucket(&self) -> &str {
         &self.bucket_name
     }
+
+    async fn presign_get(&self, key: &str, expiry_seconds: u32) -> Result<String, StorageError> {
+        self.bucket
+            .presign_get(key, expiry_seconds, None)
+            .await
+            .map_err(|e| StorageError::Upload(format!("R2 presign_get: {e}")))
+    }
 }

--- a/migrations/106_notify_delivery_expire_at.sql
+++ b/migrations/106_notify_delivery_expire_at.sql
@@ -1,0 +1,39 @@
+-- notify_deliveries.expire_at: 配信ごとの閲覧期限 (任意日時)
+-- read_tracker が expire_at > NOW() を判定し、有効なら R2 presigned URL に redirect
+ALTER TABLE alc_api.notify_deliveries
+    ADD COLUMN expire_at TIMESTAMPTZ;
+
+-- 既存行は created_at + 7 days で初期化
+UPDATE alc_api.notify_deliveries
+    SET expire_at = created_at + INTERVAL '7 days'
+    WHERE expire_at IS NULL;
+
+ALTER TABLE alc_api.notify_deliveries
+    ALTER COLUMN expire_at SET NOT NULL;
+
+ALTER TABLE alc_api.notify_deliveries
+    ALTER COLUMN expire_at SET DEFAULT (NOW() + INTERVAL '7 days');
+
+-- mark_delivery_read を拡張: r2_key + expire_at も返す
+-- read_tracker が presigned URL を組み立てるのに必要
+CREATE OR REPLACE FUNCTION alc_api.mark_delivery_read(p_read_token UUID)
+RETURNS TABLE(
+    document_id UUID,
+    tenant_id UUID,
+    r2_key TEXT,
+    expire_at TIMESTAMPTZ
+)
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = alc_api
+AS $$
+BEGIN
+    UPDATE alc_api.notify_deliveries
+    SET read_at = NOW()
+    WHERE read_token = p_read_token AND read_at IS NULL;
+
+    RETURN QUERY
+    SELECT d.document_id, d.tenant_id, doc.r2_key, d.expire_at
+    FROM alc_api.notify_deliveries d
+    JOIN alc_api.notify_documents doc ON doc.id = d.document_id
+    WHERE d.read_token = p_read_token;
+END;
+$$;

--- a/migrations/106_notify_delivery_expire_at.sql
+++ b/migrations/106_notify_delivery_expire_at.sql
@@ -16,7 +16,11 @@ ALTER TABLE alc_api.notify_deliveries
 
 -- mark_delivery_read を拡張: r2_key + expire_at も返す
 -- read_tracker が presigned URL を組み立てるのに必要
-CREATE OR REPLACE FUNCTION alc_api.mark_delivery_read(p_read_token UUID)
+-- 注: 既存の mark_delivery_read (migration 071) は戻り値型が違うので
+-- CREATE OR REPLACE は使えない (Pg 42P13)。DROP してから CREATE する。
+DROP FUNCTION IF EXISTS alc_api.mark_delivery_read(UUID);
+
+CREATE FUNCTION alc_api.mark_delivery_read(p_read_token UUID)
 RETURNS TABLE(
     document_id UUID,
     tenant_id UUID,
@@ -37,3 +41,5 @@ BEGIN
     WHERE d.read_token = p_read_token;
 END;
 $$;
+
+GRANT EXECUTE ON FUNCTION alc_api.mark_delivery_read(UUID) TO alc_api_app;

--- a/src/archive/test_helpers.rs
+++ b/src/archive/test_helpers.rs
@@ -138,6 +138,13 @@ mod tests {
         assert!(s.upload("k", b"data", "text/plain").await.is_err());
     }
 
+    #[tokio::test]
+    async fn test_storage_presign_get() {
+        let s = TestStorage::new();
+        let url = s.presign_get("foo/bar", 600).await.unwrap();
+        assert_eq!(url, "https://test-storage/foo/bar?expires=600");
+    }
+
     #[test]
     fn test_storage_put_get_keys() {
         let s = TestStorage::new();

--- a/src/archive/test_helpers.rs
+++ b/src/archive/test_helpers.rs
@@ -71,6 +71,17 @@ impl StorageBackend for TestStorage {
     fn bucket(&self) -> &str {
         "test-bucket"
     }
+
+    async fn presign_get(
+        &self,
+        key: &str,
+        expiry_seconds: u32,
+    ) -> Result<String, alc_core::storage::StorageError> {
+        Ok(format!(
+            "https://test-storage/{}?expires={}",
+            key, expiry_seconds
+        ))
+    }
 }
 
 #[cfg(test)]

--- a/tests/common/mock_storage.rs
+++ b/tests/common/mock_storage.rs
@@ -75,4 +75,15 @@ impl StorageBackend for MockStorage {
     fn bucket(&self) -> &str {
         &self.bucket_name
     }
+
+    async fn presign_get(
+        &self,
+        key: &str,
+        expiry_seconds: u32,
+    ) -> Result<String, alc_core::storage::StorageError> {
+        Ok(format!(
+            "https://mock-storage/{}/{}?expires={}",
+            self.bucket_name, key, expiry_seconds
+        ))
+    }
 }

--- a/tests/mock_helpers/repos_d.rs
+++ b/tests/mock_helpers/repos_d.rs
@@ -454,6 +454,8 @@ impl NotifyDeliveryRepository for MockNotifyDeliveryRepository {
         Ok(Some(ReadResult {
             document_id: Uuid::new_v4(),
             tenant_id: Uuid::new_v4(),
+            r2_key: "mock/key".into(),
+            expire_at: chrono::Utc::now() + chrono::Duration::days(7),
         }))
     }
     async fn list_by_document(


### PR DESCRIPTION
## 問題

配信メッセージの「▶ 詳細を見る」リンクをタップ → frontend のログイン画面に飛ぶ →
**LINE WORKS in-app webview だと Google OAuth が \`disallowed_useragent\` で拒否される**
ため、受信者が PDF を見られない事態だった。

## 修正

- read_tracker を「フロントへリダイレクト」から **「R2 presigned URL へ 302」** に書き換え。
  LINE WORKS webview に PDF が直接表示される (OAuth 不要)。
- 配信ごとに **retention_days を選択可** (1/7/30/90 日)、Postgres の
  \`notify_deliveries.expire_at\` で絶対期限を保持。
- read_tracker は expire_at で 410 Gone 判定 → 期限内なら 1 時間有効の
  presigned URL を都度発行 (URL 漏洩耐性も担保)。

## 期限管理は 2 段

| 期限 | 設定箇所 | 効果 |
|---|---|---|
| 配信単位の絶対期限 (1/7/30/90 日) | \`notify_deliveries.expire_at\` Postgres | backend がここで切る → 以降タップしても 410 |
| 個別 presigned URL の短期限 (1 時間) | 毎回 SDK で \`X-Amz-Expires=3600\` | URL がコピーされて誰かにシェアされても 1 時間で失効 |

## 変更内容

- \`migrations/106_notify_delivery_expire_at.sql\` 新規:
  - \`notify_deliveries.expire_at\` カラム追加 (default \`NOW() + 7 days\`)
  - \`mark_delivery_read\` 関数を r2_key + expire_at も返すよう CREATE OR REPLACE
- \`crates/alc-core/src/storage.rs\` に \`presign_get(key, expiry_secs)\` trait method
- \`crates/alc-storage/src/r2.rs\` で \`bucket.presign_get(...)\` 実装、GCS は未実装エラー
- \`crates/alc-notify/src/read_tracker.rs\` を expire_at 検証 + presigned URL 302 に書き換え
- \`crates/alc-notify/src/distribute.rs\` の DistributeRequest に \`retention_days\`
  オプション (1〜90 にクランプ、default 7)、配信時に expire_at 上書き
- \`crates/alc-core/src/repository/notify_deliveries.rs\` の ReadResult struct に
  \`r2_key\` + \`expire_at\` 追加
- 既存 \`NOTIFY_FRONTEND_URL\` env var は不要になるが、\`render.sh\` は今回触らず温存

## 関連 PR

- nuxt-notify (DistributeModal に「閲覧期限」セレクター追加) — 別 PR で進行

## 動作確認

- ローカル \`cargo check --workspace\` / \`cargo clippy -p alc-notify -- -D warnings\` PASS
- staging deploy 後に LINE WORKS で再配信 → 「詳細を見る」 → PDF が webview に
  直接表示されることを確認予定