### PR TITLE
feat(notify): 積地/卸地に担当者氏名 2 フィールド追加

### DIFF
--- a/crates/alc-notify/src/distribute.rs
+++ b/crates/alc-notify/src/distribute.rs
@@ -473,25 +473,32 @@ pub(crate) fn build_distribute_message(
             }
         };
 
-        // 場所セクション (住所と電話は indent して place の下にぶら下げる)
+        // 場所セクション (住所/担当/電話は indent して place の下にぶら下げる)
         let push_place = |lines: &mut Vec<String>,
                           prefix: &str,
                           place_key: &str,
                           address_key: &str,
-                          phone_key: &str| {
+                          phone_key: &str,
+                          person_key: &str| {
             if let Some(v) = get_str(place_key) {
                 lines.push(format!("{} {}", prefix, v));
                 if let Some(addr) = get_str(address_key) {
                     lines.push(format!("　 {}", addr));
                 }
+                if let Some(person) = get_str(person_key) {
+                    lines.push(format!("　 👤 {}", person));
+                }
                 if let Some(phone) = get_str(phone_key) {
                     lines.push(format!("　 ☎ {}", phone));
                 }
             } else {
-                // place 自体が空でも address/phone が来ていたら捨てずに親なしで列挙
+                // place 自体が空でも address/phone/person が来ていたら捨てずに親なしで列挙
                 // (defensive、ほぼ起きないが念のため)
                 if let Some(addr) = get_str(address_key) {
                     lines.push(format!("{} {}", prefix, addr));
+                }
+                if let Some(person) = get_str(person_key) {
+                    lines.push(format!("　 👤 {}", person));
                 }
                 if let Some(phone) = get_str(phone_key) {
                     lines.push(format!("　 ☎ {}", phone));
@@ -506,6 +513,7 @@ pub(crate) fn build_distribute_message(
             "loading_place",
             "loading_place_address",
             "loading_place_phone",
+            "loading_place_person",
         );
         push_place(
             &mut lines,
@@ -513,6 +521,7 @@ pub(crate) fn build_distribute_message(
             "unloading_place",
             "unloading_place_address",
             "unloading_place_phone",
+            "unloading_place_person",
         );
         push_field(&mut lines, "🕐 積込:", "loading_at");
         push_field(&mut lines, "🕓 卸し:", "unloading_at");
@@ -594,9 +603,11 @@ mod tests {
                 "loading_place": "東京都港区",
                 "loading_place_address": null,
                 "loading_place_phone": null,
+                "loading_place_person": null,
                 "unloading_place": "大阪府大阪市",
                 "unloading_place_address": null,
                 "unloading_place_phone": null,
+                "unloading_place_person": null,
                 "loading_at": "5/9 10:00",
                 "unloading_at": "5/10 14:00",
                 "notes": "冷凍便\n要時間厳守",
@@ -621,31 +632,35 @@ mod tests {
     }
 
     #[test]
-    fn message_indents_place_address_and_phone_under_place() {
-        // 積地: 会社名 + 住所 + 電話、卸地: 住所のみ (PR の代表ユースケース)
+    fn message_indents_place_address_phone_and_person_under_place() {
+        // 積地: 会社名 + 住所 + 担当 + 電話、卸地: 住所のみ
         let mut doc = build_doc();
         doc.extracted_data = Some(serde_json::json!({
             "logistics": {
                 "loading_place": "イオン関西RDC",
                 "loading_place_address": "京都府乙訓郡大山崎町字大山崎小字鏡田38",
                 "loading_place_phone": "075-959-5008",
+                "loading_place_person": "佐藤",
                 "unloading_place": "熊本県八代市新港町3-9-8",
                 "loading_at": "令和8年4月17日 (金) 19時"
             }
         }));
         let msg = build_distribute_message(&doc, "https://x/v/abc");
-        // 積地: 会社名 → 住所 → 電話の順 (indent あり)
+        // 積地: 会社名 → 住所 → 👤 担当 → ☎ 電話の順 (indent あり)
         let i_place = msg.find("📍 積地: イオン関西RDC").unwrap();
         let i_addr = msg.find("　 京都府乙訓郡").unwrap();
+        let i_person = msg.find("　 👤 佐藤").unwrap();
         let i_phone = msg.find("　 ☎ 075-959-5008").unwrap();
         let i_unload = msg.find("📦 卸地: 熊本県八代市").unwrap();
         let i_loadat = msg.find("🕐 積込:").unwrap();
         assert!(i_place < i_addr);
-        assert!(i_addr < i_phone);
+        assert!(i_addr < i_person);
+        assert!(i_person < i_phone);
         assert!(i_phone < i_unload);
         assert!(i_unload < i_loadat);
-        // 卸地は住所のみで電話なし → ☎ が 1 個だけ
+        // 卸地は住所のみ → ☎ が 1 個、👤 も 1 個 (積地のみ)
         assert_eq!(msg.matches('☎').count(), 1);
+        assert_eq!(msg.matches("👤 ").count(), 1);
     }
 
     #[test]

--- a/crates/alc-notify/src/extract.rs
+++ b/crates/alc-notify/src/extract.rs
@@ -1,9 +1,9 @@
-//! 配車系 PDF から Gemini で 12 フィールドを抽出する:
-//! 積地 (会社名/住所/電話) ・卸地 (会社名/住所/電話) ・積み/卸し日時・注意事項・
+//! 配車系 PDF から Gemini で 14 フィールドを抽出する:
+//! 積地 (会社名/住所/電話/担当) ・卸地 (会社名/住所/電話/担当) ・積み/卸し日時・注意事項・
 //! 相手先連絡先 (会社名/担当者/電話)。
 //!
 //! 受信した FAX/PDF が配車手配票だった場合、配信時の LINE 本文に要点を埋め込めるように
-//! `notify_documents.extracted_data` JSONB の `logistics` キー配下に 12 フィールドを保存する。
+//! `notify_documents.extracted_data` JSONB の `logistics` キー配下に 14 フィールドを保存する。
 //! 該当情報がない PDF (請求書・報告書等) は全フィールド `null` で確定し、配信本文は
 //! 既存テンプレ (タイトル + summary + URL) にフォールバックする。
 //!
@@ -64,22 +64,24 @@ pub(crate) fn build_logistics_prompt(self_company_hint: Option<&str>) -> String 
 
     format!(
         r#"この PDF は運送業務で受信した文書です。配車手配票・運行依頼書であれば
-以下 12 フィールドを抽出してください:
+以下 14 フィールドを抽出してください:
 
 【配車情報】
   - loading_place           : 積み込み場所の主要な識別 (会社名/施設名があればそれ、なければ住所)
   - loading_place_address   : 積み込み場所の住所 (loading_place が会社名のとき、その下に書かれた住所)
   - loading_place_phone     : 積み込み場所の電話番号 ("電話" "TEL" 等のラベル付きで書かれている時)
+  - loading_place_person    : 積み込み場所の担当者氏名 ("担当" "ご担当" 等のラベル付きで書かれている時)
   - loading_at              : 積み日時 (PDF の表記をそのまま、例: "5/9 10:00" / "令和8年4月17日 19時")
   - unloading_place         : 卸し場所の主要な識別 (会社名/施設名があればそれ、なければ住所)
   - unloading_place_address : 卸し場所の住所 (unloading_place が会社名のとき、その下の住所)
   - unloading_place_phone   : 卸し場所の電話番号 (ラベル付きで書かれている時)
+  - unloading_place_person  : 卸し場所の担当者氏名 (ラベル付きで書かれている時)
   - unloading_at            : 卸し日時 (同上)
   - notes                   : 注意事項 (冷凍便、要時間厳守、要連絡など配送上の留意点。複数あれば改行で結合)
 
 【相手先 (依頼元) 連絡先】
   - contact_company         : 連絡先の会社名 (相手先 = 依頼元・発注元・お客様の会社名)
-  - contact_person          : 担当者氏名 (相手先の担当者)
+  - contact_person          : 担当者氏名 (相手先 = 依頼元・発注元の担当者)
   - contact_phone           : 電話番号 (相手先の TEL/連絡先電話、PDF の表記そのまま)
 
 ## ルール
@@ -93,9 +95,13 @@ pub(crate) fn build_logistics_prompt(self_company_hint: Option<&str>) -> String 
   - **loading_place_address / unloading_place_address** は loading_place が会社名のときに
     その下に並んで書かれた住所 (例: "京都府乙訓郡大山崎町字大山崎小字鏡田38")。
     住所しかない場合は null (loading_place 側に既に入っているので重複させない)。
-  - **loading_place_phone / unloading_place_phone** は積み込み/卸し場所のセル内に
-    "電話" "TEL" 等のラベルで併記された電話番号。住所のすぐ下に書かれていることが多い。
-    依頼元 (相手先) の電話と混ぜないこと。
+  - **loading_place_phone / unloading_place_phone / loading_place_person / unloading_place_person**
+    は積み込み/卸し場所のセル内に "電話/TEL" "担当/ご担当" 等のラベルで併記された情報。
+    依頼元 (相手先) の `contact_*` と混ぜないこと。場所セルの **内側** にあるか、
+    場所セルの**直下/直右**にあるものだけ場所側、独立した「ご依頼元」「お客様」セル内のものは
+    contact_* 側。
+  - 同じ担当者氏名が場所セルと相手先セルの両方に書かれていることはほぼ無いが、
+    どちらか判断つかない場合は contact_person 側を優先 (場所側は null)。
   - notes は複数項目を改行 (\n) で連結する。
   - 電話番号はハイフンの有無や市外局番形式を変更せず、PDF の表記をそのまま。
   - 金額情報 (合計金額、運賃、消費税など)、支払方法、支払期日は **どのフィールドにも含めない**。
@@ -118,6 +124,10 @@ pub struct LogisticsFields {
     /// 積地の電話番号 (積み込み場所セル内の TEL ラベル付き)。
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub loading_place_phone: Option<String>,
+    /// 積地の担当者氏名 (積み込み場所セル内の "担当" ラベル付き)。
+    /// 相手先 (依頼元) の `contact_person` とは別物。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub loading_place_person: Option<String>,
     /// 卸地。会社名/施設名優先、なければ住所。
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub unloading_place: Option<String>,
@@ -127,6 +137,9 @@ pub struct LogisticsFields {
     /// 卸地の電話番号。
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub unloading_place_phone: Option<String>,
+    /// 卸地の担当者氏名。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub unloading_place_person: Option<String>,
     /// 積み日時。例: "5/9 10:00"
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub loading_at: Option<String>,
@@ -154,9 +167,11 @@ impl LogisticsFields {
             &self.loading_place,
             &self.loading_place_address,
             &self.loading_place_phone,
+            &self.loading_place_person,
             &self.unloading_place,
             &self.unloading_place_address,
             &self.unloading_place_phone,
+            &self.unloading_place_person,
             &self.loading_at,
             &self.unloading_at,
             &self.notes,
@@ -188,7 +203,7 @@ pub enum ExtractError {
 /// `responseMimeType: application/json` だけだと markdown wrap で parse 壊れる
 /// (PR #318 / `feedback_gemini_response_schema_required.md`)。schema で構造を pin する。
 ///
-/// 12 フィールドは全部 nullable な STRING。`required` には入れない (Gemini が
+/// 14 フィールドは全部 nullable な STRING。`required` には入れない (Gemini が
 /// 該当情報なしと判断した時に null にできるように)。
 fn logistics_response_schema() -> serde_json::Value {
     serde_json::json!({
@@ -197,9 +212,11 @@ fn logistics_response_schema() -> serde_json::Value {
             "loading_place":           { "type": "STRING", "nullable": true },
             "loading_place_address":   { "type": "STRING", "nullable": true },
             "loading_place_phone":     { "type": "STRING", "nullable": true },
+            "loading_place_person":    { "type": "STRING", "nullable": true },
             "unloading_place":         { "type": "STRING", "nullable": true },
             "unloading_place_address": { "type": "STRING", "nullable": true },
             "unloading_place_phone":   { "type": "STRING", "nullable": true },
+            "unloading_place_person":  { "type": "STRING", "nullable": true },
             "loading_at":              { "type": "STRING", "nullable": true },
             "unloading_at":            { "type": "STRING", "nullable": true },
             "notes":                   { "type": "STRING", "nullable": true },
@@ -208,8 +225,8 @@ fn logistics_response_schema() -> serde_json::Value {
             "contact_phone":           { "type": "STRING", "nullable": true }
         },
         "propertyOrdering": [
-            "loading_place", "loading_place_address", "loading_place_phone",
-            "unloading_place", "unloading_place_address", "unloading_place_phone",
+            "loading_place", "loading_place_address", "loading_place_phone", "loading_place_person",
+            "unloading_place", "unloading_place_address", "unloading_place_phone", "unloading_place_person",
             "loading_at", "unloading_at", "notes",
             "contact_company", "contact_person", "contact_phone"
         ]
@@ -240,7 +257,7 @@ pub(crate) fn build_extract_request_body(
             "temperature": 0.0,
             "responseMimeType": "application/json",
             "responseSchema": logistics_response_schema(),
-            // 12 フィールド × 短いテキストなので 1024 で十分余裕。
+            // 14 フィールド × 短いテキストなので 1024 で十分余裕。
             "maxOutputTokens": 1024
         }
     })
@@ -324,16 +341,18 @@ mod tests {
     // ============================================================
 
     #[test]
-    fn schema_includes_all_twelve_fields() {
+    fn schema_includes_all_fourteen_fields() {
         let schema = logistics_response_schema();
         let props = schema.pointer("/properties").unwrap().as_object().unwrap();
         for k in [
             "loading_place",
             "loading_place_address",
             "loading_place_phone",
+            "loading_place_person",
             "unloading_place",
             "unloading_place_address",
             "unloading_place_phone",
+            "unloading_place_person",
             "loading_at",
             "unloading_at",
             "notes",
@@ -347,13 +366,13 @@ mod tests {
             assert_eq!(prop["type"], "STRING");
             assert_eq!(prop["nullable"], true);
         }
-        // ordering も 12 件揃っている
+        // ordering も 14 件揃っている
         let ordering = schema
             .pointer("/propertyOrdering")
             .unwrap()
             .as_array()
             .unwrap();
-        assert_eq!(ordering.len(), 12);
+        assert_eq!(ordering.len(), 14);
     }
 
     #[test]
@@ -368,14 +387,16 @@ mod tests {
             .pointer("/contents/0/parts/1/text")
             .and_then(|v| v.as_str())
             .unwrap();
-        // 12 フィールド全て prompt 内に出現
+        // 14 フィールド全て prompt 内に出現
         for k in [
             "loading_place",
             "loading_place_address",
             "loading_place_phone",
+            "loading_place_person",
             "unloading_place",
             "unloading_place_address",
             "unloading_place_phone",
+            "unloading_place_person",
             "loading_at",
             "unloading_at",
             "notes",
@@ -484,17 +505,19 @@ mod tests {
     }
 
     #[test]
-    fn parse_response_with_place_address_and_phone() {
-        // 配車手配票で積み込み場所が「会社名 + 住所 + 電話」3 段書きされているケース
+    fn parse_response_with_place_address_phone_and_person() {
+        // 配車手配票で積み込み場所が「会社名 + 住所 + 電話 + 担当」4 段書きされているケース
         let resp = serde_json::json!({
             "candidates": [{
                 "content": { "parts": [{ "text":
                     "{\"loading_place\":\"イオン関西RDC\",\
                      \"loading_place_address\":\"京都府乙訓郡大山崎町字大山崎小字鏡田38\",\
                      \"loading_place_phone\":\"075-959-5008\",\
+                     \"loading_place_person\":\"佐藤\",\
                      \"unloading_place\":\"熊本県八代市新港町3-9-8\",\
                      \"unloading_place_address\":null,\
                      \"unloading_place_phone\":null,\
+                     \"unloading_place_person\":null,\
                      \"loading_at\":\"令和8年4月17日 (金) 19時\",\
                      \"unloading_at\":\"令和8年4月18日 (土) 8時\"}"
                 }]}
@@ -507,13 +530,15 @@ mod tests {
             Some("京都府乙訓郡大山崎町字大山崎小字鏡田38")
         );
         assert_eq!(f.loading_place_phone.as_deref(), Some("075-959-5008"));
+        assert_eq!(f.loading_place_person.as_deref(), Some("佐藤"));
         assert_eq!(
             f.unloading_place.as_deref(),
             Some("熊本県八代市新港町3-9-8")
         );
-        // 卸地は住所そのものなので _address は null (重複させない)
+        // 卸地は住所そのものなので _address/_phone/_person は null
         assert!(f.unloading_place_address.is_none());
         assert!(f.unloading_place_phone.is_none());
+        assert!(f.unloading_place_person.is_none());
         assert!(f.has_any());
     }
 


### PR DESCRIPTION
PR #321 の 4 フィールド (場所の住所/電話) に加えて、各場所に併記された
**担当者氏名** も抽出する。配車手配票では場所セル内に「担当: 山田」のように
書かれているケースがあり、ドライバーが現地で連絡する際に重要。

## 新フィールド (合計 14)

- \`loading_place_person\`   : 積み込み場所の担当者氏名
- \`unloading_place_person\` : 卸し場所の担当者氏名

**相手先 (依頼元) の \`contact_person\` とは別物**: 相手先 = 依頼元・発注元、
loading/unloading_place_person = 現場の担当者。プロンプトで明示分離。

## LINE 本文

\`\`\`
📍 積地: イオン関西RDC
　 京都府...
　 👤 佐藤
　 ☎ 075-959-5008
\`\`\`

## テスト

- 既存 + 新規計 135 件全 pass
- cargo clippy clean

## デプロイ

- migration なし
- staging で extract-recompute → 14 フィールド全返