### PR TITLE
chore(vscode): scan front/nuxt-trouble in workspace

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,6 +11,7 @@
     "daiun-salary",
     "ci-dashboard",
     "front/nuxt-pwa-carins",
+    "front/nuxt-trouble",
     "incus-sandbox",
     "nuxt-ichibanboshi"
   ],


### PR DESCRIPTION
Add front/nuxt-trouble to .vscode/settings.json git.scanRepositories list (VSCode SCM 一括管理)。同パターンの ci-dashboard / nuxt-ichibanboshi に揃える。