### PR TITLE
fix(ci): report-pending-release の version_id を tag そのものにする

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -511,12 +511,11 @@ jobs:
             echo "::warning::RELEASE_WAVE_WEBHOOK_SECRET 未設定のため pending-release report を skip"
             exit 0
           fi
-          # cloudrun の no-traffic revision tag。handler flip-cloudrun の sanitize
-          # (tr 'A-Z' 'a-z' | tr '.' '-') と揃える。version_id は表示/識別用で、
-          # 実 flip 対象は handler が target_tag (= record.tag) から pending-<tag>
-          # を再計算するため、ここで完全一致している必要はない。
-          sanitized=$(printf '%s' "$TAG" | tr 'A-Z' 'a-z' | tr '.' '-')
-          version_id="pending-${sanitized}"
+          # version_id は ci-dashboard の Pending releases 表示/識別用。cloudrun の
+          # flip は release-wave-gcp proxy が service の latestReadyRevision を anchor
+          # にするため version_id を読まない (Refs ippoan/ci-dashboard#248)。よって
+          # ダミーの pending-<tag> ではなく release tag をそのまま入れる。
+          version_id="$TAG"
           payload=$(jq -nc \
             --arg repo "$REPO" --arg version_id "$version_id" --arg tag "$TAG" \
             '{repo: $repo, version_id: $version_id, tag: $tag}')


### PR DESCRIPTION
## 何を

`report-pending-release` job が ci-dashboard に送る `version_id` を、ダミーの `pending-<tag>` → **release tag そのもの** (`v0.0.83`) に変える。コメントも現状に合わせて修正。

```diff
-          sanitized=$(printf '%s' "$TAG" | tr 'A-Z' 'a-z' | tr '.' '-')
-          version_id="pending-${sanitized}"
+          version_id="$TAG"
```

## なぜ

`/release-wave` の Pending releases に `ippoan/rust-alc-api v0.0.83 pending-…` と出ていて「揮発する pending revision tag をまだ作っているのでは?」と紛らわしかった。

調べた結果、**実害 (= flip が pending tag を探しに行く挙動) は既に #248 で解消済み**:

| レイヤー | 現状 |
|---|---|
| `deploy.yml` (Cloud Run revision tag) | `--pin-traffic-revision` で no-traffic 化のみ。`--pending-tag` は渡していない → revision tag は作っていない |
| `release-wave-gcp` flip (`cloudrun.go`) | `latestReadyRevision` を anchor。`to_revision_tag` は無視 (#248) |
| `ci-workflows` handler (`flip-cloudrun`) | body は `{project,region,service}` のみ。revision tag を渡さない (#248) |
| **本 job (`report-pending-release`)** | `version_id="pending-${sanitized}"` という**ダミー文字列**を今も生成・送信 ← これが表示の正体 |

`version_id` は本来 workers 用フィールド (wrangler version UUID = flip 実対象) で、cloudrun は flip に `latestReadyRevision` を使うため**読まない**。ダミーの `pending-<tag>` を入れる必要が無いので、`tag` をそのまま入れて表示を素直にする。

## 影響範囲 / 安全性

- **ci-dashboard 無改修**: `version_id` は `z.string().min(1)` で受けるだけ。`v0.0.83` は非空なので通る。`page.ts` の表示も非空前提で落ちない。
- cloudrun の pending→flip は `version_id` 非依存 (KV key は repo 単位、flip は `latestReadyRevision`、clear も repo 単位) なので挙動不変。
- 既存タグの打ち直しは不要。次の `v*` リリースから表示が `v0.0.83` になる。

Refs ippoan/ci-dashboard#248

---
_Generated by [Claude Code](https://claude.ai/code/session_016MsaNjU4paymBoF1RhMJgN)_