### PR TITLE
chore: add nuxt-ichibanboshi symlink + incus-sandbox to git scan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ claude-skills
 claude-hooks
 daiun-salary
 nuxt-dtako-admin
+nuxt-ichibanboshi
 ci-dashboard
 git-status-all.sh
 client_secret_*.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,7 +10,9 @@
     "nuxt-dtako-admin",
     "daiun-salary",
     "ci-dashboard",
-    "front/nuxt-pwa-carins"
+    "front/nuxt-pwa-carins",
+    "incus-sandbox",
+    "nuxt-ichibanboshi"
   ],
   "git.autoRepositoryDetection": true
 }


### PR DESCRIPTION
ローカル参照用 symlink の追加とエディタ git scan 対象の同期。

- .gitignore: `nuxt-ichibanboshi` (symlink → /home/yhonda/js/nuxt-ichibanboshi)
- .vscode/settings.json: `git.scanRepositories` に `nuxt-ichibanboshi` と `incus-sandbox` を追加

ランタイム影響なし (CLAUDE.md 例外で main 編集可なファイルのみ)。