### PR TITLE
fix(notify): preview/view_file の Content-Type を実 R2 key 拡張子で決める

### DIFF
--- a/crates/alc-notify/src/documents.rs
+++ b/crates/alc-notify/src/documents.rs
@@ -290,11 +290,16 @@ async fn preview(
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
 
+    // Content-Type は **実際の R2 key の拡張子** で決める。
+    // doc.file_name (原本ファイル名 e.g. "3164_001.pdf") で判定すると、
+    // redacted が .jpg になっていても application/pdf が返ってフロント側の
+    // PDF.js が "Invalid PDF structure" でコケる。
     let mut headers = HeaderMap::new();
-    let content_type = crate::viewer::guess_content_type(doc.file_name.as_deref());
+    let content_type = crate::viewer::guess_content_type(Some(key));
     if let Ok(v) = content_type.parse() {
         headers.insert(header::CONTENT_TYPE, v);
     }
+    // download 時のファイル名は原本ファイル名 (UX の都合) で出す。
     let cd = crate::viewer::build_inline_disposition(doc.file_name.as_deref());
     if let Ok(v) = cd.parse() {
         headers.insert(header::CONTENT_DISPOSITION, v);

--- a/crates/alc-notify/src/viewer.rs
+++ b/crates/alc-notify/src/viewer.rs
@@ -141,10 +141,14 @@ async fn view_file(
     })?;
 
     let mut headers = HeaderMap::new();
-    let content_type = guess_content_type(info.file_name.as_deref());
+    // Content-Type は **実際の R2 key** で決める。redacted は `.jpg` (PR #327 以降)
+    // で、原本ファイル名 (info.file_name) は `.pdf` のままなので、原本名で判定
+    // すると client が PDF.js でデコード試行して "Invalid PDF structure" になる。
+    let content_type = guess_content_type(Some(&info.r2_key));
     if let Ok(v) = content_type.parse() {
         headers.insert(header::CONTENT_TYPE, v);
     }
+    // download 時のファイル名は原本ファイル名 (UX の都合で .pdf を維持)。
     let cd = build_inline_disposition(info.file_name.as_deref());
     if let Ok(v) = cd.parse() {
         headers.insert(header::CONTENT_DISPOSITION, v);


### PR DESCRIPTION
PR #327 で redacted を JPEG 1 枚 (.jpg) で R2 に保存するようにしたが、preview / view_file エンドポイントは原本ファイル名 (.pdf) で Content-Type を決めていたので nuxt-notify の PDF.js が 'Invalid PDF structure' でコケていた。