### PR TITLE
perf(dtako): Y時間 export を async job + R2 並列 fetch 化

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -521,6 +521,59 @@ example で挙動を確認したら、本体コードを次の粒度で分ける
 - **「外部 API なのでテスト不可能」で放置しない** — pure 関数切り出し + wiremock で 100% 到達できる (今回の例が証拠)
 - **token/URL を const にして直接叩く** — テスト時に差し替えられない。必ず struct フィールド化する
 
+## 外部 API 連携 (notify-realtime-bus + async job 完了通知)
+
+長時間 compute (Y時間 export 13ヶ月分で 5-15s 等) を HTTP request で同期保持すると
+Cloudflare proxy timeout や Cloud Run wall-time 超過のリスクがある。これを避けるため、
+`notify-realtime-bus` Worker (DurableObject + hibernated WS、`workers/realtime-bus/` in
+nuxt-notify repo) を共有 broadcaster として使い、async job pattern で frontend に
+完了通知する仕組みがある。
+
+### 使い方 (新しい async endpoint を増やすとき)
+
+1. **`crates/alc-core/src/realtime_bus.rs::RealtimeBus`** を AppState 経由で取得
+   - env vars: `NOTIFY_REDACT_BROADCAST_URL` / `NOTIFY_REDACT_BROADCAST_SECRET` を共有
+     (RedactBroadcaster と同一 Worker / 同一 secret)
+   - `from_env()` で None になり得る → endpoint 側で 503 を返して silent failure を防ぐ
+2. **POST /jobs ハンドラ**: 即時 `202 { job_id: Uuid }` を返し、`tokio::spawn` で compute
+3. **完了時に `bus.broadcast(&event)` を呼ぶ**。event は `Serialize` で以下の必須 field を含む:
+   - `tenant_id: Uuid` — Worker が DurableObject id を引くキー
+   - `document_id: Uuid` — Worker validation 必須 (subject id を入れる、job_id でも OK)
+   - `status: &str` — `"completed"` / `"failed"` 等
+   - 加えて `kind: &'static str` (channel discriminator) と `result` / `error` を含めると frontend が filter できる
+4. **frontend** (Nuxt) は `useYTimeExportJob` 等の composable で `wss://realtime.../subscribe`
+   に `Sec-WebSocket-Protocol: bearer, <jwt>` で接続し、`kind` + `job_id` でメッセージを filter
+
+### 既存の利用例
+
+| crate | event 型 | 用途 |
+|---|---|---|
+| `alc-notify` | `RedactEvent` (`crates/alc-core/src/redact_broadcast.rs`) | 文書 redact 完了通知 (PR #314 phase 2.5) |
+| `alc-dtako` | `YTimeJobEvent` (`crates/alc-dtako/src/dtako_y_time_export/mod.rs`) | Y時間 export 完了通知 (PR perf/y-time-async-job、2026-05-10) |
+
+### 罠
+
+- **Worker `/broadcast` は `tenant_id` / `document_id` / `status` を strict validate する**
+  → どの event 型でもこの 3 field を必ず含めること
+- **WebSocket payload size**: CF DurableObject の text fan-out は 1 MB 上限。`YTimeExportResponse`
+  (~288 KB max) は問題ないが、巨大 result を inline で運ぶ前に必ずサイズ想定を確認する
+- **in-memory job state**: result は WS 1 発で運ぶだけで DB 永続化していない。reload や Cloud Run
+  再起動で結果ロスト → user は再 export。許容できないユースケースなら DB job table を別途設計する
+- **`realtime_bus` None 時の挙動**: silent に compute だけ走らせると result 行方不明で UX 最悪 →
+  POST /jobs ハンドラ側で 503 を返して frontend が同期 GET にフォールバック (or エラー表示) できるようにする
+- **タグリリース必須**: deploy には realtime-bus URL/secret が Cloud Run env として注入されている
+  必要がある (`/tag-release patch` で CI 自動デプロイ → user 指示)
+
+### 並列 R2 fetch のパターン (Y時間 export 高速化、2026-05-10)
+
+`futures::stream::iter().buffer_unordered(N)` で R2 fetch を並列化することで wall time を大幅短縮可能。
+具体実装は `crates/alc-dtako/src/dtako_y_time_export/mod.rs::compute_y_time_export` を参照。
+
+- `R2_FETCH_CONCURRENCY = 16` (200/16 = 12.5 並列ラウンド ≈ 3.75s 想定)
+- `pool.close()` / DB error injection は対象外 (R2 fetch は DB connection 不要)
+- mock 統合テストは `crates/alc-storage::MockStorage` + wiremock realtime-bus で構築可
+  (`tests/mock_tests/mock_dtako_y_time_export_test.rs::post_jobs_returns_202_and_broadcasts_completed_event` 参照)
+
 ## テスト
 
 - テストインフラ: `docker-compose.yml` (PostgreSQL 16, port 54322) + `tests/common/mod.rs` ヘルパー

--- a/crates/alc-core/src/lib.rs
+++ b/crates/alc-core/src/lib.rs
@@ -12,6 +12,7 @@ pub mod auth_middleware;
 pub mod fcm;
 pub mod middleware;
 pub mod models;
+pub mod realtime_bus;
 pub mod redact_broadcast;
 pub mod repo;
 pub mod repository;
@@ -102,6 +103,12 @@ pub struct AppState {
     /// が terminal 状態で呼び、Cloudflare Worker (notify-realtime-bus) の DO 経由で
     /// admin ブラウザに WS push する。未設定なら no-op (Phase 3 デプロイ前は空でも安全)。
     pub redact_broadcaster: Option<Arc<redact_broadcast::RedactBroadcaster>>,
+    /// 任意の Serialize ペイロードを同 notify-realtime-bus Worker に流す汎用クライアント。
+    /// `RedactBroadcaster` と同じ env vars / 同じ Worker / 同じ secret を共有するが、
+    /// payload 型を選ばないので redact 以外の async job 完了通知 (Y時間 export 等)
+    /// にも使える。env vars 未設定なら None で no-op (POST /jobs 系は 503 返却で
+    /// 検知すること、silent に compute しないため)。
+    pub realtime_bus: Option<Arc<realtime_bus::RealtimeBus>>,
     pub trouble_tickets: Arc<dyn TroubleTicketsRepository>,
     pub trouble_files: Arc<dyn TroubleFilesRepository>,
     pub trouble_workflow: Arc<dyn TroubleWorkflowRepository>,

--- a/crates/alc-core/src/realtime_bus.rs
+++ b/crates/alc-core/src/realtime_bus.rs
@@ -1,0 +1,248 @@
+//! 任意の `Serialize` ペイロードを notify-realtime-bus Worker `/broadcast` へ
+//! POST する汎用クライアント。
+//!
+//! 用途:
+//! - redact 完了通知 (`crates/alc-core/src/redact_broadcast.rs` の RedactBroadcaster
+//!   が同 Worker に送る既存仕様と互換)
+//! - Y時間 export job 完了通知 (Phase: 2026-05-10 perf 改善、`crates/alc-dtako/src/dtako_y_time_export/`)
+//! - 今後の async job 完了系イベント全般
+//!
+//! Worker (`workers/realtime-bus/src/index.ts`) は payload に `tenant_id` /
+//! `document_id` / `status` の 3 フィールドを必須要求する (現行実装、2026-05-08 phase
+//! 2.5 時点)。新しい event 型を流す場合、これらを **必ず** 含めること
+//! (`document_id` には job_id 等の subject id を入れる運用)。
+//!
+//! env vars は RedactBroadcaster と共有 (`NOTIFY_REDACT_BROADCAST_URL` /
+//! `NOTIFY_REDACT_BROADCAST_SECRET`)。同一 Worker / 同一 secret に POST するため、
+//! どちらの broadcaster を使っても fan-out 経路は同じ。frontend は payload の
+//! `kind` フィールド (or 既存 redact では document_id 一致) で disambiguate する。
+
+use std::time::Duration;
+
+const HEADER_SECRET: &str = "X-Broadcast-Secret";
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// notify-realtime-bus Worker の `/broadcast` に POST する汎用クライアント。
+///
+/// 1 instance / app で AppState に Option<Arc<...>> として持つ想定。
+pub struct RealtimeBus {
+    client: reqwest::Client,
+    endpoint: String,
+    secret: String,
+}
+
+impl RealtimeBus {
+    /// Production 用構築。
+    pub fn new(endpoint: String, secret: String) -> Self {
+        Self {
+            client: reqwest::Client::new(),
+            endpoint,
+            secret,
+        }
+    }
+
+    /// 環境変数から構築。両方欠けるか空なら `None`。RedactBroadcaster と同 env var を
+    /// 共有 (どちらを使っても同 Worker に到達する)。
+    pub fn from_env() -> Option<Self> {
+        Self::from_env_lookup(|k| std::env::var(k).ok())
+    }
+
+    /// env 依存を分離したテスト可能な実装。
+    fn from_env_lookup<F: Fn(&str) -> Option<String>>(getter: F) -> Option<Self> {
+        let endpoint = getter("NOTIFY_REDACT_BROADCAST_URL").filter(|s| !s.is_empty())?;
+        let secret = getter("NOTIFY_REDACT_BROADCAST_SECRET").filter(|s| !s.is_empty())?;
+        Some(Self::new(endpoint, secret))
+    }
+
+    /// 任意の Serialize 値を Worker `/broadcast` に POST する。
+    /// 失敗してもエラーは伝搬しない (warn のみ)。
+    ///
+    /// 呼び出し側で `tenant_id` / `document_id` / `status` を含めること
+    /// (Worker validation 必須)。`kind` 等の追加 field は透過的に流れる。
+    pub async fn broadcast<T: serde::Serialize + ?Sized>(&self, payload: &T) {
+        let res = self
+            .client
+            .post(&self.endpoint)
+            .header(HEADER_SECRET, &self.secret)
+            .header("Content-Type", "application/json")
+            .timeout(REQUEST_TIMEOUT)
+            .json(payload)
+            .send()
+            .await;
+
+        // tracing マクロを 1 行に collapse して llvm-cov のマルチライン未到達を回避
+        match res {
+            Ok(r) if r.status().is_success() => {
+                tracing::debug!(endpoint = %self.endpoint, "realtime_bus broadcast ok")
+            }
+            Ok(r) => {
+                tracing::warn!(endpoint = %self.endpoint, http = %r.status(), "realtime_bus broadcast http error")
+            }
+            Err(e) => {
+                tracing::warn!(endpoint = %self.endpoint, error = %e, "realtime_bus broadcast http call failed")
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use serde::Serialize;
+    use wiremock::matchers::{header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[derive(Serialize)]
+    struct TestEvent {
+        tenant_id: &'static str,
+        document_id: &'static str,
+        status: &'static str,
+        kind: &'static str,
+    }
+
+    fn ev() -> TestEvent {
+        TestEvent {
+            tenant_id: "00000000-0000-0000-0000-000000000000",
+            document_id: "11111111-1111-1111-1111-111111111111",
+            status: "completed",
+            kind: "y_time_export",
+        }
+    }
+
+    // --- from_env_lookup ---
+
+    /// 1 つの `_ => None` 分岐を `HashMap::get` 経由に集約して、各テストごとに
+    /// 別個の closure を持たせず llvm-cov のカバレッジを確実にする。
+    fn make_getter(
+        url: Option<&'static str>,
+        secret: Option<&'static str>,
+    ) -> impl Fn(&str) -> Option<String> {
+        let mut map = std::collections::HashMap::new();
+        if let Some(v) = url {
+            map.insert("NOTIFY_REDACT_BROADCAST_URL", v.to_string());
+        }
+        if let Some(v) = secret {
+            map.insert("NOTIFY_REDACT_BROADCAST_SECRET", v.to_string());
+        }
+        move |k| map.get(k).cloned()
+    }
+
+    #[test]
+    fn from_env_lookup_returns_some_when_both_set() {
+        let b = RealtimeBus::from_env_lookup(make_getter(Some("https://r/broadcast"), Some("s")))
+            .unwrap();
+        assert_eq!(b.endpoint, "https://r/broadcast");
+        assert_eq!(b.secret, "s");
+    }
+
+    #[test]
+    fn from_env_lookup_none_when_url_missing() {
+        assert!(RealtimeBus::from_env_lookup(make_getter(None, Some("s"))).is_none());
+    }
+
+    #[test]
+    fn from_env_lookup_none_when_secret_missing() {
+        assert!(
+            RealtimeBus::from_env_lookup(make_getter(Some("https://r/broadcast"), None)).is_none()
+        );
+    }
+
+    #[test]
+    fn from_env_lookup_none_when_url_empty() {
+        assert!(RealtimeBus::from_env_lookup(make_getter(Some(""), Some("s"))).is_none());
+    }
+
+    #[test]
+    fn from_env_lookup_none_when_secret_empty() {
+        assert!(
+            RealtimeBus::from_env_lookup(make_getter(Some("https://r/broadcast"), Some("")))
+                .is_none()
+        );
+    }
+
+    /// pure restore helper。env mutation を 1 関数に集約し、`Some` / `None` 両分岐を
+    /// テスト 2 件で確実にカバーする (CI 環境で saved=None でも Some 分岐が落ちない)。
+    fn restore_env(key: &str, saved: Option<String>) {
+        match saved {
+            Some(v) => std::env::set_var(key, v),
+            None => std::env::remove_var(key),
+        }
+    }
+
+    #[test]
+    fn restore_env_some_writes_value() {
+        let key = "__REALTIME_BUS_TEST_RESTORE_SOME__";
+        restore_env(key, Some("v".into()));
+        assert_eq!(std::env::var(key).unwrap(), "v");
+        std::env::remove_var(key);
+    }
+
+    #[test]
+    fn restore_env_none_removes_var() {
+        let key = "__REALTIME_BUS_TEST_RESTORE_NONE__";
+        std::env::set_var(key, "x");
+        restore_env(key, None);
+        assert!(std::env::var(key).is_err());
+    }
+
+    #[test]
+    fn from_env_uses_real_env() {
+        let saved_url = std::env::var("NOTIFY_REDACT_BROADCAST_URL").ok();
+        let saved_secret = std::env::var("NOTIFY_REDACT_BROADCAST_SECRET").ok();
+
+        std::env::set_var("NOTIFY_REDACT_BROADCAST_URL", "https://test/broadcast");
+        std::env::set_var("NOTIFY_REDACT_BROADCAST_SECRET", "test-secret");
+        let b = RealtimeBus::from_env().expect("env vars set above");
+        assert_eq!(b.endpoint, "https://test/broadcast");
+        assert_eq!(b.secret, "test-secret");
+
+        std::env::set_var("NOTIFY_REDACT_BROADCAST_URL", "");
+        std::env::set_var("NOTIFY_REDACT_BROADCAST_SECRET", "");
+        assert!(RealtimeBus::from_env().is_none());
+
+        restore_env("NOTIFY_REDACT_BROADCAST_URL", saved_url);
+        restore_env("NOTIFY_REDACT_BROADCAST_SECRET", saved_secret);
+    }
+
+    // --- broadcast ---
+
+    #[tokio::test]
+    async fn broadcast_success_sends_secret_header_and_body() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/broadcast"))
+            .and(header("X-Broadcast-Secret", "s3cret"))
+            .and(header("Content-Type", "application/json"))
+            .and(wiremock::matchers::body_string_contains(
+                "\"y_time_export\"",
+            ))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = RealtimeBus::new(format!("{}/broadcast", server.uri()), "s3cret".into());
+        client.broadcast(&ev()).await;
+    }
+
+    #[tokio::test]
+    async fn broadcast_4xx_does_not_panic() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/broadcast"))
+            .respond_with(ResponseTemplate::new(401).set_body_string("unauthorized"))
+            .mount(&server)
+            .await;
+
+        let client = RealtimeBus::new(format!("{}/broadcast", server.uri()), "wrong".into());
+        client.broadcast(&ev()).await;
+    }
+
+    #[tokio::test]
+    async fn broadcast_unreachable_endpoint_does_not_panic() {
+        // 127.0.0.1:1 は接続拒否 → reqwest::Error
+        let client = RealtimeBus::new("http://127.0.0.1:1/broadcast".into(), "s".into());
+        client.broadcast(&ev()).await;
+    }
+}

--- a/crates/alc-dtako/src/dtako_y_time_export/mod.rs
+++ b/crates/alc-dtako/src/dtako_y_time_export/mod.rs
@@ -1,13 +1,25 @@
 //! Y時間 export JSON エンドポイント。
 //!
-//! `GET /api/dtako/y-time-export?driver_cd=X&from=YYYY-MM-DD&to=YYYY-MM-DD`
+//! 同期 GET と async job (POST + WS 完了通知) の 2 系統を提供する。
 //!
+//! - **同期 GET** `GET /api/dtako/y-time-export?driver_cd=X&from=YYYY-MM-DD&to=YYYY-MM-DD`
+//!   従来通り compute → JSON return。Cloud Run wall time が長い (13ヶ月で 5-15s)
+//!   ため Cloudflare proxy 経由 frontend からは推奨しない。後方互換のため残置。
+//!
+//! - **async job** `POST /api/dtako/y-time-export/jobs?driver_cd=X&from=...&to=...`
+//!   即時 `202 { job_id }` を返し、background tokio::spawn で compute → 完了時に
+//!   `realtime_bus` (notify-realtime-bus Worker) へ result を inline broadcast。
+//!   frontend (`useYTimeExportJob` composable) が `Sec-WebSocket-Protocol: bearer,<jwt>`
+//!   で `wss://realtime.../subscribe` を listen し、`kind="y_time_export"` &
+//!   `job_id` 一致のイベントで result を受け取る。HTTP の長時間保持を回避し、
+//!   202 から WS event 到着まで通常 5-15 秒。
+//!
+//! 共通 compute 部:
 //! 1. driver_cd → employees.id を解決
 //! 2. dtako_operations から期間内 (`reading_date ± 1 day`) の運行を列挙
-//! 3. 各 unko_no について R2 から KUDGIVT.csv を都度 fetch
+//! 3. 各 unko_no について R2 から KUDGIVT.csv を **並列 fetch** (buffer_unordered 16)
 //! 4. `split_by_rest` で segment 化、event_cd=301 を sum して rest_minutes 算出
 //! 5. 1 暦日 2 始業 ルールで bucketing
-//! 6. JSON で返す
 //!
 //! xlsx 生成は frontend Worker 側 (nuxt-dtako-admin) で行う。
 
@@ -17,35 +29,142 @@ pub mod models;
 
 use crate::DtakoState;
 use alc_core::auth_middleware::TenantId;
+use alc_core::storage::StorageBackend;
 use axum::{
     extract::{Query, State},
     http::StatusCode,
-    routing::get,
+    routing::{get, post},
     Json, Router,
 };
 use chrono::{DateTime, Utc};
+use futures::stream::StreamExt;
+use serde::Serialize;
+use std::sync::Arc;
+use uuid::Uuid;
 
 use builder::{build_y_time_rows, SegmentInput};
 use csv_aggregator::{build_segment_inputs, fetch_and_parse_kudgivt};
 use models::{YTimeDriver, YTimeExportQuery, YTimeExportResponse, YTimePeriod};
+
+/// R2 から KUDGIVT.csv を並列 fetch する際の同時実行数。
+///
+/// 13ヶ月レンジで unko_no が 100-200 件、1 fetch ~300ms とすると 200/16 ≈ 3.75 秒で完了する想定。
+/// R2 rate limit 安全圏、TCP socket 枯渇懸念なし。
+const R2_FETCH_CONCURRENCY: usize = 16;
 
 pub fn tenant_router<S>() -> Router<S>
 where
     DtakoState: axum::extract::FromRef<S>,
     S: Clone + Send + Sync + 'static,
 {
-    Router::new().route("/dtako/y-time-export", get(get_y_time_export))
+    Router::new()
+        .route("/dtako/y-time-export", get(get_y_time_export))
+        .route("/dtako/y-time-export/jobs", post(post_y_time_export_job))
 }
 
+/// 同期 GET: 後方互換用。compute 完了まで HTTP を保持する。
 async fn get_y_time_export(
     State(state): State<DtakoState>,
     tenant: axum::Extension<TenantId>,
     Query(q): Query<YTimeExportQuery>,
 ) -> Result<Json<YTimeExportResponse>, (StatusCode, String)> {
     let tenant_id = tenant.0 .0;
+    let resp = compute_y_time_export(&state, tenant_id, q)
+        .await
+        .map_err(compute_error_to_response)?;
+    Ok(Json(resp))
+}
 
+/// async job: 即 202 を返して background で compute → realtime_bus へ result を broadcast。
+///
+/// `realtime_bus` 未設定 (env vars 欠落) の場合、silent に compute だけ走って
+/// result が行方不明になるのを避けるため `503` を返す。
+async fn post_y_time_export_job(
+    State(state): State<DtakoState>,
+    tenant: axum::Extension<TenantId>,
+    Query(q): Query<YTimeExportQuery>,
+) -> Result<(StatusCode, Json<StartJobResponse>), (StatusCode, String)> {
+    let tenant_id = tenant.0 .0;
+
+    // 即時バリデーション (compute 内でも再度確認するが、202 を返してから報告するより
+    // 400 で即落としたほうが UX 良い)
     if q.from > q.to {
         return Err((StatusCode::BAD_REQUEST, "from > to".to_string()));
+    }
+
+    // realtime_bus がないと job 完了通知ができない → 503 で失敗を返す
+    let bus = state.realtime_bus.clone().ok_or((
+        StatusCode::SERVICE_UNAVAILABLE,
+        "realtime_bus not configured (NOTIFY_REDACT_BROADCAST_URL/SECRET 未設定)".to_string(),
+    ))?;
+
+    let job_id = Uuid::new_v4();
+    tracing::info!(
+        job_id = %job_id,
+        tenant_id = %tenant_id,
+        driver_cd = %q.driver_cd,
+        "y-time-export: job spawned"
+    );
+
+    let bg_state = state.clone();
+    let bg_query = q.clone();
+    tokio::spawn(async move {
+        let started = std::time::Instant::now();
+        let outcome = compute_y_time_export(&bg_state, tenant_id, bg_query).await;
+        let elapsed_ms = started.elapsed().as_millis();
+
+        let event = match outcome {
+            Ok(result) => {
+                tracing::info!(
+                    job_id = %job_id,
+                    rows = result.rows.len(),
+                    warnings = result.warnings.len(),
+                    elapsed_ms,
+                    "y-time-export: job completed"
+                );
+                YTimeJobEvent {
+                    kind: "y_time_export",
+                    tenant_id,
+                    document_id: job_id,
+                    job_id,
+                    status: "completed",
+                    result: Some(result),
+                    error: None,
+                }
+            }
+            Err(err) => {
+                let msg = compute_error_to_message(&err);
+                tracing::warn!(
+                    job_id = %job_id,
+                    error = %msg,
+                    elapsed_ms,
+                    "y-time-export: job failed"
+                );
+                YTimeJobEvent {
+                    kind: "y_time_export",
+                    tenant_id,
+                    document_id: job_id,
+                    job_id,
+                    status: "failed",
+                    result: None,
+                    error: Some(msg),
+                }
+            }
+        };
+        bus.broadcast(&event).await;
+    });
+
+    Ok((StatusCode::ACCEPTED, Json(StartJobResponse { job_id })))
+}
+
+/// 同期 / async 共通の compute コア。テストはこの関数単位で書く。
+pub async fn compute_y_time_export(
+    state: &DtakoState,
+    tenant_id: Uuid,
+    q: YTimeExportQuery,
+) -> Result<YTimeExportResponse, ComputeError> {
+    if q.from > q.to {
+        return Err(ComputeError::BadRequest("from > to".to_string()));
     }
 
     // 1. driver_cd lookup
@@ -55,17 +174,9 @@ async fn get_y_time_export(
         .await
         .map_err(|e| {
             tracing::error!("lookup_driver error: {e}");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "internal error".to_string(),
-            )
+            ComputeError::Internal("internal error".to_string())
         })?
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                format!("driver_cd not found: {}", q.driver_cd),
-            )
-        })?;
+        .ok_or_else(|| ComputeError::NotFound(format!("driver_cd not found: {}", q.driver_cd)))?;
 
     // 2. 期間内の運行列挙
     let operations = state
@@ -74,64 +185,103 @@ async fn get_y_time_export(
         .await
         .map_err(|e| {
             tracing::error!("list_operations error: {e}");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "internal error".to_string(),
-            )
+            ComputeError::Internal("internal error".to_string())
         })?;
 
     let storage = state
         .dtako_storage
         .as_ref()
-        .ok_or_else(|| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "dtako storage not configured".to_string(),
-            )
-        })?
+        .ok_or_else(|| ComputeError::Internal("dtako storage not configured".to_string()))?
         .clone();
 
-    // 3-4. 各 unko_no について CSV 取得 + segment 化 + 301 sum
-    let mut all_segments: Vec<SegmentInput> = Vec::new();
+    // 3. 各 unko_no について R2 から CSV 並列 fetch
+    let fetch_started = std::time::Instant::now();
     let mut warnings: Vec<String> = Vec::new();
+
+    // 3-A. 欠落チェックを sync で先に潰し、有効 op だけ並列対象に残す。
+    //      順序保持のため warning も先に push (旧逐次実装と同じ順番)
+    let mut targets: Vec<FetchTarget> = Vec::with_capacity(operations.len());
     for op in operations {
-        let (departure_at, return_at) = match (op.departure_at, op.return_at) {
-            (Some(d), Some(r)) => (d, r),
+        match (op.departure_at, op.return_at) {
+            (Some(d), Some(r)) => {
+                targets.push(FetchTarget {
+                    unko_no: op.unko_no,
+                    r2_key_prefix: op.r2_key_prefix,
+                    crew_role: op.crew_role,
+                    departure_at: d,
+                    return_at: r,
+                });
+            }
             _ => {
                 warnings.push(format!(
                     "{}: departure_at/return_at が不足、skip",
                     op.unko_no
                 ));
-                continue;
             }
-        };
+        }
+    }
 
-        let events = match fetch_and_parse_kudgivt(
-            storage.as_ref(),
-            tenant_id,
-            &op.unko_no,
-            op.r2_key_prefix.as_deref(),
-            op.crew_role,
-        )
-        .await
-        {
-            Ok(e) => e,
+    let target_count = targets.len();
+
+    // 3-B. 並列 fetch (buffer_unordered で R2_FETCH_CONCURRENCY 件まで concurrent)
+    let storage_for_fetch: Arc<dyn StorageBackend> = storage.clone();
+    let fetched: Vec<FetchResult> = futures::stream::iter(targets.into_iter().map(|t| {
+        let storage_inner = storage_for_fetch.clone();
+        async move {
+            let res = fetch_and_parse_kudgivt(
+                storage_inner.as_ref(),
+                tenant_id,
+                &t.unko_no,
+                t.r2_key_prefix.as_deref(),
+                t.crew_role,
+            )
+            .await;
+            FetchResult {
+                target: t,
+                outcome: res,
+            }
+        }
+    }))
+    .buffer_unordered(R2_FETCH_CONCURRENCY)
+    .collect()
+    .await;
+
+    let fetch_elapsed_ms = fetch_started.elapsed().as_millis();
+    tracing::info!(
+        targets = target_count,
+        concurrency = R2_FETCH_CONCURRENCY,
+        fetch_elapsed_ms,
+        "y-time-export: parallel R2 fetch done"
+    );
+
+    // 3-C. sync 後処理: ok→segment 化 + extend、err→warning push
+    let mut all_segments: Vec<SegmentInput> = Vec::with_capacity(target_count);
+    for FetchResult { target, outcome } in fetched {
+        match outcome {
+            Ok(events) => {
+                let segs = build_segment_inputs(
+                    &events,
+                    naive(target.departure_at),
+                    naive(target.return_at),
+                );
+                all_segments.extend(segs);
+            }
             Err(err) => {
-                tracing::warn!("fetch KUDGIVT failed unko_no={} err={}", op.unko_no, err);
-                warnings.push(format!("{}: KUDGIVT 取得失敗 ({})", op.unko_no, err));
-                continue;
+                tracing::warn!(
+                    "fetch KUDGIVT failed unko_no={} err={}",
+                    target.unko_no,
+                    err
+                );
+                warnings.push(format!("{}: KUDGIVT 取得失敗 ({})", target.unko_no, err));
             }
-        };
-
-        let segs = build_segment_inputs(&events, naive(departure_at), naive(return_at));
-        all_segments.extend(segs);
+        }
     }
 
     // 5. bucketing
     let (rows, build_warnings) = build_y_time_rows(all_segments, q.from, q.to);
     warnings.extend(build_warnings);
 
-    Ok(Json(YTimeExportResponse {
+    Ok(YTimeExportResponse {
         driver: YTimeDriver {
             cd: q.driver_cd,
             name: driver_name,
@@ -142,7 +292,80 @@ async fn get_y_time_export(
         },
         rows,
         warnings,
-    }))
+    })
+}
+
+/// `compute_y_time_export` の戻り値型。HTTP 層で `(StatusCode, String)` に変換する。
+#[derive(Debug)]
+pub enum ComputeError {
+    BadRequest(String),
+    NotFound(String),
+    Internal(String),
+}
+
+impl std::fmt::Display for ComputeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::BadRequest(m) | Self::NotFound(m) | Self::Internal(m) => write!(f, "{m}"),
+        }
+    }
+}
+
+impl std::error::Error for ComputeError {}
+
+fn compute_error_to_response(err: ComputeError) -> (StatusCode, String) {
+    match err {
+        ComputeError::BadRequest(m) => (StatusCode::BAD_REQUEST, m),
+        ComputeError::NotFound(m) => (StatusCode::NOT_FOUND, m),
+        ComputeError::Internal(m) => (StatusCode::INTERNAL_SERVER_ERROR, m),
+    }
+}
+
+fn compute_error_to_message(err: &ComputeError) -> String {
+    err.to_string()
+}
+
+/// async job 起動時の即時レスポンス。
+#[derive(Debug, Clone, Serialize)]
+pub struct StartJobResponse {
+    pub job_id: Uuid,
+}
+
+/// realtime-bus Worker `/broadcast` に送る Y時間 export 用イベント。
+///
+/// Worker は `tenant_id` / `document_id` / `status` を必須要求するため、
+/// `document_id` には `job_id` (UUID) を入れて満たす。frontend は `kind` &
+/// `job_id` で disambiguate する。
+///
+/// `result` は完了時のみ Some、288 KB 程度までの JSON を inline で運ぶ。
+#[derive(Debug, Clone, Serialize)]
+pub struct YTimeJobEvent {
+    pub kind: &'static str,
+    pub tenant_id: Uuid,
+    /// Worker validation を通すため必須。`job_id` と同値を入れる。
+    pub document_id: Uuid,
+    pub job_id: Uuid,
+    /// `completed` | `failed`
+    pub status: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<YTimeExportResponse>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// 並列 fetch のための target tuple。
+struct FetchTarget {
+    unko_no: String,
+    r2_key_prefix: Option<String>,
+    crew_role: i32,
+    departure_at: DateTime<Utc>,
+    return_at: DateTime<Utc>,
+}
+
+/// 並列 fetch 結果と元 target をペアで保持。
+struct FetchResult {
+    target: FetchTarget,
+    outcome: Result<Vec<alc_csv_parser::kudgivt::KudgivtRow>, csv_aggregator::AggregatorError>,
 }
 
 /// `DateTime<Utc>` → `NaiveDateTime` (TZ なし wall clock 抽出)。
@@ -152,4 +375,99 @@ async fn get_y_time_export(
 /// `naive_utc()` で時刻部だけ取り出せば JST wall clock として扱える。
 fn naive(dt: DateTime<Utc>) -> chrono::NaiveDateTime {
     dt.naive_utc()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compute_error_response_mapping() {
+        assert_eq!(
+            compute_error_to_response(ComputeError::BadRequest("bad".into())),
+            (StatusCode::BAD_REQUEST, "bad".to_string())
+        );
+        assert_eq!(
+            compute_error_to_response(ComputeError::NotFound("nope".into())),
+            (StatusCode::NOT_FOUND, "nope".to_string())
+        );
+        assert_eq!(
+            compute_error_to_response(ComputeError::Internal("oops".into())),
+            (StatusCode::INTERNAL_SERVER_ERROR, "oops".to_string())
+        );
+    }
+
+    #[test]
+    fn compute_error_message_passthrough() {
+        assert_eq!(
+            compute_error_to_message(&ComputeError::BadRequest("x".into())),
+            "x"
+        );
+        assert_eq!(
+            compute_error_to_message(&ComputeError::NotFound("y".into())),
+            "y"
+        );
+        assert_eq!(
+            compute_error_to_message(&ComputeError::Internal("z".into())),
+            "z"
+        );
+    }
+
+    #[test]
+    fn y_time_job_event_serialization_includes_kind_and_job_id() {
+        let job_id = Uuid::nil();
+        let tenant_id = Uuid::nil();
+        let ev = YTimeJobEvent {
+            kind: "y_time_export",
+            tenant_id,
+            document_id: job_id,
+            job_id,
+            status: "failed",
+            result: None,
+            error: Some("oops".to_string()),
+        };
+        let json = serde_json::to_string(&ev).expect("serialize");
+        assert!(
+            json.contains("\"kind\":\"y_time_export\""),
+            "kind discriminator missing in {json}"
+        );
+        assert!(
+            json.contains("\"job_id\""),
+            "job_id field missing in {json}"
+        );
+        assert!(
+            json.contains("\"document_id\""),
+            "document_id field required by realtime-bus Worker missing in {json}"
+        );
+        assert!(
+            json.contains("\"status\":\"failed\""),
+            "status missing in {json}"
+        );
+        // result が None のときは skip_serializing_if で消える
+        assert!(
+            !json.contains("\"result\""),
+            "result should be omitted when None: {json}"
+        );
+    }
+
+    #[test]
+    fn start_job_response_shape() {
+        let r = StartJobResponse {
+            job_id: Uuid::nil(),
+        };
+        let json = serde_json::to_string(&r).expect("serialize");
+        assert_eq!(
+            json,
+            "{\"job_id\":\"00000000-0000-0000-0000-000000000000\"}"
+        );
+    }
+
+    #[test]
+    #[allow(clippy::assertions_on_constants)]
+    fn r2_fetch_concurrency_is_in_safe_range() {
+        // 16 でなくてもいいが、過大設定回帰を防ぐ。
+        // 1 (= 逐次) は禁止、200+ は R2 rate limit リスク。
+        assert!(R2_FETCH_CONCURRENCY >= 4);
+        assert!(R2_FETCH_CONCURRENCY <= 64);
+    }
 }

--- a/crates/alc-dtako/src/lib.rs
+++ b/crates/alc-dtako/src/lib.rs
@@ -21,6 +21,7 @@ pub mod dtako_y_time_export;
 
 use std::sync::Arc;
 
+use alc_core::realtime_bus::RealtimeBus;
 use alc_core::repository::{
     DtakoCsvProxyRepository, DtakoDailyHoursRepository, DtakoDriversRepository,
     DtakoEventClassificationsRepository, DtakoLogsRepository, DtakoOperationsRepository,
@@ -48,6 +49,10 @@ pub struct DtakoState {
     pub dtako_work_times: Arc<dyn DtakoWorkTimesRepository>,
     pub dtako_y_time_export: Arc<dyn DtakoYTimeExportRepository>,
     pub dtako_storage: Option<Arc<dyn StorageBackend>>,
+    /// Y時間 export async job の完了通知を notify-realtime-bus に流すための共有
+    /// クライアント。env vars 未設定 (ローカル / sandbox) なら None で、POST /jobs
+    /// は 503 を返す。`AppState.realtime_bus` の参照を持ち回すだけ。
+    pub realtime_bus: Option<Arc<RealtimeBus>>,
 }
 
 impl axum::extract::FromRef<alc_core::AppState> for DtakoState {
@@ -67,6 +72,7 @@ impl axum::extract::FromRef<alc_core::AppState> for DtakoState {
             dtako_work_times: state.dtako_work_times.clone(),
             dtako_y_time_export: state.dtako_y_time_export.clone(),
             dtako_storage: state.dtako_storage.clone(),
+            realtime_bus: state.realtime_bus.clone(),
         }
     }
 }

--- a/crates/dtako-api/src/main.rs
+++ b/crates/dtako-api/src/main.rs
@@ -85,6 +85,7 @@ async fn main() {
         dtako_work_times: Arc::new(PgDtakoWorkTimesRepository::new(pool.clone())),
         dtako_y_time_export: Arc::new(PgDtakoYTimeExportRepository::new(pool.clone())),
         dtako_storage,
+        realtime_bus: alc_core::realtime_bus::RealtimeBus::from_env().map(Arc::new),
     };
 
     let tenant_protected = Router::new()

--- a/src/main.rs
+++ b/src/main.rs
@@ -319,6 +319,7 @@ async fn main() -> anyhow::Result<()> {
         lineworks_channels,
         notify_storage,
         redact_broadcaster: alc_core::redact_broadcast::RedactBroadcaster::from_env().map(Arc::new),
+        realtime_bus: alc_core::realtime_bus::RealtimeBus::from_env().map(Arc::new),
         trouble_tickets,
         trouble_files,
         trouble_workflow,

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -365,6 +365,7 @@ fn build_app_state(
         lineworks_channels,
         notify_storage: None,
         redact_broadcaster: None,
+        realtime_bus: None,
         trouble_tickets,
         trouble_files,
         trouble_workflow,

--- a/tests/mock_helpers/app_state.rs
+++ b/tests/mock_helpers/app_state.rs
@@ -74,6 +74,7 @@ pub fn setup_mock_app_state() -> AppState {
         lineworks_channels: Arc::new(MockLineworksChannelsRepository::default()),
         notify_storage: None,
         redact_broadcaster: None,
+        realtime_bus: None,
         trouble_tickets: Arc::new(MockTroubleTicketsRepository::default()),
         trouble_files: Arc::new(MockTroubleFilesRepository::default()),
         trouble_workflow: Arc::new(MockTroubleWorkflowRepository::default()),

--- a/tests/mock_tests/mock_dtako_y_time_export_test.rs
+++ b/tests/mock_tests/mock_dtako_y_time_export_test.rs
@@ -239,3 +239,217 @@ async fn happy_path_with_kudgivt_yields_one_row() {
     assert_eq!(r["rest_next_0_5"].as_i64().unwrap(), 0);
     assert_eq!(r["rest_next_5_22"].as_i64().unwrap(), 0);
 }
+
+// --- async job (POST /jobs) ---
+//
+// 仕様:
+//   POST /api/dtako/y-time-export/jobs
+//   - 即時 202 { job_id } を返す
+//   - background tokio::spawn で compute → realtime_bus へ broadcast
+//   - realtime_bus 未設定なら 503 (silent failure 防止)
+
+#[tokio::test]
+async fn post_jobs_returns_503_when_realtime_bus_not_configured() {
+    let state = setup_mock_app_state();
+    // realtime_bus は default で None
+
+    let base_url = crate::common::spawn_test_server(state).await;
+    let client = reqwest::Client::new();
+    let res = client
+        .post(format!(
+            "{base_url}/api/dtako/y-time-export/jobs?driver_cd=D1&from=2024-04-01&to=2024-04-30"
+        ))
+        .header("Authorization", test_auth_header())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 503);
+}
+
+#[tokio::test]
+async fn post_jobs_returns_400_when_from_after_to_even_with_bus() {
+    let mut state = setup_mock_app_state();
+    state.realtime_bus = Some(Arc::new(alc_core::realtime_bus::RealtimeBus::new(
+        "http://127.0.0.1:1/broadcast".into(),
+        "s".into(),
+    )));
+
+    let base_url = crate::common::spawn_test_server(state).await;
+    let client = reqwest::Client::new();
+    let res = client
+        .post(format!(
+            "{base_url}/api/dtako/y-time-export/jobs?driver_cd=D1&from=2024-04-30&to=2024-04-01"
+        ))
+        .header("Authorization", test_auth_header())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 400);
+}
+
+#[tokio::test]
+async fn post_jobs_returns_202_and_broadcasts_completed_event() {
+    use wiremock::matchers::{header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    // wiremock /broadcast を立てて realtime_bus を向ける
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/broadcast"))
+        .and(header("X-Broadcast-Secret", "s3cret"))
+        .and(wiremock::matchers::body_string_contains(
+            "\"kind\":\"y_time_export\"",
+        ))
+        .and(wiremock::matchers::body_string_contains("\"completed\""))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let bus = Arc::new(alc_core::realtime_bus::RealtimeBus::new(
+        format!("{}/broadcast", server.uri()),
+        "s3cret".into(),
+    ));
+
+    // happy path 用の DB / R2 を構築 (既存 happy_path_with_kudgivt_yields_one_row と同じ)
+    let mut state = setup_mock_app_state();
+    state.realtime_bus = Some(bus);
+    let driver_id = uuid::Uuid::new_v4();
+    let tenant_id = test_tenant_id();
+    let unko_no = "U_OK_JOB";
+
+    upload_kudgivt(
+        state.dtako_storage.as_ref().unwrap().as_ref(),
+        &tenant_id,
+        unko_no,
+        &minimal_kudgivt_csv(),
+    )
+    .await;
+
+    let mock = MockDtakoYTimeExportRepository::default()
+        .with_driver(driver_id, "テスト 一郎")
+        .with_operations(vec![YTimeExportOperation {
+            unko_no: unko_no.into(),
+            crew_role: 1,
+            departure_at: Some(chrono::Utc.with_ymd_and_hms(2024, 4, 15, 9, 0, 0).unwrap()),
+            return_at: Some(chrono::Utc.with_ymd_and_hms(2024, 4, 15, 18, 0, 0).unwrap()),
+            r2_key_prefix: None,
+        }]);
+    state.dtako_y_time_export = Arc::new(mock);
+
+    let base_url = crate::common::spawn_test_server(state).await;
+    let client = reqwest::Client::new();
+    let res = client
+        .post(format!(
+            "{base_url}/api/dtako/y-time-export/jobs?driver_cd=D1&from=2024-04-15&to=2024-04-15"
+        ))
+        .header("Authorization", test_auth_header())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 202);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert!(body.get("job_id").and_then(|v| v.as_str()).is_some());
+
+    // background spawn → broadcast 到達まで少し待機。
+    // wiremock の expect(1) が満たされない場合 server.verify() で panic する。
+    for _ in 0..50 {
+        if !server
+            .received_requests()
+            .await
+            .unwrap_or_default()
+            .is_empty()
+        {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+    let received = server.received_requests().await.unwrap();
+    assert!(
+        !received.is_empty(),
+        "expected at least 1 broadcast call within 2.5s"
+    );
+    let payload = std::str::from_utf8(&received[0].body).unwrap();
+    assert!(
+        payload.contains("\"kind\":\"y_time_export\""),
+        "kind missing in {payload}"
+    );
+    assert!(
+        payload.contains("\"status\":\"completed\""),
+        "status not completed in {payload}"
+    );
+    assert!(
+        payload.contains("\"job_id\""),
+        "job_id missing in {payload}"
+    );
+    // result inline で運ばれている
+    assert!(
+        payload.contains("\"result\""),
+        "result inline missing in {payload}"
+    );
+    assert!(
+        payload.contains("\"rows\""),
+        "rows missing in result of {payload}"
+    );
+}
+
+#[tokio::test]
+async fn post_jobs_broadcasts_failed_event_when_driver_unknown() {
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/broadcast"))
+        .and(wiremock::matchers::body_string_contains("\"failed\""))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let mut state = setup_mock_app_state();
+    state.realtime_bus = Some(Arc::new(alc_core::realtime_bus::RealtimeBus::new(
+        format!("{}/broadcast", server.uri()),
+        "s".into(),
+    )));
+    // dtako_y_time_export は default → driver lookup で None → failed
+
+    let base_url = crate::common::spawn_test_server(state).await;
+    let client = reqwest::Client::new();
+    let res = client
+        .post(format!(
+            "{base_url}/api/dtako/y-time-export/jobs?driver_cd=NOPE&from=2024-04-01&to=2024-04-30"
+        ))
+        .header("Authorization", test_auth_header())
+        .send()
+        .await
+        .unwrap();
+    // job 起動自体は成功 (realtime_bus 設定済) → 202、failure は WS event で返す
+    assert_eq!(res.status(), 202);
+
+    for _ in 0..50 {
+        if !server
+            .received_requests()
+            .await
+            .unwrap_or_default()
+            .is_empty()
+        {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+    let received = server.received_requests().await.unwrap();
+    assert!(
+        !received.is_empty(),
+        "expected failed broadcast within 2.5s"
+    );
+    let payload = std::str::from_utf8(&received[0].body).unwrap();
+    assert!(
+        payload.contains("\"status\":\"failed\""),
+        "expected failed in {payload}"
+    );
+    assert!(
+        payload.contains("\"error\""),
+        "expected error message in {payload}"
+    );
+}


### PR DESCRIPTION
京都ソフト案件 Y時間 Excel export の backend wall time (driver 1664 / 13ヶ月で 41-107秒) を解消する 2 軸の改善。

## アーキテクチャ

```
[browser]
  │ POST /api/dtako/y-time-export/jobs (新)
  ▼
[rust-alc-api]
  │ 即時 202 { job_id }
  │
  │ tokio::spawn:
  │  - DB lookup_driver / list_operations
  │  - 並列 R2 fetch (futures::stream::buffer_unordered(16))
  │  - build_segment_inputs / build_y_time_rows
  │  - realtime_bus.broadcast(YTimeJobEvent { kind:\"y_time_export\", result, ... })
  ▼
[notify-realtime-bus Worker (nuxt-notify, 共用)]
  │ tenant_id → DurableObject → fan-out
  ▼
[browser WS] /subscribe (Sec-WebSocket-Protocol: bearer,<jwt>)
  │ kind=y_time_export & job_id 一致のメッセージで result 受領
  ▼
  [server route] xlsx 生成 → blob download
```

## 主な変更

### A. 並列 R2 fetch
- crates/alc-dtako/src/dtako_y_time_export/mod.rs::compute_y_time_export
- 逐次 await ループ → futures::stream::iter().buffer_unordered(16)
- 200 unko_no × 300ms / 16 ≈ 3.75s で完了想定

### B. 新エンドポイント POST /api/dtako/y-time-export/jobs
- 即時 202 + { job_id } 返却
- background tokio::spawn で compute → realtime_bus に inline result を broadcast
- 既存 GET は後方互換のため残置

### C. 汎用 RealtimeBus (crates/alc-core/src/realtime_bus.rs)
- 既存 RedactBroadcaster と同 env vars (NOTIFY_REDACT_BROADCAST_URL/SECRET) を共有
- broadcast<T: Serialize>() で任意 payload を流せる generic 版
- from_env None 時は POST /jobs が 503 で失敗 (silent failure 防止)

### D. テスト追加 (合計 +20)
- alc-core 新 unit 11 件 (RealtimeBus + wiremock)
- alc-dtako 新 unit 5 件 (compute_error mapping, event serialization, etc.)
- mock integration 4 件 (503 when bus None / 400 / 202 + completed broadcast / 202 + failed broadcast)
- 既存 6 件は変更なしで pass

### E. CLAUDE.md
- ## 外部 API 連携 (notify-realtime-bus + async job 完了通知) を追記
- 新しい async endpoint を増やす手順、罠、既存利用例

## 期待効果
- backend wall time: **41-107s → 5-15s** (~85% 削減見込)
- HTTP 長時間保持を解消、Cloudflare proxy timeout / 503 リスク排除
- staging deploy 後に Cloud Run logs textPayload:\"y-time-export\" で elapsed_ms 確認

## frontend
nuxt-dtako-admin の対応 PR を別途出します (CI pass 後)。
それまでは frontend は既存 GET フォールバックで動作 (互換維持)。

## 関連
- 引き継ぎ: handover_20260510_y_time_backend_perf.md
- 計画: ~/.claude/plans/memory-eager-petal.md (approved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)