### PR TITLE
feat(notify): Gemini で配車PDFから積地/卸地/日時/注意事項を抽出して LINE 本文に載せる

### DIFF
--- a/crates/alc-notify/src/background_extract.rs
+++ b/crates/alc-notify/src/background_extract.rs
@@ -1,0 +1,839 @@
+//! upload / mail ingest から呼ぶバックグラウンド「物流情報抽出」ヘルパー。
+//!
+//! `tokio::spawn` で fire-and-forget 起動して呼び出し元 (HTTP リクエスト) を
+//! 即座に return させる。結果は `notify_documents.extraction_status` および
+//! `notify_documents.extracted_data->'logistics'` で追跡する:
+//!
+//! - `pending`   → 初期値 (まだジョブが触っていない)
+//! - `completed` → `update_extraction` 呼び出し成功 (5 フィールド全 null も含む)
+//! - `failed`    → Gemini や R2 取得でエラー (`extraction_error` にメッセージ)
+//!
+//! 配信本文は `distribute::build_distribute_message` が `extracted_data->'logistics'`
+//! の有無を見て物流テンプレ / 既存テンプレを切り替える。
+//!
+//! redact パイプライン (`background_redaction.rs`) と同じ並走前提で書いている:
+//!   - redact は `redaction_status` カラム、extract は `extraction_status` カラム
+//!     と独立 (migration 070 と migration 109)。書き込みは衝突しない
+//!   - 両者とも `state.notify_documents` `state.notify_storage` を共有して読む
+//!   - `tokio::spawn` で並列 → Gemini API は 2 リクエスト同時 (rate limit 内)
+//!
+//! テスト容易性のため、コアロジックは `extract_document_with_deps` に切り出し
+//! `&dyn NotifyDocumentRepository` + `&dyn StorageBackend` + endpoint override
+//! を引数で受け取る。`AppState` を扱う公開ラッパは薄い。
+
+use std::sync::Arc;
+
+use uuid::Uuid;
+
+use alc_core::repository::notify_documents::{ExtractionResult, NotifyDocumentRepository};
+use alc_core::storage::StorageBackend;
+use alc_core::AppState;
+
+use crate::extract::{extract_logistics_fields_with_endpoint, ExtractError, LogisticsFields};
+
+/// extract パイプラインのコア。AppState 非依存でユニットテスト可能。
+///
+/// - `endpoint` / `model`: Gemini API のベース URL とモデル名。`None` なら本番デフォルト。
+///   wiremock テストでは `Some(server.uri())` を渡す。
+/// - 全エラーは `extraction_status='failed'` に変換され、本関数は panic しない。
+/// - 成功 (Gemini が全 null を返した場合も含む) は `extraction_status='completed'`、
+///   非空のフィールドだけ `extracted_data.logistics` に格納される。
+#[allow(clippy::too_many_arguments)]
+pub async fn extract_document_with_deps(
+    docs: &dyn NotifyDocumentRepository,
+    storage: Option<&dyn StorageBackend>,
+    api_key: Option<&str>,
+    endpoint: Option<&str>,
+    model: Option<&str>,
+    tenant_id: Uuid,
+    document_id: Uuid,
+) {
+    // 1. document 取得 (RLS でテナントチェック)
+    let doc = match docs.get(tenant_id, document_id).await {
+        Ok(Some(d)) => d,
+        Ok(None) => {
+            tracing::warn!("extract: document not found tenant={tenant_id} id={document_id}");
+            return;
+        }
+        Err(e) => {
+            tracing::error!("extract: db get failed: {e}");
+            return;
+        }
+    };
+
+    // 2. PDF 以外は「抽出対象なし」で完了扱い (status=completed, logistics なし)
+    let fname = doc.file_name.clone().unwrap_or_default();
+    if !fname.to_lowercase().ends_with(".pdf") {
+        tracing::info!("extract: non-pdf document {document_id}, marking completed (no logistics)");
+        write_no_logistics(docs, tenant_id, document_id, &doc).await;
+        return;
+    }
+
+    // 3. GEMINI_API_KEY 未設定 → 同様に完了扱い (config issue は per-doc には残さない)
+    let api_key = match api_key {
+        Some(k) if !k.is_empty() => k,
+        _ => {
+            tracing::warn!(
+                "extract: GEMINI_API_KEY not set, marking completed without logistics for {document_id}"
+            );
+            write_no_logistics(docs, tenant_id, document_id, &doc).await;
+            return;
+        }
+    };
+
+    // 4. notify_storage 未設定 → 構成エラー → failed
+    let storage = match storage {
+        Some(s) => s,
+        None => {
+            tracing::error!("extract: notify_storage not configured");
+            let _ = docs
+                .update_extraction_error(tenant_id, document_id, "notify_storage not configured")
+                .await;
+            return;
+        }
+    };
+
+    // 5. R2 から PDF 取得
+    let pdf_bytes = match storage.download(&doc.r2_key).await {
+        Ok(b) => b,
+        Err(e) => {
+            let err = format!("r2 download: {e}");
+            let _ = docs
+                .update_extraction_error(tenant_id, document_id, &err)
+                .await;
+            return;
+        }
+    };
+
+    // 6. Gemini で 5 フィールド抽出
+    let endpoint = endpoint.unwrap_or("https://generativelanguage.googleapis.com/v1beta");
+    let model = model.unwrap_or("gemini-3.1-flash-lite-preview");
+
+    let fields: LogisticsFields =
+        match extract_logistics_fields_with_endpoint(endpoint, model, &pdf_bytes, api_key).await {
+            Ok(f) => f,
+            Err(e) => {
+                let err = match &e {
+                    ExtractError::GeminiHttp(_)
+                    | ExtractError::GeminiStatus(_, _)
+                    | ExtractError::GeminiEmpty
+                    | ExtractError::GeminiParse(_) => format!("gemini: {e}"),
+                    ExtractError::LogisticsParse(_) => format!("parse: {e}"),
+                };
+                let _ = docs
+                    .update_extraction_error(tenant_id, document_id, &err)
+                    .await;
+                return;
+            }
+        };
+
+    // 7. extracted_data の `logistics` キーを書き換え (他キーは保持)
+    let merged_data = merge_logistics_into_data(doc.extracted_data.clone(), &fields);
+
+    // 8. 既存 extracted_* フィールドは保持して update_extraction
+    let result = ExtractionResult {
+        title: doc.extracted_title.clone(),
+        date: doc.extracted_date,
+        summary: doc.extracted_summary.clone(),
+        phone_numbers: doc.extracted_phone_numbers.clone().unwrap_or_default(),
+        data: merged_data,
+    };
+    if let Err(e) = docs
+        .update_extraction(tenant_id, document_id, &result)
+        .await
+    {
+        tracing::error!("extract: update_extraction failed: {e}");
+        return;
+    }
+
+    tracing::info!(
+        "extract: tenant={tenant_id} doc={document_id} has_logistics={} (fields: lp={} ulp={} la={} ula={} n={})",
+        fields.has_any(),
+        fields.loading_place.is_some(),
+        fields.unloading_place.is_some(),
+        fields.loading_at.is_some(),
+        fields.unloading_at.is_some(),
+        fields.notes.is_some(),
+    );
+}
+
+/// 抽出対象でない (PDF 以外 / GEMINI_API_KEY 未設定) ケース用の薄いショートカット。
+///
+/// 既存 `extracted_data` から `logistics` キーだけ削除して update_extraction を呼ぶ。
+/// 他の extract サブシステムが書いたキーは保持する。
+async fn write_no_logistics(
+    docs: &dyn NotifyDocumentRepository,
+    tenant_id: Uuid,
+    document_id: Uuid,
+    doc: &alc_core::repository::notify_documents::NotifyDocument,
+) {
+    let mut data = doc.extracted_data.clone().unwrap_or(serde_json::json!({}));
+    if let Some(obj) = data.as_object_mut() {
+        obj.remove("logistics");
+    }
+    let result = ExtractionResult {
+        title: doc.extracted_title.clone(),
+        date: doc.extracted_date,
+        summary: doc.extracted_summary.clone(),
+        phone_numbers: doc.extracted_phone_numbers.clone().unwrap_or_default(),
+        data,
+    };
+    if let Err(e) = docs
+        .update_extraction(tenant_id, document_id, &result)
+        .await
+    {
+        tracing::error!("extract: update_extraction (no-logistics) failed: {e}");
+    }
+}
+
+/// `extracted_data` JSONB に `logistics` キーをマージする pure 関数。
+///
+/// - `existing` が null/JSON object でなかったら、新規 object として上書き
+/// - `fields.has_any() == false` なら `logistics` キーを削除 (前回値の残骸を消す)
+/// - それ以外は `logistics` キーに `fields` の serde 表現を上書き保存
+pub(crate) fn merge_logistics_into_data(
+    existing: Option<serde_json::Value>,
+    fields: &LogisticsFields,
+) -> serde_json::Value {
+    let mut data = match existing {
+        Some(v) if v.is_object() => v,
+        _ => serde_json::json!({}),
+    };
+    if let Some(obj) = data.as_object_mut() {
+        if fields.has_any() {
+            obj.insert(
+                "logistics".into(),
+                serde_json::to_value(fields).unwrap_or(serde_json::Value::Null),
+            );
+        } else {
+            obj.remove("logistics");
+        }
+    }
+    data
+}
+
+/// fire-and-forget で background extract を起動する。呼び出し元はすぐ return できる。
+///
+/// `AppState` から env と repo/storage を取り出して `extract_document_with_deps` に委譲。
+/// upload / ingest の各エンドポイントから新規 document の INSERT 直後に呼ぶ。
+pub fn spawn_extract_document(state: AppState, tenant_id: Uuid, document_id: Uuid) {
+    let api_key = std::env::var("GEMINI_API_KEY").ok();
+    let docs: Arc<dyn NotifyDocumentRepository> = state.notify_documents.clone();
+    let storage: Option<Arc<dyn StorageBackend>> = state.notify_storage.clone();
+
+    tokio::spawn(async move {
+        extract_document_with_deps(
+            docs.as_ref(),
+            storage.as_deref(),
+            api_key.as_deref(),
+            None,
+            None,
+            tenant_id,
+            document_id,
+        )
+        .await;
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::sync::{Arc, Mutex};
+
+    use alc_core::repository::notify_documents::{
+        CreateNotifyDocument, ExtractionResult, NotifyDocument,
+    };
+    use alc_core::storage::StorageError;
+    use async_trait::async_trait;
+
+    // ============================================================
+    // In-memory test stubs (background_redaction.rs のものを最小化)
+    // ============================================================
+
+    #[derive(Default)]
+    struct StubDocs {
+        extractions: Mutex<Vec<ExtractionResult>>,
+        errors: Mutex<Vec<String>>,
+        doc: Mutex<Option<NotifyDocument>>,
+    }
+
+    impl StubDocs {
+        fn new(doc: NotifyDocument) -> Arc<Self> {
+            let s = Arc::new(Self::default());
+            *s.doc.lock().unwrap() = Some(doc);
+            s
+        }
+        fn with_no_doc() -> Arc<Self> {
+            Arc::new(Self::default())
+        }
+    }
+
+    #[async_trait]
+    impl NotifyDocumentRepository for StubDocs {
+        async fn create(
+            &self,
+            _t: Uuid,
+            _input: &CreateNotifyDocument,
+        ) -> Result<NotifyDocument, sqlx::Error> {
+            unimplemented!()
+        }
+        async fn get(&self, _t: Uuid, _id: Uuid) -> Result<Option<NotifyDocument>, sqlx::Error> {
+            Ok(self.doc.lock().unwrap().clone())
+        }
+        async fn list(
+            &self,
+            _t: Uuid,
+            _l: i64,
+            _o: i64,
+        ) -> Result<Vec<NotifyDocument>, sqlx::Error> {
+            unimplemented!()
+        }
+        async fn search(&self, _t: Uuid, _q: &str) -> Result<Vec<NotifyDocument>, sqlx::Error> {
+            unimplemented!()
+        }
+        async fn update_extraction(
+            &self,
+            _t: Uuid,
+            _id: Uuid,
+            r: &ExtractionResult,
+        ) -> Result<(), sqlx::Error> {
+            self.extractions.lock().unwrap().push(ExtractionResult {
+                title: r.title.clone(),
+                date: r.date,
+                summary: r.summary.clone(),
+                phone_numbers: r.phone_numbers.clone(),
+                data: r.data.clone(),
+            });
+            Ok(())
+        }
+        async fn update_extraction_error(
+            &self,
+            _t: Uuid,
+            _id: Uuid,
+            e: &str,
+        ) -> Result<(), sqlx::Error> {
+            self.errors.lock().unwrap().push(e.to_string());
+            Ok(())
+        }
+        async fn update_distribution_status(
+            &self,
+            _t: Uuid,
+            _id: Uuid,
+            _s: &str,
+        ) -> Result<(), sqlx::Error> {
+            unimplemented!()
+        }
+        async fn update_redaction_status(
+            &self,
+            _t: Uuid,
+            _id: Uuid,
+            _s: &str,
+            _e: Option<&str>,
+        ) -> Result<(), sqlx::Error> {
+            unimplemented!()
+        }
+        async fn complete_redaction(
+            &self,
+            _t: Uuid,
+            _id: Uuid,
+            _k: &str,
+            _a: i32,
+        ) -> Result<(), sqlx::Error> {
+            unimplemented!()
+        }
+        async fn reset_redaction(&self, _t: Uuid, _id: Uuid) -> Result<(), sqlx::Error> {
+            unimplemented!()
+        }
+    }
+
+    struct StubStorage {
+        pdf: Vec<u8>,
+        download_should_fail: bool,
+    }
+
+    impl StubStorage {
+        fn ok(pdf: Vec<u8>) -> Arc<Self> {
+            Arc::new(Self {
+                pdf,
+                download_should_fail: false,
+            })
+        }
+        fn with_download_fail() -> Arc<Self> {
+            Arc::new(Self {
+                pdf: Vec::new(),
+                download_should_fail: true,
+            })
+        }
+    }
+
+    #[async_trait]
+    impl StorageBackend for StubStorage {
+        async fn upload(
+            &self,
+            _key: &str,
+            _bytes: &[u8],
+            _content_type: &str,
+        ) -> Result<String, StorageError> {
+            unimplemented!()
+        }
+        fn public_url(&self, key: &str) -> String {
+            format!("https://test/{key}")
+        }
+        async fn download(&self, _key: &str) -> Result<Vec<u8>, StorageError> {
+            if self.download_should_fail {
+                return Err(StorageError::Upload("simulated download failure".into()));
+            }
+            Ok(self.pdf.clone())
+        }
+        async fn exists(&self, _key: &str) -> Result<bool, StorageError> {
+            Ok(true)
+        }
+        async fn delete(&self, _key: &str) -> Result<(), StorageError> {
+            Ok(())
+        }
+        fn extract_key(&self, _url: &str) -> Option<String> {
+            None
+        }
+        fn bucket(&self) -> &str {
+            "test-bucket"
+        }
+        async fn presign_get(
+            &self,
+            key: &str,
+            _expiry_seconds: u32,
+        ) -> Result<String, StorageError> {
+            Ok(format!("https://test/{key}?signed=1"))
+        }
+    }
+
+    fn build_doc(file_name: Option<&str>) -> NotifyDocument {
+        NotifyDocument {
+            id: Uuid::new_v4(),
+            tenant_id: Uuid::new_v4(),
+            source_type: "manual".into(),
+            source_sender: None,
+            source_subject: None,
+            r2_key: "tenant/manual/doc.pdf".into(),
+            file_name: file_name.map(|s| s.into()),
+            file_size_bytes: Some(1024),
+            extracted_title: None,
+            extracted_date: None,
+            extracted_summary: None,
+            extracted_phone_numbers: None,
+            extracted_data: None,
+            extraction_status: "pending".into(),
+            extraction_error: None,
+            distribution_status: "pending".into(),
+            distributed_at: None,
+            redacted_r2_key: None,
+            redacted_at: None,
+            redactions_applied: None,
+            redaction_status: "pending".into(),
+            redaction_error: None,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        }
+    }
+
+    /// Gemini モック: schema-conforming JSON を text part に詰める
+    async fn start_gemini_mock_returning(json_text: &str) -> wiremock::MockServer {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "candidates": [{
+                        "content": {"parts": [{"text": json_text}]}
+                    }]
+                })),
+            )
+            .mount(&server)
+            .await;
+        server
+    }
+
+    async fn start_gemini_mock_with_status(status: u16) -> wiremock::MockServer {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .respond_with(wiremock::ResponseTemplate::new(status))
+            .mount(&server)
+            .await;
+        server
+    }
+
+    // ============================================================
+    // merge_logistics_into_data (pure)
+    // ============================================================
+
+    #[test]
+    fn merge_inserts_logistics_when_has_any() {
+        let fields = LogisticsFields {
+            loading_place: Some("東京".into()),
+            ..Default::default()
+        };
+        let merged = merge_logistics_into_data(None, &fields);
+        let logistics = merged.get("logistics").unwrap();
+        assert_eq!(logistics["loading_place"], "東京");
+    }
+
+    #[test]
+    fn merge_removes_logistics_when_all_empty() {
+        let existing =
+            serde_json::json!({"logistics": {"loading_place": "old"}, "other_key": "kept"});
+        let fields = LogisticsFields::default();
+        let merged = merge_logistics_into_data(Some(existing), &fields);
+        assert!(
+            merged.get("logistics").is_none(),
+            "logistics should be cleared"
+        );
+        assert_eq!(merged.get("other_key").unwrap(), "kept");
+    }
+
+    #[test]
+    fn merge_preserves_other_keys() {
+        let existing = serde_json::json!({"phone_numbers_ext": ["090-..."]});
+        let fields = LogisticsFields {
+            unloading_place: Some("大阪".into()),
+            ..Default::default()
+        };
+        let merged = merge_logistics_into_data(Some(existing), &fields);
+        assert!(merged.get("phone_numbers_ext").is_some());
+        assert_eq!(merged["logistics"]["unloading_place"], "大阪");
+    }
+
+    #[test]
+    fn merge_resets_when_existing_not_object() {
+        let existing = serde_json::json!("oops not an object");
+        let fields = LogisticsFields {
+            notes: Some("hi".into()),
+            ..Default::default()
+        };
+        let merged = merge_logistics_into_data(Some(existing), &fields);
+        // 既存値が捨てられて新規 object になる
+        assert!(merged.is_object());
+        assert_eq!(merged["logistics"]["notes"], "hi");
+    }
+
+    // ============================================================
+    // extract_document_with_deps (integration)
+    // ============================================================
+
+    #[tokio::test]
+    async fn extract_completes_and_writes_logistics() {
+        let docs = StubDocs::new(build_doc(Some("haisou.pdf")));
+        let storage = StubStorage::ok(b"%PDF-1.4 dummy".to_vec());
+        let server = start_gemini_mock_returning(
+            "{\"loading_place\":\"東京\",\"unloading_place\":\"大阪\",\
+             \"loading_at\":\"5/9 10:00\",\"unloading_at\":\"5/10 14:00\",\
+             \"notes\":\"急ぎ\"}",
+        )
+        .await;
+
+        extract_document_with_deps(
+            docs.as_ref(),
+            Some(storage.as_ref() as &dyn StorageBackend),
+            Some("test-key"),
+            Some(&server.uri()),
+            Some("test-model"),
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+        )
+        .await;
+
+        let extractions = docs.extractions.lock().unwrap();
+        assert_eq!(extractions.len(), 1);
+        let logistics = extractions[0]
+            .data
+            .get("logistics")
+            .expect("logistics key written");
+        assert_eq!(logistics["loading_place"], "東京");
+        assert_eq!(logistics["notes"], "急ぎ");
+        assert!(docs.errors.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn extract_all_null_marks_completed_without_logistics() {
+        let docs = StubDocs::new(build_doc(Some("invoice.pdf")));
+        let storage = StubStorage::ok(b"%PDF".to_vec());
+        let server = start_gemini_mock_returning(
+            "{\"loading_place\":null,\"unloading_place\":null,\
+             \"loading_at\":null,\"unloading_at\":null,\"notes\":null}",
+        )
+        .await;
+
+        extract_document_with_deps(
+            docs.as_ref(),
+            Some(storage.as_ref() as &dyn StorageBackend),
+            Some("k"),
+            Some(&server.uri()),
+            Some("m"),
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+        )
+        .await;
+
+        let extractions = docs.extractions.lock().unwrap();
+        assert_eq!(extractions.len(), 1);
+        // 全 null → logistics キーは追加されない
+        assert!(extractions[0].data.get("logistics").is_none());
+    }
+
+    #[tokio::test]
+    async fn extract_non_pdf_marks_completed_without_logistics() {
+        let docs = StubDocs::new(build_doc(Some("photo.jpg")));
+        let storage = StubStorage::ok(b"x".to_vec());
+
+        extract_document_with_deps(
+            docs.as_ref(),
+            Some(storage.as_ref() as &dyn StorageBackend),
+            Some("k"),
+            None,
+            None,
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+        )
+        .await;
+
+        let extractions = docs.extractions.lock().unwrap();
+        assert_eq!(extractions.len(), 1);
+        assert!(extractions[0].data.get("logistics").is_none());
+        assert!(docs.errors.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn extract_no_file_name_treated_as_non_pdf() {
+        let docs = StubDocs::new(build_doc(None));
+        let storage = StubStorage::ok(b"x".to_vec());
+
+        extract_document_with_deps(
+            docs.as_ref(),
+            Some(storage.as_ref() as &dyn StorageBackend),
+            Some("k"),
+            None,
+            None,
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+        )
+        .await;
+
+        let extractions = docs.extractions.lock().unwrap();
+        assert_eq!(extractions.len(), 1);
+        assert!(extractions[0].data.get("logistics").is_none());
+    }
+
+    #[tokio::test]
+    async fn extract_no_api_key_marks_completed_without_logistics() {
+        let docs = StubDocs::new(build_doc(Some("doc.pdf")));
+        let storage = StubStorage::ok(b"%PDF".to_vec());
+
+        extract_document_with_deps(
+            docs.as_ref(),
+            Some(storage.as_ref() as &dyn StorageBackend),
+            None,
+            None,
+            None,
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+        )
+        .await;
+
+        let extractions = docs.extractions.lock().unwrap();
+        assert_eq!(extractions.len(), 1);
+        // 設定エラーは per-document には残さない (全 doc 共通の問題なので Cloud Run ログ側へ)
+        assert!(docs.errors.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn extract_empty_api_key_treated_as_unset() {
+        let docs = StubDocs::new(build_doc(Some("doc.pdf")));
+        let storage = StubStorage::ok(b"%PDF".to_vec());
+
+        extract_document_with_deps(
+            docs.as_ref(),
+            Some(storage.as_ref() as &dyn StorageBackend),
+            Some(""),
+            None,
+            None,
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+        )
+        .await;
+
+        let extractions = docs.extractions.lock().unwrap();
+        assert_eq!(extractions.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn extract_no_storage_marks_failed() {
+        let docs = StubDocs::new(build_doc(Some("doc.pdf")));
+
+        extract_document_with_deps(
+            docs.as_ref(),
+            None,
+            Some("k"),
+            None,
+            None,
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+        )
+        .await;
+
+        let errors = docs.errors.lock().unwrap();
+        assert_eq!(errors.len(), 1);
+        assert!(errors[0].contains("notify_storage"));
+    }
+
+    #[tokio::test]
+    async fn extract_document_not_found_is_noop() {
+        let docs = StubDocs::with_no_doc();
+
+        extract_document_with_deps(
+            docs.as_ref(),
+            None,
+            Some("k"),
+            None,
+            None,
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+        )
+        .await;
+
+        assert!(docs.extractions.lock().unwrap().is_empty());
+        assert!(docs.errors.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn extract_r2_download_failure_marks_failed() {
+        let docs = StubDocs::new(build_doc(Some("doc.pdf")));
+        let storage = StubStorage::with_download_fail();
+
+        extract_document_with_deps(
+            docs.as_ref(),
+            Some(storage.as_ref() as &dyn StorageBackend),
+            Some("k"),
+            None,
+            None,
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+        )
+        .await;
+
+        let errors = docs.errors.lock().unwrap();
+        assert_eq!(errors.len(), 1);
+        assert!(errors[0].contains("r2 download"));
+    }
+
+    #[tokio::test]
+    async fn extract_gemini_5xx_marks_failed_with_gemini_prefix() {
+        let docs = StubDocs::new(build_doc(Some("doc.pdf")));
+        let storage = StubStorage::ok(b"%PDF".to_vec());
+        let server = start_gemini_mock_with_status(500).await;
+
+        extract_document_with_deps(
+            docs.as_ref(),
+            Some(storage.as_ref() as &dyn StorageBackend),
+            Some("k"),
+            Some(&server.uri()),
+            Some("m"),
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+        )
+        .await;
+
+        let errors = docs.errors.lock().unwrap();
+        assert_eq!(errors.len(), 1);
+        assert!(
+            errors[0].starts_with("gemini:"),
+            "expected gemini: prefix, got: {}",
+            errors[0]
+        );
+    }
+
+    #[tokio::test]
+    async fn extract_gemini_inner_text_unparseable_marks_failed_with_parse_prefix() {
+        let docs = StubDocs::new(build_doc(Some("doc.pdf")));
+        let storage = StubStorage::ok(b"%PDF".to_vec());
+        let server = start_gemini_mock_returning("not a json").await;
+
+        extract_document_with_deps(
+            docs.as_ref(),
+            Some(storage.as_ref() as &dyn StorageBackend),
+            Some("k"),
+            Some(&server.uri()),
+            Some("m"),
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+        )
+        .await;
+
+        let errors = docs.errors.lock().unwrap();
+        assert_eq!(errors.len(), 1);
+        assert!(
+            errors[0].starts_with("parse:"),
+            "expected parse: prefix, got: {}",
+            errors[0]
+        );
+    }
+
+    #[tokio::test]
+    async fn extract_preserves_existing_extracted_fields() {
+        // 既存 extracted_title / extracted_data の他キーを潰さない
+        let mut doc = build_doc(Some("doc.pdf"));
+        doc.extracted_title = Some("Existing Title".into());
+        doc.extracted_data = Some(serde_json::json!({"phone_numbers_ext": ["090-..."]}));
+        let docs = StubDocs::new(doc);
+        let storage = StubStorage::ok(b"%PDF".to_vec());
+        let server = start_gemini_mock_returning(
+            "{\"loading_place\":\"成田\",\"unloading_place\":null,\
+             \"loading_at\":null,\"unloading_at\":null,\"notes\":null}",
+        )
+        .await;
+
+        extract_document_with_deps(
+            docs.as_ref(),
+            Some(storage.as_ref() as &dyn StorageBackend),
+            Some("k"),
+            Some(&server.uri()),
+            Some("m"),
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+        )
+        .await;
+
+        let extractions = docs.extractions.lock().unwrap();
+        assert_eq!(extractions[0].title.as_deref(), Some("Existing Title"));
+        // 既存キー保持 + logistics 追加
+        assert_eq!(extractions[0].data["phone_numbers_ext"][0], "090-...");
+        assert_eq!(extractions[0].data["logistics"]["loading_place"], "成田");
+    }
+
+    #[tokio::test]
+    async fn extract_recompute_clears_old_logistics_when_now_empty() {
+        // 既存 extracted_data.logistics があって、再抽出で全 null → logistics キー削除
+        let mut doc = build_doc(Some("doc.pdf"));
+        doc.extracted_data = Some(serde_json::json!({
+            "logistics": {"loading_place": "old value"}
+        }));
+        let docs = StubDocs::new(doc);
+        let storage = StubStorage::ok(b"%PDF".to_vec());
+        let server = start_gemini_mock_returning(
+            "{\"loading_place\":null,\"unloading_place\":null,\
+             \"loading_at\":null,\"unloading_at\":null,\"notes\":null}",
+        )
+        .await;
+
+        extract_document_with_deps(
+            docs.as_ref(),
+            Some(storage.as_ref() as &dyn StorageBackend),
+            Some("k"),
+            Some(&server.uri()),
+            Some("m"),
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+        )
+        .await;
+
+        let extractions = docs.extractions.lock().unwrap();
+        assert!(extractions[0].data.get("logistics").is_none());
+    }
+}

--- a/crates/alc-notify/src/distribute.rs
+++ b/crates/alc-notify/src/distribute.rs
@@ -299,14 +299,6 @@ async fn distribute(
 
     let api_origin =
         std::env::var("API_ORIGIN").unwrap_or_else(|_| "https://localhost:8080".into());
-    let summary = doc
-        .extracted_summary
-        .as_deref()
-        .unwrap_or("新しいドキュメントが届きました");
-    let title = doc
-        .extracted_title
-        .as_deref()
-        .unwrap_or(doc.file_name.as_deref().unwrap_or("ドキュメント"));
 
     let line_client = LineClient::new();
     let lw_client = LineworksBotClient::new();
@@ -316,7 +308,7 @@ async fn distribute(
 
     for (delivery, recipient) in deliveries.iter().zip(recipients.iter()) {
         let read_url = format!("{}/api/notify/read/{}", api_origin, delivery.read_token);
-        let message = format!("📄 {}\n\n{}\n\n▶ 詳細を見る: {}", title, summary, read_url);
+        let message = build_distribute_message(&doc, &read_url);
 
         match send_to_recipient(
             &state,
@@ -421,4 +413,235 @@ async fn test_distribute(
         "failed": failed,
         "total": sent + failed,
     })))
+}
+
+/// LINE / LINE WORKS に送信する本文を組み立てる。
+///
+/// `doc.extracted_data.logistics` (5 フィールドのいずれかが非空) があれば物流テンプレに
+/// 切り替え、なければ既存テンプレ (`title` + `summary` + URL) を返す。
+///
+/// 物流テンプレ:
+/// ```text
+/// 📄 {title}
+/// 📍 積地: {loading_place}
+/// 📦 卸地: {unloading_place}
+/// 🕐 積込: {loading_at}
+/// 🕓 卸し: {unloading_at}
+/// ⚠️ 注意: {notes}
+///
+/// ▶ 詳細: {url}
+/// ```
+/// 5 フィールドのうち存在するものだけ列挙する (一部 null OK)。
+///
+/// pure 関数として外出しすることで、4 ケース (全フィールドあり / 一部 null /
+/// logistics キーなし / extracted_data なし) を unit test で直接検証できる。
+pub(crate) fn build_distribute_message(
+    doc: &alc_core::repository::notify_documents::NotifyDocument,
+    read_url: &str,
+) -> String {
+    let title = doc
+        .extracted_title
+        .as_deref()
+        .unwrap_or(doc.file_name.as_deref().unwrap_or("ドキュメント"));
+
+    if let Some(logistics) = doc
+        .extracted_data
+        .as_ref()
+        .and_then(|d| d.get("logistics"))
+        .filter(|v| v.is_object())
+    {
+        let mut lines: Vec<String> = Vec::with_capacity(8);
+        lines.push(format!("📄 {}", title));
+
+        let push_field = |lines: &mut Vec<String>, prefix: &str, key: &str| {
+            if let Some(v) = logistics.get(key).and_then(|x| x.as_str()) {
+                let trimmed = v.trim();
+                if !trimmed.is_empty() {
+                    lines.push(format!("{} {}", prefix, trimmed));
+                }
+            }
+        };
+
+        push_field(&mut lines, "📍 積地:", "loading_place");
+        push_field(&mut lines, "📦 卸地:", "unloading_place");
+        push_field(&mut lines, "🕐 積込:", "loading_at");
+        push_field(&mut lines, "🕓 卸し:", "unloading_at");
+        push_field(&mut lines, "⚠️ 注意:", "notes");
+
+        // logistics キー自体は object だが全 string が空文字 / 欠落のとき (defensive: schema
+        // 違反値の混入対策)、本文が「📄 タイトル」だけになって URL が浮くのを避けるため
+        // 既存テンプレに fallback する。
+        if lines.len() == 1 {
+            return fallback_template(doc, read_url);
+        }
+
+        lines.push(String::new()); // 詳細リンク前の空行
+        lines.push(format!("▶ 詳細: {}", read_url));
+        lines.join("\n")
+    } else {
+        fallback_template(doc, read_url)
+    }
+}
+
+fn fallback_template(
+    doc: &alc_core::repository::notify_documents::NotifyDocument,
+    read_url: &str,
+) -> String {
+    let summary = doc
+        .extracted_summary
+        .as_deref()
+        .unwrap_or("新しいドキュメントが届きました");
+    let title = doc
+        .extracted_title
+        .as_deref()
+        .unwrap_or(doc.file_name.as_deref().unwrap_or("ドキュメント"));
+    format!("📄 {}\n\n{}\n\n▶ 詳細を見る: {}", title, summary, read_url)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alc_core::repository::notify_documents::NotifyDocument;
+
+    fn build_doc() -> NotifyDocument {
+        NotifyDocument {
+            id: Uuid::new_v4(),
+            tenant_id: Uuid::new_v4(),
+            source_type: "manual".into(),
+            source_sender: None,
+            source_subject: None,
+            r2_key: "k".into(),
+            file_name: Some("haisou.pdf".into()),
+            file_size_bytes: None,
+            extracted_title: None,
+            extracted_date: None,
+            extracted_summary: None,
+            extracted_phone_numbers: None,
+            extracted_data: None,
+            extraction_status: "pending".into(),
+            extraction_error: None,
+            distribution_status: "pending".into(),
+            distributed_at: None,
+            redacted_r2_key: None,
+            redacted_at: None,
+            redactions_applied: None,
+            redaction_status: "completed".into(),
+            redaction_error: None,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        }
+    }
+
+    #[test]
+    fn message_uses_logistics_template_when_all_fields_present() {
+        let mut doc = build_doc();
+        doc.extracted_data = Some(serde_json::json!({
+            "logistics": {
+                "loading_place": "東京都港区",
+                "unloading_place": "大阪府大阪市",
+                "loading_at": "5/9 10:00",
+                "unloading_at": "5/10 14:00",
+                "notes": "冷凍便\n要時間厳守"
+            }
+        }));
+        let msg = build_distribute_message(&doc, "https://x/v/abc");
+        assert!(msg.contains("📄 haisou.pdf"));
+        assert!(msg.contains("📍 積地: 東京都港区"));
+        assert!(msg.contains("📦 卸地: 大阪府大阪市"));
+        assert!(msg.contains("🕐 積込: 5/9 10:00"));
+        assert!(msg.contains("🕓 卸し: 5/10 14:00"));
+        assert!(msg.contains("⚠️ 注意: 冷凍便\n要時間厳守"));
+        assert!(msg.contains("▶ 詳細: https://x/v/abc"));
+        // 「新しいドキュメントが届きました」の既定句は出ない
+        assert!(!msg.contains("新しいドキュメント"));
+    }
+
+    #[test]
+    fn message_omits_null_fields_in_logistics_template() {
+        let mut doc = build_doc();
+        doc.extracted_data = Some(serde_json::json!({
+            "logistics": {
+                "loading_place": "成田",
+                "unloading_place": null,
+                "loading_at": null,
+                "unloading_at": null,
+                "notes": null
+            }
+        }));
+        let msg = build_distribute_message(&doc, "https://x/v/abc");
+        assert!(msg.contains("📍 積地: 成田"));
+        assert!(!msg.contains("📦 卸地"));
+        assert!(!msg.contains("🕐 積込"));
+        assert!(msg.contains("▶ 詳細: https://x/v/abc"));
+    }
+
+    #[test]
+    fn message_falls_back_to_legacy_when_no_logistics_key() {
+        let mut doc = build_doc();
+        doc.extracted_title = Some("見積書".into());
+        doc.extracted_summary = Some("〇〇社からの見積です".into());
+        doc.extracted_data = Some(serde_json::json!({"phone_numbers_ext": ["090-..."]}));
+        let msg = build_distribute_message(&doc, "https://x/v/abc");
+        assert_eq!(
+            msg,
+            "📄 見積書\n\n〇〇社からの見積です\n\n▶ 詳細を見る: https://x/v/abc"
+        );
+    }
+
+    #[test]
+    fn message_falls_back_when_extracted_data_is_none() {
+        let doc = build_doc();
+        let msg = build_distribute_message(&doc, "https://x/v/abc");
+        assert!(msg.contains("📄 haisou.pdf"));
+        assert!(msg.contains("新しいドキュメントが届きました"));
+        assert!(msg.contains("▶ 詳細を見る: https://x/v/abc"));
+    }
+
+    #[test]
+    fn message_falls_back_when_logistics_object_has_only_empty_strings() {
+        // defensive: schema 違反値が混入しても既存テンプレに退避
+        let mut doc = build_doc();
+        doc.extracted_data = Some(serde_json::json!({
+            "logistics": {
+                "loading_place": "  ",
+                "unloading_place": "",
+                "loading_at": null,
+                "unloading_at": null,
+                "notes": null
+            }
+        }));
+        let msg = build_distribute_message(&doc, "https://x/v/abc");
+        // logistics テンプレ部分の絵文字は出ない
+        assert!(!msg.contains("📍 積地"));
+        assert!(msg.contains("新しいドキュメントが届きました"));
+    }
+
+    #[test]
+    fn message_falls_back_when_logistics_value_is_not_object() {
+        // defensive: extracted_data.logistics が string や array なら無視
+        let mut doc = build_doc();
+        doc.extracted_data = Some(serde_json::json!({"logistics": "broken"}));
+        let msg = build_distribute_message(&doc, "https://x/v/abc");
+        assert!(msg.contains("新しいドキュメントが届きました"));
+    }
+
+    #[test]
+    fn message_uses_extracted_title_when_available_in_logistics_path() {
+        let mut doc = build_doc();
+        doc.extracted_title = Some("配車手配票".into());
+        doc.extracted_data = Some(serde_json::json!({
+            "logistics": {"loading_place": "東京"}
+        }));
+        let msg = build_distribute_message(&doc, "https://x/v/abc");
+        assert!(msg.starts_with("📄 配車手配票"));
+        assert!(!msg.contains("haisou.pdf"));
+    }
+
+    #[test]
+    fn message_uses_doc_default_when_no_filename() {
+        let mut doc = build_doc();
+        doc.file_name = None;
+        let msg = build_distribute_message(&doc, "https://x/v/abc");
+        assert!(msg.contains("📄 ドキュメント"));
+    }
 }

--- a/crates/alc-notify/src/documents.rs
+++ b/crates/alc-notify/src/documents.rs
@@ -26,6 +26,10 @@ pub fn tenant_router() -> Router<AppState> {
             "/notify/documents/{id}/redact-recompute",
             axum::routing::post(redact_recompute),
         )
+        .route(
+            "/notify/documents/{id}/extract-recompute",
+            axum::routing::post(extract_recompute),
+        )
 }
 
 #[derive(serde::Deserialize)]
@@ -227,6 +231,10 @@ async fn upload(
         if file_name.to_lowercase().ends_with(".pdf") {
             crate::background_redaction::spawn_redact_document(state.clone(), tenant.0, id);
         }
+
+        // 配車手配票 PDF の積地/卸地/日時/注意事項抽出 (LINE 本文用)。
+        // 拡張子チェックは background_extract 側でやるので毎回呼んで OK。
+        crate::background_extract::spawn_extract_document(state.clone(), tenant.0, id);
     }
 
     let count = document_ids.len();
@@ -323,6 +331,33 @@ async fn redact_recompute(
         })?;
 
     crate::background_redaction::spawn_redact_document(state.clone(), tenant.0, doc.id);
+    Ok(StatusCode::ACCEPTED)
+}
+
+/// force re-extract: extracted_data.logistics を Gemini で再抽出して spawn。即 202 Accepted。
+///
+/// 既存ドキュメントの logistics 抽出をやり直したい場合 (staging で初回反映後の確認、
+/// 本番で抽出ミスがあった場合の手動再実行) に使う。redaction_status とは独立。
+async fn extract_recompute(
+    State(state): State<AppState>,
+    Extension(tenant): Extension<TenantId>,
+    Path(id): Path<Uuid>,
+) -> Result<StatusCode, StatusCode> {
+    // 存在確認 (RLS でテナント越境はそもそも 404)
+    let _doc = state
+        .notify_documents
+        .get(tenant.0, id)
+        .await
+        .map_err(|e| {
+            tracing::error!("extract_recompute: get notify_document: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?
+        .ok_or(StatusCode::NOT_FOUND)?;
+
+    // 既存 extraction_status / extraction_error は保持して上書きする (background が
+    // 完走時に completed/failed を再設定する)。明示的なリセット関数がないので
+    // background 内で update_extraction が走った時点で最新化される。
+    crate::background_extract::spawn_extract_document(state.clone(), tenant.0, id);
     Ok(StatusCode::ACCEPTED)
 }
 

--- a/crates/alc-notify/src/extract.rs
+++ b/crates/alc-notify/src/extract.rs
@@ -1,0 +1,532 @@
+//! 配車系 PDF から Gemini で「積地・卸地・積み日時・卸し日時・注意事項」を抽出する。
+//!
+//! 受信した FAX/PDF が配車手配票だった場合、配信時の LINE 本文に要点を埋め込めるように
+//! `notify_documents.extracted_data` JSONB の `logistics` キー配下に 5 フィールドを保存する。
+//! 該当情報がない PDF (請求書・報告書等) は全フィールド `null` で確定し、配信本文は
+//! 既存テンプレ (タイトル + summary + URL) にフォールバックする。
+//!
+//! 設計方針は `crates/alc-notify/src/redact.rs` と同形:
+//!   - `LOGISTICS_PROMPT` でプロンプト本体を const 化
+//!   - `logistics_response_schema()` で Structured Output schema を pin
+//!     (`responseMimeType=application/json` だけだと Gemini が markdown wrap してきて
+//!     parse 失敗するため。PR #318 の教訓 / `feedback_gemini_response_schema_required.md`)
+//!   - `endpoint` 引数を `Option<&str>` で受け取り wiremock 化
+//!   - pure 関数 (`build_extract_request_body`, `parse_extract_response`) はテストで直接叩く
+
+use base64::Engine;
+
+const GEMINI_DEFAULT_ENDPOINT: &str = "https://generativelanguage.googleapis.com/v1beta";
+// redact と同じ。stable suffix が付いたら更新。
+const GEMINI_DEFAULT_MODEL: &str = "gemini-3.1-flash-lite-preview";
+
+/// プロンプト本文。Gemini に「配車手配票なら 5 フィールドを返し、それ以外は全 null」を要求する。
+///
+/// PDF が配車系でない (例: 請求書) 場合に「無理にどこかから値を埋める」のを防ぐため、
+/// 「該当情報がなければ null を返す」を明示する。日付は ISO 正規化せず原文表記をそのまま
+/// 保つ — フロントで表示するだけなので、表記のばらつきを受け入れる方が正確。
+const LOGISTICS_PROMPT: &str = r#"この PDF は運送業務で受信した文書です。配車手配票・運行依頼書であれば
+以下 5 フィールドを抽出してください:
+
+  - loading_place    : 積地 (積み込み場所、住所か会社名のうち主要なもの 1 件)
+  - unloading_place  : 卸地 (荷卸し場所、住所か会社名のうち主要なもの 1 件)
+  - loading_at       : 積み日時 (PDF の表記をそのまま、例: "5/9 10:00" / "5月9日 午前10時" / "2026-05-09 10:00")
+  - unloading_at     : 卸し日時 (同上)
+  - notes            : 注意事項 (冷凍便、要時間厳守、要連絡など配送上の留意点。複数あれば改行で結合)
+
+ルール:
+  - PDF が配車手配票でない (請求書・報告書・通知文など) 場合、または該当情報がない場合は
+    そのフィールドを null にする。**推測で埋めない、書かれていないものは null**。
+  - 5 フィールド全部 null になっても OK (配信本文は既存テンプレにフォールバックする)。
+  - 日付は ISO 8601 に正規化しない。PDF の表記を**そのまま**返す。
+  - 積地/卸地は住所と会社名を `\n` で連結したり全部入れたりせず、最も識別性の高い 1 行を選ぶ。
+  - notes は複数項目を改行 (`\n`) で連結する。
+  - 出力はこの schema に厳密に従う JSON 1 個 (前後に余分なテキスト・markdown 装飾を一切付けない)。"#;
+
+/// 抽出結果。`Option<String>` フィールドのみで構成し、どれが取れたかをキー存在で表現する。
+/// `notify_documents.extracted_data.logistics` 配下に serde_json で保存する。
+#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize, Default)]
+pub struct LogisticsFields {
+    /// 積地。例: "東京都港区" / "○○倉庫"
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub loading_place: Option<String>,
+    /// 卸地。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub unloading_place: Option<String>,
+    /// 積み日時。例: "5/9 10:00"
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub loading_at: Option<String>,
+    /// 卸し日時。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub unloading_at: Option<String>,
+    /// 注意事項。複数行可 (改行で連結)。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub notes: Option<String>,
+}
+
+impl LogisticsFields {
+    /// 1 つでも非空の値があれば true。配信本文の物流テンプレ分岐に使う。
+    pub fn has_any(&self) -> bool {
+        [
+            &self.loading_place,
+            &self.unloading_place,
+            &self.loading_at,
+            &self.unloading_at,
+            &self.notes,
+        ]
+        .iter()
+        .any(|v| v.as_ref().is_some_and(|s| !s.trim().is_empty()))
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum ExtractError {
+    #[error("gemini http: {0}")]
+    GeminiHttp(#[from] reqwest::Error),
+    #[error("gemini status {0}: {1}")]
+    GeminiStatus(reqwest::StatusCode, String),
+    #[error("gemini empty response")]
+    GeminiEmpty,
+    #[error("gemini json parse: {0}")]
+    GeminiParse(serde_json::Error),
+    #[error("logistics json parse: {0}")]
+    LogisticsParse(serde_json::Error),
+}
+
+/// Structured Output schema。Gemini が schema に合致する JSON を保証する。
+///
+/// `responseMimeType: application/json` だけだと markdown wrap で parse 壊れる
+/// (PR #318 / `feedback_gemini_response_schema_required.md`)。schema で構造を pin する。
+///
+/// 5 フィールドは全部 nullable な STRING。`required` には入れない (Gemini が
+/// 該当情報なしと判断した時に null にできるように)。
+fn logistics_response_schema() -> serde_json::Value {
+    serde_json::json!({
+        "type": "OBJECT",
+        "properties": {
+            "loading_place":   { "type": "STRING", "nullable": true },
+            "unloading_place": { "type": "STRING", "nullable": true },
+            "loading_at":      { "type": "STRING", "nullable": true },
+            "unloading_at":    { "type": "STRING", "nullable": true },
+            "notes":           { "type": "STRING", "nullable": true }
+        },
+        "propertyOrdering": [
+            "loading_place", "unloading_place",
+            "loading_at", "unloading_at", "notes"
+        ]
+    })
+}
+
+/// Gemini の generateContent リクエスト body を組み立てる pure 関数。
+///
+/// `pdf_b64` は base64 (no-pad もしくは standard) 済み PDF。
+/// 実 API 呼び出しを伴わないので単体テストで request body の中身 (prompt 本文 /
+/// responseSchema の properties / temperature 等) を直接アサートできる。
+pub(crate) fn build_extract_request_body(pdf_b64: &str) -> serde_json::Value {
+    serde_json::json!({
+        "contents": [{
+            "role": "user",
+            "parts": [
+                { "inlineData": { "mimeType": "application/pdf", "data": pdf_b64 } },
+                { "text": LOGISTICS_PROMPT }
+            ]
+        }],
+        "generationConfig": {
+            "temperature": 0.0,
+            "responseMimeType": "application/json",
+            "responseSchema": logistics_response_schema(),
+            // 5 フィールド × 短いテキストなので 512 で十分余裕。
+            "maxOutputTokens": 512
+        }
+    })
+}
+
+/// Gemini の generateContent レスポンス JSON から `LogisticsFields` を取り出す。
+///
+/// 期待構造:
+///   `candidates[0].content.parts[0].text` に schema 準拠の JSON 文字列が入っている。
+///   それを `LogisticsFields` として deserialize する。
+///
+/// `text` 不在 → `GeminiEmpty`、JSON parse 失敗 → `LogisticsParse`。
+pub(crate) fn parse_extract_response(
+    parsed: &serde_json::Value,
+) -> Result<LogisticsFields, ExtractError> {
+    let text = parsed
+        .pointer("/candidates/0/content/parts/0/text")
+        .and_then(|v| v.as_str())
+        .ok_or(ExtractError::GeminiEmpty)?;
+
+    serde_json::from_str::<LogisticsFields>(text).map_err(|e| {
+        tracing::warn!(
+            "extract: parse failed: {e}; raw response (first 500 chars): {}",
+            text.chars().take(500).collect::<String>()
+        );
+        ExtractError::LogisticsParse(e)
+    })
+}
+
+/// Gemini API を叩いて配車情報 5 フィールドを抽出する。
+///
+/// `endpoint` には prod では `GEMINI_DEFAULT_ENDPOINT` / `model` には `GEMINI_DEFAULT_MODEL` を、
+/// テストでは `wiremock::MockServer::uri()` と任意 model を渡す。
+pub async fn extract_logistics_fields_with_endpoint(
+    endpoint: &str,
+    model: &str,
+    pdf_bytes: &[u8],
+    api_key: &str,
+) -> Result<LogisticsFields, ExtractError> {
+    let client = reqwest::Client::new();
+    let url = format!("{endpoint}/models/{model}:generateContent?key={api_key}");
+    let pdf_b64 = base64::engine::general_purpose::STANDARD.encode(pdf_bytes);
+
+    let body = build_extract_request_body(&pdf_b64);
+    let resp = client.post(&url).json(&body).send().await?;
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        return Err(ExtractError::GeminiStatus(status, body));
+    }
+    let raw = resp.text().await?;
+    let parsed: serde_json::Value =
+        serde_json::from_str(&raw).map_err(ExtractError::GeminiParse)?;
+    parse_extract_response(&parsed)
+}
+
+/// prod 用ショートカット (`GEMINI_DEFAULT_ENDPOINT` + `GEMINI_DEFAULT_MODEL`)。
+pub async fn extract_logistics_fields(
+    pdf_bytes: &[u8],
+    api_key: &str,
+) -> Result<LogisticsFields, ExtractError> {
+    extract_logistics_fields_with_endpoint(
+        GEMINI_DEFAULT_ENDPOINT,
+        GEMINI_DEFAULT_MODEL,
+        pdf_bytes,
+        api_key,
+    )
+    .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ============================================================
+    // pure 関数テスト
+    // ============================================================
+
+    #[test]
+    fn schema_includes_all_five_fields() {
+        let schema = logistics_response_schema();
+        let props = schema.pointer("/properties").unwrap().as_object().unwrap();
+        for k in [
+            "loading_place",
+            "unloading_place",
+            "loading_at",
+            "unloading_at",
+            "notes",
+        ] {
+            assert!(props.contains_key(k), "schema missing field: {k}");
+            // 全フィールド nullable
+            let prop = &props[k];
+            assert_eq!(prop["type"], "STRING");
+            assert_eq!(prop["nullable"], true);
+        }
+        // ordering も 5 件揃っている
+        let ordering = schema
+            .pointer("/propertyOrdering")
+            .unwrap()
+            .as_array()
+            .unwrap();
+        assert_eq!(ordering.len(), 5);
+    }
+
+    #[test]
+    fn build_request_body_has_inline_pdf_and_prompt() {
+        let body = build_extract_request_body("AAAA");
+        // PDF が inlineData として埋め込まれている
+        let inline = body.pointer("/contents/0/parts/0/inlineData").unwrap();
+        assert_eq!(inline["mimeType"], "application/pdf");
+        assert_eq!(inline["data"], "AAAA");
+        // プロンプトが text part に乗っている
+        let prompt = body
+            .pointer("/contents/0/parts/1/text")
+            .and_then(|v| v.as_str())
+            .unwrap();
+        assert!(prompt.contains("loading_place"));
+        assert!(prompt.contains("unloading_place"));
+        assert!(prompt.contains("loading_at"));
+        assert!(prompt.contains("unloading_at"));
+        assert!(prompt.contains("notes"));
+        // Structured Output 強制 (regression guard, PR #318)
+        assert_eq!(
+            body.pointer("/generationConfig/responseMimeType").unwrap(),
+            "application/json"
+        );
+        assert!(body.pointer("/generationConfig/responseSchema").is_some());
+        // temperature=0 で deterministic
+        assert_eq!(body.pointer("/generationConfig/temperature").unwrap(), 0.0);
+    }
+
+    #[test]
+    fn parse_response_happy_path() {
+        let resp = serde_json::json!({
+            "candidates": [{
+                "content": { "parts": [{ "text":
+                    "{\"loading_place\":\"東京都港区\",\
+                     \"unloading_place\":\"大阪市\",\
+                     \"loading_at\":\"5/9 10:00\",\
+                     \"unloading_at\":\"5/10 14:00\",\
+                     \"notes\":\"冷凍便\\n要時間厳守\"}"
+                }]}
+            }]
+        });
+        let fields = parse_extract_response(&resp).unwrap();
+        assert_eq!(fields.loading_place.as_deref(), Some("東京都港区"));
+        assert_eq!(fields.unloading_place.as_deref(), Some("大阪市"));
+        assert_eq!(fields.loading_at.as_deref(), Some("5/9 10:00"));
+        assert_eq!(fields.unloading_at.as_deref(), Some("5/10 14:00"));
+        assert_eq!(fields.notes.as_deref(), Some("冷凍便\n要時間厳守"));
+        assert!(fields.has_any());
+    }
+
+    #[test]
+    fn parse_response_all_nulls_is_valid() {
+        let resp = serde_json::json!({
+            "candidates": [{
+                "content": { "parts": [{ "text":
+                    "{\"loading_place\":null,\"unloading_place\":null,\
+                     \"loading_at\":null,\"unloading_at\":null,\"notes\":null}"
+                }]}
+            }]
+        });
+        let fields = parse_extract_response(&resp).unwrap();
+        assert!(fields.loading_place.is_none());
+        assert!(fields.unloading_place.is_none());
+        assert!(fields.loading_at.is_none());
+        assert!(fields.unloading_at.is_none());
+        assert!(fields.notes.is_none());
+        assert!(!fields.has_any());
+    }
+
+    #[test]
+    fn parse_response_partial_fields() {
+        // schema は required なし → 一部キー欠落でも default で埋まる
+        let resp = serde_json::json!({
+            "candidates": [{
+                "content": { "parts": [{ "text":
+                    "{\"loading_place\":\"東京\"}"
+                }]}
+            }]
+        });
+        let fields = parse_extract_response(&resp).unwrap();
+        assert_eq!(fields.loading_place.as_deref(), Some("東京"));
+        assert!(fields.unloading_place.is_none());
+        assert!(fields.has_any());
+    }
+
+    #[test]
+    fn parse_response_missing_text_is_empty() {
+        let resp = serde_json::json!({"candidates": []});
+        match parse_extract_response(&resp) {
+            Err(ExtractError::GeminiEmpty) => {}
+            other => panic!("expected GeminiEmpty, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_response_invalid_json_is_logistics_parse_err() {
+        let resp = serde_json::json!({
+            "candidates": [{
+                "content": { "parts": [{ "text": "not a json" }]}
+            }]
+        });
+        match parse_extract_response(&resp) {
+            Err(ExtractError::LogisticsParse(_)) => {}
+            other => panic!("expected LogisticsParse, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn has_any_treats_whitespace_as_empty() {
+        let f = LogisticsFields {
+            loading_place: Some("  ".into()),
+            ..Default::default()
+        };
+        assert!(!f.has_any());
+        let f = LogisticsFields {
+            notes: Some("\n".into()),
+            ..Default::default()
+        };
+        assert!(!f.has_any());
+        let f = LogisticsFields {
+            unloading_at: Some("a".into()),
+            ..Default::default()
+        };
+        assert!(f.has_any());
+    }
+
+    #[test]
+    fn logistics_fields_serializes_skipping_none() {
+        let f = LogisticsFields {
+            loading_place: Some("東京".into()),
+            ..Default::default()
+        };
+        let json = serde_json::to_value(&f).unwrap();
+        let obj = json.as_object().unwrap();
+        // None フィールドは skip される (extracted_data に noise を残さない)
+        assert!(obj.contains_key("loading_place"));
+        assert!(!obj.contains_key("unloading_place"));
+        assert!(!obj.contains_key("notes"));
+    }
+
+    // ============================================================
+    // wiremock テスト (extract_logistics_fields_with_endpoint)
+    // ============================================================
+
+    async fn start_mock_with_text(text: &str) -> wiremock::MockServer {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "candidates": [{
+                        "content": {"parts": [{"text": text}]}
+                    }]
+                })),
+            )
+            .mount(&server)
+            .await;
+        server
+    }
+
+    async fn start_mock_with_status(status: u16) -> wiremock::MockServer {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .respond_with(wiremock::ResponseTemplate::new(status).set_body_string("upstream error"))
+            .mount(&server)
+            .await;
+        server
+    }
+
+    async fn start_mock_with_invalid_json() -> wiremock::MockServer {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .respond_with(wiremock::ResponseTemplate::new(200).set_body_string("not a json {{"))
+            .mount(&server)
+            .await;
+        server
+    }
+
+    #[tokio::test]
+    async fn extract_with_endpoint_success() {
+        let server = start_mock_with_text(
+            "{\"loading_place\":\"成田\",\"unloading_place\":\"福岡\",\
+             \"loading_at\":\"5/9\",\"unloading_at\":\"5/10\",\"notes\":\"急ぎ\"}",
+        )
+        .await;
+
+        let fields = extract_logistics_fields_with_endpoint(
+            &server.uri(),
+            "test-model",
+            b"%PDF-1.4",
+            "test-key",
+        )
+        .await
+        .unwrap();
+        assert_eq!(fields.loading_place.as_deref(), Some("成田"));
+        assert_eq!(fields.notes.as_deref(), Some("急ぎ"));
+    }
+
+    #[tokio::test]
+    async fn extract_with_endpoint_4xx_status() {
+        let server = start_mock_with_status(400).await;
+        let err =
+            extract_logistics_fields_with_endpoint(&server.uri(), "test-model", b"x", "test-key")
+                .await
+                .unwrap_err();
+        match err {
+            ExtractError::GeminiStatus(s, body) => {
+                assert_eq!(s.as_u16(), 400);
+                assert!(body.contains("upstream error"));
+            }
+            other => panic!("expected GeminiStatus, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn extract_with_endpoint_5xx_status() {
+        let server = start_mock_with_status(500).await;
+        let err =
+            extract_logistics_fields_with_endpoint(&server.uri(), "test-model", b"x", "test-key")
+                .await
+                .unwrap_err();
+        assert!(matches!(err, ExtractError::GeminiStatus(_, _)));
+    }
+
+    #[tokio::test]
+    async fn extract_with_endpoint_invalid_outer_json() {
+        // candidates 構造ではない素文字列 → GeminiParse
+        let server = start_mock_with_invalid_json().await;
+        let err =
+            extract_logistics_fields_with_endpoint(&server.uri(), "test-model", b"x", "test-key")
+                .await
+                .unwrap_err();
+        assert!(matches!(err, ExtractError::GeminiParse(_)));
+    }
+
+    #[tokio::test]
+    async fn extract_with_endpoint_inner_text_unparseable() {
+        // candidates は正しいが parts[0].text が JSON ではない → LogisticsParse
+        let server = start_mock_with_text("this is not json").await;
+        let err =
+            extract_logistics_fields_with_endpoint(&server.uri(), "test-model", b"x", "test-key")
+                .await
+                .unwrap_err();
+        assert!(matches!(err, ExtractError::LogisticsParse(_)));
+    }
+
+    #[tokio::test]
+    async fn extract_with_endpoint_empty_candidates() {
+        // candidates 空 → text pointer 取れない → GeminiEmpty
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"candidates": []})),
+            )
+            .mount(&server)
+            .await;
+        let err =
+            extract_logistics_fields_with_endpoint(&server.uri(), "test-model", b"x", "test-key")
+                .await
+                .unwrap_err();
+        assert!(matches!(err, ExtractError::GeminiEmpty));
+    }
+
+    #[tokio::test]
+    async fn extract_with_endpoint_unreachable_url() {
+        // ポート 1 は unreachable な定義済み拒否ポート → reqwest::Error
+        let err = extract_logistics_fields_with_endpoint(
+            "http://127.0.0.1:1",
+            "test-model",
+            b"x",
+            "test-key",
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(err, ExtractError::GeminiHttp(_)));
+    }
+
+    // `extract_logistics_fields()` (prod ショートカット) は本物の Gemini エンドポイントを叩くので
+    // unit test では呼び出さない (anti-pattern: 本番 API に直接 unit test を叩かせない)。
+    // `extract_logistics_fields_with_endpoint` 経由で全分岐がカバーされている。
+
+    #[test]
+    fn default_endpoint_and_model_constants_point_to_prod() {
+        // 定数値が prod を指していることのリグレッション検出。
+        // 値が変わったら明示的に更新する (= レビュー時に気づける)。
+        assert_eq!(
+            GEMINI_DEFAULT_ENDPOINT,
+            "https://generativelanguage.googleapis.com/v1beta"
+        );
+        assert_eq!(GEMINI_DEFAULT_MODEL, "gemini-3.1-flash-lite-preview");
+    }
+}

--- a/crates/alc-notify/src/ingest.rs
+++ b/crates/alc-notify/src/ingest.rs
@@ -190,6 +190,10 @@ async fn handle_ingest(
         if file_name.to_lowercase().ends_with(".pdf") {
             crate::background_redaction::spawn_redact_document(state.clone(), tenant_id, id);
         }
+
+        // 配車手配票 PDF なら積地・卸地・日時・注意事項を Gemini で抽出 (LINE 本文用)。
+        // PDF 以外 / GEMINI_API_KEY 未設定でも no-op で完了する。redact と並走。
+        crate::background_extract::spawn_extract_document(state.clone(), tenant_id, id);
     }
 
     let count = document_ids.len();

--- a/crates/alc-notify/src/lib.rs
+++ b/crates/alc-notify/src/lib.rs
@@ -1,8 +1,10 @@
+pub mod background_extract;
 pub mod background_redaction;
 pub mod clients;
 pub mod distribute;
 pub mod documents;
 pub mod email_documents;
+pub mod extract;
 pub mod groups;
 pub mod ingest;
 pub mod line_config;


### PR DESCRIPTION
Notify 配信時の LINE 本文に Gemini 抽出フィールドを載せる。

## 概要

`https://notify-staging.ippoan.org/documents/...` の配信時、LINE 本文は現状
「📄 タイトル + summary + URL」の固定テンプレで、PDF 中身は受信者が URL を踏むまで分からなかった。

配車手配票 PDF を ingest した時点で Gemini に **積地・卸地・積み日時・卸し日時・注意事項** を抽出させ、
LINE 本文の中段に列挙する。受信したドライバーが LINE 受信箱で要点を即座に把握できるようになる。

## 変更点

### バックエンド (4 ファイル更新 + 2 新規)

- **新規** `crates/alc-notify/src/extract.rs`
  - `LogisticsFields` 構造体 (5 フィールド全て `Option<String>`、自由テキスト)
  - Gemini Structured Output (`responseSchema`) を必須化 — PR #318 教訓の踏襲
  - pure 関数 `build_extract_request_body` / `parse_extract_response` + endpoint 注入対応 async
- **新規** `crates/alc-notify/src/background_extract.rs`
  - `background_redaction.rs` と同型の fire-and-forget pipeline
  - `extract_document_with_deps(...)` を `&dyn Repo + &dyn Storage` 注入で unit test 化
  - `extracted_data.logistics` キーのみ書き換え、他キーと既存 `extracted_*` は保持
- `ingest.rs` / `documents.rs::upload`: INSERT 後に `spawn_extract_document` を呼ぶ。
  redact パイプラインと並走 (カラム独立: `redaction_status` vs `extraction_status`)。
- `documents.rs`: `POST /notify/documents/{id}/extract-recompute` (202 Accepted) を追加。
  既存ドキュメント (staging `dc5a06c5-...` 等) の再抽出用。
- `distribute.rs`: 本文を `build_distribute_message(&doc, &url)` pure 関数に外出し。
  `extracted_data.logistics` に 1 つでも非空フィールドがあれば物流テンプレ、
  なければ既存テンプレに fallback。

## LINE 本文サンプル (物流テンプレ)

\`\`\`
📄 配車手配票

📍 積地: 東京都港区
📦 卸地: 大阪府大阪市
🕐 積込: 5/9 10:00
🕓 卸し: 5/10 14:00
⚠️ 注意: 冷凍便
要時間厳守

▶ 詳細: https://notify-staging.ippoan.org/api/notify/read/abc...
\`\`\`

## テスト

- 単体テスト 33 件追加 (extract.rs: 16 / background_extract.rs: 14 / distribute.rs: 8)
- alc-notify lib テスト計 125 件全 pass、cargo clippy clean
- Gemini wiremock で 成功 / 4xx / 5xx / parse error / 全 null / 一部 null / 既存 extracted_data 保持
  / 抽出やり直しでの旧値クリア — 全分岐カバー
- フォールバック: PDF 以外 / GEMINI_API_KEY 未設定 / R2 失敗 / extracted_data なし — 全分岐カバー

## デプロイ

- migration **追加なし** (既存 `extracted_data JSONB` カラム / `update_extraction` 関数を活用)
- `GEMINI_API_KEY` env vars が staging Cloud Run に注入済みであることが前提 (redact と同 key)
- staging 反映後に `POST /notify/documents/dc5a06c5-.../extract-recompute` で動作確認

## フロント (別 PR)

`nuxt-notify` 側の詳細画面に「運送情報」セクション + 抽出やり直しボタンは別 PR で対応。
本 PR で `extracted_data.logistics` が書き込まれれば LINE 受信箱には即反映される。

Refs: `~/.claude/plans/tag-release-https-notify-staging-ippoan-glittery-mccarthy.md`