### PR TITLE
ci: smoke /api/notify/ingest on staging after deploy (Refs #354)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -458,6 +458,7 @@ jobs:
       ref_name: ${{ github.ref_name }}
     secrets:
       GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
+      NOTIFY_WORKER_SECRET_STAGING: ${{ secrets.NOTIFY_WORKER_SECRET_STAGING }}
 
   auto-merge:
     name: Auto Merge

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,8 @@ on:
     secrets:
       GCP_SA_KEY:
         required: true
+      NOTIFY_WORKER_SECRET_STAGING:
+        required: false
 
 # Environment is derived from github context:
 #   pull_request → staging
@@ -345,6 +347,59 @@ jobs:
             --region ${{ env.REGION }} --project ${{ env.PROJECT }} \
             --format 'value(status.url)')
           echo "::notice ::Gateway URL: $URL"
+
+  # ---------------------------------------------------------------------------
+  # Staging: smoke test /api/notify/ingest after staging deploy
+  #
+  # email-receiver Worker から backend に届く shared secret 経路の検証。
+  # GitHub Actions secret NOTIFY_WORKER_SECRET_STAGING の値で
+  # rust-alc-api-staging /api/notify/ingest を叩く:
+  #   - 401 -> secret drift (GCP / Cloud Run env binding / GitHub org secret のどこかで不一致) -> fail
+  #   - 404 -> auth pass、tenant 存在しない (= 期待) -> pass
+  #   - 400 -> auth pass、body 検証で reject -> pass
+  #   - 200 -> auth pass、何かが起きた (smoke tenant が偶然存在) -> pass
+  # ingest は gateway を経由せず backend に直接届く設計 (email-receiver Worker
+  # の INGEST_ENDPOINT_STAGING と同じ URL)。
+  # ---------------------------------------------------------------------------
+  smoke-staging-ingest:
+    name: "Smoke /api/notify/ingest on staging"
+    needs: [deploy-services]
+    if: >-
+      always() &&
+      github.event_name == 'pull_request' &&
+      needs.deploy-services.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: POST /api/notify/ingest with NOTIFY_WORKER_SECRET_STAGING
+        env:
+          SECRET: ${{ secrets.NOTIFY_WORKER_SECRET_STAGING }}
+          INGEST_URL: https://rust-alc-api-staging-566bls5vfq-an.a.run.app/api/notify/ingest
+        run: |
+          set -eu
+          if [ -z "${SECRET:-}" ]; then
+            echo "::error::NOTIFY_WORKER_SECRET_STAGING is empty — check org secret sync (secrets-inventory sync-from-gcp ... ?targets=gh)"
+            exit 1
+          fi
+          # tenant_short_id に意図的に存在しない 8 文字 hex を渡し、
+          # auth 通過後 404 (tenant not found) で返ることを期待する。
+          http=$(curl -sS -o /tmp/body -w "%{http_code}" -X POST \
+            "$INGEST_URL" \
+            -H "x-worker-secret: $SECRET" \
+            -H "Content-Type: application/json" \
+            --data-binary '{"tenant_short_id":"smk00000"}')
+          echo "HTTP $http"
+          head -c 500 /tmp/body || true
+          echo
+          if [ "$http" = "401" ]; then
+            echo "::error::auth failed — NOTIFY_WORKER_SECRET_STAGING in this repo does not match the value bound to rust-alc-api-staging (Cloud Run env -> GCP notify-worker-secret-staging). Check secrets-inventory get_drift."
+            exit 1
+          fi
+          # 4xx (other than 401) / 200 はすべて auth 通過 = secret OK
+          if [ "$http" -lt 200 ] || [ "$http" -ge 500 ]; then
+            echo "::error::unexpected HTTP $http (5xx implies backend not yet ready or other issue)"
+            exit 1
+          fi
+          echo "::notice::ingest auth accepted (HTTP $http) — NOTIFY_WORKER_SECRET_STAGING OK"
 
   # ---------------------------------------------------------------------------
   # Production: update archive job


### PR DESCRIPTION
## Summary

`deploy.yml` の `deploy-services` (staging) 完了後に走る smoke job を 1 つ追加。`NOTIFY_WORKER_SECRET_STAGING` shared secret が **email-receiver Worker 側 ↔ rust-alc-api backend 側** で整合しているかを CI で機械的に確認する。

## なぜこの形か

email-receiver は Cloudflare **Email** Worker で、外部から HTTP では trigger できない (CI から `curl` で叩けない)。代わりに **検証側 = backend の `/api/notify/ingest`** を CI が叩いて、auth 通過するかどうかで shared secret の整合を判定する。

```
GitHub Actions secret NOTIFY_WORKER_SECRET_STAGING
   └─ curl -X POST .../api/notify/ingest
       -H "x-worker-secret: $SECRET"
       -d '{"tenant_short_id":"smk00000"}'
          │
          ▼
       rust-alc-api-staging (Cloud Run)
         env NOTIFY_WORKER_SECRET = ${GCP notify-worker-secret-staging}
          │
          ▼
       constant_time_eq(provided, expected)
          │
          ├── true  → tenant_short_id lookup → 404 (smk00000 は存在しない)
          └── false → 401
```

| HTTP | 判定 |
|---|---|
| `401` | secret drift (GCP / Cloud Run env binding / GitHub org secret のどこかで不一致) — **fail** |
| `404` | auth pass、tenant 不在で expected (期待) — pass |
| `400` | auth pass、payload 検証で reject — pass |
| `200` | auth pass、tenant が偶然存在して何か起きた — pass |
| `5xx` | unexpected — fail |

ingest endpoint は **gateway を経由せず backend 直接** (email-receiver Worker の `INGEST_ENDPOINT_STAGING` と同じ URL `https://rust-alc-api-staging-566bls5vfq-an.a.run.app/api/notify/ingest`)。

## 事前準備 (完了済み)

org secret `NOTIFY_WORKER_SECRET_STAGING` は secrets-inventory 経由で GCP から push 済み:

```
POST /mcp/sync-from-gcp/notify-worker-secret-staging?targets=gh&gh_name=NOTIFY_WORKER_SECRET_STAGING&visibility=all -> 200 ok
```

値は LLM context を経由していない (Refs `secret-rotate-pipe` skill の経路と同じ HTTP route)。

## なぜ secret-verify では足りないか

`secret-verify` は **GCP に secret が存在すること** + **wrangler に binding が宣言されていること** までしか確認しない。Cloud Run の env var が実 binding に届いて、しかも値が一致しているかは保証しない。この smoke は最後の一マイルを CI で押さえる。

ペア: ippoan/nuxt-notify#73 (`NOTIFY_REDACT_BROADCAST_SECRET_STAGING` 側を realtime-bus `/broadcast` で同型に検証)

## test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` 両 file 構文 OK
- [ ] PR で deploy-services → smoke-staging-ingest が走る
- [ ] smoke が 404 (期待) で pass
- [ ] (negative test, optional) secret を壊して 401 で fail することを確認

Refs #354

---
_Generated by [Claude Code](https://claude.ai/code/session_01MZhUL9wivVAbSuTRLEAFkT)_