### PR TITLE
ci: add release-wave.yml handler caller

### DIFF
--- a/.github/workflows/release-wave.yml
+++ b/.github/workflows/release-wave.yml
@@ -1,0 +1,33 @@
+name: Release Wave
+
+# Release Wave 機構の caller (薄い ~10 行 wrapper)。
+# ci-dashboard から repository_dispatch で stage / flip / rollback event を
+# 受けて、ci-workflows の release-wave-handler.yml reusable に処理を委譲する。
+#
+# 親 issue: ippoan/ci-dashboard#137 / #237
+# Reusable: ippoan/ci-workflows/.github/workflows/release-wave-handler.yml
+# Repo config: ippoan/ci-workflows/config/release-wave-targets.yaml の
+#              `ippoan/rust-alc-api` entry (platform=cloudrun, 6 service)
+#
+# cloudrun path の stage は「tag push のみ」実施し、実 deploy (no-traffic
+# --tag pending-...) は本 repo の deploy.yml (on: push: tags: ['v*']) に委譲、
+# release-wave-gcp /cloudrun/stage-check を poll して staged を confirm する。
+
+on:
+  repository_dispatch:
+    types:
+      - release-wave-stage
+      - release-wave-flip
+      - release-wave-rollback
+      - release-wave-traffic-rollback   # frontend 単独 rollback (cloudflare-workers)
+      - release-wave-backend-rollback    # backend 単独 rollback (cloudrun)
+
+permissions:
+  contents: write     # tag push (stage 時)
+  id-token: write     # GCP WIF (cloudrun path)
+  packages: read      # @ippoan/* GitHub Packages dep install
+
+jobs:
+  handler:
+    uses: ippoan/ci-workflows/.github/workflows/release-wave-handler.yml@main
+    secrets: inherit


### PR DESCRIPTION
## 背景

ippoan/ci-dashboard#237: Release Wave で各 repo の **stage が pending のまま進まない** root cause 調査の一環。

ci-dashboard は wave start 時に `release-wave-stage` を各 repo へ `repository_dispatch` で送るが、本 repo には handler caller (`release-wave.yml`) が存在せず **dispatch が no-op** になっていた。そのため stage callback (`/webhooks/release-wave/stage-report`) が一度も飛ばず、stage が `pending` のまま固定 → Approve & Flip が disabled のままになる。

実証: auth-worker のみ `release-wave.yml` を持ち、stage が `done` まで進む。本 repo / nuxt-notify / nuxt-trouble は caller 欠落で `pending` 固定 (live workflow run / stage-report callback ログで確認)。

## 変更

auth-worker と同じ ~10 行の caller を追加。`stage` / `flip` / `rollback` 系 dispatch を `ci-workflows/.github/workflows/release-wave-handler.yml@main` に委譲する。

本 repo は `release-wave-targets.yaml` で **platform=cloudrun (6 service)**。cloudrun の stage は「tag push のみ」実施し、実 no-traffic deploy (`--no-traffic --tag pending-...`) は既存 `deploy.yml` (`on: push: tags: ['v*']`) に委譲、release-wave-gcp `/cloudrun/stage-check` poll で staged を confirm する設計。これは issue #237 が期待する「preview は tag 時点」と整合する。

Refs ippoan/ci-dashboard#237 Refs ippoan/ci-dashboard#137

---
_Generated by [Claude Code](https://claude.ai/code/session_01FNdmSA2s9AGH86Pu9eubVN)_