### PR TITLE
fix(ci): repair invalid migration-safety-check.yml (empty expression literal)

### DIFF
--- a/.github/workflows/migration-safety-check.yml
+++ b/.github/workflows/migration-safety-check.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           set -euo pipefail
           # ファイル名は git tracked path だが PR 作成者が任意のファイル名を選べるので
-          # ${{ }} 直接展開ではなく env 経由で受ける (command injection 防止)。
+          # GitHub Actions 式で直接展開せず env 経由で受ける (command injection 防止)。
           # mapfile + quoted "${files[@]}" で空白/特殊文字を含むパスも安全に渡す。
           mapfile -t files <<< "$ADDED_FILES"
           report=$(bash .github/scripts/migration-safety-check.sh "${files[@]}")


### PR DESCRIPTION
## 症状

`.github/workflows/migration-safety-check.yml` が **Invalid workflow file (Line: 55, Col: 14): An expression was expected** で毎 push 赤くなっていた。

## 原因

`Run safety check` step の `run:` ブロック内**コメント**に、空の GitHub Actions 式リテラル（`${EXPR}` の中身が空のもの）が書かれていた:

```
# <空式> 直接展開ではなく env 経由で受ける (command injection 防止)。
```

GitHub Actions は `run:` 文字列全体を shell に渡す前に式展開するため、**シェルコメント内であっても**空式を評価しようとして「An expression was expected」になり、workflow file 全体が invalid 判定になっていた（actionlint でも `unexpected end of input while parsing ... expecting IDENT` として再現）。

## 修正

当該コメントから式リテラルを除去（文言を平文に変更）するだけ。実処理（`env: ADDED_FILES` 経由で受け取り `mapfile` + quoted 展開する command-injection-safe パターン）は一切変更なし。

`actionlint` clean。

Refs ippoan/ci-dashboard#137

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPNy9CVxrt1JgUZzDgAwYN)_