### PR TITLE
feat: snapshot hook 統合 (rust-alc-api consumer)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# rust-alc-api pre-commit hook
+#
+# 1. plan/snapshot 整合性 (npx dev-plans-snapshot check)
+#    - drift 検出 (snapshot ↔ ippoan/ippoan-dev-plans の Issue 状態)
+#    - if_flag!("name#sha") の name+sha が snapshot に登録済みか
+# 2. cargo fmt --check
+# 3. cargo clippy --workspace --all-targets -- -D warnings
+#
+# 有効化: git config core.hooksPath .githooks
+# 無効化: git config --unset core.hooksPath
+
+set -euo pipefail
+
+ROOT=$(git rev-parse --show-toplevel)
+cd "$ROOT"
+
+# --- 1. snapshot 整合性 ----------------------------------------------------
+
+if [[ ! -d node_modules ]]; then
+  echo "[pre-commit] node_modules がありません。先に 'npm install' を実行してください。" >&2
+  exit 1
+fi
+
+if [[ -z "${GITHUB_TOKEN:-}${GH_TOKEN:-}" ]]; then
+  if command -v gh >/dev/null 2>&1; then
+    GITHUB_TOKEN=$(gh auth token 2>/dev/null || true)
+    export GITHUB_TOKEN
+  fi
+fi
+
+if [[ -z "${GITHUB_TOKEN:-}${GH_TOKEN:-}" ]]; then
+  echo "[pre-commit] GITHUB_TOKEN unavailable, skipping snapshot:check (CI で確実に走るので OK)" >&2
+else
+  if ! npx --no-install dev-plans-snapshot check; then
+    echo "" >&2
+    echo "[pre-commit] snapshot 整合性チェック失敗" >&2
+    echo "  drift の場合: npm run snapshot && git add manifests/production.snapshot.json" >&2
+    echo "  flag 未登録の場合: ippoan/ippoan-dev-plans に scope:rust-alc-api ラベル付き Issue を作成" >&2
+    exit 1
+  fi
+fi
+
+# --- 2. cargo fmt ---------------------------------------------------------
+
+if command -v cargo >/dev/null 2>&1; then
+  if ! cargo fmt --check; then
+    echo "" >&2
+    echo "[pre-commit] cargo fmt 違反。'cargo fmt --all' で整形してください。" >&2
+    exit 1
+  fi
+fi
+
+# --- 3. cargo clippy ------------------------------------------------------
+# 重い (~30s+) ので SKIP_CLIPPY=1 でスキップ可。CI では必ず走る。
+
+if [[ "${SKIP_CLIPPY:-0}" != "1" ]] && command -v cargo >/dev/null 2>&1; then
+  if ! cargo clippy --workspace --all-targets --quiet -- -D warnings; then
+    echo "" >&2
+    echo "[pre-commit] cargo clippy 違反。修正してください。(SKIP_CLIPPY=1 で一時 skip 可、CI は走ります)" >&2
+    exit 1
+  fi
+fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,9 +137,12 @@ jobs:
     name: Snapshot Check
     needs: [pr-limit]
     if: "always() && !(github.ref == 'refs/heads/main' && github.event_name == 'push') && (needs.pr-limit.result == 'success' || needs.pr-limit.result == 'skipped')"
+    permissions:
+      contents: read
+      packages: read
     uses: ippoan/ci-workflows/.github/workflows/snapshot-check.yml@main
     secrets:
-      PAT: ${{ secrets.TAG_RELEASE_PAT }}
+      PAT: ${{ secrets.GITHUB_TOKEN }}
 
   check:
     name: Format & Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,14 @@ jobs:
           fi
           echo "::endgroup::"
 
+  snapshot-check:
+    name: Snapshot Check
+    needs: [pr-limit]
+    if: "always() && !(github.ref == 'refs/heads/main' && github.event_name == 'push') && (needs.pr-limit.result == 'success' || needs.pr-limit.result == 'skipped')"
+    uses: ippoan/ci-workflows/.github/workflows/snapshot-check.yml@main
+    secrets:
+      PAT: ${{ secrets.TAG_RELEASE_PAT }}
+
   check:
     name: Format & Lint
     needs: [pr-limit]
@@ -440,10 +448,11 @@ jobs:
 
   auto-merge:
     name: Auto Merge
-    needs: [check, coverage-check, build-image]
+    needs: [snapshot-check, check, coverage-check, build-image]
     if: >-
       always() &&
       github.event_name == 'pull_request' &&
+      needs.snapshot-check.result == 'success' &&
       needs.check.result == 'success' &&
       needs.coverage-check.result == 'success' &&
       needs.build-image.result == 'success'

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+@ippoan:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -577,6 +577,44 @@ example で挙動を確認したら、本体コードを次の粒度で分ける
 - **DB エラー注入**: `BEGIN → ALTER TABLE RENAME → テスト → ROLLBACK` パターン (PostgreSQL DDL は ROLLBACK 可能)
 - **SSE テスト**: コアロジックを `pub async fn xxx_core()` に抽出し、SSE ラッパーとは別にテスト可能にする
 
+## Plan / Snapshot 管理
+
+`ippoan/ippoan-dev-plans` repo で管理している plan/feature flag を本 repo の `manifests/production.snapshot.json` に複製し、pre-commit hook + CI で整合性を機械的に保証する。
+
+### 仕組み
+
+| layer | 役割 |
+|---|---|
+| `ippoan/ippoan-dev-plans` Issue (`label:plan` + `scope:rust-alc-api` or `scope:cross-repo`) | plan/flag の正本 |
+| `manifests/production.snapshot.json` | 上の Issue を fetch して固めたスナップショット (per-flag SHA 付き) |
+| `npm run snapshot` (= `npx dev-plans-snapshot build`) | snapshot 再生成 |
+| `npm run snapshot:check` | drift 検出 + コードの `if_flag!("name#sha")` 参照が snapshot と一致するか検証 |
+| `.githooks/pre-commit` | commit 前に snapshot:check + cargo fmt/clippy |
+| `.github/workflows/ci.yml` の `snapshot-check` job | PR で同じチェックを CI 防衛線として再実行 (auto-merge の必須 needs) |
+
+### flag 識別子は `name#sha` ハイブリッド
+
+```rust
+if_flag!("trouble_ack_modal#9f1c3a8b")
+```
+
+- `name`: human-readable snake_case
+- `sha`: `sha256("${plan_id}|${id}|${source_issue}").hex.slice(0,8)` — Issue の identity が変わると SHA も変わるので、code 側の旧参照が即座に検出される
+- snapshot に同 name 複数 entry (異 SHA) が並んでも、code は SHA で disambiguate される
+
+### 日常運用ルール
+
+- **新規 flag を導入する前に必ず plan Issue を立てる**: `ippoan/ippoan-dev-plans` で `scope:rust-alc-api` (または `scope:cross-repo`) ラベル付き Issue を作成 → 本文の YAML block に `id` / `plan_id` を書く → `npm run snapshot` で取り込む
+- **commit する前に hook を有効化**: `git config core.hooksPath .githooks` (clone 直後 1 度だけ)
+- **`npm install` が前提**: `.npmrc` で `@ippoan` scope を GHCR に向けている。`NODE_AUTH_TOKEN` (PAT with `read:packages`) が必要
+- **drift で落ちたら**: `npm run snapshot && git add manifests/production.snapshot.json && git commit ...`
+- **stale sha で落ちたら**: snapshot を再生成するか、code 側を新 sha に書き換える
+- **clippy 重い時**: `SKIP_CLIPPY=1 git commit ...` で skip 可、CI で必ず走る
+
+### マクロ実装
+
+`if_flag!()` マクロ本体は `alc-core` (`ippoan/ippoan-dev-plans#6` で計画中) で定義予定。本 PR (#2) ではマクロは不要 — hook の grep 用 regex (`/\bif_flag!\(\s*"([a-z][a-z0-9_]+)#([a-f0-9]{8})"/g`) と snapshot 機構のレールだけ敷く。
+
 ## ブランチワークフロー
 
 **main に直接 merge/push してはいけない。** 複数の Claude が並行作業しているため、main を直接変更すると他の worktree や作業に影響する。

--- a/README.md
+++ b/README.md
@@ -17,3 +17,29 @@
 - 乗務員管理 API
 - 顔写真アップロード (Cloud Storage)
 - RLS によるマルチテナントデータ分離
+
+## Snapshot hook (plan 整合性チェック)
+
+`ippoan/ippoan-dev-plans` で管理している plan / feature flag の状態と本 repo の `manifests/production.snapshot.json` の整合性を pre-commit hook + CI で機械的に保証する。
+
+### 初回 setup (clone 直後 1 度だけ)
+
+```bash
+NODE_AUTH_TOKEN=$(gh auth token) npm install
+git config core.hooksPath .githooks
+```
+
+`.npmrc` は `@ippoan` scope を GHCR registry に向ける設定済み。`NODE_AUTH_TOKEN` には `read:packages` scope の PAT (Personal Access Token) が必要 — `gh auth token` が動けば一旦 OK、CI 用に長期運用する場合は専用 PAT を `~/.npmrc` に置く。
+
+### 日常運用
+
+| 状況 | 対処 |
+|---|---|
+| `if_flag!("name#sha")` を新規追加 | 先に `ippoan/ippoan-dev-plans` で `scope:rust-alc-api` ラベル付きの plan Issue を作る → `npm run snapshot` で snapshot 更新 → commit |
+| pre-commit が drift で落ちた | `npm run snapshot && git add manifests/production.snapshot.json` |
+| pre-commit が "stale sha" で落ちた | snapshot を再生成して新 sha に追従 (`npm run snapshot`)、もしくは code 側を新 sha に書き換え |
+| clippy が遅い (~30s+) | `SKIP_CLIPPY=1 git commit ...` で一時 skip、CI で必ず走る |
+
+### CI 防衛線
+
+`.github/workflows/ci.yml` の `snapshot-check` job が `ippoan/ci-workflows/.github/workflows/snapshot-check.yml@main` を呼んで同じチェックを CI 上で再実行。`auto-merge` job の `needs` に含まれているので必須チェック扱い。

--- a/dev-plans.config.js
+++ b/dev-plans.config.js
@@ -1,0 +1,5 @@
+export default {
+  scopeLabels: ["rust-alc-api", "cross-repo"],
+  grepPatterns: [/\bif_flag!\(\s*"([a-z][a-z0-9_]+)#([a-f0-9]{8})"/g],
+  sourceDirs: ["src", "crates"],
+};

--- a/manifests/production.snapshot.json
+++ b/manifests/production.snapshot.json
@@ -1,0 +1,13 @@
+{
+  "generated_at": "2026-05-02T08:49:07.625Z",
+  "issues_last_updated_at": "2026-05-02T08:20:37Z",
+  "source": {
+    "owner": "ippoan",
+    "repo": "ippoan-dev-plans"
+  },
+  "scope_filter": [
+    "rust-alc-api",
+    "cross-repo"
+  ],
+  "flags": []
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,277 @@
+{
+  "name": "rust-alc-api-tooling",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "rust-alc-api-tooling",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@ippoan/dev-plans-snapshot": "^0.1.0"
+      }
+    },
+    "node_modules/@ippoan/dev-plans-snapshot": {
+      "version": "0.1.0",
+      "resolved": "https://npm.pkg.github.com/download/@ippoan/dev-plans-snapshot/0.1.0/031f0d1315ceff6cbd39528a6670b84035a45ff8",
+      "integrity": "sha512-HQcE/c+aFVV28naAfZZZ4WXyQ4tW3fBTH+Gkyc3+jWpCuQi5egDRmLxSaHSuxnYBd8K6j+Ap85mptyaqDur2Kw==",
+      "dev": true,
+      "license": "UNLICENSED",
+      "dependencies": {
+        "@octokit/rest": "^21.0.2",
+        "yaml": "^2.6.1"
+      },
+      "bin": {
+        "dev-plans-snapshot": "cli.js"
+      }
+    },
+    "node_modules/@octokit/auth-token": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-5.1.2.tgz",
+      "integrity": "sha512-JcQDsBdg49Yky2w2ld20IHAlwr8d/d8N6NiOXbtuoPCqzbsiJgF633mVUw3x4mo0H5ypataQIX7SFu3yy44Mpw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-6.1.6.tgz",
+      "integrity": "sha512-kIU8SLQkYWGp3pVKiYzA5OSaNF5EE03P/R8zEmmrG6XwOg5oBjXyQVVIauQ0dgau4zYhpZEhJrvIYt6oM+zZZA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@octokit/auth-token": "^5.0.0",
+        "@octokit/graphql": "^8.2.2",
+        "@octokit/request": "^9.2.3",
+        "@octokit/request-error": "^6.1.8",
+        "@octokit/types": "^14.0.0",
+        "before-after-hook": "^3.0.2",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "10.1.4",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-10.1.4.tgz",
+      "integrity": "sha512-OlYOlZIsfEVZm5HCSR8aSg02T2lbUWOsCQoPKfTXJwDzcHQBrVBGdGXb89dv2Kw2ToZaRtudp8O3ZIYoaOjKlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^14.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-8.2.2.tgz",
+      "integrity": "sha512-Yi8hcoqsrXGdt0yObxbebHXFOiUA+2v3n53epuOg1QUgOB6c4XzvisBNVXJSl8RYA5KrDuSL2yq9Qmqe5N0ryA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request": "^9.2.3",
+        "@octokit/types": "^14.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "25.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-25.1.0.tgz",
+      "integrity": "sha512-idsIggNXUKkk0+BExUn1dQ92sfysJrje03Q0bv0e+KPLrvyqZF8MnBpFz8UNfYDwB3Ie7Z0TByjWfzxt7vseaA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "11.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-11.6.0.tgz",
+      "integrity": "sha512-n5KPteiF7pWKgBIBJSk8qzoZWcUkza2O6A0za97pMGVrGfPdltxrfmfF5GucHYvHGZD8BdaZmmHGz5cX/3gdpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.10.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/openapi-types": {
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/types": {
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^24.2.0"
+      }
+    },
+    "node_modules/@octokit/plugin-request-log": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-5.3.1.tgz",
+      "integrity": "sha512-n/lNeCtq+9ofhC15xzmJCNKP2BWTv8Ih2TTy+jatNCCq/gQP/V7rK3fjIfuz0pDWDALO/o/4QY4hyOF6TQQFUw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "13.5.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-13.5.0.tgz",
+      "integrity": "sha512-9Pas60Iv9ejO3WlAX3maE1+38c5nqbJXV5GrncEfkndIpZrJ/WPMRd2xYDcPPEt5yzpxcjw9fWNoPhsSGzqKqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.10.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/openapi-types": {
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/types": {
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^24.2.0"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.2.4.tgz",
+      "integrity": "sha512-q8ybdytBmxa6KogWlNa818r0k1wlqzNC+yNkcQDECHvQo8Vmstrg18JwqJHdJdUiHD2sjlwBgSm9kHkOKe2iyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/endpoint": "^10.1.4",
+        "@octokit/request-error": "^6.1.8",
+        "@octokit/types": "^14.0.0",
+        "fast-content-type-parse": "^2.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "6.1.8",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-6.1.8.tgz",
+      "integrity": "sha512-WEi/R0Jmq+IJKydWlKDmryPcmdYSVjL3ekaiEL1L9eo1sUnqMJ+grqmC9cjk7CA7+b2/T397tO5d8YLOH3qYpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^14.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/rest": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-21.1.1.tgz",
+      "integrity": "sha512-sTQV7va0IUVZcntzy1q3QqPm/r8rWtDCqpRAmb8eXXnKkjoQEtFe3Nt5GTVsHft+R6jJoHeSiVLcgcvhtue/rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/core": "^6.1.4",
+        "@octokit/plugin-paginate-rest": "^11.4.2",
+        "@octokit/plugin-request-log": "^5.3.1",
+        "@octokit/plugin-rest-endpoint-methods": "^13.3.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-14.1.0.tgz",
+      "integrity": "sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^25.1.0"
+      }
+    },
+    "node_modules/before-after-hook": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-3.0.2.tgz",
+      "integrity": "sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/fast-content-type-parse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-2.0.1.tgz",
+      "integrity": "sha512-nGqtvLrj5w0naR6tDPfB4cUmYCqouzyQiz6C5y/LtcDllJdrcc6WaWW6iXyIIOErTa/XRybj28aasdn4LkVk6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/universal-user-agent": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
+      "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "rust-alc-api-tooling",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Repo-local tooling for rust-alc-api (snapshot hook). Not published.",
+  "type": "module",
+  "scripts": {
+    "snapshot": "dev-plans-snapshot build",
+    "snapshot:check": "dev-plans-snapshot check"
+  },
+  "devDependencies": {
+    "@ippoan/dev-plans-snapshot": "^0.1.0"
+  }
+}


### PR DESCRIPTION
## Summary

Resolves ippoan/ippoan-dev-plans#2.

`ippoan/ippoan-dev-plans` で管理している plan Issue を本 repo の `manifests/production.snapshot.json` に複製し、pre-commit hook + CI で drift / 未登録 flag / removed 残存を機械的に検知する。flag は現状 0 個 (レール敷設のみ)。

### 仕組み

- `if_flag!("name#sha")` 形式の参照を `src/` / `crates/` から grep し、snapshot に登録された `(id, sha)` と突合
- snapshot の `issues_last_updated_at` を GitHub Issue 状態と比較して drift 検知
- 失敗時は対応する plan Issue (`scope:rust-alc-api` または `scope:cross-repo`) を `ippoan/ippoan-dev-plans` に作るか、`npm run snapshot` で再生成して revert

### 追加ファイル

| Path | 役割 |
|---|---|
| `package.json` / `package-lock.json` | `@ippoan/dev-plans-snapshot` v0.1.0 を devDep |
| `.npmrc` | `@ippoan` scope を GHCR registry に向ける |
| `dev-plans.config.js` | `scopeLabels`/`grepPatterns`/`sourceDirs` を rust-alc-api 向けに設定 |
| `manifests/production.snapshot.json` | 初期 snapshot (flags: []) |
| `.githooks/pre-commit` | snapshot:check → cargo fmt → cargo clippy (`SKIP_CLIPPY=1` で skip 可) |
| `.github/workflows/ci.yml` | `snapshot-check` job 追加 (reusable workflow 使用)、auto-merge needs に追加 |
| `README.md` / `CLAUDE.md` | setup 手順 + 運用ルール |

### 依存 (merge + publish 済)

- ippoan/ippoan-dev-plans#10 → `@ippoan/dev-plans-snapshot@0.1.0` GHCR publish
- ippoan/ci-workflows#5 → `snapshot-check.yml` reusable workflow

### ローカル smoke

- `npm install` 成功、lockfile 生成
- `npm run snapshot` で 6 plan issues fetch、`scope:rust-alc-api,cross-repo` で filter、flags: [] (YAML block 持つ Issue が無い)
- `npm run snapshot:check` → drift OK / 0 flag refs match
- `cargo fmt --check` → 通過

## Test plan

- [ ] CI: `snapshot-check` job 緑
- [ ] CI: 既存 `check` / `test-matrix` / `coverage-check` / `build-image` 緑
- [ ] CI: `auto-merge` job が `snapshot-check` の成功に依存している
- [ ] (将来) `if_flag!("ghost_flag#deadbeef")` を一時挿入 → CI 落ちる回帰テストは plan Issue 単位で別 PR にて

🤖 Generated with [Claude Code](https://claude.com/claude-code)