### PR TITLE
fix(notify): LINE 配信用画像 URL を /image.jpg に変更 (拡張子なしだと画像判定されない)

### DIFF
--- a/crates/alc-notify/src/distribute.rs
+++ b/crates/alc-notify/src/distribute.rs
@@ -343,9 +343,12 @@ async fn distribute(
     for (delivery, recipient) in deliveries.iter().zip(recipients.iter()) {
         let read_url = format!("{}/api/notify/read/{}", api_origin, delivery.read_token);
         let message = build_distribute_message(&doc, &read_url);
+        // 注: URL を `.jpg` 終わりにするのは必須。LINE Messaging API / LINE WORKS
+        // Bot は image message の `originalContentUrl` を **拡張子で** 画像判定
+        // するため、`/image` (拡張子なし) だと URL がテキストリンクとして表示される。
         let image_url = if send_image {
             Some(format!(
-                "{}/api/notify/v/{}/image",
+                "{}/api/notify/v/{}/image.jpg",
                 api_origin, delivery.read_token
             ))
         } else {

--- a/crates/alc-notify/src/viewer.rs
+++ b/crates/alc-notify/src/viewer.rs
@@ -26,6 +26,15 @@ pub fn public_router() -> Router<AppState> {
     Router::new()
         .route("/notify/v/{token}", axum::routing::get(view_metadata))
         .route("/notify/v/{token}/file", axum::routing::get(view_file))
+        // LINE Messaging API / LINE WORKS Bot は image message の
+        // `originalContentUrl` を URL の **末尾拡張子** で判定する。`/image`
+        // (拡張子なし) だと画像とみなされず URL がテキストリンクとして表示される。
+        // `.jpg` 付きに変えると両者で inline 画像展開される。
+        .route(
+            "/notify/v/{token}/image.jpg",
+            axum::routing::get(view_image),
+        )
+        // 後方互換: 旧 `/image` (拡張子なし) も残す。生成側は .jpg を新規発行。
         .route("/notify/v/{token}/image", axum::routing::get(view_image))
 }
 


### PR DESCRIPTION
LINE Messaging API / LINE WORKS Bot は image message の originalContentUrl を URL の末尾拡張子で画像判定する。staging で URL がテキストリンクとして表示されて画像にならない問題を確認。

- viewer.rs: /image.jpg route 追加 (旧 /image も後方互換で残す)
- distribute.rs: URL 生成側で .jpg 終わりにする