### PR TITLE
feat(notify): public viewer page redirect

### DIFF
--- a/crates/alc-core/src/repository/notify_deliveries.rs
+++ b/crates/alc-core/src/repository/notify_deliveries.rs
@@ -46,6 +46,20 @@ pub struct ReadResult {
     pub expire_at: chrono::DateTime<chrono::Utc>,
 }
 
+/// lookup_delivery_for_view の戻り値 (公開 viewer ページ用、既読化しない)
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct DeliveryViewInfo {
+    pub document_id: Uuid,
+    pub tenant_id: Uuid,
+    pub r2_key: String,
+    pub file_name: Option<String>,
+    pub file_size_bytes: Option<i64>,
+    pub source_subject: Option<String>,
+    pub source_sender: Option<String>,
+    pub source_received_at: Option<chrono::DateTime<chrono::Utc>>,
+    pub expire_at: chrono::DateTime<chrono::Utc>,
+}
+
 #[async_trait]
 pub trait NotifyDeliveryRepository: Send + Sync {
     /// ドキュメントに対して全受信者分の配信レコードを一括作成
@@ -68,6 +82,10 @@ pub trait NotifyDeliveryRepository: Send + Sync {
 
     /// 既読記録 (SECURITY DEFINER 関数経由、テナント不要)
     async fn mark_read(&self, read_token: Uuid) -> Result<Option<ReadResult>, sqlx::Error>;
+
+    /// 公開 viewer ページ用の閲覧情報 (既読化しない、SECURITY DEFINER 関数経由)
+    async fn get_for_view(&self, read_token: Uuid)
+        -> Result<Option<DeliveryViewInfo>, sqlx::Error>;
 
     async fn list_by_document(
         &self,

--- a/crates/alc-notify/src/lib.rs
+++ b/crates/alc-notify/src/lib.rs
@@ -11,3 +11,4 @@ pub mod lineworks_directory;
 pub mod read_tracker;
 pub mod recipients;
 pub mod repo;
+pub mod viewer;

--- a/crates/alc-notify/src/read_tracker.rs
+++ b/crates/alc-notify/src/read_tracker.rs
@@ -1,11 +1,14 @@
-//! 既読トラッキング + 公開ファイル配信
+//! 既読トラッキング — メッセージ内リンクのクリックハンドラ。
 //!
-//! メッセージ内リンク `/api/notify/read/{token}` がクリックされると:
-//! 1. mark_delivery_read で既読更新 + r2_key + expire_at を取得
+//! 流れ:
+//! 1. `mark_delivery_read` で既読更新 + r2_key + expire_at を取得
+//!    (既読済みでも r2_key と expire_at は返るが、未読時のみ read_at を更新)
 //! 2. expire_at 経過後なら 410 Gone (リンク失効)
-//! 3. 期限内なら R2 の presigned URL (短期、最大 1 時間) を発行 → 302 redirect
+//! 3. 期限内なら nuxt-notify の公開 viewer ページ `/v/{token}` に 302 redirect
+//!    (ログイン不要、Google OAuth ブロック回避、ブランディング/メタデータ表示可能)
 //!
-//! ログイン不要で LINE WORKS in-app browser から見られる (Google OAuth ブロック回避)。
+//! 公開 viewer ページが内部で `/api/notify/v/{token}` (メタデータ) と
+//! `/api/notify/v/{token}/file` (R2 presigned URL リダイレクト) を呼ぶ。
 
 use axum::{
     extract::{Path, State},
@@ -17,15 +20,17 @@ use uuid::Uuid;
 
 use alc_core::AppState;
 
-/// presigned URL の有効期間 (秒)。delivery.expire_at までの残期間と
-/// この値の小さい方を採用する。LINE トークから複数回タップしても
-/// 都度新規発行されるので、単一 URL の漏洩耐性を上げる目的。
-const PRESIGN_DEFAULT_SECS: i64 = 3600;
-/// presigned URL の最低秒数 (R2/S3 の最小値に対する安全マージン)
-const PRESIGN_MIN_SECS: i64 = 60;
-
 pub fn public_router() -> Router<AppState> {
     Router::new().route("/notify/read/{token}", axum::routing::get(read_redirect))
+}
+
+pub(crate) fn frontend_url() -> String {
+    std::env::var("NOTIFY_FRONTEND_URL").unwrap_or_else(|_| "https://notify.example.com".into())
+}
+
+pub(crate) fn build_view_url(frontend_url: &str, token: Uuid) -> String {
+    let trimmed = frontend_url.trim_end_matches('/');
+    format!("{trimmed}/v/{token}")
 }
 
 async fn read_redirect(
@@ -44,27 +49,44 @@ async fn read_redirect(
     let r = result.ok_or(StatusCode::NOT_FOUND)?;
 
     // 配信単位の絶対期限 (= notify_deliveries.expire_at) を超えたら 410
-    let now = chrono::Utc::now();
-    if r.expire_at <= now {
+    if r.expire_at <= chrono::Utc::now() {
         return Err(StatusCode::GONE);
     }
 
-    // 残期間と PRESIGN_DEFAULT_SECS の小さい方を採用 (PRESIGN_MIN_SECS で下限ガード)
-    let remaining = (r.expire_at - now).num_seconds();
-    let presign_secs = remaining.clamp(PRESIGN_MIN_SECS, PRESIGN_DEFAULT_SECS) as u32;
+    let url = build_view_url(&frontend_url(), token);
+    Ok((StatusCode::FOUND, [(header::LOCATION, url)]).into_response())
+}
 
-    let storage = state.notify_storage.as_ref().ok_or_else(|| {
-        tracing::error!("notify_storage not configured");
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?;
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-    let presigned_url = storage
-        .presign_get(&r.r2_key, presign_secs)
-        .await
-        .map_err(|e| {
-            tracing::error!("presign_get: {e}");
-            StatusCode::INTERNAL_SERVER_ERROR
-        })?;
+    #[test]
+    fn build_view_url_appends_token() {
+        let token = Uuid::nil();
+        let url = build_view_url("https://notify.example.com", token);
+        assert_eq!(
+            url,
+            "https://notify.example.com/v/00000000-0000-0000-0000-000000000000"
+        );
+    }
 
-    Ok((StatusCode::FOUND, [(header::LOCATION, presigned_url)]).into_response())
+    #[test]
+    fn build_view_url_strips_trailing_slash() {
+        let token = Uuid::nil();
+        let url = build_view_url("https://notify.example.com/", token);
+        assert_eq!(
+            url,
+            "https://notify.example.com/v/00000000-0000-0000-0000-000000000000"
+        );
+    }
+
+    #[test]
+    fn frontend_url_uses_env_when_set() {
+        // 並列テストで環境変数を直接弄らないよう、デフォルト経路だけ
+        // 確認する。env var 注入経路は staging E2E でカバーする。
+        std::env::remove_var("NOTIFY_FRONTEND_URL");
+        let url = frontend_url();
+        assert!(url.starts_with("https://"));
+    }
 }

--- a/crates/alc-notify/src/repo/notify_deliveries.rs
+++ b/crates/alc-notify/src/repo/notify_deliveries.rs
@@ -88,6 +88,17 @@ impl NotifyDeliveryRepository for PgNotifyDeliveryRepository {
             .await
     }
 
+    async fn get_for_view(
+        &self,
+        read_token: Uuid,
+    ) -> Result<Option<DeliveryViewInfo>, sqlx::Error> {
+        // SECURITY DEFINER 関数経由 — 既読化せず閲覧情報のみ取得
+        sqlx::query_as::<_, DeliveryViewInfo>("SELECT * FROM alc_api.lookup_delivery_for_view($1)")
+            .bind(read_token)
+            .fetch_optional(&self.pool)
+            .await
+    }
+
     async fn list_by_document(
         &self,
         tenant_id: Uuid,

--- a/crates/alc-notify/src/viewer.rs
+++ b/crates/alc-notify/src/viewer.rs
@@ -1,0 +1,185 @@
+//! 公開 viewer (ログイン不要) — nuxt-notify の `/v/{token}` ページから呼ばれる。
+//!
+//! 既読化はしない (それは `/api/notify/read/{token}` の責務)。
+//! トークンが有効である限り何度でも閲覧できる。
+//!
+//! - GET /api/notify/v/{token}      → メタデータ JSON (件名 / 送信者 / ファイル名 / 受信日時 / 期限)
+//! - GET /api/notify/v/{token}/file → R2 presigned URL (inline) に 302 redirect
+
+use axum::{
+    extract::{Path, State},
+    http::{header, StatusCode},
+    response::{IntoResponse, Response},
+    Json, Router,
+};
+use uuid::Uuid;
+
+use alc_core::repository::notify_deliveries::DeliveryViewInfo;
+use alc_core::AppState;
+
+/// presigned URL の最大有効期間 (秒)。delivery.expire_at までの残期間と
+/// この値の小さい方を採用する。
+pub(crate) const PRESIGN_DEFAULT_SECS: i64 = 3600;
+/// presigned URL の最低秒数 (R2/S3 の最小値に対する安全マージン)
+pub(crate) const PRESIGN_MIN_SECS: i64 = 60;
+
+pub fn public_router() -> Router<AppState> {
+    Router::new()
+        .route("/notify/v/{token}", axum::routing::get(view_metadata))
+        .route("/notify/v/{token}/file", axum::routing::get(view_file))
+}
+
+#[derive(serde::Serialize, Debug, PartialEq)]
+pub struct ViewMetadata {
+    pub file_name: Option<String>,
+    pub file_size_bytes: Option<i64>,
+    pub source_subject: Option<String>,
+    pub source_sender: Option<String>,
+    pub source_received_at: Option<chrono::DateTime<chrono::Utc>>,
+    pub expire_at: chrono::DateTime<chrono::Utc>,
+}
+
+pub(crate) fn build_metadata(info: &DeliveryViewInfo) -> ViewMetadata {
+    ViewMetadata {
+        file_name: info.file_name.clone(),
+        file_size_bytes: info.file_size_bytes,
+        source_subject: info.source_subject.clone(),
+        source_sender: info.source_sender.clone(),
+        source_received_at: info.source_received_at,
+        expire_at: info.expire_at,
+    }
+}
+
+/// 期限を判定する純関数。期限切れなら 410 Gone、有効なら使う秒数を返す。
+pub(crate) fn presign_secs_or_gone(
+    expire_at: chrono::DateTime<chrono::Utc>,
+    now: chrono::DateTime<chrono::Utc>,
+) -> Result<u32, StatusCode> {
+    if expire_at <= now {
+        return Err(StatusCode::GONE);
+    }
+    let remaining = (expire_at - now).num_seconds();
+    Ok(remaining.clamp(PRESIGN_MIN_SECS, PRESIGN_DEFAULT_SECS) as u32)
+}
+
+async fn view_metadata(
+    State(state): State<AppState>,
+    Path(token): Path<Uuid>,
+) -> Result<Json<ViewMetadata>, StatusCode> {
+    let info = state
+        .notify_deliveries
+        .get_for_view(token)
+        .await
+        .map_err(|e| {
+            tracing::error!("get_for_view: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?
+        .ok_or(StatusCode::NOT_FOUND)?;
+
+    presign_secs_or_gone(info.expire_at, chrono::Utc::now())?;
+    Ok(Json(build_metadata(&info)))
+}
+
+async fn view_file(
+    State(state): State<AppState>,
+    Path(token): Path<Uuid>,
+) -> Result<Response, StatusCode> {
+    let info = state
+        .notify_deliveries
+        .get_for_view(token)
+        .await
+        .map_err(|e| {
+            tracing::error!("get_for_view: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?
+        .ok_or(StatusCode::NOT_FOUND)?;
+
+    let secs = presign_secs_or_gone(info.expire_at, chrono::Utc::now())?;
+
+    let storage = state.notify_storage.as_ref().ok_or_else(|| {
+        tracing::error!("notify_storage not configured");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    let url = storage.presign_get(&info.r2_key, secs).await.map_err(|e| {
+        tracing::error!("presign_get: {e}");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    Ok((StatusCode::FOUND, [(header::LOCATION, url)]).into_response())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_info(expire_in_hours: i64) -> DeliveryViewInfo {
+        DeliveryViewInfo {
+            document_id: Uuid::new_v4(),
+            tenant_id: Uuid::new_v4(),
+            r2_key: "tenant/email/msg/file.pdf".into(),
+            file_name: Some("file.pdf".into()),
+            file_size_bytes: Some(2048),
+            source_subject: Some("件名".into()),
+            source_sender: Some("from@example.com".into()),
+            source_received_at: Some(chrono::Utc::now()),
+            expire_at: chrono::Utc::now() + chrono::Duration::hours(expire_in_hours),
+        }
+    }
+
+    #[test]
+    fn build_metadata_copies_all_fields() {
+        let info = sample_info(24);
+        let m = build_metadata(&info);
+        assert_eq!(m.file_name, info.file_name);
+        assert_eq!(m.file_size_bytes, info.file_size_bytes);
+        assert_eq!(m.source_subject, info.source_subject);
+        assert_eq!(m.source_sender, info.source_sender);
+        assert_eq!(m.source_received_at, info.source_received_at);
+        assert_eq!(m.expire_at, info.expire_at);
+        // r2_key と document_id / tenant_id は外に漏らさない
+        let json = serde_json::to_string(&m).unwrap();
+        assert!(!json.contains("r2_key"));
+        assert!(!json.contains("document_id"));
+        assert!(!json.contains("tenant_id"));
+    }
+
+    #[test]
+    fn presign_secs_clamps_to_default_when_remaining_is_long() {
+        let now = chrono::Utc::now();
+        let expire = now + chrono::Duration::days(7);
+        let secs = presign_secs_or_gone(expire, now).unwrap();
+        assert_eq!(secs as i64, PRESIGN_DEFAULT_SECS);
+    }
+
+    #[test]
+    fn presign_secs_clamps_to_min_when_remaining_is_short() {
+        let now = chrono::Utc::now();
+        let expire = now + chrono::Duration::seconds(10);
+        let secs = presign_secs_or_gone(expire, now).unwrap();
+        assert_eq!(secs as i64, PRESIGN_MIN_SECS);
+    }
+
+    #[test]
+    fn presign_secs_uses_remaining_in_window() {
+        let now = chrono::Utc::now();
+        let expire = now + chrono::Duration::seconds(900);
+        let secs = presign_secs_or_gone(expire, now).unwrap();
+        assert_eq!(secs, 900);
+    }
+
+    #[test]
+    fn presign_secs_returns_gone_when_expired() {
+        let now = chrono::Utc::now();
+        let expire = now - chrono::Duration::seconds(1);
+        let err = presign_secs_or_gone(expire, now).unwrap_err();
+        assert_eq!(err, StatusCode::GONE);
+    }
+
+    #[test]
+    fn presign_secs_returns_gone_at_exact_boundary() {
+        let now = chrono::Utc::now();
+        let err = presign_secs_or_gone(now, now).unwrap_err();
+        assert_eq!(err, StatusCode::GONE);
+    }
+}

--- a/migrations/107_notify_view_lookup.sql
+++ b/migrations/107_notify_view_lookup.sql
@@ -1,0 +1,29 @@
+-- 配信トークンから既読化せずに閲覧用情報をルックアップする SECURITY DEFINER 関数。
+-- nuxt-notify の公開 viewer ページ (/v/{token}) が呼び出す:
+--   GET /api/notify/v/{token}      → メタデータ JSON
+--   GET /api/notify/v/{token}/file → R2 presigned URL に redirect
+-- どちらも既読化はしない (既読は /api/notify/read/{token} で確定)。
+CREATE OR REPLACE FUNCTION alc_api.lookup_delivery_for_view(p_read_token UUID)
+RETURNS TABLE(
+    document_id UUID,
+    tenant_id UUID,
+    r2_key TEXT,
+    file_name TEXT,
+    file_size_bytes BIGINT,
+    source_subject TEXT,
+    source_sender TEXT,
+    source_received_at TIMESTAMPTZ,
+    expire_at TIMESTAMPTZ
+)
+LANGUAGE sql SECURITY DEFINER SET search_path = alc_api
+AS $$
+    SELECT d.document_id, d.tenant_id,
+           doc.r2_key, doc.file_name, doc.file_size_bytes,
+           doc.source_subject, doc.source_sender, doc.source_received_at,
+           d.expire_at
+    FROM alc_api.notify_deliveries d
+    JOIN alc_api.notify_documents doc ON doc.id = d.document_id
+    WHERE d.read_token = p_read_token
+$$;
+
+GRANT EXECUTE ON FUNCTION alc_api.lookup_delivery_for_view(UUID) TO alc_api_app;

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -45,6 +45,7 @@ pub use alc_notify::lineworks_channels as notify_lineworks_channels;
 pub use alc_notify::lineworks_directory as notify_lineworks_directory;
 pub use alc_notify::read_tracker as notify_read_tracker;
 pub use alc_notify::recipients as notify_recipients;
+pub use alc_notify::viewer as notify_viewer;
 pub use alc_tenko::daily_health;
 pub use alc_tenko::equipment_failures;
 pub use alc_tenko::health_baselines;
@@ -157,6 +158,7 @@ pub fn router() -> Router<AppState> {
         .merge(notify_ingest::public_router())
         .merge(notify_line_webhook::public_router())
         .merge(notify_read_tracker::public_router())
+        .merge(notify_viewer::public_router())
         .merge(access_requests::public_router())
         .merge(trouble_schedules::fire_router());
 

--- a/tests/mock_helpers/repos_d.rs
+++ b/tests/mock_helpers/repos_d.rs
@@ -458,6 +458,23 @@ impl NotifyDeliveryRepository for MockNotifyDeliveryRepository {
             expire_at: chrono::Utc::now() + chrono::Duration::days(7),
         }))
     }
+    async fn get_for_view(
+        &self,
+        _read_token: Uuid,
+    ) -> Result<Option<DeliveryViewInfo>, sqlx::Error> {
+        check_fail!(self);
+        Ok(Some(DeliveryViewInfo {
+            document_id: Uuid::new_v4(),
+            tenant_id: Uuid::new_v4(),
+            r2_key: "mock/key".into(),
+            file_name: Some("mock.pdf".into()),
+            file_size_bytes: Some(1024),
+            source_subject: Some("Mock subject".into()),
+            source_sender: Some("sender@example.com".into()),
+            source_received_at: Some(chrono::Utc::now()),
+            expire_at: chrono::Utc::now() + chrono::Duration::days(7),
+        }))
+    }
     async fn list_by_document(
         &self,
         _tenant_id: Uuid,


### PR DESCRIPTION
## Summary
- LINE 配信リンク `/api/notify/read/{token}` のリダイレクト先を、R2 presigned URL から nuxt-notify の公開 viewer ページ `{NOTIFY_FRONTEND_URL}/v/{token}` に変更
- 公開ページが内部で呼ぶ API を 2 本追加 (どちらも認証不要):
  - `GET /api/notify/v/{token}` — メタデータ JSON (件名 / 送信者 / ファイル名 / 受信日時 / 期限)
  - `GET /api/notify/v/{token}/file` — R2 presigned URL (inline) に 302 redirect
- 既読化は /read のみで実施。/v/{token}/file は何度でも開ける (高齢者の二度押し対応)
- migration 107 で SECURITY DEFINER 関数 `lookup_delivery_for_view` を追加 (UPDATE せず pure SELECT)
- 単体テスト 9 件追加 (viewer + read_tracker)

frontend (nuxt-notify) の対応 PR は別途。

## Test plan
- [x] cargo fmt
- [x] cargo check --all-targets
- [x] cargo test -p alc-notify --lib (新規 9 件 pass)
- [ ] CI: ci.yml + migrate-test
- [ ] staging E2E:
  - \`curl -sI <api>/api/notify/read/<token>\` → 302 Location が \`<frontend>/v/<token>\`
  - \`curl -s <api>/api/notify/v/<token>\` → メタデータ JSON
  - \`curl -sI <api>/api/notify/v/<token>/file\` → 302 R2 presigned URL