### PR TITLE
feat(dtako): vehicle_settings_dumps テーブル + endpoint

### DIFF
--- a/crates/alc-core/src/lib.rs
+++ b/crates/alc-core/src/lib.rs
@@ -40,7 +40,7 @@ use repository::{
     TroubleCategoriesRepository, TroubleFilesRepository, TroubleNotificationPrefsRepository,
     TroubleOfficesRepository, TroubleProgressStatusesRepository, TroubleSchedulesRepository,
     TroubleTaskStatusesRepository, TroubleTaskTypesRepository, TroubleTasksRepository,
-    TroubleTicketsRepository, TroubleWorkflowRepository,
+    TroubleTicketsRepository, TroubleWorkflowRepository, VehicleSettingsDumpsRepository,
 };
 use storage::StorageBackend;
 
@@ -70,6 +70,7 @@ pub struct AppState {
     pub dtako_vehicles: Arc<dyn DtakoVehiclesRepository>,
     pub dtako_work_times: Arc<dyn DtakoWorkTimesRepository>,
     pub dtako_y_time_export: Arc<dyn DtakoYTimeExportRepository>,
+    pub vehicle_settings_dumps: Arc<dyn VehicleSettingsDumpsRepository>,
     pub employees: Arc<dyn EmployeeRepository>,
     pub equipment_failures: Arc<dyn EquipmentFailuresRepository>,
     pub guidance_records: Arc<dyn GuidanceRecordsRepository>,

--- a/crates/alc-core/src/models.rs
+++ b/crates/alc-core/src/models.rs
@@ -743,6 +743,23 @@ pub struct DtakoVehicle {
     pub vehicle_name: String,
 }
 
+// --- Vehicle Settings Dump (R2 車輛設定 dump メタデータ) ---
+
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+pub struct VehicleSettingsDump {
+    pub id: Uuid,
+    pub tenant_id: Uuid,
+    pub vehicle_cd: String,
+    pub dump_dir: String,
+    pub machine_id: Option<String>,
+    pub firm_main_app: Option<String>,
+    pub r2_json_key: String,
+    pub r2_cfg_key: String,
+    pub uploaded_at: DateTime<Utc>,
+    pub uploaded_by: Option<Uuid>,
+    pub created_at: DateTime<Utc>,
+}
+
 // --- Dtako: Event Classification ---
 
 #[derive(Debug, Clone, Serialize, Deserialize, FromRow)]

--- a/crates/alc-core/src/repository/mod.rs
+++ b/crates/alc-core/src/repository/mod.rs
@@ -53,6 +53,7 @@ pub mod trouble_task_types;
 pub mod trouble_tasks;
 pub mod trouble_tickets;
 pub mod trouble_workflow;
+pub mod vehicle_settings_dumps;
 pub mod webhook;
 
 pub use api_tokens::{ApiTokenRow, ApiTokensRepository};
@@ -110,4 +111,7 @@ pub use trouble_task_types::TroubleTaskTypesRepository;
 pub use trouble_tasks::{TroubleTasksFilter, TroubleTasksRepository, TroubleTasksSortBy};
 pub use trouble_tickets::TroubleTicketsRepository;
 pub use trouble_workflow::TroubleWorkflowRepository;
+pub use vehicle_settings_dumps::{
+    VehicleSettingsDumpInput, VehicleSettingsDumpSummary, VehicleSettingsDumpsRepository,
+};
 pub use webhook::WebhookRepository;

--- a/crates/alc-core/src/repository/vehicle_settings_dumps.rs
+++ b/crates/alc-core/src/repository/vehicle_settings_dumps.rs
@@ -1,0 +1,55 @@
+use async_trait::async_trait;
+use uuid::Uuid;
+
+use crate::models::VehicleSettingsDump;
+
+/// `vehicle_settings_dumps` テーブルの Repository trait。
+///
+/// フロント (nuxt-dtako-admin) が R2 への PUT 成功後に `register` を呼んで
+/// dump メタデータを INSERT する。読み出しは「車輛別履歴」「テナント集計」の 2 パターン。
+#[async_trait]
+pub trait VehicleSettingsDumpsRepository: Send + Sync {
+    /// dump の登録 (冪等: 同じ (tenant_id, vehicle_cd, dump_dir) は ON CONFLICT で UPDATE)。
+    async fn register(
+        &self,
+        tenant_id: Uuid,
+        input: VehicleSettingsDumpInput,
+    ) -> Result<VehicleSettingsDump, sqlx::Error>;
+
+    /// 指定 vehicle_cd の dump を uploaded_at DESC で返す。
+    async fn list_by_vehicle_cd(
+        &self,
+        tenant_id: Uuid,
+        vehicle_cd: &str,
+    ) -> Result<Vec<VehicleSettingsDump>, sqlx::Error>;
+
+    /// テナントの全車輛分集計 (vehicle_cd, count, latest_uploaded_at)。
+    async fn summary_by_vehicle(
+        &self,
+        tenant_id: Uuid,
+    ) -> Result<Vec<VehicleSettingsDumpSummary>, sqlx::Error>;
+
+    /// テナントに dump が存在する vehicle_cd 集合 (未確認車輛抽出用)。
+    async fn confirmed_vehicle_cds(
+        &self,
+        tenant_id: Uuid,
+    ) -> Result<Vec<String>, sqlx::Error>;
+}
+
+#[derive(Debug, Clone)]
+pub struct VehicleSettingsDumpInput {
+    pub vehicle_cd: String,
+    pub dump_dir: String,
+    pub machine_id: Option<String>,
+    pub firm_main_app: Option<String>,
+    pub r2_json_key: String,
+    pub r2_cfg_key: String,
+    pub uploaded_by: Option<Uuid>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct VehicleSettingsDumpSummary {
+    pub vehicle_cd: String,
+    pub count: i64,
+    pub latest_uploaded_at: chrono::DateTime<chrono::Utc>,
+}

--- a/crates/alc-core/src/repository/vehicle_settings_dumps.rs
+++ b/crates/alc-core/src/repository/vehicle_settings_dumps.rs
@@ -30,10 +30,7 @@ pub trait VehicleSettingsDumpsRepository: Send + Sync {
     ) -> Result<Vec<VehicleSettingsDumpSummary>, sqlx::Error>;
 
     /// テナントに dump が存在する vehicle_cd 集合 (未確認車輛抽出用)。
-    async fn confirmed_vehicle_cds(
-        &self,
-        tenant_id: Uuid,
-    ) -> Result<Vec<String>, sqlx::Error>;
+    async fn confirmed_vehicle_cds(&self, tenant_id: Uuid) -> Result<Vec<String>, sqlx::Error>;
 }
 
 #[derive(Debug, Clone)]

--- a/crates/alc-core/src/repository/vehicle_settings_dumps.rs
+++ b/crates/alc-core/src/repository/vehicle_settings_dumps.rs
@@ -47,7 +47,10 @@ pub struct VehicleSettingsDumpInput {
     pub uploaded_by: Option<Uuid>,
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+// FromRow を derive しておくことで query_as が使える。
+// trait 定義と一緒に alc-core 側に記述して、orphan rule 違反を避ける
+// (同じコードによって PgVehicleSettingsDumpsRepository が summary_by_vehicle を query_as で使える)。
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, sqlx::FromRow)]
 pub struct VehicleSettingsDumpSummary {
     pub vehicle_cd: String,
     pub count: i64,

--- a/crates/alc-dtako/src/lib.rs
+++ b/crates/alc-dtako/src/lib.rs
@@ -18,6 +18,7 @@ pub mod dtako_upload;
 pub mod dtako_vehicles;
 pub mod dtako_work_times;
 pub mod dtako_y_time_export;
+pub mod vehicle_settings_dumps;
 
 use std::sync::Arc;
 
@@ -26,7 +27,7 @@ use alc_core::repository::{
     DtakoEventClassificationsRepository, DtakoLogsRepository, DtakoOperationsRepository,
     DtakoRestraintReportPdfRepository, DtakoRestraintReportRepository, DtakoScraperRepository,
     DtakoUploadRepository, DtakoVehiclesRepository, DtakoWorkTimesRepository,
-    DtakoYTimeExportRepository,
+    DtakoYTimeExportRepository, VehicleSettingsDumpsRepository,
 };
 use alc_core::storage::StorageBackend;
 
@@ -47,6 +48,7 @@ pub struct DtakoState {
     pub dtako_vehicles: Arc<dyn DtakoVehiclesRepository>,
     pub dtako_work_times: Arc<dyn DtakoWorkTimesRepository>,
     pub dtako_y_time_export: Arc<dyn DtakoYTimeExportRepository>,
+    pub vehicle_settings_dumps: Arc<dyn VehicleSettingsDumpsRepository>,
     pub dtako_storage: Option<Arc<dyn StorageBackend>>,
 }
 
@@ -66,6 +68,7 @@ impl axum::extract::FromRef<alc_core::AppState> for DtakoState {
             dtako_vehicles: state.dtako_vehicles.clone(),
             dtako_work_times: state.dtako_work_times.clone(),
             dtako_y_time_export: state.dtako_y_time_export.clone(),
+            vehicle_settings_dumps: state.vehicle_settings_dumps.clone(),
             dtako_storage: state.dtako_storage.clone(),
         }
     }

--- a/crates/alc-dtako/src/repo/mod.rs
+++ b/crates/alc-dtako/src/repo/mod.rs
@@ -11,6 +11,7 @@ pub mod dtako_upload;
 pub mod dtako_vehicles;
 pub mod dtako_work_times;
 pub mod dtako_y_time_export;
+pub mod vehicle_settings_dumps;
 
 pub use dtako_csv_proxy::PgDtakoCsvProxyRepository;
 pub use dtako_daily_hours::PgDtakoDailyHoursRepository;
@@ -25,3 +26,4 @@ pub use dtako_upload::PgDtakoUploadRepository;
 pub use dtako_vehicles::PgDtakoVehiclesRepository;
 pub use dtako_work_times::PgDtakoWorkTimesRepository;
 pub use dtako_y_time_export::PgDtakoYTimeExportRepository;
+pub use vehicle_settings_dumps::PgVehicleSettingsDumpsRepository;

--- a/crates/alc-dtako/src/repo/vehicle_settings_dumps.rs
+++ b/crates/alc-dtako/src/repo/vehicle_settings_dumps.rs
@@ -107,16 +107,3 @@ impl VehicleSettingsDumpsRepository for PgVehicleSettingsDumpsRepository {
         Ok(rows.into_iter().map(|(cd,)| cd).collect())
     }
 }
-
-// VehicleSettingsDumpSummary は serde デリーブだけだと query_as に使えないので
-// ここで FromRow を手動実装する。trait 側に記述すると alc-core に sqlx 依存が漏れるため。
-impl<'r> sqlx::FromRow<'r, sqlx::postgres::PgRow> for VehicleSettingsDumpSummary {
-    fn from_row(row: &'r sqlx::postgres::PgRow) -> Result<Self, sqlx::Error> {
-        use sqlx::Row;
-        Ok(VehicleSettingsDumpSummary {
-            vehicle_cd: row.try_get("vehicle_cd")?,
-            count: row.try_get("count")?,
-            latest_uploaded_at: row.try_get("latest_uploaded_at")?,
-        })
-    }
-}

--- a/crates/alc-dtako/src/repo/vehicle_settings_dumps.rs
+++ b/crates/alc-dtako/src/repo/vehicle_settings_dumps.rs
@@ -91,10 +91,7 @@ impl VehicleSettingsDumpsRepository for PgVehicleSettingsDumpsRepository {
         .await
     }
 
-    async fn confirmed_vehicle_cds(
-        &self,
-        tenant_id: Uuid,
-    ) -> Result<Vec<String>, sqlx::Error> {
+    async fn confirmed_vehicle_cds(&self, tenant_id: Uuid) -> Result<Vec<String>, sqlx::Error> {
         let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
         let rows: Vec<(String,)> = sqlx::query_as(
             "SELECT DISTINCT vehicle_cd \

--- a/crates/alc-dtako/src/repo/vehicle_settings_dumps.rs
+++ b/crates/alc-dtako/src/repo/vehicle_settings_dumps.rs
@@ -1,0 +1,122 @@
+use async_trait::async_trait;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use alc_core::models::VehicleSettingsDump;
+use alc_core::tenant::TenantConn;
+
+pub use alc_core::repository::vehicle_settings_dumps::*;
+
+pub struct PgVehicleSettingsDumpsRepository {
+    pool: PgPool,
+}
+
+impl PgVehicleSettingsDumpsRepository {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl VehicleSettingsDumpsRepository for PgVehicleSettingsDumpsRepository {
+    async fn register(
+        &self,
+        tenant_id: Uuid,
+        input: VehicleSettingsDumpInput,
+    ) -> Result<VehicleSettingsDump, sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        // ON CONFLICT で処理 — 同じ zip を 2 回投げたケースや R2 put 後の retry に保証をもたせる。
+        // 上書きしたい (machine_id が達う 等) ので DO UPDATE を使う。
+        sqlx::query_as::<_, VehicleSettingsDump>(
+            r#"
+            INSERT INTO alc_api.vehicle_settings_dumps
+              (tenant_id, vehicle_cd, dump_dir, machine_id, firm_main_app,
+               r2_json_key, r2_cfg_key, uploaded_by)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+            ON CONFLICT (tenant_id, vehicle_cd, dump_dir) DO UPDATE
+              SET machine_id    = EXCLUDED.machine_id,
+                  firm_main_app = EXCLUDED.firm_main_app,
+                  r2_json_key   = EXCLUDED.r2_json_key,
+                  r2_cfg_key    = EXCLUDED.r2_cfg_key,
+                  uploaded_by   = COALESCE(EXCLUDED.uploaded_by, alc_api.vehicle_settings_dumps.uploaded_by),
+                  uploaded_at   = now()
+            RETURNING *
+            "#,
+        )
+        .bind(tenant_id)
+        .bind(&input.vehicle_cd)
+        .bind(&input.dump_dir)
+        .bind(input.machine_id.as_deref())
+        .bind(input.firm_main_app.as_deref())
+        .bind(&input.r2_json_key)
+        .bind(&input.r2_cfg_key)
+        .bind(input.uploaded_by)
+        .fetch_one(&mut *tc.conn)
+        .await
+    }
+
+    async fn list_by_vehicle_cd(
+        &self,
+        tenant_id: Uuid,
+        vehicle_cd: &str,
+    ) -> Result<Vec<VehicleSettingsDump>, sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        sqlx::query_as::<_, VehicleSettingsDump>(
+            "SELECT * FROM alc_api.vehicle_settings_dumps \
+             WHERE tenant_id = $1 AND vehicle_cd = $2 \
+             ORDER BY uploaded_at DESC",
+        )
+        .bind(tenant_id)
+        .bind(vehicle_cd)
+        .fetch_all(&mut *tc.conn)
+        .await
+    }
+
+    async fn summary_by_vehicle(
+        &self,
+        tenant_id: Uuid,
+    ) -> Result<Vec<VehicleSettingsDumpSummary>, sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        sqlx::query_as::<_, VehicleSettingsDumpSummary>(
+            "SELECT vehicle_cd, \
+                    COUNT(*)::BIGINT  AS count, \
+                    MAX(uploaded_at)  AS latest_uploaded_at \
+             FROM alc_api.vehicle_settings_dumps \
+             WHERE tenant_id = $1 \
+             GROUP BY vehicle_cd \
+             ORDER BY vehicle_cd",
+        )
+        .bind(tenant_id)
+        .fetch_all(&mut *tc.conn)
+        .await
+    }
+
+    async fn confirmed_vehicle_cds(
+        &self,
+        tenant_id: Uuid,
+    ) -> Result<Vec<String>, sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        let rows: Vec<(String,)> = sqlx::query_as(
+            "SELECT DISTINCT vehicle_cd \
+             FROM alc_api.vehicle_settings_dumps \
+             WHERE tenant_id = $1",
+        )
+        .bind(tenant_id)
+        .fetch_all(&mut *tc.conn)
+        .await?;
+        Ok(rows.into_iter().map(|(cd,)| cd).collect())
+    }
+}
+
+// VehicleSettingsDumpSummary は serde デリーブだけだと query_as に使えないので
+// ここで FromRow を手動実装する。trait 側に記述すると alc-core に sqlx 依存が漏れるため。
+impl<'r> sqlx::FromRow<'r, sqlx::postgres::PgRow> for VehicleSettingsDumpSummary {
+    fn from_row(row: &'r sqlx::postgres::PgRow) -> Result<Self, sqlx::Error> {
+        use sqlx::Row;
+        Ok(VehicleSettingsDumpSummary {
+            vehicle_cd: row.try_get("vehicle_cd")?,
+            count: row.try_get("count")?,
+            latest_uploaded_at: row.try_get("latest_uploaded_at")?,
+        })
+    }
+}

--- a/crates/alc-dtako/src/vehicle_settings_dumps.rs
+++ b/crates/alc-dtako/src/vehicle_settings_dumps.rs
@@ -1,0 +1,142 @@
+//! `/api/dtako/vehicle-settings-dumps` エンドポイント。
+//!
+//! フロント (nuxt-dtako-admin) が R2 へ PUT した後にここを叩いて
+//! dump メタデータを DB に登録する。読み出しは 「車輛別履歴」「テナント合計」。
+//!
+//! ohishi-exp/nuxt-dtako-admin#39 でフロントが R2 list を直接叩いていた部分を
+//! 本 endpoint で置き換えると、list の cursor pagination をスキップして
+//! 1 query で済むようになる。
+
+use axum::{
+    extract::{Path, Query, State},
+    http::StatusCode,
+    routing::{get, post},
+    Json, Router,
+};
+use serde::{Deserialize, Serialize};
+
+use alc_core::auth_middleware::{AuthUser, TenantId};
+use alc_core::models::VehicleSettingsDump;
+use alc_core::repository::vehicle_settings_dumps::{
+    VehicleSettingsDumpInput, VehicleSettingsDumpSummary,
+};
+
+use crate::DtakoState;
+
+pub fn tenant_router<S>() -> Router<S>
+where
+    DtakoState: axum::extract::FromRef<S>,
+    S: Clone + Send + Sync + 'static,
+{
+    Router::new()
+        .route(
+            "/vehicle-settings-dumps",
+            post(register_dump),
+        )
+        .route(
+            "/vehicle-settings-dumps/summary",
+            get(list_summary),
+        )
+        .route(
+            "/vehicle-settings-dumps/:vehicle_cd",
+            get(list_by_vehicle),
+        )
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RegisterRequest {
+    pub vehicle_cd: String,
+    pub dump_dir: String,
+    pub machine_id: Option<String>,
+    pub firm_main_app: Option<String>,
+    pub r2_json_key: String,
+    pub r2_cfg_key: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RegisterResponse {
+    #[serde(flatten)]
+    pub dump: VehicleSettingsDump,
+}
+
+async fn register_dump(
+    State(state): State<DtakoState>,
+    tenant: axum::Extension<TenantId>,
+    user: Option<axum::Extension<AuthUser>>,
+    Json(body): Json<RegisterRequest>,
+) -> Result<Json<RegisterResponse>, StatusCode> {
+    let tenant_id = tenant.0 .0;
+    let uploaded_by = user.and_then(|u| u.0.id);
+
+    // 入力バリデーション: empty / 制限超え
+    if body.vehicle_cd.is_empty() || body.vehicle_cd.len() > 32 {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+    if body.dump_dir.is_empty() || body.dump_dir.len() > 64 {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+    if !body.r2_json_key.starts_with("vehicle-settings/")
+        || !body.r2_cfg_key.starts_with("vehicle-settings/")
+    {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+
+    let input = VehicleSettingsDumpInput {
+        vehicle_cd: body.vehicle_cd,
+        dump_dir: body.dump_dir,
+        machine_id: body.machine_id,
+        firm_main_app: body.firm_main_app,
+        r2_json_key: body.r2_json_key,
+        r2_cfg_key: body.r2_cfg_key,
+        uploaded_by,
+    };
+
+    let dump = state
+        .vehicle_settings_dumps
+        .register(tenant_id, input)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = ?e, "failed to register vehicle settings dump");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    Ok(Json(RegisterResponse { dump }))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ListByVehicleQuery {
+    // 予約 (将来 limit / cursor を取りたいときを見越して struct 化)
+}
+
+async fn list_by_vehicle(
+    State(state): State<DtakoState>,
+    tenant: axum::Extension<TenantId>,
+    Path(vehicle_cd): Path<String>,
+    Query(_q): Query<ListByVehicleQuery>,
+) -> Result<Json<Vec<VehicleSettingsDump>>, StatusCode> {
+    let tenant_id = tenant.0 .0;
+    if vehicle_cd.is_empty() || vehicle_cd.len() > 32 {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+
+    let dumps = state
+        .vehicle_settings_dumps
+        .list_by_vehicle_cd(tenant_id, &vehicle_cd)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    Ok(Json(dumps))
+}
+
+async fn list_summary(
+    State(state): State<DtakoState>,
+    tenant: axum::Extension<TenantId>,
+) -> Result<Json<Vec<VehicleSettingsDumpSummary>>, StatusCode> {
+    let tenant_id = tenant.0 .0;
+    let summary = state
+        .vehicle_settings_dumps
+        .summary_by_vehicle(tenant_id)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    Ok(Json(summary))
+}

--- a/crates/alc-dtako/src/vehicle_settings_dumps.rs
+++ b/crates/alc-dtako/src/vehicle_settings_dumps.rs
@@ -15,7 +15,7 @@ use axum::{
 };
 use serde::{Deserialize, Serialize};
 
-use alc_core::auth_middleware::{AuthUser, TenantId};
+use alc_core::auth_middleware::TenantId;
 use alc_core::models::VehicleSettingsDump;
 use alc_core::repository::vehicle_settings_dumps::{
     VehicleSettingsDumpInput, VehicleSettingsDumpSummary,
@@ -62,11 +62,9 @@ pub struct RegisterResponse {
 async fn register_dump(
     State(state): State<DtakoState>,
     tenant: axum::Extension<TenantId>,
-    user: Option<axum::Extension<AuthUser>>,
     Json(body): Json<RegisterRequest>,
 ) -> Result<Json<RegisterResponse>, StatusCode> {
     let tenant_id = tenant.0 .0;
-    let uploaded_by = user.and_then(|u| u.0.id);
 
     // 入力バリデーション: empty / 制限超え
     if body.vehicle_cd.is_empty() || body.vehicle_cd.len() > 32 {
@@ -81,6 +79,8 @@ async fn register_dump(
         return Err(StatusCode::BAD_REQUEST);
     }
 
+    // uploaded_by は現時点では記録しない (AuthUser の user_id は String だがカラムは UUID
+    // なので、パース処理をそろえるまでは保留)。Phase 4 で考える。
     let input = VehicleSettingsDumpInput {
         vehicle_cd: body.vehicle_cd,
         dump_dir: body.dump_dir,
@@ -88,7 +88,7 @@ async fn register_dump(
         firm_main_app: body.firm_main_app,
         r2_json_key: body.r2_json_key,
         r2_cfg_key: body.r2_cfg_key,
-        uploaded_by,
+        uploaded_by: None,
     };
 
     let dump = state

--- a/crates/alc-dtako/src/vehicle_settings_dumps.rs
+++ b/crates/alc-dtako/src/vehicle_settings_dumps.rs
@@ -28,10 +28,14 @@ where
     DtakoState: axum::extract::FromRef<S>,
     S: Clone + Send + Sync + 'static,
 {
+    // axum v0.8+ では `:capture` でなく `{capture}` を使う
     Router::new()
         .route("/vehicle-settings-dumps", post(register_dump))
         .route("/vehicle-settings-dumps/summary", get(list_summary))
-        .route("/vehicle-settings-dumps/:vehicle_cd", get(list_by_vehicle))
+        .route(
+            "/vehicle-settings-dumps/{vehicle_cd}",
+            get(list_by_vehicle),
+        )
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/alc-dtako/src/vehicle_settings_dumps.rs
+++ b/crates/alc-dtako/src/vehicle_settings_dumps.rs
@@ -29,18 +29,9 @@ where
     S: Clone + Send + Sync + 'static,
 {
     Router::new()
-        .route(
-            "/vehicle-settings-dumps",
-            post(register_dump),
-        )
-        .route(
-            "/vehicle-settings-dumps/summary",
-            get(list_summary),
-        )
-        .route(
-            "/vehicle-settings-dumps/:vehicle_cd",
-            get(list_by_vehicle),
-        )
+        .route("/vehicle-settings-dumps", post(register_dump))
+        .route("/vehicle-settings-dumps/summary", get(list_summary))
+        .route("/vehicle-settings-dumps/:vehicle_cd", get(list_by_vehicle))
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/alc-dtako/src/vehicle_settings_dumps.rs
+++ b/crates/alc-dtako/src/vehicle_settings_dumps.rs
@@ -32,10 +32,7 @@ where
     Router::new()
         .route("/vehicle-settings-dumps", post(register_dump))
         .route("/vehicle-settings-dumps/summary", get(list_summary))
-        .route(
-            "/vehicle-settings-dumps/{vehicle_cd}",
-            get(list_by_vehicle),
-        )
+        .route("/vehicle-settings-dumps/{vehicle_cd}", get(list_by_vehicle))
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/dtako-api/src/main.rs
+++ b/crates/dtako-api/src/main.rs
@@ -15,7 +15,7 @@ use alc_dtako::repo::{
     PgDtakoEventClassificationsRepository, PgDtakoLogsRepository, PgDtakoOperationsRepository,
     PgDtakoRestraintReportPdfRepository, PgDtakoRestraintReportRepository,
     PgDtakoScraperRepository, PgDtakoUploadRepository, PgDtakoVehiclesRepository,
-    PgDtakoWorkTimesRepository, PgDtakoYTimeExportRepository,
+    PgDtakoWorkTimesRepository, PgDtakoYTimeExportRepository, PgVehicleSettingsDumpsRepository,
 };
 use alc_dtako::DtakoState;
 
@@ -82,6 +82,7 @@ async fn main() {
         dtako_scraper: Arc::new(PgDtakoScraperRepository::new(pool.clone())),
         dtako_upload: Arc::new(PgDtakoUploadRepository::new(pool.clone())),
         dtako_vehicles: Arc::new(PgDtakoVehiclesRepository::new(pool.clone())),
+        vehicle_settings_dumps: Arc::new(PgVehicleSettingsDumpsRepository::new(pool.clone())),
         dtako_work_times: Arc::new(PgDtakoWorkTimesRepository::new(pool.clone())),
         dtako_y_time_export: Arc::new(PgDtakoYTimeExportRepository::new(pool.clone())),
         dtako_storage,
@@ -98,6 +99,7 @@ async fn main() {
         .merge(alc_dtako::dtako_scraper::tenant_router())
         .merge(alc_dtako::dtako_upload::tenant_router())
         .merge(alc_dtako::dtako_vehicles::tenant_router())
+        .merge(alc_dtako::vehicle_settings_dumps::tenant_router())
         .merge(alc_dtako::dtako_work_times::tenant_router())
         .nest("/dtako-logs", alc_dtako::dtako_logs::tenant_router())
         .layer(axum_middleware::from_fn(require_tenant_header));

--- a/migrations/110_create_vehicle_settings_dumps.sql
+++ b/migrations/110_create_vehicle_settings_dumps.sql
@@ -1,0 +1,43 @@
+-- vehicle_settings_dumps: nuxt-dtako-admin が R2 に保存した車輛設定 dump の
+-- メタデータを追跡するテーブル。実体 (json + cfg) は R2 上にあり、
+-- 本テーブルは 「どの車輛にいつ dump が上がったか」 を高速に取り出す
+-- インデックスとして使う (フロントが R2 list せず 1 query で未確認車輛や
+-- 履歴を取れるようにするため)。
+--
+-- 関連:
+--   - ohishi-exp/nuxt-dtako-admin#38 / #39 / #40 / #41
+--   - ippoan/rust-alc-api#347
+
+CREATE TABLE IF NOT EXISTS alc_api.vehicle_settings_dumps (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id       UUID NOT NULL,
+    -- dtako_vehicles.vehicle_cd と同じキー。FK は張らない (車輛マスタ未登録
+    -- の車輛も dump だけはアップロードされうるため、緊さずにしておく)
+    vehicle_cd      VARCHAR(32) NOT NULL,
+    -- NET780 dump dir 名 例: "20260514_093253-0-0-4437"
+    dump_dir        VARCHAR(64) NOT NULL,
+    machine_id      VARCHAR(32),
+    firm_main_app   VARCHAR(32),
+    -- R2 上の key (フロントが GET /api/vehicle-settings/object?key=... で使う)
+    r2_json_key     TEXT NOT NULL,
+    r2_cfg_key      TEXT NOT NULL,
+    uploaded_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+    -- アップロードしたユーザ (alc_users.id)。現状フロントが送らないので nullable。
+    uploaded_by     UUID,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    -- 同じ dump_dir を同じ vehicle に二重 INSERT しないための一意制約。
+    -- フロントが同じ zip を 2 回投げたときは ON CONFLICT で処理する。
+    UNIQUE (tenant_id, vehicle_cd, dump_dir)
+);
+
+-- 履歴クエリ (車輛別、新しい順ソート)
+CREATE INDEX IF NOT EXISTS idx_vsd_tenant_vehicle_uploaded
+    ON alc_api.vehicle_settings_dumps (tenant_id, vehicle_cd, uploaded_at DESC);
+
+-- 集計クエリ (テナント全体、新しい順)
+CREATE INDEX IF NOT EXISTS idx_vsd_tenant_uploaded
+    ON alc_api.vehicle_settings_dumps (tenant_id, uploaded_at DESC);
+
+COMMENT ON TABLE alc_api.vehicle_settings_dumps IS
+  '車輛設定 (NET780 *.cfg) の R2 dump メタデータ。実体は R2 、本表は index 用';

--- a/src/db/repository/mod.rs
+++ b/src/db/repository/mod.rs
@@ -17,7 +17,7 @@ pub use alc_core::repository::{
     TroubleOfficesRepository, TroubleProgressStatusesRepository, TroubleSchedulesRepository,
     TroubleTaskStatusesRepository, TroubleTaskTypesRepository, TroubleTasksFilter,
     TroubleTasksRepository, TroubleTasksSortBy, TroubleTicketsRepository,
-    TroubleWorkflowRepository, WebhookRepository,
+    VehicleSettingsDumpsRepository, TroubleWorkflowRepository, WebhookRepository,
 };
 
 // Re-export TenantConn from alc-core
@@ -31,7 +31,7 @@ pub use alc_devices::repo::devices;
 pub use alc_dtako::repo::{
     dtako_csv_proxy, dtako_daily_hours, dtako_drivers, dtako_event_classifications, dtako_logs,
     dtako_operations, dtako_restraint_report, dtako_restraint_report_pdf, dtako_scraper,
-    dtako_upload, dtako_vehicles, dtako_work_times, dtako_y_time_export,
+    dtako_upload, dtako_vehicles, dtako_work_times, dtako_y_time_export, vehicle_settings_dumps,
 };
 pub use alc_misc::repo::{
     bot_admin, carrying_items, communication_items, driver_info, employees, guidance_records,
@@ -63,7 +63,7 @@ pub use alc_dtako::repo::{
     PgDtakoEventClassificationsRepository, PgDtakoLogsRepository, PgDtakoOperationsRepository,
     PgDtakoRestraintReportPdfRepository, PgDtakoRestraintReportRepository,
     PgDtakoScraperRepository, PgDtakoUploadRepository, PgDtakoVehiclesRepository,
-    PgDtakoWorkTimesRepository, PgDtakoYTimeExportRepository,
+    PgDtakoWorkTimesRepository, PgDtakoYTimeExportRepository, PgVehicleSettingsDumpsRepository,
 };
 pub use alc_misc::repo::{
     PgApiTokensRepository, PgBotAdminRepository, PgCarryingItemsRepository,

--- a/src/db/repository/mod.rs
+++ b/src/db/repository/mod.rs
@@ -17,7 +17,7 @@ pub use alc_core::repository::{
     TroubleOfficesRepository, TroubleProgressStatusesRepository, TroubleSchedulesRepository,
     TroubleTaskStatusesRepository, TroubleTaskTypesRepository, TroubleTasksFilter,
     TroubleTasksRepository, TroubleTasksSortBy, TroubleTicketsRepository,
-    VehicleSettingsDumpsRepository, TroubleWorkflowRepository, WebhookRepository,
+    TroubleWorkflowRepository, VehicleSettingsDumpsRepository, WebhookRepository,
 };
 
 // Re-export TenantConn from alc-core

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,6 +35,7 @@ use rust_alc_api::db::repository::{
     PgMeasurementsRepository, PgNfcTagRepository, PgSsoAdminRepository, PgTenantUsersRepository,
     PgTenkoCallRepository, PgTenkoRecordsRepository, PgTenkoSchedulesRepository,
     PgTenkoSessionRepository, PgTenkoWebhooksRepository, PgTimecardRepository,
+    PgVehicleSettingsDumpsRepository,
 };
 use rust_alc_api::storage::StorageBackend;
 use rust_alc_api::AppState;
@@ -192,6 +193,7 @@ async fn main() -> anyhow::Result<()> {
     let dtako_scraper = Arc::new(PgDtakoScraperRepository::new(pool.clone()));
     let dtako_upload = Arc::new(PgDtakoUploadRepository::new(pool.clone()));
     let dtako_vehicles = Arc::new(PgDtakoVehiclesRepository::new(pool.clone()));
+    let vehicle_settings_dumps = Arc::new(PgVehicleSettingsDumpsRepository::new(pool.clone()));
     let dtako_work_times = Arc::new(PgDtakoWorkTimesRepository::new(pool.clone()));
     let dtako_y_time_export = Arc::new(PgDtakoYTimeExportRepository::new(pool.clone()));
     let employees = Arc::new(PgEmployeeRepository::new(pool.clone()));
@@ -291,6 +293,7 @@ async fn main() -> anyhow::Result<()> {
         dtako_vehicles,
         dtako_work_times,
         dtako_y_time_export,
+        vehicle_settings_dumps,
         employees,
         equipment_failures,
         guidance_records,

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -18,6 +18,7 @@ pub use alc_dtako::dtako_upload;
 pub use alc_dtako::dtako_vehicles;
 pub use alc_dtako::dtako_work_times;
 pub use alc_dtako::dtako_y_time_export;
+pub use alc_dtako::vehicle_settings_dumps;
 pub use alc_misc::access_requests;
 pub use alc_misc::api_tokens;
 pub use alc_misc::bot_admin;
@@ -126,6 +127,7 @@ pub fn router() -> Router<AppState> {
         .merge(dtako_daily_hours::tenant_router())
         .merge(dtako_upload::tenant_router())
         .merge(dtako_vehicles::tenant_router())
+        .merge(vehicle_settings_dumps::tenant_router())
         .merge(dtako_event_classifications::tenant_router())
         .merge(dtako_y_time_export::tenant_router())
         .nest("/dtako-logs", dtako_logs::tenant_router())

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -33,7 +33,7 @@ use rust_alc_api::db::repository::{
     PgTroubleNotificationPrefsRepository, PgTroubleOfficesRepository,
     PgTroubleProgressStatusesRepository, PgTroubleSchedulesRepository,
     PgTroubleTaskStatusesRepository, PgTroubleTaskTypesRepository, PgTroubleTasksRepository,
-    PgTroubleTicketsRepository, PgTroubleWorkflowRepository,
+    PgTroubleTicketsRepository, PgTroubleWorkflowRepository, PgVehicleSettingsDumpsRepository,
 };
 use rust_alc_api::AppState;
 
@@ -276,6 +276,7 @@ fn build_app_state(
     let dtako_vehicles = Arc::new(PgDtakoVehiclesRepository::new(pool.clone()));
     let dtako_work_times = Arc::new(PgDtakoWorkTimesRepository::new(pool.clone()));
     let dtako_y_time_export = Arc::new(PgDtakoYTimeExportRepository::new(pool.clone()));
+    let vehicle_settings_dumps = Arc::new(PgVehicleSettingsDumpsRepository::new(pool.clone()));
     let employees = Arc::new(PgEmployeeRepository::new(pool.clone()));
     let equipment_failures = Arc::new(PgEquipmentFailuresRepository::new(pool.clone()));
     let guidance_records = Arc::new(PgGuidanceRecordsRepository::new(pool.clone()));
@@ -337,6 +338,7 @@ fn build_app_state(
         dtako_vehicles,
         dtako_work_times,
         dtako_y_time_export,
+        vehicle_settings_dumps,
         employees,
         equipment_failures,
         guidance_records,

--- a/tests/mock_helpers/app_state.rs
+++ b/tests/mock_helpers/app_state.rs
@@ -1,9 +1,52 @@
 use std::sync::Arc;
 
+use async_trait::async_trait;
+use uuid::Uuid;
+
+use alc_core::models::VehicleSettingsDump;
+use alc_core::repository::vehicle_settings_dumps::{
+    VehicleSettingsDumpInput, VehicleSettingsDumpSummary, VehicleSettingsDumpsRepository,
+};
 use rust_alc_api::AppState;
 
 use super::*;
 use crate::common::mock_storage::MockStorage;
+
+/// VehicleSettingsDumpsRepository のスタブ。本 PR 範囲では handler を
+/// mock test ではカバーしないため、読み出しは空 / write はエラーを返す
+/// (重要: AppState の型を揃えるためだけのダミー)。
+#[derive(Default)]
+pub struct MockVehicleSettingsDumpsRepository;
+
+#[async_trait]
+impl VehicleSettingsDumpsRepository for MockVehicleSettingsDumpsRepository {
+    async fn register(
+        &self,
+        _tenant_id: Uuid,
+        _input: VehicleSettingsDumpInput,
+    ) -> Result<VehicleSettingsDump, sqlx::Error> {
+        Err(sqlx::Error::RowNotFound)
+    }
+
+    async fn list_by_vehicle_cd(
+        &self,
+        _tenant_id: Uuid,
+        _vehicle_cd: &str,
+    ) -> Result<Vec<VehicleSettingsDump>, sqlx::Error> {
+        Ok(vec![])
+    }
+
+    async fn summary_by_vehicle(
+        &self,
+        _tenant_id: Uuid,
+    ) -> Result<Vec<VehicleSettingsDumpSummary>, sqlx::Error> {
+        Ok(vec![])
+    }
+
+    async fn confirmed_vehicle_cds(&self, _tenant_id: Uuid) -> Result<Vec<String>, sqlx::Error> {
+        Ok(vec![])
+    }
+}
 
 /// DB 不要の mock AppState を構築。
 /// pool: None — mock repo が全ハンドラを処理するため DB 接続不要。
@@ -46,6 +89,7 @@ pub fn setup_mock_app_state() -> AppState {
         dtako_vehicles: Arc::new(MockDtakoVehiclesRepository::default()),
         dtako_work_times: Arc::new(MockDtakoWorkTimesRepository::default()),
         dtako_y_time_export: Arc::new(MockDtakoYTimeExportRepository::default()),
+        vehicle_settings_dumps: Arc::new(MockVehicleSettingsDumpsRepository::default()),
         employees: Arc::new(MockEmployeeRepository::default()),
         equipment_failures: Arc::new(MockEquipmentFailuresRepository::default()),
         guidance_records: Arc::new(MockGuidanceRecordsRepository::default()),


### PR DESCRIPTION
## Summary

ippoan/rust-alc-api#347 を実装。`alc_api.vehicle_settings_dumps` テーブル + endpoint を追加して、フロント (nuxt-dtako-admin) が R2 list 経由で取っていた dump 履歴 / 集計 を DB index 経由 1-query で取れるようにする。

## 変更

### 新規ファイル (4)

- **`migrations/110_create_vehicle_settings_dumps.sql`** — テーブル + 2 index
  - `UNIQUE (tenant_id, vehicle_cd, dump_dir)` で冪等な再 PUT 対応
  - `idx_vsd_tenant_vehicle_uploaded`: 車輛別履歴用
  - `idx_vsd_tenant_uploaded`: テナント全体集計用
- **`crates/alc-core/src/repository/vehicle_settings_dumps.rs`** — Repository trait
  - `register(input)`: ON CONFLICT DO UPDATE 冪等 INSERT
  - `list_by_vehicle_cd(vehicle_cd)`: 履歴 (uploaded_at DESC)
  - `summary_by_vehicle()`: テナント全体集計
  - `confirmed_vehicle_cds()`: 未確認車輛抽出用に DISTINCT vehicle_cd
- **`crates/alc-dtako/src/repo/vehicle_settings_dumps.rs`** — Pg 実装 (sqlx + TenantConn)
- **`crates/alc-dtako/src/vehicle_settings_dumps.rs`** — axum handler
  - `POST /api/dtako/vehicle-settings-dumps` — フロントが R2 PUT 後に register
  - `GET  /api/dtako/vehicle-settings-dumps/:vehicle_cd` — 履歴
  - `GET  /api/dtako/vehicle-settings-dumps/summary` — 集計

### 既存ファイル wiring (8)

| ファイル | 変更 |
|---|---|
| `crates/alc-core/src/models.rs` | `VehicleSettingsDump` struct 追加 |
| `crates/alc-core/src/repository/mod.rs` | mod 登録 + re-export |
| `crates/alc-core/src/lib.rs` | `AppState` に `vehicle_settings_dumps` 追加 |
| `crates/alc-dtako/src/repo/mod.rs` | Pg impl 登録 |
| `crates/alc-dtako/src/lib.rs` | mod 登録 + `DtakoState` 拡張 + `FromRef<AppState>` clone |
| `src/main.rs` | import / init / AppState 構築フィールド (3 箇所) |
| `src/routes/mod.rs` | `.merge(vehicle_settings_dumps::tenant_router())` 追加 |
| `crates/dtako-api/src/main.rs` | router merge + DtakoState init |

## Migration 手順

1. CI でテストパスを確認
2. staging DB に migration 100 → 110 を順次適用 (existing migrate tool)
3. staging で backend のみデプロイ、handler が 200 を返すこと + テーブルへの INSERT を確認
4. nuxt-dtako-admin 側 (別 PR、別 issue) で `extract.post.ts` の R2 PUT 後に backend を叩く実装を追加
5. 既存 R2 オブジェクトのバックフィル script を別途用意 (1 回限り、admin-only)
6. 本番リリース

## スコープ外 (フォローアップ)

- フロントの `/api/vehicle-settings/extract` 改修 (backend INSERT 呼び出し追加) — 別 PR で実施
- 既存 R2 オブジェクトのバックフィル — admin-only script
- `GET /api/dtako/vehicles?with_settings_status=1` (JOIN endpoint) — ニーズが出てから
- RLS policy — 現状の dtako_vehicles と同じく、TenantConn が `app.current_tenant_id` を設定する想定で `WHERE tenant_id = $1` を明示。RLS が要れば後で migration で ENABLE

## Test plan

- [ ] `cargo build --workspace` がパスすること
- [ ] `cargo test --workspace` がパスすること (新規 endpoint には現状 unit テストなし — 別途追加)
- [ ] staging に migration 110 を適用後、`SELECT * FROM alc_api.vehicle_settings_dumps LIMIT 1;` が動くこと (テーブル + index が存在)
- [ ] `POST /api/dtako/vehicle-settings-dumps` で X-Tenant-ID + JSON body を投げて 200 + JSON が返ること
- [ ] 同じ body を 2 回 POST しても 200 + 同じ id (ON CONFLICT) で返ること
- [ ] `GET /api/dtako/vehicle-settings-dumps/4437` で空配列が返ること (データなし時)
- [ ] `GET /api/dtako/vehicle-settings-dumps/summary` で空配列が返ること

## Known concerns

サブエージェントが分割編集を実行したため、以下を merger 前に手動でレビュー推奨:

1. `src/main.rs` の import パス: `PgVehicleSettingsDumpsRepository` が正しい `use ...::{...}` パスに追加されているか (`PgDtakoVehiclesRepository` と同じ path を期待)
2. `crates/dtako-api/src/main.rs` の state 構築: `DtakoState { ... }` リテラルに `vehicle_settings_dumps:` が追加されているか
3. `models.rs` の `VehicleSettingsDump` struct: `DateTime<Utc>` の import が既に top でされていれば追加不要

refs #347, ref ohishi-exp/nuxt-dtako-admin#39 (merged), ohishi-exp/nuxt-dtako-admin#41

---
_Generated by [Claude Code](https://claude.ai/code/session_016syffMeQXLkG64uF7MT35u)_