### PR TITLE
fix(migrations): 106 を RLS で死なない形に書き換え

### DIFF
--- a/migrations/106_notify_delivery_expire_at.sql
+++ b/migrations/106_notify_delivery_expire_at.sql
@@ -1,18 +1,16 @@
 -- notify_deliveries.expire_at: 配信ごとの閲覧期限 (任意日時)
 -- read_tracker が expire_at > NOW() を判定し、有効なら R2 presigned URL に redirect
+--
+-- NOT NULL + DEFAULT を ADD COLUMN と同時に指定する。
+-- PostgreSQL 11+ では NOT NULL DEFAULT 付き ADD COLUMN は table rewrite せず、
+-- DML (UPDATE) も発行せず、メタデータのみ更新する高速操作。RLS は DML にしか
+-- 効かないので migration 実行ロール (alc_api_app, NOBYPASSRLS) でも問題なく通る。
+--
+-- 既存行は migration 実行時刻 + 7 days となる (本来 created_at + 7 days にしたかったが、
+-- 既存行を UPDATE で backfill しようとすると RLS にブロックされて 0 行になり、
+-- 続く SET NOT NULL が失敗する。古い配信のリンクが多少延命するだけで害なし)。
 ALTER TABLE alc_api.notify_deliveries
-    ADD COLUMN expire_at TIMESTAMPTZ;
-
--- 既存行は created_at + 7 days で初期化
-UPDATE alc_api.notify_deliveries
-    SET expire_at = created_at + INTERVAL '7 days'
-    WHERE expire_at IS NULL;
-
-ALTER TABLE alc_api.notify_deliveries
-    ALTER COLUMN expire_at SET NOT NULL;
-
-ALTER TABLE alc_api.notify_deliveries
-    ALTER COLUMN expire_at SET DEFAULT (NOW() + INTERVAL '7 days');
+    ADD COLUMN expire_at TIMESTAMPTZ NOT NULL DEFAULT (NOW() + INTERVAL '7 days');
 
 -- mark_delivery_read を拡張: r2_key + expire_at も返す
 -- read_tracker が presigned URL を組み立てるのに必要


### PR DESCRIPTION
## Summary
本番 migrate Job がコケた件の修正。

旧 106 は `ADD COLUMN (nullable) → UPDATE → SET NOT NULL` の 3 段だが、migrate Job は `alc_api_app` (NOBYPASSRLS) で実行されるため、RLS 経由で UPDATE が 0 行ヒット → SET NOT NULL で死亡。staging は揮発 DB なので再現せず、本番 Supabase で表面化。

修正: `ADD COLUMN ... TIMESTAMPTZ NOT NULL DEFAULT (NOW() + INTERVAL '7 days')` を 1 文で。PG 11+ では rewrite/UPDATE 発行なしのメタデータ操作で RLS 関係なし。

副作用: 本番既存行の expire_at が migration 実行時刻 + 7 days になる (本来は created_at + 7 days)。古い配信のリンクが多少延命するだけで害なし。

## Test plan
- [x] cargo check
- [ ] CI: migrate-test ジョブ
- [ ] merge → /tag-release patch で本番再デプロイ → migrate Job 成功

## staging 影響
旧 106 のチェックサムが `_sqlx_migrations` に残るため、staging では初回 migrate がチェックサム不一致で失敗するが、emptyDir 揮発のためコールドスタート後 (15分アイドル後) に自動回復する。