### PR TITLE
feat(trouble): allow any non-terminal state to transition to terminal

### DIFF
--- a/crates/alc-trouble/src/repo/trouble_workflow.rs
+++ b/crates/alc-trouble/src/repo/trouble_workflow.rs
@@ -248,12 +248,16 @@ impl TroubleWorkflowRepository for PgTroubleWorkflowRepository {
         }
 
         // デフォルト遷移を作成
+        // (0,3) / (1,3) を含めることで、任意の非 terminal 状態から
+        // terminal (完了) へ直接遷移できるようにする。(2,3) は既存なので重複させない。
         let transitions = [
             (0, 1, "対応開始"),
             (1, 2, "解決"),
             (2, 3, "完了"),
             (1, 0, "差し戻し"),
             (2, 1, "再対応"),
+            (0, 3, "完了"),
+            (1, 3, "完了"),
         ];
 
         for (from_idx, to_idx, label) in &transitions {

--- a/migrations/111_trouble_workflow_any_to_terminal.sql
+++ b/migrations/111_trouble_workflow_any_to_terminal.sql
@@ -1,0 +1,30 @@
+-- 既存テナントの trouble ワークフローに「各非 terminal 状態 → terminal 状態」
+-- への遷移を冪等にバックフィルする。
+--
+-- 背景: デフォルトワークフロー (新規→対応中→解決→完了) では「完了」へは
+-- 「解決」からしか遷移できず、新規/対応中のチケットを直接「完了」にできない。
+-- `POST /api/trouble/tickets/{id}/transition` が is_transition_allowed=false で
+-- 422 を返してしまう。これを「任意の非 terminal 状態 → terminal へ遷移可能」に
+-- 揃える (Refs ippoan/nuxt-trouble#122)。
+--
+-- 新規テナントは setup_defaults (crates/alc-trouble/src/repo/trouble_workflow.rs)
+-- の transitions 配列に (new→closed) / (in_progress→closed) を追加済みなので
+-- 最初から任意→完了可。本 migration は既存テナント分の補填。
+--
+-- RLS: trouble_workflow_transitions は ENABLE ROW LEVEL SECURITY のみ
+-- (FORCE 無し) なので、テーブル owner (= migration 実行ロール) は RLS を
+-- bypass し全テナント横断で INSERT できる。
+-- UNIQUE(tenant_id, from_state_id, to_state_id) + NOT EXISTS で冪等性を担保。
+
+INSERT INTO alc_api.trouble_workflow_transitions (tenant_id, from_state_id, to_state_id, label)
+SELECT s.tenant_id, s.id, t.id, '完了'
+FROM alc_api.trouble_workflow_states s
+JOIN alc_api.trouble_workflow_states t
+  ON t.tenant_id = s.tenant_id AND t.is_terminal = TRUE
+WHERE s.is_terminal = FALSE
+  AND NOT EXISTS (
+    SELECT 1 FROM alc_api.trouble_workflow_transitions x
+    WHERE x.tenant_id = s.tenant_id
+      AND x.from_state_id = s.id
+      AND x.to_state_id = t.id
+  );


### PR DESCRIPTION
## 背景

トラブルワークフローのデフォルト遷移は 新規(new)→対応中(in_progress)→解決(resolved)→完了(closed, terminal) の一本道で、「完了」へは「解決」からしか遷移できなかった。

そのため新規/対応中のチケットを直接「完了」にできず、`POST /api/trouble/tickets/{id}/transition` が `is_transition_allowed=false` (`crates/alc-trouble/src/tickets.rs`) で **422 Unprocessable Entity** を返していた。

ユーザー要望「どの状態からも完了可にする」に合わせ、**任意の非 terminal 状態 → terminal 状態** へ遷移できるようにする。

## 変更内容

1. **`crates/alc-trouble/src/repo/trouble_workflow.rs` の `setup_defaults`**
   デフォルト `transitions` 配列に `(new→closed, "完了")` / `(in_progress→closed, "完了")` を追加。`(resolved→closed)` は既存なので重複させない。新規テナントは最初から任意→完了可になる。

2. **`migrations/111_trouble_workflow_any_to_terminal.sql` (新規)**
   既存全テナントの workflow に「各非 terminal 状態 → terminal 状態」遷移を **冪等に** バックフィル。`UNIQUE(tenant_id, from_state_id, to_state_id)` + `NOT EXISTS` で再実行安全。
   `trouble_workflow_transitions` は `ENABLE ROW LEVEL SECURITY` のみ (FORCE 無し) なので、テーブル owner = migration 実行ロールが RLS を bypass して全テナント横断 INSERT できる。

## 遷移グラフ (デフォルト)

| from | to | label |
|---|---|---|
| new | in_progress | 対応開始 |
| in_progress | resolved | 解決 |
| resolved | closed | 完了 |
| in_progress | new | 差し戻し |
| resolved | in_progress | 再対応 |
| **new** | **closed** | **完了** (追加) |
| **in_progress** | **closed** | **完了** (追加) |

## 検証

- ローカル: `cargo fmt --check` ✅ / `cargo check -p alc-trouble` ✅
- clippy / test / migration (splinter/RLS) は CI に委譲 (CLAUDE.md 方針)
- 既存テスト (`tests/trouble_test.rs`) は transitions を `>= 4` でしか検証しておらず states 数 (4) も不変のため影響なし

Refs ippoan/nuxt-trouble#122

https://claude.ai/code/session_012zLhVkMuDnAyBWZNLnuorh

---
_Generated by [Claude Code](https://claude.ai/code/session_012zLhVkMuDnAyBWZNLnuorh)_