### PR TITLE
feat(deploy): no-traffic production release (deploy/release separation)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -499,4 +499,10 @@ jobs:
       contents: write
       pull-requests: write
     secrets:
+      # GitHub App installation token を優先 (ci-workflows#65)。App は独自の
+      # rate-limit bucket を持つので、user PAT の GraphQL quota を食わず
+      # "API rate limit already exceeded for user ID" の intermittent fail を
+      # 回避できる。org に CI_APP_ID/KEY が無ければ自動で AUTO_MERGE_PAT に fallback。
+      CI_APP_ID: ${{ secrets.CI_APP_ID }}
+      CI_APP_PRIVATE_KEY: ${{ secrets.CI_APP_PRIVATE_KEY }}
       AUTO_MERGE_PAT: ${{ secrets.TAG_RELEASE_PAT }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -199,18 +199,43 @@ jobs:
       - name: Render and deploy
         env:
           ENV_SCRAPER_URL: ${{ vars.SCRAPER_URL }}
+          REF_NAME: ${{ inputs.ref_name }}
+          SERVICE: ${{ matrix.service }}
         run: |
+          set -euo pipefail
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             DEPLOY_ENV="staging"
           else
             DEPLOY_ENV="production"
           fi
-          RENDER_ARGS="${{ matrix.service }} ${DEPLOY_ENV} ${{ inputs.image_sha }}"
+          RENDER_ARGS="${SERVICE} ${DEPLOY_ENV} ${{ inputs.image_sha }}"
 
           if [ "${DEPLOY_ENV}" = "staging" ]; then
             STAGING_URL="${{ vars.STAGING_API_URL }}"
             DB_IMAGE="${{ env.AR_PREFIX }}/${{ env.REPO }}-staging-db:latest"
             RENDER_ARGS="${RENDER_ARGS} --staging-url ${STAGING_URL} --db-image ${DB_IMAGE}"
+          else
+            # production: 新 revision を 0% (no-traffic) で deploy し、traffic は現
+            # revision に残す。実際の切替は Release Wave flip に委ねる (Refs #137 Phase 5)。
+            # 現在 traffic を受けている revision を解決して --pin-traffic-revision に渡す。
+            case "${SERVICE}" in
+              backend) PROD_SVC="rust-alc-api" ;;
+              *)       PROD_SVC="rust-alc-api-${SERVICE}" ;;
+            esac
+            CURRENT_REV=""
+            if SVC_JSON=$(gcloud run services describe "$PROD_SVC" \
+                 --region ${{ env.REGION }} --project ${{ env.PROJECT }} --format=json 2>/dev/null); then
+              CURRENT_REV=$(printf '%s' "$SVC_JSON" | jq -r \
+                '(([.status.traffic[]? | select((.percent // 0) > 0) | .revisionName] | map(select(. != null)))[0]) // .status.latestReadyRevisionName // ""')
+            fi
+            # tag を Cloud Run revision tag charset (lowercase [a-z0-9-]) に正規化
+            SANITIZED=$(printf '%s' "${REF_NAME:-}" | tr 'A-Z' 'a-z' | tr -c 'a-z0-9-' '-' | sed 's/-\{2,\}/-/g; s/^-//; s/-$//')
+            if [ -n "$CURRENT_REV" ]; then
+              RENDER_ARGS="${RENDER_ARGS} --pin-traffic-revision ${CURRENT_REV} --pending-tag pending-${SANITIZED}"
+              echo "::notice::production no-traffic deploy: keep 100% on ${CURRENT_REV}; new revision -> 0% (tag pending-${SANITIZED}). Release Wave flip will switch traffic."
+            else
+              echo "::warning::no current revision for ${PROD_SVC} (first deploy?) — deploying with Cloud Run default traffic (latest 100%)."
+            fi
           fi
 
           bash cloudrun/render.sh ${RENDER_ARGS} > /tmp/service.yaml
@@ -272,7 +297,10 @@ jobs:
         uses: google-github-actions/setup-gcloud@v2
 
       - name: Render gateway YAML with service URLs
+        env:
+          REF_NAME: ${{ inputs.ref_name }}
         run: |
+          set -euo pipefail
           # Discover backend/service URLs
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             BACKEND_URL=$(gcloud run services describe rust-alc-api-staging \
@@ -310,7 +338,25 @@ jobs:
 
           # Render gateway YAML
           if [ "${{ github.event_name }}" = "pull_request" ]; then GW_ENV="staging"; else GW_ENV="production"; fi
-          bash cloudrun/render.sh gateway ${GW_ENV} ${{ inputs.image_sha }} \
+          GW_RENDER_ARGS="gateway ${GW_ENV} ${{ inputs.image_sha }}"
+          if [ "${GW_ENV}" = "production" ]; then
+            # production gateway も新 revision を 0% (no-traffic) で deploy し traffic は
+            # 現 revision に残す (切替は Release Wave flip)。Refs #137 Phase 5。
+            CURRENT_REV=""
+            if GW_JSON=$(gcloud run services describe rust-alc-api-gateway \
+                 --region ${{ env.REGION }} --project ${{ env.PROJECT }} --format=json 2>/dev/null); then
+              CURRENT_REV=$(printf '%s' "$GW_JSON" | jq -r \
+                '(([.status.traffic[]? | select((.percent // 0) > 0) | .revisionName] | map(select(. != null)))[0]) // .status.latestReadyRevisionName // ""')
+            fi
+            SANITIZED=$(printf '%s' "${REF_NAME:-}" | tr 'A-Z' 'a-z' | tr -c 'a-z0-9-' '-' | sed 's/-\{2,\}/-/g; s/^-//; s/-$//')
+            if [ -n "$CURRENT_REV" ]; then
+              GW_RENDER_ARGS="${GW_RENDER_ARGS} --pin-traffic-revision ${CURRENT_REV} --pending-tag pending-${SANITIZED}"
+              echo "::notice::gateway production no-traffic deploy: keep 100% on ${CURRENT_REV}; new revision -> 0% (tag pending-${SANITIZED})."
+            else
+              echo "::warning::no current revision for rust-alc-api-gateway (first deploy?) — default traffic (latest 100%)."
+            fi
+          fi
+          bash cloudrun/render.sh ${GW_RENDER_ARGS} \
             > /tmp/gateway.yaml
 
           # Replace gateway URL placeholders

--- a/cloudrun/render.sh
+++ b/cloudrun/render.sh
@@ -27,10 +27,20 @@ fi
 
 STAGING_URL=""
 DB_IMAGE=""
+# production no-traffic deploy 用 (Refs #137 Phase 5 / ci-dashboard#157):
+#   --pin-traffic-revision <rev>  現在 100% を受けている revision。指定すると新
+#       revision は 0% で deploy され、traffic は <rev> に残る (= release は flip
+#       しない、切替は Release Wave flip に委ねる)。空なら従来どおり latest に 100%。
+#   --pending-tag <tag>  新 revision に付ける Cloud Run revision tag。Release Wave
+#       flip が `--to-revision-tag <tag>` で切替対象にする (例: pending-v1-42-0)。
+PIN_TRAFFIC_REVISION=""
+PENDING_TAG=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --staging-url) STAGING_URL="$2"; shift 2 ;;
     --db-image) DB_IMAGE="$2"; shift 2 ;;
+    --pin-traffic-revision) PIN_TRAFFIC_REVISION="$2"; shift 2 ;;
+    --pending-tag) PENDING_TAG="$2"; shift 2 ;;
     *) echo "Unknown option: $1" >&2; exit 1 ;;
   esac
 done
@@ -519,5 +529,27 @@ if [[ "$ENV" == "staging" && "$SERVICE" != "gateway" ]]; then
         - name: pg-data
           emptyDir:
             sizeLimit: 1Gi
+YAML
+fi
+
+# ---------------------------------------------------------------------------
+# Traffic block (production no-traffic release)
+#
+# PIN_TRAFFIC_REVISION が指定されている時のみ emit する。新 revision (latest) を
+# 0% + pending tag で deploy し、traffic は現行 revision に 100% 残す。これで
+# `gcloud run services replace` が release で勝手にフリップするのを防ぎ、実際の
+# 切替は Release Wave flip (= revision tag 指定の update-traffic) に委ねる。
+#   - PIN_TRAFFIC_REVISION 空 (初回 deploy 等) → traffic block を出さない =
+#     Cloud Run default の「latest に 100%」に従う (= 初回は flip 許容)。
+#   - staging では指定しない (= staging は latest が常に live で良い)。
+# Refs ippoan/ci-dashboard#137 Phase 5 / #157。
+# ---------------------------------------------------------------------------
+if [[ -n "$PIN_TRAFFIC_REVISION" ]]; then
+  cat <<YAML
+  traffic:
+    - revisionName: ${PIN_TRAFFIC_REVISION}
+      percent: 100
+    - latestRevision: true
+      percent: 0$( [[ -n "$PENDING_TAG" ]] && printf '\n      tag: %s' "$PENDING_TAG" )
 YAML
 fi


### PR DESCRIPTION
## 目的

production (`v*` tag) release が `gcloud run services replace` で新 revision に **100% 即フリップ**していたのを deploy/release 分離に直す。release は新 revision を **0% (no-traffic)** で deploy し、traffic は現 revision に残す。実トラフィック切替は **Release Wave flip** に委ねる (Refs #137 Phase 5)。#360 (verify-no-traffic CI) を production release で green にする本丸。

## 変更

**`cloudrun/render.sh`** — `--pin-traffic-revision` / `--pending-tag` オプション追加。指定時に `spec.traffic` を「現 revision 100% + latest 0% (tag: pending-<sanitized>)」で emit。staging では指定せず従来どおり latest 100%。

**`.github/workflows/deploy.yml`** — production の `deploy-services` / `deploy-gateway` で `replace` 前に現 traffic revision を `describe` で解決し pin。`pending-<sanitized ref_name>` tag は `release-wave-handler` flip が切替対象にする tag と一致。初回 deploy は default (latest 100%) に fallback。

**`.github/workflows/ci.yml` (auto-merge App token, 追加)** — auto-merge job が `AUTO_MERGE_PAT` (個人 PAT) しか渡しておらず、ci-workflows#65 の **GitHub App installation token パス**が使われていなかった (`CI_APP_ID` 空 → PAT fallback)。結果 `gh pr merge --auto` が個人 user の GraphQL quota を消費し **"API rate limit already exceeded for user ID 87104778"** で intermittent fail していた。`CI_APP_ID` / `CI_APP_PRIVATE_KEY` を forward し、App token (独自 rate-limit bucket) を優先するよう修正。org に App secrets が無ければ従来どおり PAT fallback (後方互換)。

## 安全性

- `services replace` 失敗時は新 revision が serving に入らず現 revision 継続 → 本番ダウンにならず「リリース失敗」で安全側。
- traffic 値・tag は env + sanitize で injection なし。

## ⚠ 検証

実 Cloud Run トラフィック挙動はこの PR の CI では検証不可 (`verify-no-traffic` は `v*` tag 時のみ)。最初の release で #360 が実挙動を gate/検出する。render.sh の YAML はローカル parse 検証済み。auto-merge App-token パスはこの PR の auto-merge 実行自体で確認できる。

Refs ippoan/ci-dashboard#137
Refs ippoan/ci-dashboard#157
Refs ippoan/ci-workflows#65