### PR TITLE
chore: gitignore incus-sandbox symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ node_modules/
 MODULE.bazel.lock
 backup/
 setup-bazel
+incus-sandbox


### PR DESCRIPTION
ローカル開発で incus-sandbox repo (~/git/incus-sandbox) へのシンボリックリンク (rust-alc-api/incus-sandbox) が tracked にならないよう .gitignore に追加。

[今回の経緯]
session 中に local main に gitlink (ippoan-dev-plans) 混入 + main 直 commit 違反の commit 14f8c9f が紛れていた (memory `feedback_pr_push_post_cleanup.md` の罠の再発)。
`git reset --hard origin/main` で drop した上で、.gitignore の正当な変更だけこの PR で出している。