### PR TITLE
ci: add migration safety check for rollback-unsafe SQL patterns

### DIFF
--- a/.github/scripts/migration-safety-check.sh
+++ b/.github/scripts/migration-safety-check.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+#
+# migration-safety-check.sh
+#
+# rollback 安全性の観点で SQL migration を検査する。
+# 正規表現ベース。将来 sqlparser-rs (AST) に差し替え予定。
+#
+# 使い方:
+#   bash migration-safety-check.sh <file1.sql> [file2.sql ...]
+#
+# 出力:
+#   stdout に human-readable な検出結果
+#   GITHUB_OUTPUT が定義されていれば machine-readable な結果も書き込む:
+#     unsafe_count=<int>
+#     unsafe_files=<JSON array>
+#     findings_json=<JSON>
+#
+# 終了コード:
+#   常に 0 (= warning only、Actions step を fail させない)
+#   stderr へのエラーは exit 2
+
+set -uo pipefail
+
+if [[ $# -eq 0 ]]; then
+  echo "usage: $0 <file1.sql> [file2.sql ...]" >&2
+  exit 2
+fi
+
+# SQL コメント除去 (-- 行コメント / /* ブロックコメント */)
+strip_sql_comments() {
+  local file="$1"
+  # 1) /* ... */ をスペース 1 個に置換 (改行は維持しない、行番号がずれるが検査目的なので可)
+  # 2) -- 以降の行末コメントを削除
+  # POSIX awk で /* */ 跨ぎ行ブロック削除は煩雑なので perl で一括処理
+  perl -0777 -pe 's{/\*.*?\*/}{ }gs; s{--[^\n]*}{}g' "$file"
+}
+
+# 検出パターン定義。3 行 1 セット (id / regex / message)。
+# regex は PCRE (grep -niP) / case-insensitive で match。
+# regex 内の `|` と衝突しないよう delimiter ではなく行単位で持つ。
+PATTERN_IDS=(
+  'drop_table'
+  'drop_column'
+  'drop_schema'
+  'truncate'
+  'alter_column_type'
+  'rename'
+  'set_not_null'
+  'drop_default'
+)
+PATTERN_REGEXES=(
+  '\bDROP\s+TABLE\b'
+  '\bDROP\s+COLUMN\b'
+  '\bDROP\s+SCHEMA\b'
+  '\bTRUNCATE\b'
+  '\bALTER\s+(?:TABLE\s+\S+\s+)?(?:ALTER|MODIFY)\s+COLUMN\s+\S+\s+(?:SET\s+DATA\s+)?TYPE\b'
+  '\bRENAME\s+(?:TO|COLUMN|CONSTRAINT)\b'
+  '\bSET\s+NOT\s+NULL\b'
+  '\bDROP\s+DEFAULT\b'
+)
+PATTERN_MESSAGES=(
+  'DROP TABLE は contract migration、rollback 不可'
+  'DROP COLUMN は contract migration、rollback 不可'
+  'DROP SCHEMA は contract migration、rollback 不可'
+  'TRUNCATE はデータ破壊、rollback 不可'
+  'ALTER COLUMN TYPE は contract migration、widening 含め rollback 不可扱い'
+  'RENAME は contract migration、rollback 不可 (index/constraint rename 含む)'
+  'SET NOT NULL は contract migration の可能性、既存 NULL 行があると失敗'
+  'DROP DEFAULT は旧 code が default 依存していた場合に rollback 不可'
+)
+
+declare -A FILE_FINDINGS=()
+TOTAL_UNSAFE=0
+UNSAFE_FILES=()
+
+# JSON エスケープ (簡易: " と \ のみ)
+json_escape() {
+  printf '%s' "$1" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()), end="")' 2>/dev/null \
+    || printf '"%s"' "$(printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g')"
+}
+
+ALL_FINDINGS_JSON='['
+FIRST_FINDING=1
+
+for file in "$@"; do
+  if [[ ! -f "$file" ]]; then
+    echo "::warning::file not found: $file" >&2
+    continue
+  fi
+
+  stripped="$(strip_sql_comments "$file")"
+  file_findings_ids=()
+  file_findings_linenos=()
+  file_findings_msgs=()
+  file_findings_snippets=()
+
+  for i in "${!PATTERN_IDS[@]}"; do
+    pid="${PATTERN_IDS[$i]}"
+    regex="${PATTERN_REGEXES[$i]}"
+    msg="${PATTERN_MESSAGES[$i]}"
+    # PCRE (-P): \b \s 等の lookahead/non-capturing group 対応
+    matches="$(printf '%s' "$stripped" | grep -niP "$regex" || true)"
+    if [[ -n "$matches" ]]; then
+      while IFS= read -r line; do
+        lineno="${line%%:*}"
+        snippet="${line#*:}"
+        if [[ ${#snippet} -gt 100 ]]; then
+          snippet="${snippet:0:100}..."
+        fi
+        file_findings_ids+=("$pid")
+        file_findings_linenos+=("$lineno")
+        file_findings_msgs+=("$msg")
+        file_findings_snippets+=("$snippet")
+      done <<< "$matches"
+    fi
+  done
+
+  if [[ ${#file_findings_ids[@]} -gt 0 ]]; then
+    UNSAFE_FILES+=("$file")
+    TOTAL_UNSAFE=$((TOTAL_UNSAFE + ${#file_findings_ids[@]}))
+    echo ""
+    echo "## $file"
+    echo ""
+    for j in "${!file_findings_ids[@]}"; do
+      pid="${file_findings_ids[$j]}"
+      lineno="${file_findings_linenos[$j]}"
+      msg="${file_findings_msgs[$j]}"
+      snippet="${file_findings_snippets[$j]}"
+      echo "- L${lineno} [$pid] $msg"
+      echo "    > \`${snippet}\`"
+
+      # JSON 構築
+      if [[ $FIRST_FINDING -eq 0 ]]; then
+        ALL_FINDINGS_JSON+=','
+      fi
+      FIRST_FINDING=0
+      ALL_FINDINGS_JSON+=$(printf '{"file":%s,"pattern":%s,"line":%s,"message":%s,"snippet":%s}' \
+        "$(json_escape "$file")" \
+        "$(json_escape "$pid")" \
+        "$lineno" \
+        "$(json_escape "$msg")" \
+        "$(json_escape "$snippet")")
+    done
+  else
+    echo ""
+    echo "## $file"
+    echo ""
+    echo "- rollback-safe (no contract pattern detected)"
+  fi
+done
+
+ALL_FINDINGS_JSON+=']'
+
+echo ""
+echo "---"
+echo ""
+echo "**Summary**: $TOTAL_UNSAFE unsafe pattern(s) across ${#UNSAFE_FILES[@]} file(s)"
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  {
+    echo "unsafe_count=$TOTAL_UNSAFE"
+
+    # unsafe_files を JSON array で
+    if [[ ${#UNSAFE_FILES[@]} -eq 0 ]]; then
+      echo 'unsafe_files=[]'
+    else
+      printf 'unsafe_files=['
+      for i in "${!UNSAFE_FILES[@]}"; do
+        [[ $i -gt 0 ]] && printf ','
+        json_escape "${UNSAFE_FILES[$i]}"
+      done
+      printf ']\n'
+    fi
+
+    # findings_json は multi-line 対応で heredoc 形式
+    delimiter="EOF_FINDINGS_$RANDOM"
+    echo "findings_json<<$delimiter"
+    echo "$ALL_FINDINGS_JSON"
+    echo "$delimiter"
+  } >> "$GITHUB_OUTPUT"
+fi
+
+exit 0

--- a/.github/workflows/migration-safety-check.yml
+++ b/.github/workflows/migration-safety-check.yml
@@ -1,0 +1,168 @@
+name: Migration Safety Check
+
+# PR で追加された migration SQL に rollback 不可な contract パターンが含まれていないか検査する。
+# warning only (block しない)。判定ロジックは .github/scripts/migration-safety-check.sh に切り出し。
+# 将来 sqlparser-rs (AST ベース) に差し替え予定。
+
+on:
+  pull_request:
+    paths:
+      - 'migrations/**.sql'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Collect added migration files
+        id: collect
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          # SHA は GitHub 生成の 40-char hex で injection リスクなしだが、念のため env 経由で受ける。
+          # PR で追加 (Added) されたファイルのみ対象。変更 (Modified) は適用済み migration の
+          # 改変禁止ルールで別途禁じているのでここでは扱わない。
+          added=$(git diff --name-only --diff-filter=A "$BASE_SHA"..."$HEAD_SHA" -- 'migrations/*.sql' || true)
+          if [[ -z "$added" ]]; then
+            echo "added_count=0" >> "$GITHUB_OUTPUT"
+            echo "no added migrations"
+            exit 0
+          fi
+          {
+            echo "added_count=$(echo "$added" | wc -l | tr -d ' ')"
+            echo 'added_files<<EOF_ADDED'
+            echo "$added"
+            echo 'EOF_ADDED'
+          } >> "$GITHUB_OUTPUT"
+          echo "added files:"
+          echo "$added"
+
+      - name: Run safety check
+        id: check
+        if: steps.collect.outputs.added_count != '0'
+        env:
+          ADDED_FILES: ${{ steps.collect.outputs.added_files }}
+        run: |
+          set -euo pipefail
+          # ファイル名は git tracked path だが PR 作成者が任意のファイル名を選べるので
+          # ${{ }} 直接展開ではなく env 経由で受ける (command injection 防止)。
+          # mapfile + quoted "${files[@]}" で空白/特殊文字を含むパスも安全に渡す。
+          mapfile -t files <<< "$ADDED_FILES"
+          report=$(bash .github/scripts/migration-safety-check.sh "${files[@]}")
+          {
+            echo 'report<<EOF_REPORT'
+            echo "$report"
+            echo 'EOF_REPORT'
+          } >> "$GITHUB_OUTPUT"
+          echo "$report"
+
+      - name: Post sticky PR comment
+        if: steps.collect.outputs.added_count != '0'
+        uses: actions/github-script@v7
+        env:
+          REPORT: ${{ steps.check.outputs.report }}
+          UNSAFE_COUNT: ${{ steps.check.outputs.unsafe_count }}
+        with:
+          script: |
+            const marker = '<!-- migration-safety-check -->';
+            const unsafe = parseInt(process.env.UNSAFE_COUNT || '0', 10);
+            const heading = unsafe > 0
+              ? `### Migration Safety Check — needs-rollback-review (${unsafe} pattern${unsafe > 1 ? 's' : ''})`
+              : '### Migration Safety Check — rollback-safe';
+            const body = [
+              marker,
+              heading,
+              '',
+              process.env.REPORT || '(no report)',
+              '',
+              '> 正規表現ベースの検査 (false-positive 含む)。warning only — block はしない。',
+              '> 将来 sqlparser-rs で AST ベースに差し替え予定。',
+              '> Refs ippoan/ci-dashboard#137',
+            ].join('\n');
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+            const existing = comments.find(c => (c.body || '').startsWith(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
+      - name: Apply labels
+        if: steps.collect.outputs.added_count != '0'
+        uses: actions/github-script@v7
+        env:
+          UNSAFE_COUNT: ${{ steps.check.outputs.unsafe_count }}
+        with:
+          script: |
+            const unsafe = parseInt(process.env.UNSAFE_COUNT || '0', 10);
+            const toAdd = unsafe > 0 ? 'needs-rollback-review' : 'rollback-safe';
+            const toRemove = unsafe > 0 ? 'rollback-safe' : 'needs-rollback-review';
+
+            // ラベルが repo に存在しなければ作成
+            const labelSpec = {
+              'rollback-safe':           { color: '0e8a16', description: 'PR の追加 migration が rollback-safe と判定された' },
+              'needs-rollback-review':   { color: 'd93f0b', description: 'PR の追加 migration に rollback 不可な contract パターンを検出' },
+            };
+            for (const [name, spec] of Object.entries(labelSpec)) {
+              try {
+                await github.rest.issues.getLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name,
+                });
+              } catch (e) {
+                if (e.status === 404) {
+                  await github.rest.issues.createLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    name,
+                    color: spec.color,
+                    description: spec.description,
+                  });
+                } else { throw e; }
+              }
+            }
+
+            // 排他: 反対ラベルが付いていれば剥がす
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                name: toRemove,
+              });
+            } catch (e) {
+              if (e.status !== 404) throw e;
+            }
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: [toAdd],
+            });


### PR DESCRIPTION
## Summary

PR で追加された `migrations/**.sql` に対し、rollback 不可な contract pattern を機械検出する GitHub Action を追加。Release Wave 機構 (ippoan/ci-dashboard#137) の Phase 1。

## 検出パターン (正規表現ベース)

| pattern | 理由 |
|---|---|
| `DROP TABLE/COLUMN/SCHEMA` | 旧 revision の SELECT が失敗 → rollback 不可 |
| `TRUNCATE` | データ破壊、rollback 不可 |
| `ALTER COLUMN ... TYPE` | widening 含めて区別不能、unsafe 扱い |
| `RENAME` (TO/COLUMN/CONSTRAINT) | 旧 code が旧名で参照 → rollback 不可 |
| `SET NOT NULL` | 既存 NULL 行があると失敗 |
| `DROP DEFAULT` | 旧 code が default 依存時に rollback 不可 |

SQL コメント (`-- 行` / `/* ブロック */`) は除去してから判定。文字列リテラル内の擬似マッチは regex 版の既知 false-positive として許容。

## 動作

- trigger: `pull_request`, paths: `migrations/**.sql`
- 対象: 追加ファイルのみ (`git diff --diff-filter=A base...head`)
- 検出結果:
  - 0 件 → `rollback-safe` ラベル付与 + 安全である旨の sticky comment
  - 1 件以上 → `needs-rollback-review` ラベル付与 + 詳細を sticky comment で警告
- **block しない** (warning only)
- 排他ラベル: 反対ラベルが付いていれば剥がす
- ラベル未作成時は自動作成 (color/description 設定込み)

## ファイル構成

| path | 内容 |
|---|---|
| `.github/workflows/migration-safety-check.yml` | trigger + 差分収集 + script 呼び出し + label/comment |
| `.github/scripts/migration-safety-check.sh` | 単体実行可能な判定 script (`bash script.sh file1.sql ...`)、GITHUB_OUTPUT に machine-readable JSON も書き出す |

将来 `sqlparser-rs` で AST ベースに差し替え予定。workflow YAML 側を触らずに script だけ swap できる構成。

## セキュリティ

untrusted 入力 (PR base/head SHA、追加ファイル名) は全て `env:` 経由で受けてから bash 変数に格納 (command injection 防止)。`run:` ブロックで `${{ }}` 直接展開しない。

## Test plan

- [ ] 安全な migration のみ含む PR で `rollback-safe` ラベルが付くこと
- [ ] `DROP COLUMN` 等を含む PR で `needs-rollback-review` ラベルが付き sticky comment が出ること
- [ ] 同 PR への push で comment が増殖せず update されること
- [ ] migration を含まない PR では job 自体 skip されること (paths filter)

Refs ippoan/ci-dashboard#137

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cm4uPMVQZHWm5eFurYMJif)_