### PR TITLE
ci: report dev :latest image to ci-dashboard compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -441,6 +441,17 @@ jobs:
             docker push "${REPO}${suffix}:latest"
           done
 
+      # 新しい :latest dev image (= frontend の integration test が相手にする
+      # image) を ci-dashboard の compatibility matrix に記録する。current_image
+      # は main commit SHA。本番トラフィックには一切触れない (Refs ippoan/ci-dashboard#157)。
+      - name: Report backend dev image (compatibility)
+        uses: ippoan/ci-workflows/.github/actions/report-backend-deploy@main
+        with:
+          repo: ${{ github.repository }}
+          current_image: ${{ github.sha }}
+          deployed_by: rust-alc-api-dev-latest
+          webhook_secret: ${{ secrets.RELEASE_WAVE_WEBHOOK_SECRET }}
+
   deploy:
     name: Deploy
     needs: [build-image, coverage-check]
@@ -459,7 +470,6 @@ jobs:
     secrets:
       GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
       NOTIFY_WORKER_SECRET_STAGING: ${{ secrets.NOTIFY_WORKER_SECRET_STAGING }}
-      RELEASE_WAVE_WEBHOOK_SECRET: ${{ secrets.RELEASE_WAVE_WEBHOOK_SECRET }}
 
   auto-merge:
     name: Auto Merge

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -459,6 +459,7 @@ jobs:
     secrets:
       GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
       NOTIFY_WORKER_SECRET_STAGING: ${{ secrets.NOTIFY_WORKER_SECRET_STAGING }}
+      RELEASE_WAVE_WEBHOOK_SECRET: ${{ secrets.RELEASE_WAVE_WEBHOOK_SECRET }}
 
   auto-merge:
     name: Auto Merge

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,8 @@ on:
         required: true
       NOTIFY_WORKER_SECRET_STAGING:
         required: false
+      RELEASE_WAVE_WEBHOOK_SECRET:
+        required: false
 
 # Environment is derived from github context:
 #   pull_request → staging
@@ -347,6 +349,31 @@ jobs:
             --region ${{ env.REGION }} --project ${{ env.PROJECT }} \
             --format 'value(status.url)')
           echo "::notice ::Gateway URL: $URL"
+
+  # ---------------------------------------------------------------------------
+  # Production: report current prod image to ci-dashboard compatibility (Refs #157)
+  #
+  # production (v* tag) deploy が全 service + gateway 成功した後、現 prod image
+  # = version tag を ci-dashboard の backend-deploy-report webhook に記録する。
+  # これで Release Wave compatibility matrix が「consumer frontend がこの image を
+  # test 済みか」を突合できるようになる。staging (PR) deploy では打たない
+  # (compatibility は production image 基準のため)。
+  # ---------------------------------------------------------------------------
+  report-backend-deploy:
+    name: "Report backend deploy (compatibility)"
+    needs: [deploy-gateway]
+    if: >-
+      always() &&
+      startsWith(github.ref, 'refs/tags/v') &&
+      needs.deploy-gateway.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ippoan/ci-workflows/.github/actions/report-backend-deploy@main
+        with:
+          repo: ${{ github.repository }}
+          current_image: ${{ inputs.ref_name }}
+          deployed_by: rust-alc-api-deploy
+          webhook_secret: ${{ secrets.RELEASE_WAVE_WEBHOOK_SECRET }}
 
   # ---------------------------------------------------------------------------
   # Staging: smoke test /api/notify/ingest after staging deploy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,8 +14,6 @@ on:
         required: true
       NOTIFY_WORKER_SECRET_STAGING:
         required: false
-      RELEASE_WAVE_WEBHOOK_SECRET:
-        required: false
 
 # Environment is derived from github context:
 #   pull_request → staging
@@ -349,31 +347,6 @@ jobs:
             --region ${{ env.REGION }} --project ${{ env.PROJECT }} \
             --format 'value(status.url)')
           echo "::notice ::Gateway URL: $URL"
-
-  # ---------------------------------------------------------------------------
-  # Production: report current prod image to ci-dashboard compatibility (Refs #157)
-  #
-  # production (v* tag) deploy が全 service + gateway 成功した後、現 prod image
-  # = version tag を ci-dashboard の backend-deploy-report webhook に記録する。
-  # これで Release Wave compatibility matrix が「consumer frontend がこの image を
-  # test 済みか」を突合できるようになる。staging (PR) deploy では打たない
-  # (compatibility は production image 基準のため)。
-  # ---------------------------------------------------------------------------
-  report-backend-deploy:
-    name: "Report backend deploy (compatibility)"
-    needs: [deploy-gateway]
-    if: >-
-      always() &&
-      startsWith(github.ref, 'refs/tags/v') &&
-      needs.deploy-gateway.result == 'success'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: ippoan/ci-workflows/.github/actions/report-backend-deploy@main
-        with:
-          repo: ${{ github.repository }}
-          current_image: ${{ inputs.ref_name }}
-          deployed_by: rust-alc-api-deploy
-          webhook_secret: ${{ secrets.RELEASE_WAVE_WEBHOOK_SECRET }}
 
   # ---------------------------------------------------------------------------
   # Staging: smoke test /api/notify/ingest after staging deploy


### PR DESCRIPTION
## 概要

Release Wave compatibility (`ippoan/ci-dashboard#157`) のデータ源として、**main push で `:latest` dev image を作るタイミング**で、その image を ci-dashboard の compatibility matrix に記録する。

## なぜ production `v*` deploy ではなく dev `:latest` か

当初 production (`v*` tag) deploy 時に report する実装にしたが、2 点の理由で誤りだった:

1. **`v*` deploy は本番トラフィックフリップを伴う。** `cloudrun/render.sh` は `traffic:` ブロックを出力せず、`gcloud run services replace` は traffic 指定の無い spec を replace すると新 revision に **100% 本番トラフィックを向ける**。つまり「compat グラフを埋めるために v* を打つ」= 本番デプロイそのもので、データ投入目的には使えない。
2. **frontend の integration test は `rust-alc-api:latest` (dev image) 相手に走る。** compat の突合基準も dev/latest image であるべきで、production の version tag ではない。

## 変更

- **`ci.yml`** `docker-latest` job (main push で `dev → :sha + :latest` を作る所、本番トラフィック無関係) の末尾に `report-backend-deploy` step を追加。`current_image = github.sha` (= `:latest` の実体) を記録する。
- `deploy.yml` は変更なし（前コミットの v* 配線は撤去済み）。

`RELEASE_WAVE_WEBHOOK_SECRET` は ci.yml から org secret を直接参照。secret 値は composite action 内で `env:` + `jq` 経由で扱い injection 無し。

## 効果

main merge 毎に `backend::ippoan/rust-alc-api` の `current_image` が最新 dev SHA に更新される。consumer frontend (nuxt-notify 等) が次に CI を回すと、その SHA を test 済みとして緑 edge を report し、`/release-wave` の「Compatibility (all consumers)」グラフに描画される。backend image が進めば未追従の frontend は赤になり、drift が可視化される。

Refs ippoan/ci-dashboard#157