### PR TITLE
fix(notify): staging/Dockerfile.app にも libpdfium.so install を追加

### DIFF
--- a/staging/Dockerfile.app
+++ b/staging/Dockerfile.app
@@ -2,7 +2,18 @@ FROM debian:trixie-slim
 
 ARG BINARY_NAME=rust-alc-api
 
-RUN apt-get update && apt-get install -y ca-certificates postgresql-client && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y ca-certificates postgresql-client curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# PDFium (Chromium prebuilt) — used by alc-notify::redact for PDF rasterize.
+# bblanchon/pdfium-binaries: linux-x64.tgz contains lib/libpdfium.so (~12 MB).
+# Backend バイナリは alc-notify を含み libpdfium.so を dlopen する。
+ARG PDFIUM_VERSION=chromium/7825
+RUN curl -fsSL "https://github.com/bblanchon/pdfium-binaries/releases/download/${PDFIUM_VERSION}/pdfium-linux-x64.tgz" \
+    | tar -xz -C /tmp \
+    && cp /tmp/lib/libpdfium.so /usr/lib/libpdfium.so \
+    && ldconfig \
+    && rm -rf /tmp/lib /tmp/include /tmp/LICENSE /tmp/PDFiumConfig.cmake /tmp/VERSION 2>/dev/null || true
 
 COPY ${BINARY_NAME} /usr/local/bin/
 COPY migrate /usr/local/bin/


### PR DESCRIPTION
PR #325 で root Dockerfile に pdfium 追加したが staging deploy は staging/Dockerfile.app を使うため反映漏れ。staging で 'apply: pdfium: bind_to_system_library: libpdfium.so: cannot open shared object file' エラー発生 → 修正。

🤖 Generated with [Claude Code](https://claude.com/claude-code)