### PR TITLE
fix(notify): R2 presigned URL に response-content-disposition=inline

### DIFF
--- a/crates/alc-storage/src/r2.rs
+++ b/crates/alc-storage/src/r2.rs
@@ -2,6 +2,7 @@ use alc_core::storage::{StorageBackend, StorageError};
 use s3::bucket::Bucket;
 use s3::creds::Credentials;
 use s3::Region;
+use std::collections::HashMap;
 
 pub struct R2Backend {
     bucket: Box<Bucket>,
@@ -133,8 +134,15 @@ impl StorageBackend for R2Backend {
     }
 
     async fn presign_get(&self, key: &str, expiry_seconds: u32) -> Result<String, StorageError> {
+        // response-content-disposition=inline でブラウザ・webview に強制 inline 表示。
+        // 添付ダウンロードに行かず、PDF/画像が webview 内で開く。
+        let mut queries = HashMap::new();
+        queries.insert(
+            "response-content-disposition".to_string(),
+            "inline".to_string(),
+        );
         self.bucket
-            .presign_get(key, expiry_seconds, None)
+            .presign_get(key, expiry_seconds, Some(queries))
             .await
             .map_err(|e| StorageError::Upload(format!("R2 presign_get: {e}")))
     }


### PR DESCRIPTION
## 問題

LINE WORKS in-app webview や一部ブラウザは Content-Disposition が attachment 既定
だとダウンロードダイアログを出してしまい、PDF が webview 内で開かない。

## 修正

R2 presigned URL の query に \`response-content-disposition=inline\` を付加して、
PDF/画像が webview 内でそのまま inline 表示されるようにする。

\`crates/alc-storage/src/r2.rs\` の \`presign_get\` 内で \`HashMap\` を組み立て、
\`bucket.presign_get(..., Some(queries))\` に渡す。

## 影響範囲

- read_tracker → R2 リダイレクトの単一フローで presign_get を使う
- 他に \`presign_get\` を呼ぶ箇所はないので副作用なし

## 設計判断

trait シグネチャ (\`presign_get(&self, key, expiry_secs)\`) は据え置き、R2 impl 側
で常に inline を内包する形にした (YAGNI)。ダウンロード強制が要件化したらその時
\`presign_get_attachment\` のような method を分ける方針。

## 動作確認

- ローカル \`cargo check -p alc-storage\` PASS
- staging deploy 後、LINE WORKS で配信再テスト → 「詳細」タップ → PDF が
  webview 内で inline 表示されることを確認