### PR TITLE
ci(release-wave): caller の on:types から release-wave-stage を除去

### DIFF
--- a/.github/workflows/release-wave.yml
+++ b/.github/workflows/release-wave.yml
@@ -1,7 +1,7 @@
 name: Release Wave
 
 # Release Wave 機構の caller (薄い ~10 行 wrapper)。
-# ci-dashboard から repository_dispatch で stage / flip / rollback event を
+# ci-dashboard から repository_dispatch で flip / rollback event を
 # 受けて、ci-workflows の release-wave-handler.yml reusable に処理を委譲する。
 #
 # 親 issue: ippoan/ci-dashboard#137 / #237
@@ -9,21 +9,20 @@ name: Release Wave
 # Repo config: ippoan/ci-workflows/config/release-wave-targets.yaml の
 #              `ippoan/rust-alc-api` entry (platform=cloudrun, 6 service)
 #
-# cloudrun path の stage は「tag push のみ」実施し、実 deploy (no-traffic
-# --tag pending-...) は本 repo の deploy.yml (on: push: tags: ['v*']) に委譲、
-# release-wave-gcp /cloudrun/stage-check を poll して staged を confirm する。
+# stage 段は ci-workflows#96 で撤去した。no-traffic revision (--tag pending-...)
+# の用意は本 repo の deploy.yml (on: push: tags: ['v*']) に委譲し、wave は
+# Pending releases を flip するだけ。
 
 on:
   repository_dispatch:
     types:
-      - release-wave-stage
       - release-wave-flip
       - release-wave-rollback
       - release-wave-traffic-rollback   # frontend 単独 rollback (cloudflare-workers)
       - release-wave-backend-rollback    # backend 単独 rollback (cloudrun)
 
 permissions:
-  contents: write     # tag push (stage 時)
+  contents: write     # tag push
   id-token: write     # GCP WIF (cloudrun path)
   packages: read      # @ippoan/* GitHub Packages dep install
 


### PR DESCRIPTION
## 概要

ci-workflows#96 の stage 撤去に伴う caller cleanup。ci-dashboard #246（stage dispatch 廃止）+ ci-workflows #101（handler の stage-* job / `release-wave-stage` event 撤去）が merged されたので、本 repo の `release-wave.yml` caller が `release-wave-stage` を listen する必要がなくなった。

- `on: repository_dispatch: types` から `release-wave-stage` を除去（`release-wave-flip` / `-rollback` / `-traffic-rollback` / `-backend-rollback` のみ）。
- header コメントの stage 記述を更新（no-traffic revision の用意は deploy.yml に委譲、wave は Pending releases を flip するだけ）。`permissions` の `# tag push (stage 時)` も整理。

純粋に caller の listen 対象を実態に合わせる cleanup。dispatch 元は既に消えているので挙動変化なし。

Refs ippoan/ci-workflows#96
Refs ippoan/ci-dashboard#244

---
_Generated by [Claude Code](https://claude.ai/code/session_01MYnhZeg24YNLyZsSb87YTo)_