### PR TITLE
feat(notify): LINE / LINE WORKS にテキスト→画像の順で配信、redact 済 JPEG を inline 表示

### DIFF
--- a/crates/alc-notify/src/clients/line.rs
+++ b/crates/alc-notify/src/clients/line.rs
@@ -561,6 +561,117 @@ mod tests {
         assert!(matches!(err, LineError::Http(_)));
     }
 
+    // --- push_image tests (push_text と同じパターン) ---
+
+    #[tokio::test]
+    async fn push_image_success() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/oauth2/v2.1/token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "access_token": "tok",
+                "expires_in": 86400u64,
+                "token_type": "Bearer",
+            })))
+            .mount(&server)
+            .await;
+
+        // request body に image / originalContentUrl / previewImageUrl が乗っている
+        // ことを直接 wiremock matcher で検証 (regression guard)
+        Mock::given(method("POST"))
+            .and(path("/v2/bot/message/push"))
+            .and(header("Authorization", "Bearer tok"))
+            .and(wiremock::matchers::body_string_contains("\"image\""))
+            .and(wiremock::matchers::body_string_contains(
+                "\"originalContentUrl\":\"https://example.com/img.jpg\"",
+            ))
+            .and(wiremock::matchers::body_string_contains(
+                "\"previewImageUrl\":\"https://example.com/preview.jpg\"",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_string("{}"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = LineClient::with_endpoints(
+            format!("{}/oauth2/v2.1/token", server.uri()),
+            format!("{}/v2/bot/message/push", server.uri()),
+        );
+
+        client
+            .push_image(
+                &test_config(),
+                "U123",
+                "https://example.com/img.jpg",
+                "https://example.com/preview.jpg",
+            )
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn push_image_failure_returns_send_failed() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/oauth2/v2.1/token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "access_token": "tok",
+                "expires_in": 86400u64,
+                "token_type": "Bearer",
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/v2/bot/message/push"))
+            .respond_with(ResponseTemplate::new(400).set_body_string("invalid url"))
+            .mount(&server)
+            .await;
+
+        let client = LineClient::with_endpoints(
+            format!("{}/oauth2/v2.1/token", server.uri()),
+            format!("{}/v2/bot/message/push", server.uri()),
+        );
+
+        let err = client
+            .push_image(&test_config(), "U123", "https://x/o.jpg", "https://x/p.jpg")
+            .await
+            .unwrap_err();
+        match err {
+            LineError::SendFailed(msg) => {
+                assert!(msg.contains("400"));
+                assert!(msg.contains("invalid url"));
+            }
+            e => panic!("expected SendFailed, got {e:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn push_image_http_error_on_push() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/oauth2/v2.1/token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "access_token": "tok",
+                "expires_in": 86400u64,
+                "token_type": "Bearer",
+            })))
+            .mount(&server)
+            .await;
+
+        let client = LineClient::with_endpoints(
+            format!("{}/oauth2/v2.1/token", server.uri()),
+            "http://127.0.0.1:1/v2/bot/message/push".into(),
+        );
+        let err = client
+            .push_image(&test_config(), "U123", "https://x/o.jpg", "https://x/p.jpg")
+            .await
+            .unwrap_err();
+        assert!(matches!(err, LineError::Http(_)));
+    }
+
     // --- LineError Display ---
 
     #[test]

--- a/crates/alc-notify/src/clients/line.rs
+++ b/crates/alc-notify/src/clients/line.rs
@@ -204,6 +204,50 @@ impl LineClient {
 
         Ok(())
     }
+
+    /// ユーザーに画像メッセージを push する。
+    ///
+    /// `original_url` は最大 10 MB / 4096x4096 / JPEG-PNG (LINE 仕様)。
+    /// `preview_url` は最大 1 MB / 240x240 推奨。両方同じ URL でも構わない (LINE 側が
+    /// オリジナルから縮小して preview にも使える)。
+    /// 仕様: <https://developers.line.biz/ja/reference/messaging-api/#image-message>
+    pub async fn push_image(
+        &self,
+        config: &LineConfig,
+        user_id: &str,
+        original_url: &str,
+        preview_url: &str,
+    ) -> Result<(), LineError> {
+        let access_token = self.get_access_token(config).await?;
+
+        let body = serde_json::json!({
+            "to": user_id,
+            "messages": [
+                {
+                    "type": "image",
+                    "originalContentUrl": original_url,
+                    "previewImageUrl": preview_url,
+                }
+            ]
+        });
+
+        let resp = self
+            .client
+            .post(&self.push_endpoint)
+            .header("Authorization", format!("Bearer {}", access_token))
+            .json(&body)
+            .send()
+            .await?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            tracing::error!("LINE push image failed: {status} - {body}");
+            return Err(LineError::SendFailed(format!("{status}: {body}")));
+        }
+
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/crates/alc-notify/src/clients/lineworks.rs
+++ b/crates/alc-notify/src/clients/lineworks.rs
@@ -326,6 +326,93 @@ impl LineworksBotClient {
         Ok(())
     }
 
+    /// ユーザーに画像メッセージを送信。
+    ///
+    /// LINE WORKS Bot API は `content.type=image` + originalContentUrl + previewImgUrl
+    /// (注: LINE は previewImageUrl、LINE WORKS は previewImgUrl)。LINE WORKS サーバー
+    /// が URL を fetch して CDN 化、トークルームに inline 表示する。
+    /// 仕様: <https://developers.worksmobile.com/jp/docs/bot-send-image>
+    pub async fn send_image_to_user(
+        &self,
+        config_id: Uuid,
+        config: &LineworksBotConfig,
+        user_id: &str,
+        original_url: &str,
+        preview_url: &str,
+    ) -> Result<(), LineworksBotError> {
+        let token = self.get_access_token(config_id, config, "bot").await?;
+        let url = format!(
+            "{}{}/users/{}/messages",
+            self.bot_endpoint, config.bot_id, user_id
+        );
+
+        let body = serde_json::json!({
+            "content": {
+                "type": "image",
+                "originalContentUrl": original_url,
+                "previewImgUrl": preview_url,
+            }
+        });
+
+        let resp = self
+            .client
+            .post(&url)
+            .header("Authorization", format!("Bearer {}", token))
+            .json(&body)
+            .send()
+            .await?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            tracing::error!("LINE WORKS send_image_to_user failed: {status} - {body}");
+            return Err(LineworksBotError::SendFailed(format!("{status}: {body}")));
+        }
+
+        Ok(())
+    }
+
+    /// チャネル/グループに画像メッセージを送信。
+    pub async fn send_image_to_channel(
+        &self,
+        config_id: Uuid,
+        config: &LineworksBotConfig,
+        channel_id: &str,
+        original_url: &str,
+        preview_url: &str,
+    ) -> Result<(), LineworksBotError> {
+        let token = self.get_access_token(config_id, config, "bot").await?;
+        let url = format!(
+            "{}{}/channels/{}/messages",
+            self.bot_endpoint, config.bot_id, channel_id
+        );
+
+        let body = serde_json::json!({
+            "content": {
+                "type": "image",
+                "originalContentUrl": original_url,
+                "previewImgUrl": preview_url,
+            }
+        });
+
+        let resp = self
+            .client
+            .post(&url)
+            .header("Authorization", format!("Bearer {}", token))
+            .json(&body)
+            .send()
+            .await?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            tracing::error!("LINE WORKS send_image_to_channel failed: {status} - {body}");
+            return Err(LineworksBotError::SendFailed(format!("{status}: {body}")));
+        }
+
+        Ok(())
+    }
+
     /// 組織メンバー一覧を取得 (directory.read scope)
     pub async fn list_org_users(
         &self,

--- a/crates/alc-notify/src/distribute.rs
+++ b/crates/alc-notify/src/distribute.rs
@@ -106,12 +106,17 @@ async fn resolve_lineworks_config(
     ))
 }
 
-/// 受信者にメッセージを送信
+/// 受信者にメッセージを送信。
+///
+/// `image_url` が `Some` の場合、テキスト送信成功後に同 URL を image メッセージとしても
+/// 送信する (テキスト → 画像の順)。画像送信が失敗してもテキストは届いているので関数全体
+/// は成功扱い (warning ログのみ) — 画像はあくまで補助。
 async fn send_to_recipient(
     state: &AppState,
     tenant_id: Uuid,
     recipient: &alc_core::repository::notify_recipients::NotifyRecipient,
     message: &str,
+    image_url: Option<&str>,
     line_client: &LineClient,
     lw_client: &LineworksBotClient,
 ) -> Result<(), String> {
@@ -119,10 +124,21 @@ async fn send_to_recipient(
         "line" => {
             let user_id = recipient.line_user_id.as_deref().ok_or("No line_user_id")?;
             let cfg = resolve_line_config(state, tenant_id).await?;
+            // 1. テキスト先行
             line_client
                 .push_text(&cfg, user_id, message)
                 .await
-                .map_err(|e| e.to_string())
+                .map_err(|e| e.to_string())?;
+            // 2. 画像 (extracted_data あり時のみ。失敗は warn のみで成功扱い)
+            if let Some(url) = image_url {
+                if let Err(e) = line_client.push_image(&cfg, user_id, url, url).await {
+                    tracing::warn!(
+                        "LINE push_image failed for recipient {} (text was sent OK): {e}",
+                        recipient.name
+                    );
+                }
+            }
+            Ok(())
         }
         "lineworks" => {
             let user_id = recipient
@@ -130,10 +146,24 @@ async fn send_to_recipient(
                 .as_deref()
                 .ok_or("No lineworks_user_id")?;
             let (config_id, cfg) = resolve_lineworks_config(state, tenant_id).await?;
+            // 1. テキスト先行
             lw_client
                 .send_text_to_user(config_id, &cfg, user_id, message)
                 .await
-                .map_err(|e| e.to_string())
+                .map_err(|e| e.to_string())?;
+            // 2. 画像
+            if let Some(url) = image_url {
+                if let Err(e) = lw_client
+                    .send_image_to_user(config_id, &cfg, user_id, url, url)
+                    .await
+                {
+                    tracing::warn!(
+                        "LINE WORKS send_image_to_user failed for recipient {} (text was sent OK): {e}",
+                        recipient.name
+                    );
+                }
+            }
+            Ok(())
         }
         other => Err(format!("Unknown provider: {other}")),
     }
@@ -303,18 +333,31 @@ async fn distribute(
     let line_client = LineClient::new();
     let lw_client = LineworksBotClient::new();
 
+    // image メッセージは PDF + extracted_data.logistics がある時のみ送る
+    // (PDF 以外、または配車手配票でない PDF は画像送信しない)
+    let send_image = should_send_image(&doc);
+
     let mut sent = 0;
     let mut failed = 0;
 
     for (delivery, recipient) in deliveries.iter().zip(recipients.iter()) {
         let read_url = format!("{}/api/notify/read/{}", api_origin, delivery.read_token);
         let message = build_distribute_message(&doc, &read_url);
+        let image_url = if send_image {
+            Some(format!(
+                "{}/api/notify/v/{}/image",
+                api_origin, delivery.read_token
+            ))
+        } else {
+            None
+        };
 
         match send_to_recipient(
             &state,
             tenant_id,
             recipient,
             &message,
+            image_url.as_deref(),
             &line_client,
             &lw_client,
         )
@@ -395,6 +438,7 @@ async fn test_distribute(
             tenant_id,
             recipient,
             &input.message,
+            None, // テスト配信は画像なし (テキストのみ)
             &line_client,
             &lw_client,
         )
@@ -544,6 +588,33 @@ pub(crate) fn build_distribute_message(
     } else {
         fallback_template(doc, read_url)
     }
+}
+
+/// 画像メッセージ (LINE / LINE WORKS の inline 表示) を送るべきかを判定する。
+///
+/// 配車手配票 PDF のように `extracted_data.logistics` が抽出済みかつ PDF 拡張子の
+/// 場合のみ true。テキスト PDF や画像なし PDF は false (extract_first_page_jpeg で
+/// 415 を返すので、無駄打ちを避ける)。
+///
+/// pure 関数。filename と extracted_data だけで判定。
+pub(crate) fn should_send_image(
+    doc: &alc_core::repository::notify_documents::NotifyDocument,
+) -> bool {
+    let is_pdf = doc
+        .file_name
+        .as_deref()
+        .map(|n| n.to_lowercase().ends_with(".pdf"))
+        .unwrap_or(false);
+    if !is_pdf {
+        return false;
+    }
+    let has_logistics = doc
+        .extracted_data
+        .as_ref()
+        .and_then(|d| d.get("logistics"))
+        .filter(|v| v.is_object())
+        .is_some();
+    has_logistics
 }
 
 fn fallback_template(

--- a/crates/alc-notify/src/redact.rs
+++ b/crates/alc-notify/src/redact.rs
@@ -908,6 +908,49 @@ fn find_first_image_xobject(
     Ok(best.map(|(id, _)| id))
 }
 
+/// PDF の 1 ページ目に埋め込まれた最大サイズの DCTDecode (JPEG) 画像を取り出す。
+///
+/// FAX 由来 PDF が前提 (1 page = 1 image XObject、DCTDecode フィルタ)。FAX 系は
+/// JPEG の上に zlib 圧縮を被せていることが多いので、`/FlateDecode` 配列が含まれる
+/// ケースは Flate を解凍してから生 JPEG bytes を返す。
+///
+/// LINE / LINE WORKS の image メッセージで配信するため、redact 済 PDF から
+/// 「画面で見えている画像そのもの」を取り出す用途。`apply_redactions` の前半部分と
+/// 同じロジックで、書き換えはしない。
+///
+/// pure 関数 (HTTP / DB に触らない)。テキスト PDF 等で JPEG が見つからない場合は
+/// `PageNoImage(1)` を返す。
+pub fn extract_first_page_jpeg(pdf_bytes: &[u8]) -> Result<Vec<u8>, RedactError> {
+    let doc = Document::load_mem(pdf_bytes)?;
+    let pages: Vec<ObjectId> = doc.get_pages().into_values().collect();
+    if pages.is_empty() {
+        return Err(RedactError::PageNotFound(1));
+    }
+    let page_id = pages[0];
+    let image_obj_id =
+        find_first_image_xobject(&doc, page_id)?.ok_or(RedactError::PageNoImage(1))?;
+    let stream = doc.get_object(image_obj_id)?.as_stream()?;
+    let has_flate = match stream.dict.get(b"Filter") {
+        Ok(Object::Array(arr)) => arr
+            .first()
+            .and_then(|o| o.as_name().ok())
+            .map(|n| n == b"FlateDecode")
+            .unwrap_or(false),
+        _ => false,
+    };
+    let raw = stream.content.clone();
+    let jpeg = if has_flate {
+        let mut decoded = Vec::with_capacity(raw.len() * 4);
+        ZlibDecoder::new(raw.as_slice())
+            .read_to_end(&mut decoded)
+            .map_err(RedactError::PdfIo)?;
+        decoded
+    } else {
+        raw
+    };
+    Ok(jpeg)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/alc-notify/src/viewer.rs
+++ b/crates/alc-notify/src/viewer.rs
@@ -26,6 +26,7 @@ pub fn public_router() -> Router<AppState> {
     Router::new()
         .route("/notify/v/{token}", axum::routing::get(view_metadata))
         .route("/notify/v/{token}/file", axum::routing::get(view_file))
+        .route("/notify/v/{token}/image", axum::routing::get(view_image))
 }
 
 #[derive(serde::Serialize, Debug, PartialEq)]
@@ -150,6 +151,65 @@ async fn view_file(
     }
 
     Ok((StatusCode::OK, headers, bytes).into_response())
+}
+
+/// `/api/notify/v/{token}/image` — redact 済 PDF の 1 ページ目に埋め込まれた
+/// JPEG 画像を取り出して `image/jpeg` で返す。LINE / LINE WORKS の image メッセージ
+/// (`originalContentUrl` / `previewImgUrl`) で参照される URL。
+///
+/// view_file と同じ token 認可パスを使う。lookup_delivery_for_view が返す `r2_key`
+/// は `COALESCE(redacted_r2_key, r2_key)` なので redact 済があればそれが取れる。
+///
+/// PDF が画像を持たない (テキストベース等) 場合は 415 Unsupported Media Type を返す
+/// — LINE / LINE WORKS は失敗時 image メッセージを送らないので、distribute 側で
+/// 受信ステータスを見て fallback する責任を負う (テキストだけ送り続ける)。
+async fn view_image(
+    State(state): State<AppState>,
+    Path(token): Path<Uuid>,
+) -> Result<Response, StatusCode> {
+    let info = state
+        .notify_deliveries
+        .get_for_view(token)
+        .await
+        .map_err(|e| {
+            tracing::error!("view_image: get_for_view: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?
+        .ok_or(StatusCode::NOT_FOUND)?;
+
+    check_not_expired(info.expire_at, chrono::Utc::now())?;
+
+    let storage = state.notify_storage.as_ref().ok_or_else(|| {
+        tracing::error!("view_image: notify_storage not configured");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    let pdf_bytes = storage.download(&info.r2_key).await.map_err(|e| {
+        tracing::error!("view_image: notify_storage.download: {e}");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    // PDF から JPEG を取り出す。テキスト PDF / 画像なし PDF では PageNoImage が返る。
+    let jpeg_bytes = crate::redact::extract_first_page_jpeg(&pdf_bytes).map_err(|e| match &e {
+        crate::redact::RedactError::PageNoImage(_) => {
+            tracing::info!("view_image: pdf has no embedded jpeg, returning 415");
+            StatusCode::UNSUPPORTED_MEDIA_TYPE
+        }
+        _ => {
+            tracing::error!("view_image: extract_first_page_jpeg: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        }
+    })?;
+
+    let mut headers = HeaderMap::new();
+    if let Ok(v) = "image/jpeg".parse() {
+        headers.insert(header::CONTENT_TYPE, v);
+    }
+    // image はインライン表示を意図 (LINE WORKS は CDN 取り込み、ブラウザは inline 表示)
+    if let Ok(v) = "inline".parse() {
+        headers.insert(header::CONTENT_DISPOSITION, v);
+    }
+    Ok((StatusCode::OK, headers, jpeg_bytes).into_response())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
ユーザー要望: 「lineworksの配信時、画像そのままリンクではなく、送れないか？」

LINE と LINE WORKS の両方で **image メッセージタイプ** を使い、redact 済 PDF の
1 ページ目 JPEG を inline 表示させる。チャットを開いた時点で画像が見える。

## 配信フロー

1. テキストメッセージ (積地・卸地・日時・連絡先 + 詳細 URL)
2. 画像メッセージ (`/api/notify/v/{token}/image`)

順序: **テキスト → 画像** (notification preview にテキストが出やすく、画像はチャット末尾)

画像送信失敗はテキスト送信済みなら成功扱い (warn ログのみ)。

## 新規

- 公開ヘルパー \`extract_first_page_jpeg(pdf_bytes)\` (apply_redactions の JPEG 抽出を共通化)
- 新エンドポイント \`GET /api/notify/v/{token}/image\` (token ベース、/file と同じ認可)
- \`LineClient::push_image\`
- \`LineworksBotClient::send_image_to_user / send_image_to_channel\`
- \`should_send_image(doc)\` (PDF + extracted_data.logistics の時のみ true)

## 注意

- LINE は \`previewImageUrl\` (camelCase の Image)、LINE WORKS は \`previewImgUrl\` (Img の Img)
- 画像なし PDF は 415 → 画像送信は warn ログだけ、テキストは正常配信

## テスト

- alc-notify lib テスト計 135 件全 pass
- cargo clippy clean

## 後続確認

staging で \`dc5a06c5-...\` を distribute → LINE WORKS チャットで:
- テキスト 1 件 (積地等)
- 画像 1 件 (redact 済画像 inline)

の 2 件が連続で届く。