### PR TITLE
ci: record backend compat image on staging deploy (env-deploy event)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -414,19 +414,6 @@ jobs:
             docker push "${REPO}${suffix}:dev"
           done
 
-      # :dev image (= frontend の integration test が相手にする dev image) を
-      # 更新したので、ci-dashboard の compatibility matrix に現 dev image を記録する。
-      # docker-latest は現 CI 構造では走らない (main push で check/coverage が skip
-      # される) ため、確実に走る本 job (PR) を hook にする。current_image は当該
-      # commit SHA。本番トラフィックには一切触れない (Refs ippoan/ci-dashboard#157)。
-      - name: Report backend dev image (compatibility)
-        uses: ippoan/ci-workflows/.github/actions/report-backend-deploy@main
-        with:
-          repo: ${{ github.repository }}
-          current_image: ${{ github.sha }}
-          deployed_by: rust-alc-api-dev
-          webhook_secret: ${{ secrets.RELEASE_WAVE_WEBHOOK_SECRET }}
-
   docker-latest:
     name: Tag latest
     if: "always() && github.ref == 'refs/heads/main' && github.event_name == 'push' && needs.check.result == 'success' && needs.coverage-check.result == 'success'"
@@ -472,6 +459,30 @@ jobs:
     secrets:
       GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
       NOTIFY_WORKER_SECRET_STAGING: ${{ secrets.NOTIFY_WORKER_SECRET_STAGING }}
+
+  # staging への deploy(cutover)が成功した時に、staging の現 backend image を
+  # ci-dashboard の compatibility matrix に記録する。これは "build を記録" では
+  # なく "staging 環境への deploy event を記録" で、Pact の
+  # record-deployment --environment staging と同義 (= 前バージョンを supersede し
+  # 「staging の現 image」が一意に保たれる)。frontend は integration test を
+  # この staging image 相手に走らせるので突合基準として整合する。
+  # current_image は deploy した image tag (= github.sha)。production (v* tag) では
+  # 打たない (本番トラフィックを伴う release の記録は別経路 = Release Wave flip)。
+  report-backend-compat:
+    name: Report backend image (staging)
+    needs: [deploy]
+    if: >-
+      always() &&
+      github.event_name == 'pull_request' &&
+      needs.deploy.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ippoan/ci-workflows/.github/actions/report-backend-deploy@main
+        with:
+          repo: ${{ github.repository }}
+          current_image: ${{ github.sha }}
+          deployed_by: rust-alc-api-staging
+          webhook_secret: ${{ secrets.RELEASE_WAVE_WEBHOOK_SECRET }}
 
   auto-merge:
     name: Auto Merge


### PR DESCRIPTION
## 背景

直前の #358 は compat の backend report を `docker-dev` job (= `:dev` タグを打つ **build イベント**) に置いた。しかしこれは build 単位の記録で、複数 PR が並走すると last-run-wins になり「現に staging にある image」をトラックできない。

ベストプラクティス (Pact Broker `record-deployment` / GitHub Deployments API) は **「環境への deploy(cutover)event」で・environment 単位で・immutable version をキーに記録**する。記録すると前バージョンは自動 supersede され「その環境の現バージョン」が一意に保たれる。

## 変更

- `docker-dev` の report step を**撤去**
- `deploy` job (staging cutover) 成功後・**PR 時のみ**走る `report-backend-compat` job を追加。`current_image = github.sha` (= staging に deploy された image tag)

これは `record-deployment --environment staging` と同義。production (`v*`) では打たない — 本番トラフィックを伴う release の記録は Release Wave flip 経路 (`release-wave-handler` #67) に分離。

## 突合フロー (staging 基準)

1. rust-alc-api staging deploy → `backend::ippoan/rust-alc-api.current_image = SHA`
2. frontend の staging CI が `GET backend-current-image` で同じ SHA を読み、integration test green で `tested_against` に記録
3. → 同一 SHA で突合し matrix が緑。backend が次に staging deploy して SHA が進むと、未追従 frontend は赤 (drift 可視化)
4. staging で緑の SHA を本番 promote (`:dev`→tag) → Release Wave flip で traffic 切替 (deploy/release 分離)

## 既知のフォローアップ (本 PR スコープ外)

- frontend の `docker-compose.test.yml` は現状 `rust-alc-api:latest` を pull する。matrix を厳密に truthful にするには、frontend が記録対象の backend SHA image を pull するのが望ましい (`:latest` 固定だと "記録した SHA" と "実際に test した image" が乖離し得る)。
- Release Wave flip の backend report (#67) と本 staging 記録は同一 KV キーを共有するため、wave flip 時に一時的に production tag で上書きされる。environment 別キー化は将来の拡張候補。

Refs ippoan/ci-dashboard#157

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPNy9CVxrt1JgUZzDgAwYN)_