### PR TITLE
ci(release-wave): deploy 直後の Cloud Run 実 traffic split を ci-dashboard に報告

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -538,6 +538,24 @@ jobs:
           fi
           echo "✅ pending-release reported"
 
+      # deploy 直後 (flip 前) の実 traffic split を ci-dashboard に報告する。
+      # production の no-traffic deploy 直後は「旧 revision 100% + 新 pending 0%」
+      # 状態なので、それを GCP 実態として Backend traffic 表に出す
+      # (Refs ippoan/ci-dashboard#256)。services は release-wave-targets.yaml と揃える。
+      # best-effort: pending-release は上で報告済みなので、ここの失敗は action 内で
+      # warning 止まり (job は fail させない)。
+      - name: Report backend traffic split (pre-flip pending)
+        uses: ippoan/ci-workflows/.github/actions/report-backend-traffic-split@main
+        with:
+          repo: ${{ github.repository }}
+          gcp_project: cloudsql-sv
+          gcp_region: asia-northeast1
+          services_json: '["rust-alc-api","rust-alc-api-gateway","rust-alc-api-tenko","rust-alc-api-carins","rust-alc-api-dtako","rust-alc-api-trouble"]'
+          release_wave_gcp_base_url: https://release-wave-gcp-staging-566bls5vfq-an.a.run.app
+          gcp_api_key: ${{ secrets.RELEASE_WAVE_GCP_API_KEY }}
+          ci_dashboard_base_url: https://ci-dashboard.ippoan.org
+          webhook_secret: ${{ secrets.RELEASE_WAVE_WEBHOOK_SECRET }}
+
   auto-merge:
     name: Auto Merge
     needs: [snapshot-check, check, coverage-check, build-image]


### PR DESCRIPTION
## 概要

実 traffic % split 表示の **deploy 直後（= flip 前 pending）報告**。受け皿は ippoan/ci-dashboard#259（merged）、共通 action は ippoan/ci-workflows#108（merged）。

rust-alc-api の production は **no-traffic deploy**（`deploy.yml` の `verify-no-traffic` job が「tag release は traffic を flip してはいけない」を強制）なので、deploy 直後は「**旧 revision 100% + 新 pending revision 0%**」状態。この実態を Backend traffic 表に出すため、`report-pending-release` job で実 traffic を報告する。

Refs ippoan/ci-dashboard#256

## 変更

`ci.yml` の `report-pending-release` job（production `v*` tag deploy 後）に、ci-workflows の `report-backend-traffic-split` action 呼び出しを追加:
- 6 service（`rust-alc-api` / `-gateway` / `-tenko` / `-carins` / `-dtako` / `-trouble`）の `status.traffic[]` を release-wave-gcp の stage-check で取得 → ci-dashboard の `/webhooks/release-wave/backend-traffic-report` に POST。
- services は `release-wave-targets.yaml` と揃えた static routing なので直書き（secret ではない）。
- best-effort（pending-release は同 job で報告済みなので、traffic 報告の失敗は action 内で warning 止まり）。

## タイミング整理（push 型 3 箇所）

| タイミング | 報告内容 | 配線 |
|---|---|---|
| **deploy 直後（本 PR）** | 旧 100% + 新 pending 0% | rust-alc-api `ci.yml` |
| flip 後 | 新 active 100% | ci-workflows `release-wave-handler`（#108） |
| rollback 後 | 戻し先 100% | 同上 |

## 検証

- `ci.yml` の YAML syntax ✅
- `report-pending-release` は `startsWith(github.ref, 'refs/tags/v')` 条件付きなので、本 PR（非 tag）の CI では skip され、Rust build/test には影響しない。
- 追加 step は composite action（`uses`）+ 静的 `with` 値のみで、untrusted input を `run:` で使わない。

https://claude.ai/code/session_01P4o2JFAwvEQNcWXUsEttnM

---
_Generated by [Claude Code](https://claude.ai/code/session_01P4o2JFAwvEQNcWXUsEttnM)_