### PR TITLE
cleanup(deploy): production no-traffic deploy から不要な --pending-tag を撤去

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -228,11 +228,9 @@ jobs:
               CURRENT_REV=$(printf '%s' "$SVC_JSON" | jq -r \
                 '(([.status.traffic[]? | select((.percent // 0) > 0) | .revisionName] | map(select(. != null)))[0]) // .status.latestReadyRevisionName // ""')
             fi
-            # tag を Cloud Run revision tag charset (lowercase [a-z0-9-]) に正規化
-            SANITIZED=$(printf '%s' "${REF_NAME:-}" | tr 'A-Z' 'a-z' | tr -c 'a-z0-9-' '-' | sed 's/-\{2,\}/-/g; s/^-//; s/-$//')
             if [ -n "$CURRENT_REV" ]; then
-              RENDER_ARGS="${RENDER_ARGS} --pin-traffic-revision ${CURRENT_REV} --pending-tag pending-${SANITIZED}"
-              echo "::notice::production no-traffic deploy: keep 100% on ${CURRENT_REV}; new revision -> 0% (tag pending-${SANITIZED}). Release Wave flip will switch traffic."
+              RENDER_ARGS="${RENDER_ARGS} --pin-traffic-revision ${CURRENT_REV}"
+              echo "::notice::production no-traffic deploy: keep 100% on ${CURRENT_REV}; new revision -> 0%. Release Wave flip が最新 ready revision に traffic を振る。"
             else
               echo "::warning::no current revision for ${PROD_SVC} (first deploy?) — deploying with Cloud Run default traffic (latest 100%)."
             fi
@@ -348,10 +346,9 @@ jobs:
               CURRENT_REV=$(printf '%s' "$GW_JSON" | jq -r \
                 '(([.status.traffic[]? | select((.percent // 0) > 0) | .revisionName] | map(select(. != null)))[0]) // .status.latestReadyRevisionName // ""')
             fi
-            SANITIZED=$(printf '%s' "${REF_NAME:-}" | tr 'A-Z' 'a-z' | tr -c 'a-z0-9-' '-' | sed 's/-\{2,\}/-/g; s/^-//; s/-$//')
             if [ -n "$CURRENT_REV" ]; then
-              GW_RENDER_ARGS="${GW_RENDER_ARGS} --pin-traffic-revision ${CURRENT_REV} --pending-tag pending-${SANITIZED}"
-              echo "::notice::gateway production no-traffic deploy: keep 100% on ${CURRENT_REV}; new revision -> 0% (tag pending-${SANITIZED})."
+              GW_RENDER_ARGS="${GW_RENDER_ARGS} --pin-traffic-revision ${CURRENT_REV}"
+              echo "::notice::gateway production no-traffic deploy: keep 100% on ${CURRENT_REV}; new revision -> 0%."
             else
               echo "::warning::no current revision for rust-alc-api-gateway (first deploy?) — default traffic (latest 100%)."
             fi


### PR DESCRIPTION
## 概要

release-wave-gcp #6/#8 + ci-workflows #107 で flip が「最新 ready revision に traffic を振る」方式になり、揮発する `pending-<tag>` revision tag は誰も参照しなくなった。production no-traffic deploy が `render.sh` に渡していた dead な `--pending-tag` を撤去する。

- backend / gateway の no-traffic deploy から `--pending-tag pending-${SANITIZED}` と不要になった `SANITIZED` 計算を撤去
- `--pin-traffic-revision ${CURRENT_REV}` は **no-traffic 維持のため残す**（新 revision は引き続き 0% で配置）
- notice メッセージを更新

flip は tag 非依存（最新 ready revision を anchor）なので**動作影響なし**。`render.sh` 側の `--pending-tag` オプション handler は無害な未使用コードとして残置（cloudrun/ は worktree-edit-guard 対象のため別途）。

Refs ippoan/ci-dashboard#248
Refs #369

---
_Generated by [Claude Code](https://claude.ai/code/session_01CY9pr17zwdXcPgk47TMfwZ)_