### PR TITLE
fix(auth): return 401 (not 500) when tenant_id is missing from tenants table

### DIFF
--- a/crates/alc-core/src/auth_middleware.rs
+++ b/crates/alc-core/src/auth_middleware.rs
@@ -93,10 +93,10 @@ pub async fn require_tenant(
         // tenant が DB に実在しないなら 401 を返す (揮発性 staging で tenant が消えた
         // ケース。フロントの自動 logout → 再ログインで回復させる)。
         if !tenant_exists(pool, claims.tenant_id).await {
-            tracing::warn!(
-                "tenant {} from JWT not found in tenants table; returning 401",
-                claims.tenant_id
-            );
+            // 一行 warn! に収めるため tenant_id を一旦束縛 (複数行 `tracing::warn!` は
+            // llvm-cov が format 引数行を別 region 0 カウントし coverage 100% を割る、PR #364)。
+            let tid = claims.tenant_id;
+            tracing::warn!("tenant {tid} not in tenants table (JWT); returning 401");
             return Err(StatusCode::UNAUTHORIZED);
         }
         let auth_user = AuthUser {
@@ -121,9 +121,8 @@ pub async fn require_tenant(
         .ok_or(StatusCode::UNAUTHORIZED)?;
 
     if !tenant_exists(pool, tenant_id).await {
-        tracing::warn!(
-            "tenant {tenant_id} from X-Tenant-ID header not found in tenants table; returning 401"
-        );
+        // 一行に収める (上記 JWT 経路と同理由: 複数行 warn! は llvm-cov で uncovered 計上)。
+        tracing::warn!("tenant {tenant_id} not in tenants table (X-Tenant-ID); returning 401");
         return Err(StatusCode::UNAUTHORIZED);
     }
 

--- a/crates/alc-core/src/auth_middleware.rs
+++ b/crates/alc-core/src/auth_middleware.rs
@@ -5,6 +5,42 @@ use uuid::Uuid;
 
 use crate::auth_jwt::{verify_access_token, verify_internal_token, JwtSecret};
 
+/// `require_tenant` が tenant の実在確認に使う DB pool を Extension で受け渡すための newtype。
+///
+/// `AppState.pool` と同じ `Option<PgPool>` を保持する。`None` の場合 (mock テスト等で
+/// DB を持たないケース) は実在確認をスキップする (= fail-open)。
+/// main / テストハーネスの router 構築時に `Extension(TenantValidationPool(state.pool.clone()))`
+/// を layer する。
+#[derive(Clone)]
+pub struct TenantValidationPool(pub Option<sqlx::PgPool>);
+
+/// resolve 済みの tenant_id が `tenants` テーブルに実在するか確認する。
+///
+/// 揮発性 staging DB で tenant が消えると、ブラウザの JWT は古い tenant_id を持つが
+/// `tenants` に無く、`*_tenant_id_fkey` FK 違反で INSERT が 500 にラップされる。
+/// ここで先に 401 を返すことで、フロント (nuxt-trouble) の `onUnauthorized` →
+/// `clearAuth()` → `/login` 自動再ログインフローに乗せ、新 tenant 作成で回復させる。
+///
+/// pool が `None` (DB 無し) の場合は確認できないので `true` を返してスキップする。
+async fn tenant_exists(pool: Option<&sqlx::PgPool>, tenant_id: Uuid) -> bool {
+    let Some(pool) = pool else {
+        return true;
+    };
+    match sqlx::query_scalar::<_, bool>("SELECT EXISTS(SELECT 1 FROM tenants WHERE id = $1)")
+        .bind(tenant_id)
+        .fetch_one(pool)
+        .await
+    {
+        Ok(exists) => exists,
+        // DB エラー時は実在確認自体が失敗しているだけなので fail-open。
+        // (FK 違反由来の 500 はこの後の handler 側で従来どおり起きる)
+        Err(e) => {
+            tracing::warn!("tenant existence check query failed: {e}");
+            true
+        }
+    }
+}
+
 /// JWT 必須ミドルウェア — 管理ページ用
 ///
 /// Authorization: Bearer <jwt> ヘッダーから JWT を検証し、
@@ -41,14 +77,28 @@ pub async fn require_jwt(
 /// 2. なければ X-Tenant-ID ヘッダーにフォールバック (キオスクモード)
 pub async fn require_tenant(
     jwt_secret: Option<Extension<JwtSecret>>,
+    validation_pool: Option<Extension<TenantValidationPool>>,
     mut req: Request,
     next: Next,
 ) -> Result<Response, StatusCode> {
+    let pool = validation_pool
+        .as_ref()
+        .and_then(|Extension(p)| p.0.as_ref());
+
     // まず JWT を試行 (フラット化: 閉じ括弧の llvm-cov 問題回避)
     if let Some(Ok(claims)) = extract_bearer_token(&req)
         .zip(jwt_secret.as_ref())
         .map(|(token, Extension(secret))| verify_access_token(token, secret))
     {
+        // tenant が DB に実在しないなら 401 を返す (揮発性 staging で tenant が消えた
+        // ケース。フロントの自動 logout → 再ログインで回復させる)。
+        if !tenant_exists(pool, claims.tenant_id).await {
+            tracing::warn!(
+                "tenant {} from JWT not found in tenants table; returning 401",
+                claims.tenant_id
+            );
+            return Err(StatusCode::UNAUTHORIZED);
+        }
         let auth_user = AuthUser {
             user_id: claims.sub,
             email: claims.email,
@@ -69,6 +119,13 @@ pub async fn require_tenant(
         .and_then(|v| v.to_str().ok())
         .and_then(|v| Uuid::parse_str(v).ok())
         .ok_or(StatusCode::UNAUTHORIZED)?;
+
+    if !tenant_exists(pool, tenant_id).await {
+        tracing::warn!(
+            "tenant {tenant_id} from X-Tenant-ID header not found in tenants table; returning 401"
+        );
+        return Err(StatusCode::UNAUTHORIZED);
+    }
 
     req.extensions_mut().insert(TenantId(tenant_id));
     Ok(next.run(req).await)

--- a/src/main.rs
+++ b/src/main.rs
@@ -379,6 +379,9 @@ async fn main() -> anyhow::Result<()> {
         .nest("/api", rust_alc_api::routes::router())
         .layer(Extension(google_verifier))
         .layer(Extension(jwt_secret))
+        .layer(Extension(
+            rust_alc_api::middleware::auth::TenantValidationPool(state.pool.clone()),
+        ))
         .layer(Extension(rust_alc_api::routes::dtako_scraper::ScraperUrl(
             scraper_url,
         )))

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -616,6 +616,9 @@ pub async fn spawn_test_server_with_scraper(state: AppState, scraper_url: &str) 
         .nest("/api", rust_alc_api::routes::router())
         .layer(Extension(google_verifier))
         .layer(Extension(jwt_secret))
+        .layer(Extension(
+            rust_alc_api::middleware::auth::TenantValidationPool(state.pool.clone()),
+        ))
         .layer(Extension(ScraperUrl(scraper_url.to_string())))
         .layer(cors)
         .with_state(state);

--- a/tests/trouble_test.rs
+++ b/tests/trouble_test.rs
@@ -974,3 +974,130 @@ async fn test_trouble_ticket_search_registration_number_width() {
         }
     );
 }
+
+// ============================================================
+// tenant 実在チェック (require_tenant ミドルウェア)
+//
+// 揮発性 staging DB で tenant が消えると、ブラウザの JWT は古い tenant_id を
+// 持つが tenants テーブルに無い。従来は FK 違反で 500 になっていたが、今は
+// require_tenant が先に 401 を返す (フロントの自動 logout → 再ログインで回復)。
+// ============================================================
+
+#[tokio::test]
+async fn test_require_tenant_unknown_tenant_jwt_returns_401() {
+    test_group!("tenant 実在チェック");
+    test_case!(
+        "tenants に存在しない tenant_id の JWT は 401 (FK 違反 500 ではなく)",
+        {
+            let state = common::setup_app_state().await;
+            let base_url = common::spawn_test_server(state.clone()).await;
+
+            // tenants に INSERT しない (= 揮発性 DB で消えた状態を再現)
+            let unknown_tenant = uuid::Uuid::new_v4();
+            let jwt = common::create_test_jwt(unknown_tenant, "admin");
+            let auth = format!("Bearer {jwt}");
+            let client = reqwest::Client::new();
+
+            // 従来 FK 違反で 500 にラップされていた setup を叩く
+            let res = client
+                .post(format!("{base_url}/api/trouble/workflow/setup"))
+                .header("Authorization", &auth)
+                .send()
+                .await
+                .unwrap();
+            assert_eq!(
+                res.status(),
+                401,
+                "unknown tenant JWT must be rejected with 401"
+            );
+        }
+    );
+}
+
+#[tokio::test]
+async fn test_require_tenant_unknown_tenant_header_returns_401() {
+    test_group!("tenant 実在チェック");
+    test_case!(
+        "tenants に存在しない X-Tenant-ID ヘッダーは 401 (キオスクモード)",
+        {
+            let state = common::setup_app_state().await;
+            let base_url = common::spawn_test_server(state.clone()).await;
+
+            let unknown_tenant = uuid::Uuid::new_v4();
+            let client = reqwest::Client::new();
+
+            // JWT 無し + X-Tenant-ID ヘッダー (= キオスクモードのフォールバック経路)
+            let res = client
+                .get(format!("{base_url}/api/trouble/tickets"))
+                .header("X-Tenant-ID", unknown_tenant.to_string())
+                .send()
+                .await
+                .unwrap();
+            assert_eq!(
+                res.status(),
+                401,
+                "unknown tenant header must be rejected with 401"
+            );
+        }
+    );
+}
+
+#[tokio::test]
+async fn test_require_tenant_known_tenant_passes() {
+    test_group!("tenant 実在チェック");
+    test_case!(
+        "tenants に存在する tenant_id は通過する (実在チェック後 200)",
+        {
+            let state = common::setup_app_state().await;
+            let base_url = common::spawn_test_server(state.clone()).await;
+
+            let tenant_id = common::create_test_tenant(state.pool(), "Tenant Existence OK").await;
+            let jwt = common::create_test_jwt(tenant_id, "admin");
+            let auth = format!("Bearer {jwt}");
+            let client = reqwest::Client::new();
+
+            // 実在 tenant の JWT は tenant_exists() を通過し handler に到達
+            let res = client
+                .get(format!("{base_url}/api/trouble/tickets"))
+                .header("Authorization", &auth)
+                .send()
+                .await
+                .unwrap();
+            assert_eq!(res.status(), 200, "known tenant must pass the check");
+        }
+    );
+}
+
+#[tokio::test]
+async fn test_require_tenant_existence_check_db_error_fail_open() {
+    test_group!("tenant 実在チェック");
+    test_case!(
+        "tenant_exists の SELECT が DB エラーなら fail-open (実在チェックを諦め handler へ)",
+        {
+            let state = common::setup_app_state().await;
+            let tenant_id =
+                common::create_test_tenant(state.pool(), "Tenant Existence DBErr").await;
+            let base_url = common::spawn_test_server(state.clone()).await;
+            let jwt = common::create_test_jwt(tenant_id, "admin");
+            let auth = format!("Bearer {jwt}");
+            let client = reqwest::Client::new();
+
+            // pool を閉じると tenant_exists の SELECT が Err → fail-open でスキップ。
+            // その後 handler 自身も閉じた pool を引くので 500 になるが、
+            // ミドルウェアの fail-open 分岐 (= 401 にせず通過) を通ったことが要点。
+            state.pool().close().await;
+
+            let res = client
+                .get(format!("{base_url}/api/trouble/tickets"))
+                .header("Authorization", &auth)
+                .send()
+                .await
+                .unwrap();
+            assert_eq!(
+                res.status(),
+                500,
+                "closed pool: tenant check fails open, handler then 500s"
+            );
+        }
+    );
+}


### PR DESCRIPTION
## 背景

staging の揮発性 DB で tenant が消えると、ブラウザの JWT は古い `tenant_id` を持つが `tenants` テーブルに無く、`trouble_workflow_states` / `trouble_categories` 等の INSERT が FK 違反 (`*_tenant_id_fkey`) → `setup_defaults` handler が **500** にラップ → チケット作成不能、という事象が起きていた。

staging ログで確定:
```
Key (tenant_id)=(e49b9384-…) is not present in table "tenants"
```

フロント (nuxt-trouble) は **HTTP 401 を受けると `onUnauthorized` → `clearAuth()` + `/login` へ遷移 (自動 logout → 再ログイン)** する配線が既にある。よって「tenant 不在」を **401** で返せば、ユーザーは自動で再ログインし、新しい tenant が作られて回復する (ユーザー要望: 「FK 違反なら logout させたら」)。

## 実装 (第一候補を採用)

`crates/alc-core/src/auth_middleware.rs` の `require_tenant` で、`tenant_id` を resolve した直後 (JWT 経路 / X-Tenant-ID ヘッダー経路の両方) に `tenants` テーブルへの存在確認 (`SELECT EXISTS(SELECT 1 FROM tenants WHERE id = $1)`) を行い、無ければ `401 UNAUTHORIZED` を返す。

これで全 tenant-scoped API (trouble/tenko/carins/dtako) が一括で「tenant 不在 → 401 → フロント自動 logout」になる。

### pool の注入方法

`require_tenant` は `from_fn` middleware で `State` を直接取れないため、`AppState.pool` を `Extension(TenantValidationPool(Option<PgPool>))` newtype で注入する (`jwt_secret` を Extension で渡している既存パターンに揃えた)。注入箇所:
- `src/main.rs` (本番)
- `tests/common/mod.rs` の `spawn_test_server_with_scraper` (テストハーネス)

### 安全側の配慮

- **pool が `None`** (mock テストの `setup_mock_app_state` は `pool: None`) の場合は実在確認をスキップ → 既存 mock test 群は無影響。
- **DB エラー時は fail-open** (実在確認自体の失敗。`tracing::warn` を出して通過、FK 違反由来の 500 は従来どおり handler 側で起きる)。
- `tenants` テーブルは RLS 非対象なので `set_config` 不要で plain pool query が通る。
- 本番では tenant は常に存在するので挙動変化なし (1 回の軽量 PK lookup の overhead のみ)。

## tests への影響

- CI のカバレッジ matrix で実 DB を引く integration test は `trouble_test` / `archive_repo_test` のみ。`trouble_test` は `create_test_tenant` で tenant を seed してから JWT を発行しているので **既存テストは 401 で落ちない**。
- `tests/common/mod.rs` のハーネスに Extension 注入を追加 (全 integration test 共通)。
- `auth_middleware.rs` は `coverage_100.toml` に `type=mock` で登録されている。新ブランチのカバレッジ用に `trouble_test.rs` (CI の `mock-trouble` group) に 4 ケース追加:
  - 未 seed tenant の JWT → 401
  - 未 seed tenant の X-Tenant-ID ヘッダー → 401
  - seed 済み tenant → 200 (通過)
  - pool close で `tenant_exists` SELECT が Err → fail-open → handler 500

ローカルでは方針どおり `cargo fmt` + `cargo check` + `cargo clippy -p alc-core` (clean) のみ実行。test / coverage は CI に委譲。

Refs ippoan/nuxt-trouble#122

---
_Generated by [Claude Code](https://claude.ai/code/session_012zLhVkMuDnAyBWZNLnuorh)_