### PR TITLE
fix(ci): report backend dev image from docker-dev (docker-latest is dead)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -414,6 +414,19 @@ jobs:
             docker push "${REPO}${suffix}:dev"
           done
 
+      # :dev image (= frontend の integration test が相手にする dev image) を
+      # 更新したので、ci-dashboard の compatibility matrix に現 dev image を記録する。
+      # docker-latest は現 CI 構造では走らない (main push で check/coverage が skip
+      # される) ため、確実に走る本 job (PR) を hook にする。current_image は当該
+      # commit SHA。本番トラフィックには一切触れない (Refs ippoan/ci-dashboard#157)。
+      - name: Report backend dev image (compatibility)
+        uses: ippoan/ci-workflows/.github/actions/report-backend-deploy@main
+        with:
+          repo: ${{ github.repository }}
+          current_image: ${{ github.sha }}
+          deployed_by: rust-alc-api-dev
+          webhook_secret: ${{ secrets.RELEASE_WAVE_WEBHOOK_SECRET }}
+
   docker-latest:
     name: Tag latest
     if: "always() && github.ref == 'refs/heads/main' && github.event_name == 'push' && needs.check.result == 'success' && needs.coverage-check.result == 'success'"
@@ -440,17 +453,6 @@ jobs:
             docker push "${REPO}${suffix}:${SHA}"
             docker push "${REPO}${suffix}:latest"
           done
-
-      # 新しい :latest dev image (= frontend の integration test が相手にする
-      # image) を ci-dashboard の compatibility matrix に記録する。current_image
-      # は main commit SHA。本番トラフィックには一切触れない (Refs ippoan/ci-dashboard#157)。
-      - name: Report backend dev image (compatibility)
-        uses: ippoan/ci-workflows/.github/actions/report-backend-deploy@main
-        with:
-          repo: ${{ github.repository }}
-          current_image: ${{ github.sha }}
-          deployed_by: rust-alc-api-dev-latest
-          webhook_secret: ${{ secrets.RELEASE_WAVE_WEBHOOK_SECRET }}
 
   deploy:
     name: Deploy


### PR DESCRIPTION
## 背景

前 PR (#357) は compatibility の backend report を `docker-latest` (Tag latest) job に置いたが、**この job は現 CI 構造では一切走らない dead job** だった:

- `check` / `coverage-check` は `if: !(main push)` で **PR でのみ実行・main push では skip**
- `docker-latest` は `needs: [check, coverage-check]` かつ `if: main push && check==success && coverage==success`
- → main push では check/coverage が skip されるため条件が満たされず、`docker-latest` は常に skip

実際 #357 マージ後の main push run でも `docker-latest` は skip され、backend record は作られなかった (`/release-wave` に rust-alc-api ノードが出ない)。

## 変更

report step を **確実に走る `docker-dev` job** (PR で `:dev` image を push する所) に移設する。`current_image = github.sha`。

- rust-alc-api の PR CI 毎に `backend::ippoan/rust-alc-api` が現 dev image SHA に更新される
- **本 PR 自身の PR CI** でも `docker-dev` が走るため、マージを待たず backend ノードが作られる
- `:dev` は frontend の integration test が相手にする dev image なので、突合基準として妥当
- 本番トラフィックには一切触れない

## 残りの 1 ステップ

backend ノード出現後、nuxt-notify の CI を 1 回回せば緑 edge が描画される。

Refs ippoan/ci-dashboard#157

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPNy9CVxrt1JgUZzDgAwYN)_