### PR TITLE
feat(dtako): 24h cut + 7-cell rest split + crew_role dedup + storage upload

### DIFF
--- a/crates/alc-csv-parser/src/kudguri.rs
+++ b/crates/alc-csv-parser/src/kudguri.rs
@@ -77,8 +77,18 @@ fn build_column_index(headers: &[&str]) -> Result<ColumnIndex, String> {
     let office_name = require_col(headers, "事業所名", &mut missing);
     let vehicle_cd = require_col(headers, "車輌CD", &mut missing);
     let vehicle_name = require_col(headers, "車輌名", &mut missing);
-    let driver_cd = require_col(headers, "乗務員CD1", &mut missing);
-    let driver_name = require_col(headers, "乗務員名１", &mut missing);
+    // 「乗務員CD1」は運行 primary driver で、KUDGURI の全行で同じ値になる。
+    // 行ごとの「対象」は「対象乗務員CD」 (subject driver of this row) で、これを
+    // 採用しないと crew_role=2 副運転手の行も primary driver として登録されてしまう。
+    // 対象乗務員CD/名 が無い古い CSV (1人乗務) は乗務員CD1 にフォールバック。
+    let driver_cd = find_col(headers, "対象乗務員CD").or_else(|| find_col(headers, "乗務員CD1"));
+    if driver_cd.is_none() {
+        missing.push("対象乗務員CD or 乗務員CD1");
+    }
+    let driver_name = find_col(headers, "対象乗務員名").or_else(|| find_col(headers, "乗務員名１"));
+    if driver_name.is_none() {
+        missing.push("対象乗務員名 or 乗務員名１");
+    }
     let crew_role = require_col(headers, "対象乗務員区分", &mut missing);
 
     if !missing.is_empty() {

--- a/crates/alc-dtako/src/dtako_y_time_export/builder.rs
+++ b/crates/alc-dtako/src/dtako_y_time_export/builder.rs
@@ -2,7 +2,6 @@
 //! bucketing する pure logic。DB / R2 アクセスはここに含まない。
 
 use chrono::{NaiveDate, NaiveDateTime, Timelike};
-use std::collections::HashSet;
 
 use super::models::YTimeRow;
 
@@ -10,21 +9,28 @@ use super::models::YTimeRow;
 pub struct SegmentInput {
     pub start: NaiveDateTime,
     pub end: NaiveDateTime,
+    /// 後方互換用 (sum)。実態は rest_intervals の duration 合計と一致。
     pub rest_minutes: i32,
+    /// 各休憩 (event_cd=301) の (start, end)。bucket 確定後に時間帯別に振り分けるために必要。
+    pub rest_intervals: Vec<(NaiveDateTime, NaiveDateTime)>,
     pub note: Option<String>,
 }
+
+/// (A) cutoff: 所定労働時間 (h)。これ以上の勤務時間 (= end - start - rest) は深夜跨ぎ時に
+/// 終業日側 row に F=1 で記録、未満なら始業日 row に 24h+ 表記で記録。
+const WORK_CUTOFF_HOURS: f64 = 7.0;
 
 /// `segments` を bucketing して `YTimeRow` の列を返す。
 ///
 /// 戻り値: `(rows, warnings)`
 ///
 /// ルール:
-/// - 同日 (start.date() == end.date()) → bucket = start.date()、F 空
-/// - 翌日跨ぎ + その「終業日」に他 segment が始業している → bucket = end.date()、F=1
-///   (1 暦日 2 始業ケース、終業日側に集約)
-/// - 翌日跨ぎ + 終業日に他 segment なし → bucket = start.date()、F 空、H 列 24h+ 表記
+/// - 同日 (start.date() == end.date()) → bucket = start.date()、F=0
+/// - 深夜跨ぎ + 勤務時間 < 7h → bucket = start.date()、F=0、H 列 24h+ 表記
+/// - 深夜跨ぎ + 勤務時間 ≥ 7h → bucket = end.date()、F=1、H 列 = end の minutes_of_day
+///   (テンプレ数式が「F=1 のとき G を 0 として扱う」ので、当日 0:00 から H までを当日労働として計算)
 /// - 期間外 (`bucket_date < from || > to`) は drop
-/// - 同 bucket_date が複数: 最初の row のみ採用、警告 1 件
+/// - 同 bucket_date に複数 segment: 結合 (G=最早, H=最遅, rest=各 segment 合計, F=any)
 pub fn build_y_time_rows(
     mut segments: Vec<SegmentInput>,
     from: NaiveDate,
@@ -32,55 +38,212 @@ pub fn build_y_time_rows(
 ) -> (Vec<YTimeRow>, Vec<String>) {
     segments.sort_by_key(|s| s.start);
 
-    // 事前計算: 全 segment の start.date() の集合
-    let start_dates: HashSet<NaiveDate> = segments.iter().map(|s| s.start.date()).collect();
-
-    let mut rows: Vec<YTimeRow> = Vec::new();
     let mut warnings: Vec<String> = Vec::new();
-    let mut seen_buckets: HashSet<NaiveDate> = HashSet::new();
+    // bucket_date → 集約中の row データ
+    let mut buckets: std::collections::HashMap<NaiveDate, BucketAccum> =
+        std::collections::HashMap::new();
+    let mut bucket_order: Vec<NaiveDate> = Vec::new();
 
     for seg in segments {
+        let work_minutes = (seg.end - seg.start).num_minutes() as i32 - seg.rest_minutes;
+        let work_hours = work_minutes as f64 / 60.0;
+
         let (bucket, previous_day_start, end_min_from_bucket) =
             if seg.start.date() == seg.end.date() {
-                let end_min = minutes_of_day(seg.end);
-                (seg.start.date(), false, end_min)
-            } else if start_dates.contains(&seg.end.date()) {
-                // 1 暦日 2 始業ケース: 終業日側に集約 (F=1)
-                let end_min = minutes_of_day(seg.end);
-                (seg.end.date(), true, end_min)
+                (seg.start.date(), false, minutes_of_day(seg.end))
+            } else if work_hours >= WORK_CUTOFF_HOURS {
+                // 深夜跨ぎ + 長時間勤務 → 終業日 row F=1
+                (seg.end.date(), true, minutes_of_day(seg.end))
             } else {
-                // 翌日跨ぎだが同日に他 segment なし → 24h+ 表記
+                // 深夜跨ぎ + 短時間 → 始業日 row 24h+ 表記
                 let bucket = seg.start.date();
                 let bucket_midnight = bucket.and_hms_opt(0, 0, 0).expect("valid midnight");
                 let end_min = (seg.end - bucket_midnight).num_minutes() as i32;
                 (bucket, false, end_min)
             };
 
-        // 期間外フィルタ
+        // 期間外
         if bucket < from || bucket > to {
             continue;
         }
 
-        // 同 bucket_date が再出現 → drop + warning
-        if !seen_buckets.insert(bucket) {
-            warnings.push(format!(
-                "{bucket}: 複数 segment 検出 (1 暦日 2 始業の後半は MVP では未対応、最初の row のみ採用)"
-            ));
-            continue;
-        }
+        // 休憩 7 セル split を計算 (bucket date に対する 前日/当日/翌日 で時間帯振り分け)
+        let rest_split = split_rest_intervals(&seg.rest_intervals, bucket);
 
-        rows.push(YTimeRow {
-            date: bucket,
+        let entry = buckets.entry(bucket).or_insert_with(|| {
+            bucket_order.push(bucket);
+            BucketAccum::new(bucket)
+        });
+
+        let already_had_seg = entry.has_segment;
+        entry.merge(SegInBucket {
+            start_min: minutes_of_day(seg.start),
+            end_min: end_min_from_bucket,
             previous_day_start,
-            start_minutes_of_day: minutes_of_day(seg.start),
-            end_minutes_from_bucket_date: end_min_from_bucket,
-            rest_minutes: seg.rest_minutes,
+            rest: rest_split,
             note: seg.note,
         });
+
+        if already_had_seg {
+            warnings.push(format!(
+                "{bucket}: 複数 segment 結合 (1 行に集約: 最早始業 / 最遅終業 / 休憩合計)"
+            ));
+        }
     }
 
+    let mut rows: Vec<YTimeRow> = bucket_order
+        .into_iter()
+        .map(|d| buckets.remove(&d).expect("bucket exists").into_row())
+        .collect();
     rows.sort_by_key(|r| r.date);
     (rows, warnings)
+}
+
+/// 休憩 (event_cd=301) intervals を、bucket date を基準にして 7 セル (前日/当日/翌日 × 時間帯) に振り分け。
+fn split_rest_intervals(
+    intervals: &[(NaiveDateTime, NaiveDateTime)],
+    bucket: NaiveDate,
+) -> RestSplit {
+    let mut s = RestSplit::default();
+    let prev = bucket.pred_opt().expect("valid prev date");
+    let next = bucket.succ_opt().expect("valid next date");
+    for (start, end) in intervals {
+        // 前日
+        s.prev_5_22 += overlap_minutes(*start, *end, prev, 5 * 60, 22 * 60);
+        s.prev_22_0 += overlap_minutes(*start, *end, prev, 22 * 60, 24 * 60);
+        // 当日
+        s.today_0_5 += overlap_minutes(*start, *end, bucket, 0, 5 * 60);
+        s.today_5_22 += overlap_minutes(*start, *end, bucket, 5 * 60, 22 * 60);
+        s.today_22_0 += overlap_minutes(*start, *end, bucket, 22 * 60, 24 * 60);
+        // 翌日
+        s.next_0_5 += overlap_minutes(*start, *end, next, 0, 5 * 60);
+        s.next_5_22 += overlap_minutes(*start, *end, next, 5 * 60, 22 * 60);
+    }
+    s
+}
+
+/// interval (start, end) と (date 0:00 + start_min, date 0:00 + end_min) の重複分数。
+fn overlap_minutes(
+    a_start: NaiveDateTime,
+    a_end: NaiveDateTime,
+    date: NaiveDate,
+    start_min: i32,
+    end_min: i32,
+) -> i32 {
+    let midnight = date.and_hms_opt(0, 0, 0).expect("valid midnight");
+    let b_start = midnight + chrono::Duration::minutes(start_min as i64);
+    let b_end = midnight + chrono::Duration::minutes(end_min as i64);
+    let lo = a_start.max(b_start);
+    let hi = a_end.min(b_end);
+    if hi > lo {
+        (hi - lo).num_minutes() as i32
+    } else {
+        0
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq)]
+struct RestSplit {
+    prev_5_22: i32,
+    prev_22_0: i32,
+    today_0_5: i32,
+    today_5_22: i32,
+    today_22_0: i32,
+    next_0_5: i32,
+    next_5_22: i32,
+}
+
+impl RestSplit {
+    fn add(&mut self, other: &RestSplit) {
+        self.prev_5_22 += other.prev_5_22;
+        self.prev_22_0 += other.prev_22_0;
+        self.today_0_5 += other.today_0_5;
+        self.today_5_22 += other.today_5_22;
+        self.today_22_0 += other.today_22_0;
+        self.next_0_5 += other.next_0_5;
+        self.next_5_22 += other.next_5_22;
+    }
+}
+
+struct SegInBucket {
+    start_min: i32,
+    end_min: i32,
+    previous_day_start: bool,
+    rest: RestSplit,
+    note: Option<String>,
+}
+
+struct BucketAccum {
+    date: NaiveDate,
+    has_segment: bool,
+    /// 最早始業 (= 一番小さい start_min)
+    earliest_start: i32,
+    /// 最遅終業 (= 一番大きい end_min。bucket midnight 起点 24h+ 含む)
+    latest_end: i32,
+    rest: RestSplit,
+    previous_day_start: bool,
+    notes: Vec<String>,
+}
+
+impl BucketAccum {
+    fn new(date: NaiveDate) -> Self {
+        Self {
+            date,
+            has_segment: false,
+            earliest_start: 0,
+            latest_end: 0,
+            rest: RestSplit::default(),
+            previous_day_start: false,
+            notes: Vec::new(),
+        }
+    }
+
+    fn merge(&mut self, seg: SegInBucket) {
+        if !self.has_segment {
+            self.earliest_start = seg.start_min;
+            self.latest_end = seg.end_min;
+            self.has_segment = true;
+        } else {
+            // F=1 (前日始業) は値が大きいことが多い (前日 22:00 = 1320) ので min/max を素朴に取ると
+            // バグる。F が混在するなら「F=1 を優先」する: F=1 の start_min はそのまま記録、
+            // F=0 の start_min は無視 (テンプレ数式上 F=1 の G は 0 として扱うため、表示用)
+            if seg.previous_day_start && !self.previous_day_start {
+                // F=1 の segment を採用
+                self.earliest_start = seg.start_min;
+            } else if seg.previous_day_start == self.previous_day_start {
+                // 同じ F なら最早を取る
+                self.earliest_start = self.earliest_start.min(seg.start_min);
+            }
+            // 終業は常に最遅
+            self.latest_end = self.latest_end.max(seg.end_min);
+        }
+        self.rest.add(&seg.rest);
+        self.previous_day_start |= seg.previous_day_start;
+        if let Some(n) = seg.note {
+            self.notes.push(n);
+        }
+    }
+
+    fn into_row(self) -> YTimeRow {
+        YTimeRow {
+            date: self.date,
+            previous_day_start: self.previous_day_start,
+            start_minutes_of_day: self.earliest_start,
+            end_minutes_from_bucket_date: self.latest_end,
+            rest_prev_5_22: self.rest.prev_5_22,
+            rest_prev_22_0: self.rest.prev_22_0,
+            rest_today_0_5: self.rest.today_0_5,
+            rest_today_5_22: self.rest.today_5_22,
+            rest_today_22_0: self.rest.today_22_0,
+            rest_next_0_5: self.rest.next_0_5,
+            rest_next_5_22: self.rest.next_5_22,
+            note: if self.notes.is_empty() {
+                None
+            } else {
+                Some(self.notes.join(" / "))
+            },
+        }
+    }
 }
 
 fn minutes_of_day(dt: NaiveDateTime) -> i32 {
@@ -102,7 +265,7 @@ mod tests {
         NaiveDate::from_ymd_opt(y, m, day).unwrap()
     }
 
-    fn seg(
+    fn seg_simple(
         start: NaiveDateTime,
         end: NaiveDateTime,
         rest: i32,
@@ -112,13 +275,14 @@ mod tests {
             start,
             end,
             rest_minutes: rest,
+            rest_intervals: Vec::new(),
             note: note.map(String::from),
         }
     }
 
     #[test]
     fn single_same_day_segment() {
-        let s = seg(
+        let s = seg_simple(
             dt((2024, 4, 15), (8, 30)),
             dt((2024, 4, 15), (17, 0)),
             60,
@@ -130,59 +294,106 @@ mod tests {
         assert!(!rows[0].previous_day_start);
         assert_eq!(rows[0].start_minutes_of_day, 8 * 60 + 30);
         assert_eq!(rows[0].end_minutes_from_bucket_date, 17 * 60);
-        assert_eq!(rows[0].rest_minutes, 60);
         assert!(warns.is_empty());
     }
 
     #[test]
-    fn cross_midnight_no_followup_uses_24h_plus() {
-        // 4/15 22:30 → 4/16 06:00、4/16 に他 segment なし
-        let s = seg(
-            dt((2024, 4, 15), (22, 30)),
-            dt((2024, 4, 16), (6, 0)),
-            30,
-            None,
-        );
+    fn cross_midnight_short_work_uses_start_date_24h_plus() {
+        // 4/15 22:30 → 4/16 04:30 (work 6h, rest 30 → work 5.5h < 7h cutoff)
+        let s = SegmentInput {
+            start: dt((2024, 4, 15), (22, 30)),
+            end: dt((2024, 4, 16), (4, 30)),
+            rest_minutes: 30,
+            rest_intervals: vec![(dt((2024, 4, 16), (1, 0)), dt((2024, 4, 16), (1, 30)))],
+            note: None,
+        };
         let (rows, warns) = build_y_time_rows(vec![s], d(2024, 4, 1), d(2024, 4, 30));
         assert_eq!(rows.len(), 1);
+        // start_date 側 (4/15) に 24h+ で記録
         assert_eq!(rows[0].date, d(2024, 4, 15));
         assert!(!rows[0].previous_day_start);
         assert_eq!(rows[0].start_minutes_of_day, 22 * 60 + 30);
-        // 30:00 == 30 * 60 == 1800
-        assert_eq!(rows[0].end_minutes_from_bucket_date, 30 * 60);
+        // 28:30 = 4:30 翌日 = 28*60+30 = 1710
+        assert_eq!(rows[0].end_minutes_from_bucket_date, 28 * 60 + 30);
+        // 休憩 4/16 1:00-1:30 → 4/15 bucket では「翌日 0-5時」
+        assert_eq!(rows[0].rest_next_0_5, 30);
         assert!(warns.is_empty());
     }
 
     #[test]
-    fn cross_midnight_with_followup_uses_previous_day_flag() {
-        // 4/15 22:30 → 4/16 09:30、続いて 4/16 17:00 → 4/16 22:00
-        let s1 = seg(
-            dt((2024, 4, 15), (22, 30)),
-            dt((2024, 4, 16), (9, 30)),
-            30,
+    fn cross_midnight_long_work_uses_end_date_with_f1() {
+        // 4/15 22:00 → 4/16 06:00 (work 8h ≥ 7h cutoff)
+        let s = seg_simple(
+            dt((2024, 4, 15), (22, 0)),
+            dt((2024, 4, 16), (6, 0)),
+            0,
             None,
         );
-        let s2 = seg(
-            dt((2024, 4, 16), (17, 0)),
-            dt((2024, 4, 16), (22, 0)),
+        let (rows, _warns) = build_y_time_rows(vec![s], d(2024, 4, 1), d(2024, 4, 30));
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].date, d(2024, 4, 16));
+        assert!(rows[0].previous_day_start);
+        assert_eq!(rows[0].start_minutes_of_day, 22 * 60);
+        assert_eq!(rows[0].end_minutes_from_bucket_date, 6 * 60);
+    }
+
+    #[test]
+    fn template_example_two_starts_on_same_calendar_day() {
+        // テンプレ作者の例: 5/14 1:00-12:00 + 5/14 22:30 → 5/15 9:30
+        let s1 = seg_simple(
+            dt((2024, 5, 14), (1, 0)),
+            dt((2024, 5, 14), (12, 0)),
+            0,
+            None,
+        );
+        let s2 = seg_simple(
+            dt((2024, 5, 14), (22, 30)),
+            dt((2024, 5, 15), (9, 30)),
+            0,
+            None,
+        );
+        let (rows, warns) = build_y_time_rows(vec![s1, s2], d(2024, 5, 1), d(2024, 5, 31));
+        assert_eq!(rows.len(), 2);
+        // 5/14 row: same-day
+        assert_eq!(rows[0].date, d(2024, 5, 14));
+        assert!(!rows[0].previous_day_start);
+        assert_eq!(rows[0].start_minutes_of_day, 60);
+        assert_eq!(rows[0].end_minutes_from_bucket_date, 12 * 60);
+        // 5/15 row: cross-midnight, 11h ≥ 7h → end_date with F=1
+        assert_eq!(rows[1].date, d(2024, 5, 15));
+        assert!(rows[1].previous_day_start);
+        assert_eq!(rows[1].start_minutes_of_day, 22 * 60 + 30);
+        assert_eq!(rows[1].end_minutes_from_bucket_date, 9 * 60 + 30);
+        assert!(warns.is_empty());
+    }
+
+    #[test]
+    fn same_bucket_combine_two_segments() {
+        // 4/2 22:00 → 4/3 09:00 (11h cross-midnight, ≥ 7h → 4/3 F=1)
+        // 4/3 11:00 → 4/3 17:00 (6h same-day → 4/3)
+        // → 4/3 row に結合: F=1, 始業 22:00 (前日), 終業 17:00
+        let s1 = seg_simple(dt((2024, 4, 2), (22, 0)), dt((2024, 4, 3), (9, 0)), 0, None);
+        let s2 = seg_simple(
+            dt((2024, 4, 3), (11, 0)),
+            dt((2024, 4, 3), (17, 0)),
             0,
             None,
         );
         let (rows, warns) = build_y_time_rows(vec![s1, s2], d(2024, 4, 1), d(2024, 4, 30));
-        // s1 は 4/16 row に F=1 で集約。s2 は同 4/16 bucket と衝突して warning + drop。
         assert_eq!(rows.len(), 1);
-        assert_eq!(rows[0].date, d(2024, 4, 16));
+        assert_eq!(rows[0].date, d(2024, 4, 3));
         assert!(rows[0].previous_day_start);
-        assert_eq!(rows[0].start_minutes_of_day, 22 * 60 + 30);
-        assert_eq!(rows[0].end_minutes_from_bucket_date, 9 * 60 + 30);
+        // F=1 を優先で start = 22:00 (前日)
+        assert_eq!(rows[0].start_minutes_of_day, 22 * 60);
+        // 終業最遅 17:00
+        assert_eq!(rows[0].end_minutes_from_bucket_date, 17 * 60);
         assert_eq!(warns.len(), 1);
-        assert!(warns[0].contains("2024-04-16"));
+        assert!(warns[0].contains("複数 segment 結合"));
     }
 
     #[test]
     fn out_of_range_filtered() {
-        // bucket=4/15 だが期間 4/16〜4/30 → drop
-        let s = seg(
+        let s = seg_simple(
             dt((2024, 4, 15), (8, 0)),
             dt((2024, 4, 15), (17, 0)),
             0,
@@ -195,19 +406,19 @@ mod tests {
     #[test]
     fn multiple_distinct_days_sorted_ascending() {
         let segments = vec![
-            seg(
+            seg_simple(
                 dt((2024, 4, 18), (8, 0)),
                 dt((2024, 4, 18), (17, 0)),
                 0,
                 None,
             ),
-            seg(
+            seg_simple(
                 dt((2024, 4, 15), (8, 0)),
                 dt((2024, 4, 15), (17, 0)),
                 0,
                 None,
             ),
-            seg(
+            seg_simple(
                 dt((2024, 4, 22), (8, 0)),
                 dt((2024, 4, 22), (17, 0)),
                 0,
@@ -223,20 +434,34 @@ mod tests {
     }
 
     #[test]
-    fn null_rest_handled_as_zero() {
-        let s = seg(
-            dt((2024, 4, 15), (8, 0)),
-            dt((2024, 4, 15), (17, 0)),
-            0,
-            None,
-        );
+    fn rest_split_categorizes_by_time_of_day() {
+        // 4/15 8:00 - 4/15 22:00 (same-day) with rests:
+        //   4/15 4:00-5:00 (前日?? いや、同日の 0-5時) ← 当日 0-5
+        //   4/15 12:00-13:00 (5-22 帯) ← 当日 5-22
+        //   4/15 23:00-23:30 (22-0 帯) ← 当日 22-0
+        let s = SegmentInput {
+            start: dt((2024, 4, 15), (8, 0)),
+            end: dt((2024, 4, 15), (22, 0)),
+            rest_minutes: 150,
+            rest_intervals: vec![
+                (dt((2024, 4, 15), (4, 0)), dt((2024, 4, 15), (5, 0))),
+                (dt((2024, 4, 15), (12, 0)), dt((2024, 4, 15), (13, 0))),
+                (dt((2024, 4, 15), (23, 0)), dt((2024, 4, 15), (23, 30))),
+            ],
+            note: None,
+        };
         let (rows, _) = build_y_time_rows(vec![s], d(2024, 4, 1), d(2024, 4, 30));
-        assert_eq!(rows[0].rest_minutes, 0);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].rest_today_0_5, 60);
+        assert_eq!(rows[0].rest_today_5_22, 60);
+        assert_eq!(rows[0].rest_today_22_0, 30);
+        assert_eq!(rows[0].rest_prev_5_22, 0);
+        assert_eq!(rows[0].rest_next_0_5, 0);
     }
 
     #[test]
     fn note_passes_through() {
-        let s = seg(
+        let s = seg_simple(
             dt((2024, 4, 15), (8, 0)),
             dt((2024, 4, 15), (17, 0)),
             0,

--- a/crates/alc-dtako/src/dtako_y_time_export/csv_aggregator.rs
+++ b/crates/alc-dtako/src/dtako_y_time_export/csv_aggregator.rs
@@ -66,8 +66,10 @@ pub fn build_kudgivt_key(tenant_id: uuid::Uuid, unko_no: &str, r2_prefix: Option
 
 /// 1 運行の KUDGIVT.csv を取得して該当 crew_role の events を返す。
 ///
-/// CSV は Shift-JIS の場合と UTF-8 の場合がある (実装の歴史)。SHIFT_JIS の
-/// `(decoded, _, had_errors)` を見て、文字化けが多い場合のみ utf8 fallback。
+/// `split_csv_from_r2` (dtako_upload.rs) で per-unko CSV は **UTF-8 で保存**される
+/// (元 ZIP 内が Shift-JIS でも、split 時に decode_shift_jis を通して UTF-8 化済み)。
+/// なので UTF-8 として読む。後方互換のため Shift-JIS もフォールバックで試す
+/// (元 R2 に Shift-JIS のまま置かれた古いデータ用)。
 pub async fn fetch_and_parse_kudgivt(
     storage: &dyn StorageBackend,
     tenant_id: uuid::Uuid,
@@ -77,7 +79,11 @@ pub async fn fetch_and_parse_kudgivt(
 ) -> Result<Vec<KudgivtRow>, AggregatorError> {
     let key = build_kudgivt_key(tenant_id, unko_no, r2_prefix);
     let bytes = storage.download(&key).await?;
-    let text = decode_shift_jis(&bytes);
+    // まず UTF-8 として試す。失敗したら (= 古い Shift-JIS データ) decode_shift_jis にフォールバック
+    let text = match std::str::from_utf8(&bytes) {
+        Ok(s) => s.to_owned(),
+        Err(_) => decode_shift_jis(&bytes),
+    };
     let rows = parse_kudgivt(&text).map_err(|e| AggregatorError::Parse(e.to_string()))?;
     Ok(rows
         .into_iter()
@@ -85,24 +91,13 @@ pub async fn fetch_and_parse_kudgivt(
         .collect())
 }
 
-/// segment 内 (`[seg_start, seg_end]`) の event_cd=301 events の duration_minutes を sum。
-fn sum_break_minutes(
-    events: &[KudgivtRow],
-    seg_start: NaiveDateTime,
-    seg_end: NaiveDateTime,
-) -> i32 {
-    events
-        .iter()
-        .filter(|e| e.event_cd == "301")
-        .filter(|e| e.start_at >= seg_start && e.start_at <= seg_end)
-        .map(|e| e.duration_minutes.unwrap_or(0))
-        .sum()
-}
-
 /// 1 運行 (KUDGIVT events + departure/return) を `Vec<SegmentInput>` に変換する。
 ///
 /// - `split_by_rest` で WorkSegment を出す
 /// - 各 segment 内の 301 events を sum し rest_minutes として付与
+/// - 1 segment が 24h を超えた場合 (= 休息イベント無しで 24h+ 連続労働、改善基準告示違反データ) は
+///   **24h で強制 cut**。各 sub-segment の rest_minutes は該当範囲の 301 events を sum しなおす。
+///   これにより builder 側 ((A) bucketing) が前日/当日/翌日 (3 暦日) の範囲で対応できる
 pub fn build_segment_inputs(
     events: &[KudgivtRow],
     departure_at: NaiveDateTime,
@@ -119,11 +114,62 @@ pub fn build_segment_inputs(
 
     segments
         .into_iter()
-        .map(|s| SegmentInput {
-            start: s.start,
-            end: s.end,
-            rest_minutes: sum_break_minutes(events, s.start, s.end),
+        .flat_map(|s| split_at_24h(events, s.start, s.end))
+        .collect()
+}
+
+/// 1 WorkSegment を 24h 境界で分割。`end - start <= 24h` ならそのまま 1 個。
+fn split_at_24h(
+    events: &[KudgivtRow],
+    start: NaiveDateTime,
+    end: NaiveDateTime,
+) -> Vec<SegmentInput> {
+    let mut out = Vec::new();
+    let mut cur = start;
+    while cur < end {
+        let chunk_end = std::cmp::min(cur + chrono::Duration::hours(24), end);
+        let intervals = collect_break_intervals(events, cur, chunk_end);
+        let rest_minutes = intervals
+            .iter()
+            .map(|(s, e)| (*e - *s).num_minutes() as i32)
+            .sum();
+        out.push(SegmentInput {
+            start: cur,
+            end: chunk_end,
+            rest_minutes,
+            rest_intervals: intervals,
             note: None,
+        });
+        cur = chunk_end;
+    }
+    out
+}
+
+/// `[seg_start, seg_end]` 内の event_cd=301 の (start, end) を集める。
+/// duration_minutes が None の場合はその event は無視 (期間 0 とみなす)。
+fn collect_break_intervals(
+    events: &[KudgivtRow],
+    seg_start: NaiveDateTime,
+    seg_end: NaiveDateTime,
+) -> Vec<(NaiveDateTime, NaiveDateTime)> {
+    events
+        .iter()
+        .filter(|e| e.event_cd == "301")
+        .filter(|e| e.start_at >= seg_start && e.start_at <= seg_end)
+        .filter_map(|e| {
+            let dur = e.duration_minutes?;
+            if dur <= 0 {
+                return None;
+            }
+            let s = e.start_at;
+            let raw_end = s + chrono::Duration::minutes(dur as i64);
+            // segment 末尾でクリップ (segment 跨ぎ休憩は途中で切る)
+            let e_clip = raw_end.min(seg_end);
+            if e_clip <= s {
+                None
+            } else {
+                Some((s, e_clip))
+            }
         })
         .collect()
 }
@@ -186,18 +232,23 @@ mod tests {
     }
 
     #[test]
-    fn sum_break_minutes_filters_by_event_cd_and_range() {
+    fn collect_break_intervals_filters_by_event_cd_and_range() {
         let events = vec![
             ev("301", dt((2024, 4, 15), (10, 0, 0)), Some(30)),
             ev("301", dt((2024, 4, 15), (14, 0, 0)), Some(15)),
             ev("301", dt((2024, 4, 15), (20, 0, 0)), Some(60)), // 範囲外
             ev("302", dt((2024, 4, 15), (12, 0, 0)), Some(540)), // event_cd 違い
         ];
-        let total = sum_break_minutes(
+        let intervals = collect_break_intervals(
             &events,
             dt((2024, 4, 15), (8, 0, 0)),
             dt((2024, 4, 15), (18, 0, 0)),
         );
+        assert_eq!(intervals.len(), 2);
+        let total: i32 = intervals
+            .iter()
+            .map(|(s, e)| (*e - *s).num_minutes() as i32)
+            .sum();
         assert_eq!(total, 30 + 15);
     }
 

--- a/crates/alc-dtako/src/dtako_y_time_export/models.rs
+++ b/crates/alc-dtako/src/dtako_y_time_export/models.rs
@@ -10,16 +10,29 @@ use serde::{Deserialize, Serialize};
 pub struct YTimeRow {
     /// A 列とマッチングする bucket date (yyyy-mm-dd)
     pub date: NaiveDate,
-    /// F 列: true → `1`、false → 空。1 暦日 2 始業ケースの「終業日側」で true。
+    /// F 列: true → `1`、false → 空。1 暦日 2 始業ケース or 深夜跨ぎ + 勤務 ≥ 7h の終業日側で true。
     pub previous_day_start: bool,
-    /// G 列の元値: 始業時刻の 0:00 からの分 (0..=1439)
+    /// G 列の元値: 始業時刻の 0:00 からの分 (0..=1439)。
+    /// F=1 のとき: 前日始業時刻 (前日 0:00 起点)。
     pub start_minutes_of_day: i32,
     /// H 列の元値: 終業時刻の bucket_date 0:00 からの分。
     /// 24h 越え時は 1440 以上 (例: 翌日 09:30 → 33h30m → 2010)。
     pub end_minutes_from_bucket_date: i32,
-    /// I 列: 休憩時間 (event_cd=301 の duration sum)、分
-    pub rest_minutes: i32,
-    /// C 列: 自由文 (オプション)
+    /// I 列 (前日 5-22時): 休憩時間 (分)
+    pub rest_prev_5_22: i32,
+    /// J 列 (前日 22-0時): 休憩時間 (分)
+    pub rest_prev_22_0: i32,
+    /// K 列 (当日 0-5時): 休憩時間 (分)
+    pub rest_today_0_5: i32,
+    /// L 列 (当日 5-22時): 休憩時間 (分)
+    pub rest_today_5_22: i32,
+    /// M 列 (当日 22-0時): 休憩時間 (分)
+    pub rest_today_22_0: i32,
+    /// N 列 (翌日 0-5時): 休憩時間 (分)
+    pub rest_next_0_5: i32,
+    /// O 列 (翌日 5-22時): 休憩時間 (分)
+    pub rest_next_5_22: i32,
+    /// C 列: 自由文 (オプション)。同 bucket 結合や 24h cut 時の備考も入れる
     pub note: Option<String>,
 }
 

--- a/crates/alc-dtako/src/repo/dtako_y_time_export.rs
+++ b/crates/alc-dtako/src/repo/dtako_y_time_export.rs
@@ -48,14 +48,18 @@ impl DtakoYTimeExportRepository for PgDtakoYTimeExportRepository {
         let from_widened = from - chrono::Duration::days(1);
         let to_widened = to + chrono::Duration::days(1);
         let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        // 同じ driver_id が同じ unko_no で crew_role 1 (運転手) と 2 (副運転手) の
+        // 両方に登録されているケースがある (KUDGURI データ起因)。物理的に同じ運行な
+        // ので 1 行にまとめる必要がある。crew_role=1 を優先 (なければ 2) して 1 件のみ採用。
         sqlx::query_as::<_, YTimeExportOperation>(
-            "SELECT unko_no, crew_role, departure_at, return_at, r2_key_prefix \
+            "SELECT DISTINCT ON (unko_no) \
+                    unko_no, crew_role, departure_at, return_at, r2_key_prefix \
              FROM alc_api.dtako_operations \
              WHERE tenant_id = $1 \
                AND driver_id = $2 \
                AND reading_date BETWEEN $3 AND $4 \
                AND has_kudgivt = TRUE \
-             ORDER BY departure_at NULLS LAST",
+             ORDER BY unko_no, crew_role ASC, departure_at NULLS LAST",
         )
         .bind(tenant_id)
         .bind(driver_id)

--- a/crates/alc-storage/src/http_proxy.rs
+++ b/crates/alc-storage/src/http_proxy.rs
@@ -1,12 +1,12 @@
 //! `HttpProxyBackend` — Incus dev サンドボックス用の R2 アクセス backend。
 //!
 //! ホスト側で wrangler dev に R2 binding を持つ極小 worker を立て (例: `~/js/.dev-proxy/r2-proxy/`)、
-//! Incus 内の rust-alc-api は本 backend 経由でその HTTP サーバーから R2 オブジェクトを取得する。
+//! Incus 内の rust-alc-api は本 backend 経由でその HTTP サーバー越しに R2 を読み書きする。
 //! これにより本番 R2 keys を Incus に投入することなく、ホストの wrangler CLI 認証だけで
 //! R2 アクセスが完結する。
 //!
-//! 本 backend は **download / exists / public_url 専用**。upload / delete / presign_get は
-//! 呼び出されないことを前提に簡易 stub を返す (dev 環境でしか使わない)。
+//! GET / HEAD / PUT / DELETE をサポート。dev 環境専用。`presign_get` は未対応 (proxy では
+//! 署名 URL を発行できないため、必要なら別途公開 URL を組む)。
 
 use alc_core::storage::{StorageBackend, StorageError};
 
@@ -39,13 +39,26 @@ impl HttpProxyBackend {
 impl StorageBackend for HttpProxyBackend {
     async fn upload(
         &self,
-        _key: &str,
-        _data: &[u8],
-        _content_type: &str,
+        key: &str,
+        data: &[u8],
+        content_type: &str,
     ) -> Result<String, StorageError> {
-        Err(StorageError::Config(
-            "HttpProxyBackend is read-only (upload not supported)".to_string(),
-        ))
+        let resp = self
+            .client
+            .put(self.url(key))
+            .header("content-type", content_type)
+            .body(data.to_vec())
+            .send()
+            .await
+            .map_err(|e| StorageError::Upload(format!("proxy PUT: {e}")))?;
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            return Err(StorageError::Upload(format!(
+                "proxy PUT status {status}: {body}"
+            )));
+        }
+        Ok(self.public_url(key))
     }
 
     fn public_url(&self, key: &str) -> String {
@@ -82,10 +95,21 @@ impl StorageBackend for HttpProxyBackend {
         Ok(bytes.to_vec())
     }
 
-    async fn delete(&self, _key: &str) -> Result<(), StorageError> {
-        Err(StorageError::Config(
-            "HttpProxyBackend is read-only (delete not supported)".to_string(),
-        ))
+    async fn delete(&self, key: &str) -> Result<(), StorageError> {
+        let resp = self
+            .client
+            .delete(self.url(key))
+            .send()
+            .await
+            .map_err(|e| StorageError::Upload(format!("proxy DELETE: {e}")))?;
+        let status = resp.status();
+        if !status.is_success() && status.as_u16() != 404 {
+            let body = resp.text().await.unwrap_or_default();
+            return Err(StorageError::Upload(format!(
+                "proxy DELETE status {status}: {body}"
+            )));
+        }
+        Ok(())
     }
 
     fn extract_key(&self, url: &str) -> Option<String> {


### PR DESCRIPTION
## 変更概要

京都ソフト案件 Y時間 Excel エクスポートの本番運用に向けて、Y時間 builder と
csv aggregator を整備し、storage HTTP proxy に PUT/DELETE を追加。

## crates/alc-csv-parser
- `kudguri.rs`: 対象乗務員CD 優先 (副運転手の運行 dedup、bug fix)

## crates/alc-dtako Y時間 export
- `dtako_y_time_export/builder.rs`: cutoff 7h + 同 bucket 結合 + 休憩 7セル split
- `dtako_y_time_export/csv_aggregator.rs`: 24h cut + rest_intervals
- `dtako_y_time_export/models.rs`: YTimeRow に rest 7 fields (前日5-22 / 前日22-0 /
  当日0-5 / 当日5-22 / 当日22-0 / 翌日0-5 / 翌日5-22)
- `repo/dtako_y_time_export.rs`: DISTINCT ON unko_no

## crates/alc-storage
- `http_proxy.rs`: PUT/DELETE 実装 (テンプレ upload 対応)

## テスト

- alc-dtako 16 tests pass
- alc-csv-parser kudguri 3 tests pass

## 関連 PR

- nuxt-dtako-admin #29: 7-field 出力に対応 + JSZip rewrite で警告 0 + clearPeriod

🤖 Generated with [Claude Code](https://claude.com/claude-code)