### PR TITLE
feat(notify): 連絡先 (会社名/担当者/電話番号) 3 フィールドを追加 + 自社除外

### DIFF
--- a/crates/alc-notify/src/background_extract.rs
+++ b/crates/alc-notify/src/background_extract.rs
@@ -35,6 +35,8 @@ use crate::extract::{extract_logistics_fields_with_endpoint, ExtractError, Logis
 ///
 /// - `endpoint` / `model`: Gemini API のベース URL とモデル名。`None` なら本番デフォルト。
 ///   wiremock テストでは `Some(server.uri())` を渡す。
+/// - `self_company_hint`: 自社名 (テナント名)。`None` なら Gemini はラベル推論で
+///   自社/相手先を判定する。あれば連絡先 3 フィールドの自社除外精度が上がる。
 /// - 全エラーは `extraction_status='failed'` に変換され、本関数は panic しない。
 /// - 成功 (Gemini が全 null を返した場合も含む) は `extraction_status='completed'`、
 ///   非空のフィールドだけ `extracted_data.logistics` に格納される。
@@ -45,6 +47,7 @@ pub async fn extract_document_with_deps(
     api_key: Option<&str>,
     endpoint: Option<&str>,
     model: Option<&str>,
+    self_company_hint: Option<&str>,
     tenant_id: Uuid,
     document_id: Uuid,
 ) {
@@ -105,27 +108,34 @@ pub async fn extract_document_with_deps(
         }
     };
 
-    // 6. Gemini で 5 フィールド抽出
+    // 6. Gemini で 8 フィールド抽出 (self_company_hint で自社除外)
     let endpoint = endpoint.unwrap_or("https://generativelanguage.googleapis.com/v1beta");
     let model = model.unwrap_or("gemini-3.1-flash-lite-preview");
 
-    let fields: LogisticsFields =
-        match extract_logistics_fields_with_endpoint(endpoint, model, &pdf_bytes, api_key).await {
-            Ok(f) => f,
-            Err(e) => {
-                let err = match &e {
-                    ExtractError::GeminiHttp(_)
-                    | ExtractError::GeminiStatus(_, _)
-                    | ExtractError::GeminiEmpty
-                    | ExtractError::GeminiParse(_) => format!("gemini: {e}"),
-                    ExtractError::LogisticsParse(_) => format!("parse: {e}"),
-                };
-                let _ = docs
-                    .update_extraction_error(tenant_id, document_id, &err)
-                    .await;
-                return;
-            }
-        };
+    let fields: LogisticsFields = match extract_logistics_fields_with_endpoint(
+        endpoint,
+        model,
+        &pdf_bytes,
+        api_key,
+        self_company_hint,
+    )
+    .await
+    {
+        Ok(f) => f,
+        Err(e) => {
+            let err = match &e {
+                ExtractError::GeminiHttp(_)
+                | ExtractError::GeminiStatus(_, _)
+                | ExtractError::GeminiEmpty
+                | ExtractError::GeminiParse(_) => format!("gemini: {e}"),
+                ExtractError::LogisticsParse(_) => format!("parse: {e}"),
+            };
+            let _ = docs
+                .update_extraction_error(tenant_id, document_id, &err)
+                .await;
+            return;
+        }
+    };
 
     // 7. extracted_data の `logistics` キーを書き換え (他キーは保持)
     let merged_data = merge_logistics_into_data(doc.extracted_data.clone(), &fields);
@@ -214,20 +224,44 @@ pub(crate) fn merge_logistics_into_data(
 
 /// fire-and-forget で background extract を起動する。呼び出し元はすぐ return できる。
 ///
-/// `AppState` から env と repo/storage を取り出して `extract_document_with_deps` に委譲。
-/// upload / ingest の各エンドポイントから新規 document の INSERT 直後に呼ぶ。
+/// `AppState` から env と repo/storage/auth (テナント名取得用) を取り出して
+/// `extract_document_with_deps` に委譲。upload / ingest の各エンドポイントから新規
+/// document の INSERT 直後に呼ぶ。
+///
+/// テナント名 (`tenants.name`) は `self_company_hint` として Gemini プロンプトに
+/// 注入され、連絡先抽出時に自社情報を除外するために使われる。取得失敗時はラベル
+/// 推論にフォールバックする (extract 自体は止めない)。
 pub fn spawn_extract_document(state: AppState, tenant_id: Uuid, document_id: Uuid) {
     let api_key = std::env::var("GEMINI_API_KEY").ok();
     let docs: Arc<dyn NotifyDocumentRepository> = state.notify_documents.clone();
     let storage: Option<Arc<dyn StorageBackend>> = state.notify_storage.clone();
+    let auth = state.auth.clone();
 
     tokio::spawn(async move {
+        // tenants.name を fetch して自社除外ヒントとして渡す。失敗してもログだけ残して継続。
+        let self_company_hint: Option<String> = match auth.get_tenant_by_id(tenant_id).await {
+            Ok(Some(t)) => Some(t.name),
+            Ok(None) => {
+                tracing::warn!(
+                    "extract: tenant not found {tenant_id}, falling back to label inference"
+                );
+                None
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "extract: failed to fetch tenant name: {e}, falling back to label inference"
+                );
+                None
+            }
+        };
+
         extract_document_with_deps(
             docs.as_ref(),
             storage.as_deref(),
             api_key.as_deref(),
             None,
             None,
+            self_company_hint.as_deref(),
             tenant_id,
             document_id,
         )
@@ -535,6 +569,7 @@ mod tests {
             Some("test-key"),
             Some(&server.uri()),
             Some("test-model"),
+            None,
             Uuid::new_v4(),
             Uuid::new_v4(),
         )
@@ -567,6 +602,7 @@ mod tests {
             Some("k"),
             Some(&server.uri()),
             Some("m"),
+            None,
             Uuid::new_v4(),
             Uuid::new_v4(),
         )
@@ -587,6 +623,7 @@ mod tests {
             docs.as_ref(),
             Some(storage.as_ref() as &dyn StorageBackend),
             Some("k"),
+            None,
             None,
             None,
             Uuid::new_v4(),
@@ -611,6 +648,7 @@ mod tests {
             Some("k"),
             None,
             None,
+            None,
             Uuid::new_v4(),
             Uuid::new_v4(),
         )
@@ -629,6 +667,7 @@ mod tests {
         extract_document_with_deps(
             docs.as_ref(),
             Some(storage.as_ref() as &dyn StorageBackend),
+            None,
             None,
             None,
             None,
@@ -654,6 +693,7 @@ mod tests {
             Some(""),
             None,
             None,
+            None,
             Uuid::new_v4(),
             Uuid::new_v4(),
         )
@@ -671,6 +711,7 @@ mod tests {
             docs.as_ref(),
             None,
             Some("k"),
+            None,
             None,
             None,
             Uuid::new_v4(),
@@ -693,6 +734,7 @@ mod tests {
             Some("k"),
             None,
             None,
+            None,
             Uuid::new_v4(),
             Uuid::new_v4(),
         )
@@ -711,6 +753,7 @@ mod tests {
             docs.as_ref(),
             Some(storage.as_ref() as &dyn StorageBackend),
             Some("k"),
+            None,
             None,
             None,
             Uuid::new_v4(),
@@ -735,6 +778,7 @@ mod tests {
             Some("k"),
             Some(&server.uri()),
             Some("m"),
+            None,
             Uuid::new_v4(),
             Uuid::new_v4(),
         )
@@ -761,6 +805,7 @@ mod tests {
             Some("k"),
             Some(&server.uri()),
             Some("m"),
+            None,
             Uuid::new_v4(),
             Uuid::new_v4(),
         )
@@ -795,6 +840,7 @@ mod tests {
             Some("k"),
             Some(&server.uri()),
             Some("m"),
+            None,
             Uuid::new_v4(),
             Uuid::new_v4(),
         )
@@ -828,6 +874,7 @@ mod tests {
             Some("k"),
             Some(&server.uri()),
             Some("m"),
+            None,
             Uuid::new_v4(),
             Uuid::new_v4(),
         )
@@ -835,5 +882,49 @@ mod tests {
 
         let extractions = docs.extractions.lock().unwrap();
         assert!(extractions[0].data.get("logistics").is_none());
+    }
+
+    #[tokio::test]
+    async fn extract_passes_self_company_hint_to_gemini_request() {
+        // self_company_hint がそのまま Gemini リクエストボディに乗ることを確認。
+        // tenants.name を spawn_extract_document が fetch して渡す経路の保証。
+        let docs = StubDocs::new(build_doc(Some("doc.pdf")));
+        let storage = StubStorage::ok(b"%PDF".to_vec());
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            // request body にテナント名が含まれていることを wiremock matcher で検証
+            .and(wiremock::matchers::body_string_contains(
+                "MY_OWN_TRANSPORT_CO",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "candidates": [{
+                        "content": {"parts": [{"text":
+                            "{\"contact_company\":\"相手先会社\",\"contact_phone\":\"03-1234-5678\"}"
+                        }]}
+                    }]
+                })),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        extract_document_with_deps(
+            docs.as_ref(),
+            Some(storage.as_ref() as &dyn StorageBackend),
+            Some("k"),
+            Some(&server.uri()),
+            Some("m"),
+            Some("MY_OWN_TRANSPORT_CO"),
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+        )
+        .await;
+
+        // 抽出は完走 (mock の expect(1) が満たされた = hint がリクエストに乗った)
+        let extractions = docs.extractions.lock().unwrap();
+        assert_eq!(extractions.len(), 1);
+        let logistics = extractions[0].data.get("logistics").unwrap();
+        assert_eq!(logistics["contact_company"], "相手先会社");
     }
 }

--- a/crates/alc-notify/src/distribute.rs
+++ b/crates/alc-notify/src/distribute.rs
@@ -417,7 +417,7 @@ async fn test_distribute(
 
 /// LINE / LINE WORKS に送信する本文を組み立てる。
 ///
-/// `doc.extracted_data.logistics` (5 フィールドのいずれかが非空) があれば物流テンプレに
+/// `doc.extracted_data.logistics` (8 フィールドのいずれかが非空) があれば物流テンプレに
 /// 切り替え、なければ既存テンプレ (`title` + `summary` + URL) を返す。
 ///
 /// 物流テンプレ:
@@ -428,10 +428,14 @@ async fn test_distribute(
 /// 🕐 積込: {loading_at}
 /// 🕓 卸し: {unloading_at}
 /// ⚠️ 注意: {notes}
+/// 🏢 連絡先: {contact_company}
+/// 👤 担当: {contact_person}
+/// 📞 電話: {contact_phone}
 ///
 /// ▶ 詳細: {url}
 /// ```
-/// 5 フィールドのうち存在するものだけ列挙する (一部 null OK)。
+/// 8 フィールドのうち存在するものだけ列挙する (一部 null OK)。連絡先 3 フィールドは
+/// `extract.rs` 側で「相手先」を抽出済みで自社情報は除外されている。
 ///
 /// pure 関数として外出しすることで、4 ケース (全フィールドあり / 一部 null /
 /// logistics キーなし / extracted_data なし) を unit test で直接検証できる。
@@ -450,7 +454,7 @@ pub(crate) fn build_distribute_message(
         .and_then(|d| d.get("logistics"))
         .filter(|v| v.is_object())
     {
-        let mut lines: Vec<String> = Vec::with_capacity(8);
+        let mut lines: Vec<String> = Vec::with_capacity(11);
         lines.push(format!("📄 {}", title));
 
         let push_field = |lines: &mut Vec<String>, prefix: &str, key: &str| {
@@ -462,11 +466,16 @@ pub(crate) fn build_distribute_message(
             }
         };
 
+        // 配車情報セクション
         push_field(&mut lines, "📍 積地:", "loading_place");
         push_field(&mut lines, "📦 卸地:", "unloading_place");
         push_field(&mut lines, "🕐 積込:", "loading_at");
         push_field(&mut lines, "🕓 卸し:", "unloading_at");
         push_field(&mut lines, "⚠️ 注意:", "notes");
+        // 連絡先セクション (相手先のみ、自社は extract 側で除外済)
+        push_field(&mut lines, "🏢 連絡先:", "contact_company");
+        push_field(&mut lines, "👤 担当:", "contact_person");
+        push_field(&mut lines, "📞 電話:", "contact_phone");
 
         // logistics キー自体は object だが全 string が空文字 / 欠落のとき (defensive: schema
         // 違反値の混入対策)、本文が「📄 タイトル」だけになって URL が浮くのを避けるため
@@ -541,7 +550,10 @@ mod tests {
                 "unloading_place": "大阪府大阪市",
                 "loading_at": "5/9 10:00",
                 "unloading_at": "5/10 14:00",
-                "notes": "冷凍便\n要時間厳守"
+                "notes": "冷凍便\n要時間厳守",
+                "contact_company": "ABC運送株式会社",
+                "contact_person": "田中太郎",
+                "contact_phone": "03-1234-5678"
             }
         }));
         let msg = build_distribute_message(&doc, "https://x/v/abc");
@@ -551,9 +563,51 @@ mod tests {
         assert!(msg.contains("🕐 積込: 5/9 10:00"));
         assert!(msg.contains("🕓 卸し: 5/10 14:00"));
         assert!(msg.contains("⚠️ 注意: 冷凍便\n要時間厳守"));
+        assert!(msg.contains("🏢 連絡先: ABC運送株式会社"));
+        assert!(msg.contains("👤 担当: 田中太郎"));
+        assert!(msg.contains("📞 電話: 03-1234-5678"));
         assert!(msg.contains("▶ 詳細: https://x/v/abc"));
         // 「新しいドキュメントが届きました」の既定句は出ない
         assert!(!msg.contains("新しいドキュメント"));
+    }
+
+    #[test]
+    fn message_omits_null_contact_fields() {
+        // 連絡先 3 フィールドのうち 1 つだけ。配車情報なし。配信本文は contact 1 行 + URL のみ
+        let mut doc = build_doc();
+        doc.extracted_data = Some(serde_json::json!({
+            "logistics": {
+                "contact_phone": "06-9876-5432"
+            }
+        }));
+        let msg = build_distribute_message(&doc, "https://x/v/abc");
+        assert!(msg.contains("📞 電話: 06-9876-5432"));
+        assert!(!msg.contains("🏢 連絡先"));
+        assert!(!msg.contains("👤 担当"));
+        assert!(!msg.contains("📍 積地"));
+        assert!(msg.contains("▶ 詳細: https://x/v/abc"));
+    }
+
+    #[test]
+    fn message_includes_contact_in_correct_order_after_logistics() {
+        // 物流 + 連絡先のフィールド順序を確認: notes の後に contact_company が来る
+        let mut doc = build_doc();
+        doc.extracted_data = Some(serde_json::json!({
+            "logistics": {
+                "loading_place": "東京",
+                "notes": "冷凍",
+                "contact_company": "ABC",
+                "contact_phone": "03-1234"
+            }
+        }));
+        let msg = build_distribute_message(&doc, "https://x/v/abc");
+        let i_notes = msg.find("⚠️ 注意").unwrap();
+        let i_contact = msg.find("🏢 連絡先").unwrap();
+        let i_phone = msg.find("📞 電話").unwrap();
+        let i_url = msg.find("▶ 詳細").unwrap();
+        assert!(i_notes < i_contact);
+        assert!(i_contact < i_phone);
+        assert!(i_phone < i_url);
     }
 
     #[test]

--- a/crates/alc-notify/src/extract.rs
+++ b/crates/alc-notify/src/extract.rs
@@ -1,9 +1,23 @@
-//! 配車系 PDF から Gemini で「積地・卸地・積み日時・卸し日時・注意事項」を抽出する。
+//! 配車系 PDF から Gemini で 8 フィールドを抽出する:
+//! 「積地・卸地・積み日時・卸し日時・注意事項・連絡先会社名・担当者・電話番号」
 //!
 //! 受信した FAX/PDF が配車手配票だった場合、配信時の LINE 本文に要点を埋め込めるように
-//! `notify_documents.extracted_data` JSONB の `logistics` キー配下に 5 フィールドを保存する。
+//! `notify_documents.extracted_data` JSONB の `logistics` キー配下に 8 フィールドを保存する。
 //! 該当情報がない PDF (請求書・報告書等) は全フィールド `null` で確定し、配信本文は
 //! 既存テンプレ (タイトル + summary + URL) にフォールバックする。
+//!
+//! ## 「自社」と「相手先」の区別
+//!
+//! 配車手配票には自社の連絡先 (受注側) と相手先の連絡先 (依頼元・荷主) の両方が記載される。
+//! LINE 受信者にとって有用なのは **相手先** の連絡先なので、`self_company_hint` (テナント名)
+//! を Gemini プロンプトに渡して自社情報を除外させる。
+//!
+//! 自社判定の手がかり:
+//!   - テナント名 (DB `tenants.name`) と一致する会社名 → 自社
+//!   - 「依頼元」「お客様」「荷主」「発注元」ラベル付き → 相手先
+//!   - 「受注」「ドライバー」「配車」ラベル付き → 自社
+//!
+//! 区別がつかない時は null (誤抽出より under-extract を選ぶ)。
 //!
 //! 設計方針は `crates/alc-notify/src/redact.rs` と同形:
 //!   - `LOGISTICS_PROMPT` でプロンプト本体を const 化
@@ -19,28 +33,60 @@ const GEMINI_DEFAULT_ENDPOINT: &str = "https://generativelanguage.googleapis.com
 // redact と同じ。stable suffix が付いたら更新。
 const GEMINI_DEFAULT_MODEL: &str = "gemini-3.1-flash-lite-preview";
 
-/// プロンプト本文。Gemini に「配車手配票なら 5 フィールドを返し、それ以外は全 null」を要求する。
+/// プロンプト本文を組み立てる。`self_company_hint` (テナント名) があれば自社除外
+/// セクションを注入する。
 ///
 /// PDF が配車系でない (例: 請求書) 場合に「無理にどこかから値を埋める」のを防ぐため、
 /// 「該当情報がなければ null を返す」を明示する。日付は ISO 正規化せず原文表記をそのまま
 /// 保つ — フロントで表示するだけなので、表記のばらつきを受け入れる方が正確。
-const LOGISTICS_PROMPT: &str = r#"この PDF は運送業務で受信した文書です。配車手配票・運行依頼書であれば
-以下 5 フィールドを抽出してください:
+pub(crate) fn build_logistics_prompt(self_company_hint: Option<&str>) -> String {
+    let self_section = match self_company_hint {
+        Some(name) if !name.trim().is_empty() => format!(
+            "\n\n## 自社情報 (除外対象)\n\
+             この PDF を処理するテナント (= 自社) は **「{}」** です。\n\
+             連絡先 3 フィールド (contact_company / contact_person / contact_phone) は\n\
+             **自社ではなく相手先 (依頼元・発注元・荷主・お客様) のものを抽出**してください。\n\
+             - 自社名 (上記) が文書ヘッダ/フッタ/印鑑欄/受注欄にある場合は除外\n\
+             - 自社の電話番号・FAX 番号・担当者名と一致するものは除外\n\
+             - 自社しか書かれていない場合は連絡先 3 フィールドを全て null にする",
+            name.trim()
+        ),
+        _ => String::from(
+            "\n\n## 連絡先の判定\n\
+             連絡先 3 フィールドは「相手先 (依頼元・発注元・荷主・お客様)」のものを抽出する。\n\
+             ラベル例: 「依頼元」「お客様」「荷主」「発注元」「ご依頼元」「お得意様」「貴社」「申込元」。\n\
+             逆に「受注」「ドライバー」「業務担当」「配車」「運転手」のラベル、文書ヘッダ/印鑑/\n\
+             差出人欄の会社名は **自社側** なので除外する。\n\
+             相手先と自社の区別がつかない場合は 3 フィールドとも null にする (誤抽出より null が良い)。",
+        ),
+    };
+
+    format!(
+        r#"この PDF は運送業務で受信した文書です。配車手配票・運行依頼書であれば
+以下 8 フィールドを抽出してください:
 
   - loading_place    : 積地 (積み込み場所、住所か会社名のうち主要なもの 1 件)
   - unloading_place  : 卸地 (荷卸し場所、住所か会社名のうち主要なもの 1 件)
   - loading_at       : 積み日時 (PDF の表記をそのまま、例: "5/9 10:00" / "5月9日 午前10時" / "2026-05-09 10:00")
   - unloading_at     : 卸し日時 (同上)
   - notes            : 注意事項 (冷凍便、要時間厳守、要連絡など配送上の留意点。複数あれば改行で結合)
+  - contact_company  : 連絡先の会社名 (相手先 = 依頼元・発注元・お客様の会社名)
+  - contact_person   : 担当者氏名 (相手先の担当者)
+  - contact_phone    : 電話番号 (相手先の TEL/連絡先電話、PDF の表記そのまま)
 
-ルール:
+## ルール
+
   - PDF が配車手配票でない (請求書・報告書・通知文など) 場合、または該当情報がない場合は
     そのフィールドを null にする。**推測で埋めない、書かれていないものは null**。
-  - 5 フィールド全部 null になっても OK (配信本文は既存テンプレにフォールバックする)。
+  - 全フィールド null になっても OK (配信本文は既存テンプレにフォールバックする)。
   - 日付は ISO 8601 に正規化しない。PDF の表記を**そのまま**返す。
-  - 積地/卸地は住所と会社名を `\n` で連結したり全部入れたりせず、最も識別性の高い 1 行を選ぶ。
-  - notes は複数項目を改行 (`\n`) で連結する。
-  - 出力はこの schema に厳密に従う JSON 1 個 (前後に余分なテキスト・markdown 装飾を一切付けない)。"#;
+  - 積地/卸地は住所と会社名を改行で連結したり全部入れたりせず、最も識別性の高い 1 行を選ぶ。
+  - notes は複数項目を改行 (\n) で連結する。
+  - 電話番号はハイフンの有無や市外局番形式を変更せず、PDF の表記をそのまま。
+  - 出力はこの schema に厳密に従う JSON 1 個 (前後に余分なテキスト・markdown 装飾を一切付けない)。{self_section}"#,
+        self_section = self_section
+    )
+}
 
 /// 抽出結果。`Option<String>` フィールドのみで構成し、どれが取れたかをキー存在で表現する。
 /// `notify_documents.extracted_data.logistics` 配下に serde_json で保存する。
@@ -61,6 +107,15 @@ pub struct LogisticsFields {
     /// 注意事項。複数行可 (改行で連結)。
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub notes: Option<String>,
+    /// 連絡先 (相手先) 会社名。**自社は含めない**。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub contact_company: Option<String>,
+    /// 連絡先 (相手先) 担当者氏名。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub contact_person: Option<String>,
+    /// 連絡先 (相手先) 電話番号。PDF の表記そのまま。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub contact_phone: Option<String>,
 }
 
 impl LogisticsFields {
@@ -72,6 +127,9 @@ impl LogisticsFields {
             &self.loading_at,
             &self.unloading_at,
             &self.notes,
+            &self.contact_company,
+            &self.contact_person,
+            &self.contact_phone,
         ]
         .iter()
         .any(|v| v.as_ref().is_some_and(|s| !s.trim().is_empty()))
@@ -97,7 +155,7 @@ pub enum ExtractError {
 /// `responseMimeType: application/json` だけだと markdown wrap で parse 壊れる
 /// (PR #318 / `feedback_gemini_response_schema_required.md`)。schema で構造を pin する。
 ///
-/// 5 フィールドは全部 nullable な STRING。`required` には入れない (Gemini が
+/// 8 フィールドは全部 nullable な STRING。`required` には入れない (Gemini が
 /// 該当情報なしと判断した時に null にできるように)。
 fn logistics_response_schema() -> serde_json::Value {
     serde_json::json!({
@@ -107,11 +165,15 @@ fn logistics_response_schema() -> serde_json::Value {
             "unloading_place": { "type": "STRING", "nullable": true },
             "loading_at":      { "type": "STRING", "nullable": true },
             "unloading_at":    { "type": "STRING", "nullable": true },
-            "notes":           { "type": "STRING", "nullable": true }
+            "notes":           { "type": "STRING", "nullable": true },
+            "contact_company": { "type": "STRING", "nullable": true },
+            "contact_person":  { "type": "STRING", "nullable": true },
+            "contact_phone":   { "type": "STRING", "nullable": true }
         },
         "propertyOrdering": [
             "loading_place", "unloading_place",
-            "loading_at", "unloading_at", "notes"
+            "loading_at", "unloading_at", "notes",
+            "contact_company", "contact_person", "contact_phone"
         ]
     })
 }
@@ -119,23 +181,29 @@ fn logistics_response_schema() -> serde_json::Value {
 /// Gemini の generateContent リクエスト body を組み立てる pure 関数。
 ///
 /// `pdf_b64` は base64 (no-pad もしくは standard) 済み PDF。
+/// `self_company_hint` は自社除外用テナント名 (例: tenants.name)。None / 空文字なら
+/// プロンプトはラベル推論のみで自社判定する。
+///
 /// 実 API 呼び出しを伴わないので単体テストで request body の中身 (prompt 本文 /
 /// responseSchema の properties / temperature 等) を直接アサートできる。
-pub(crate) fn build_extract_request_body(pdf_b64: &str) -> serde_json::Value {
+pub(crate) fn build_extract_request_body(
+    pdf_b64: &str,
+    self_company_hint: Option<&str>,
+) -> serde_json::Value {
     serde_json::json!({
         "contents": [{
             "role": "user",
             "parts": [
                 { "inlineData": { "mimeType": "application/pdf", "data": pdf_b64 } },
-                { "text": LOGISTICS_PROMPT }
+                { "text": build_logistics_prompt(self_company_hint) }
             ]
         }],
         "generationConfig": {
             "temperature": 0.0,
             "responseMimeType": "application/json",
             "responseSchema": logistics_response_schema(),
-            // 5 フィールド × 短いテキストなので 512 で十分余裕。
-            "maxOutputTokens": 512
+            // 8 フィールド × 短いテキストなので 768 で十分余裕。
+            "maxOutputTokens": 768
         }
     })
 }
@@ -164,21 +232,23 @@ pub(crate) fn parse_extract_response(
     })
 }
 
-/// Gemini API を叩いて配車情報 5 フィールドを抽出する。
+/// Gemini API を叩いて配車情報 8 フィールドを抽出する。
 ///
 /// `endpoint` には prod では `GEMINI_DEFAULT_ENDPOINT` / `model` には `GEMINI_DEFAULT_MODEL` を、
 /// テストでは `wiremock::MockServer::uri()` と任意 model を渡す。
+/// `self_company_hint` には tenants.name を渡す。None / 空文字でも動くがラベル推論のみ。
 pub async fn extract_logistics_fields_with_endpoint(
     endpoint: &str,
     model: &str,
     pdf_bytes: &[u8],
     api_key: &str,
+    self_company_hint: Option<&str>,
 ) -> Result<LogisticsFields, ExtractError> {
     let client = reqwest::Client::new();
     let url = format!("{endpoint}/models/{model}:generateContent?key={api_key}");
     let pdf_b64 = base64::engine::general_purpose::STANDARD.encode(pdf_bytes);
 
-    let body = build_extract_request_body(&pdf_b64);
+    let body = build_extract_request_body(&pdf_b64, self_company_hint);
     let resp = client.post(&url).json(&body).send().await?;
     let status = resp.status();
     if !status.is_success() {
@@ -195,12 +265,14 @@ pub async fn extract_logistics_fields_with_endpoint(
 pub async fn extract_logistics_fields(
     pdf_bytes: &[u8],
     api_key: &str,
+    self_company_hint: Option<&str>,
 ) -> Result<LogisticsFields, ExtractError> {
     extract_logistics_fields_with_endpoint(
         GEMINI_DEFAULT_ENDPOINT,
         GEMINI_DEFAULT_MODEL,
         pdf_bytes,
         api_key,
+        self_company_hint,
     )
     .await
 }
@@ -214,7 +286,7 @@ mod tests {
     // ============================================================
 
     #[test]
-    fn schema_includes_all_five_fields() {
+    fn schema_includes_all_eight_fields() {
         let schema = logistics_response_schema();
         let props = schema.pointer("/properties").unwrap().as_object().unwrap();
         for k in [
@@ -223,6 +295,9 @@ mod tests {
             "loading_at",
             "unloading_at",
             "notes",
+            "contact_company",
+            "contact_person",
+            "contact_phone",
         ] {
             assert!(props.contains_key(k), "schema missing field: {k}");
             // 全フィールド nullable
@@ -230,18 +305,18 @@ mod tests {
             assert_eq!(prop["type"], "STRING");
             assert_eq!(prop["nullable"], true);
         }
-        // ordering も 5 件揃っている
+        // ordering も 8 件揃っている
         let ordering = schema
             .pointer("/propertyOrdering")
             .unwrap()
             .as_array()
             .unwrap();
-        assert_eq!(ordering.len(), 5);
+        assert_eq!(ordering.len(), 8);
     }
 
     #[test]
     fn build_request_body_has_inline_pdf_and_prompt() {
-        let body = build_extract_request_body("AAAA");
+        let body = build_extract_request_body("AAAA", None);
         // PDF が inlineData として埋め込まれている
         let inline = body.pointer("/contents/0/parts/0/inlineData").unwrap();
         assert_eq!(inline["mimeType"], "application/pdf");
@@ -251,11 +326,19 @@ mod tests {
             .pointer("/contents/0/parts/1/text")
             .and_then(|v| v.as_str())
             .unwrap();
-        assert!(prompt.contains("loading_place"));
-        assert!(prompt.contains("unloading_place"));
-        assert!(prompt.contains("loading_at"));
-        assert!(prompt.contains("unloading_at"));
-        assert!(prompt.contains("notes"));
+        // 8 フィールド全て prompt 内に出現
+        for k in [
+            "loading_place",
+            "unloading_place",
+            "loading_at",
+            "unloading_at",
+            "notes",
+            "contact_company",
+            "contact_person",
+            "contact_phone",
+        ] {
+            assert!(prompt.contains(k), "prompt missing field: {k}");
+        }
         // Structured Output 強制 (regression guard, PR #318)
         assert_eq!(
             body.pointer("/generationConfig/responseMimeType").unwrap(),
@@ -267,6 +350,40 @@ mod tests {
     }
 
     #[test]
+    fn build_request_body_includes_self_company_hint_when_provided() {
+        let body = build_extract_request_body("AAAA", Some("テスト運輸株式会社"));
+        let prompt = body
+            .pointer("/contents/0/parts/1/text")
+            .and_then(|v| v.as_str())
+            .unwrap();
+        assert!(prompt.contains("テスト運輸株式会社"));
+        assert!(prompt.contains("自社情報 (除外対象)"));
+        // 「依頼元」「お客様」等のラベル推論セクションは hint なし側
+        assert!(!prompt.contains("## 連絡先の判定\n"));
+    }
+
+    #[test]
+    fn build_request_body_uses_label_inference_when_hint_empty() {
+        let body = build_extract_request_body("AAAA", Some("   "));
+        let prompt = body
+            .pointer("/contents/0/parts/1/text")
+            .and_then(|v| v.as_str())
+            .unwrap();
+        // 空白だけの hint は None と同じ扱い
+        assert!(!prompt.contains("自社情報 (除外対象)"));
+        assert!(prompt.contains("## 連絡先の判定"));
+        assert!(prompt.contains("依頼元"));
+    }
+
+    #[test]
+    fn build_logistics_prompt_explicit_none_uses_label_inference() {
+        let p = build_logistics_prompt(None);
+        assert!(!p.contains("自社情報 (除外対象)"));
+        assert!(p.contains("依頼元"));
+        assert!(p.contains("ドライバー"));
+    }
+
+    #[test]
     fn parse_response_happy_path() {
         let resp = serde_json::json!({
             "candidates": [{
@@ -275,7 +392,10 @@ mod tests {
                      \"unloading_place\":\"大阪市\",\
                      \"loading_at\":\"5/9 10:00\",\
                      \"unloading_at\":\"5/10 14:00\",\
-                     \"notes\":\"冷凍便\\n要時間厳守\"}"
+                     \"notes\":\"冷凍便\\n要時間厳守\",\
+                     \"contact_company\":\"ABC運送\",\
+                     \"contact_person\":\"田中太郎\",\
+                     \"contact_phone\":\"03-1234-5678\"}"
                 }]}
             }]
         });
@@ -285,6 +405,9 @@ mod tests {
         assert_eq!(fields.loading_at.as_deref(), Some("5/9 10:00"));
         assert_eq!(fields.unloading_at.as_deref(), Some("5/10 14:00"));
         assert_eq!(fields.notes.as_deref(), Some("冷凍便\n要時間厳守"));
+        assert_eq!(fields.contact_company.as_deref(), Some("ABC運送"));
+        assert_eq!(fields.contact_person.as_deref(), Some("田中太郎"));
+        assert_eq!(fields.contact_phone.as_deref(), Some("03-1234-5678"));
         assert!(fields.has_any());
     }
 
@@ -294,7 +417,9 @@ mod tests {
             "candidates": [{
                 "content": { "parts": [{ "text":
                     "{\"loading_place\":null,\"unloading_place\":null,\
-                     \"loading_at\":null,\"unloading_at\":null,\"notes\":null}"
+                     \"loading_at\":null,\"unloading_at\":null,\"notes\":null,\
+                     \"contact_company\":null,\"contact_person\":null,\
+                     \"contact_phone\":null}"
                 }]}
             }]
         });
@@ -304,7 +429,31 @@ mod tests {
         assert!(fields.loading_at.is_none());
         assert!(fields.unloading_at.is_none());
         assert!(fields.notes.is_none());
+        assert!(fields.contact_company.is_none());
+        assert!(fields.contact_person.is_none());
+        assert!(fields.contact_phone.is_none());
         assert!(!fields.has_any());
+    }
+
+    #[test]
+    fn parse_response_only_contact_fields() {
+        // 配車情報なし、連絡先 3 つのみある PDF (例: 取引先からのお知らせ)
+        let resp = serde_json::json!({
+            "candidates": [{
+                "content": { "parts": [{ "text":
+                    "{\"contact_company\":\"取引先株式会社\",\
+                     \"contact_person\":\"山田\",\
+                     \"contact_phone\":\"06-1234-5678\"}"
+                }]}
+            }]
+        });
+        let fields = parse_extract_response(&resp).unwrap();
+        assert_eq!(fields.contact_company.as_deref(), Some("取引先株式会社"));
+        assert_eq!(fields.contact_person.as_deref(), Some("山田"));
+        assert_eq!(fields.contact_phone.as_deref(), Some("06-1234-5678"));
+        assert!(fields.loading_place.is_none());
+        // contact だけでも has_any = true
+        assert!(fields.has_any());
     }
 
     #[test]
@@ -419,7 +568,9 @@ mod tests {
     async fn extract_with_endpoint_success() {
         let server = start_mock_with_text(
             "{\"loading_place\":\"成田\",\"unloading_place\":\"福岡\",\
-             \"loading_at\":\"5/9\",\"unloading_at\":\"5/10\",\"notes\":\"急ぎ\"}",
+             \"loading_at\":\"5/9\",\"unloading_at\":\"5/10\",\"notes\":\"急ぎ\",\
+             \"contact_company\":\"ABC運送\",\"contact_person\":\"田中\",\
+             \"contact_phone\":\"03-1234-5678\"}",
         )
         .await;
 
@@ -428,20 +579,29 @@ mod tests {
             "test-model",
             b"%PDF-1.4",
             "test-key",
+            None,
         )
         .await
         .unwrap();
         assert_eq!(fields.loading_place.as_deref(), Some("成田"));
         assert_eq!(fields.notes.as_deref(), Some("急ぎ"));
+        assert_eq!(fields.contact_company.as_deref(), Some("ABC運送"));
+        assert_eq!(fields.contact_person.as_deref(), Some("田中"));
+        assert_eq!(fields.contact_phone.as_deref(), Some("03-1234-5678"));
     }
 
     #[tokio::test]
     async fn extract_with_endpoint_4xx_status() {
         let server = start_mock_with_status(400).await;
-        let err =
-            extract_logistics_fields_with_endpoint(&server.uri(), "test-model", b"x", "test-key")
-                .await
-                .unwrap_err();
+        let err = extract_logistics_fields_with_endpoint(
+            &server.uri(),
+            "test-model",
+            b"x",
+            "test-key",
+            None,
+        )
+        .await
+        .unwrap_err();
         match err {
             ExtractError::GeminiStatus(s, body) => {
                 assert_eq!(s.as_u16(), 400);
@@ -454,10 +614,15 @@ mod tests {
     #[tokio::test]
     async fn extract_with_endpoint_5xx_status() {
         let server = start_mock_with_status(500).await;
-        let err =
-            extract_logistics_fields_with_endpoint(&server.uri(), "test-model", b"x", "test-key")
-                .await
-                .unwrap_err();
+        let err = extract_logistics_fields_with_endpoint(
+            &server.uri(),
+            "test-model",
+            b"x",
+            "test-key",
+            None,
+        )
+        .await
+        .unwrap_err();
         assert!(matches!(err, ExtractError::GeminiStatus(_, _)));
     }
 
@@ -465,10 +630,15 @@ mod tests {
     async fn extract_with_endpoint_invalid_outer_json() {
         // candidates 構造ではない素文字列 → GeminiParse
         let server = start_mock_with_invalid_json().await;
-        let err =
-            extract_logistics_fields_with_endpoint(&server.uri(), "test-model", b"x", "test-key")
-                .await
-                .unwrap_err();
+        let err = extract_logistics_fields_with_endpoint(
+            &server.uri(),
+            "test-model",
+            b"x",
+            "test-key",
+            None,
+        )
+        .await
+        .unwrap_err();
         assert!(matches!(err, ExtractError::GeminiParse(_)));
     }
 
@@ -476,10 +646,15 @@ mod tests {
     async fn extract_with_endpoint_inner_text_unparseable() {
         // candidates は正しいが parts[0].text が JSON ではない → LogisticsParse
         let server = start_mock_with_text("this is not json").await;
-        let err =
-            extract_logistics_fields_with_endpoint(&server.uri(), "test-model", b"x", "test-key")
-                .await
-                .unwrap_err();
+        let err = extract_logistics_fields_with_endpoint(
+            &server.uri(),
+            "test-model",
+            b"x",
+            "test-key",
+            None,
+        )
+        .await
+        .unwrap_err();
         assert!(matches!(err, ExtractError::LogisticsParse(_)));
     }
 
@@ -494,10 +669,15 @@ mod tests {
             )
             .mount(&server)
             .await;
-        let err =
-            extract_logistics_fields_with_endpoint(&server.uri(), "test-model", b"x", "test-key")
-                .await
-                .unwrap_err();
+        let err = extract_logistics_fields_with_endpoint(
+            &server.uri(),
+            "test-model",
+            b"x",
+            "test-key",
+            None,
+        )
+        .await
+        .unwrap_err();
         assert!(matches!(err, ExtractError::GeminiEmpty));
     }
 
@@ -509,10 +689,43 @@ mod tests {
             "test-model",
             b"x",
             "test-key",
+            None,
         )
         .await
         .unwrap_err();
         assert!(matches!(err, ExtractError::GeminiHttp(_)));
+    }
+
+    #[tokio::test]
+    async fn extract_with_endpoint_passes_self_hint_in_request_body() {
+        // mock 経由で self_company_hint がプロンプトに乗ることを確認 (request body inspection)
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::body_string_contains(
+                "テスト運輸株式会社",
+            ))
+            .and(wiremock::matchers::body_string_contains("自社情報"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "candidates": [{
+                        "content": {"parts": [{"text": "{\"contact_company\":\"相手先\"}"}]}
+                    }]
+                })),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let fields = extract_logistics_fields_with_endpoint(
+            &server.uri(),
+            "test-model",
+            b"x",
+            "test-key",
+            Some("テスト運輸株式会社"),
+        )
+        .await
+        .unwrap();
+        assert_eq!(fields.contact_company.as_deref(), Some("相手先"));
     }
 
     // `extract_logistics_fields()` (prod ショートカット) は本物の Gemini エンドポイントを叩くので


### PR DESCRIPTION
PR #319 の 5 フィールドに加え、配車手配票から **相手先 (依頼元・お客様)** の
連絡先 3 フィールドを抽出し、LINE 配信本文と詳細画面に表示する。

## 追加フィールド

| キー              | 内容                            |
|-------------------|---------------------------------|
| `contact_company` | 連絡先 (相手先) 会社名          |
| `contact_person`  | 担当者氏名                      |
| `contact_phone`   | 電話番号 (PDF 表記そのまま)     |

## 自社/相手先の識別

配車手配票には自社 (受注側) と相手先 (依頼元) の両方の連絡先が載るので、
**自社情報の混入を防ぐ仕組み**を入れた:

1. `spawn_extract_document` が `state.auth.get_tenant_by_id(tenant_id)` で
   `tenants.name` を fetch
2. `self_company_hint` として Gemini プロンプトに渡し、
   「自社は『○○○○』です。連絡先は相手先のみ抽出」と明示
3. hint が `None` ならラベル推論にフォールバック
   (「依頼元」「お客様」=相手先、「受注」「ドライバー」=自社)
4. 区別がつかない時は 3 フィールドとも null (誤抽出より under-extract)

## LINE 本文 (物流テンプレ拡張)

```
📄 配車手配票
📍 積地: 東京都港区
📦 卸地: 大阪府大阪市
🕐 積込: 5/9 10:00
🕓 卸し: 5/10 14:00
⚠️ 注意: 冷凍便
🏢 連絡先: ABC運送株式会社
👤 担当: 田中太郎
📞 電話: 03-1234-5678

▶ 詳細: https://...
```

## テスト

- 新規テスト 6 件 (extract: 4 / background_extract: 1 / distribute: 1)
- 既存テスト 14 件を新シグネチャに更新
- alc-notify lib テスト計 133 件全 pass、cargo clippy clean
- wiremock matcher でテナント名がリクエスト body に乗ることを直接アサート

## デプロイ

- migration **追加なし** (既存 `extracted_data JSONB` を活用)
- staging Cloud Run の `GEMINI_API_KEY` は PR #319 で注入済 (再利用)
- 新フィールドは schema 拡張のみなので、staging で `extract-recompute` を叩けば
  既存ドキュメントも 8 フィールド全部返す

## 関連 PR

- nuxt-notify (フロント側): 連絡先 3 フィールド表示は別 PR で対応