### PR TITLE
ci(deploy): production no-traffic revision に preview tag を付与

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -230,7 +230,15 @@ jobs:
             fi
             if [ -n "$CURRENT_REV" ]; then
               RENDER_ARGS="${RENDER_ARGS} --pin-traffic-revision ${CURRENT_REV}"
-              echo "::notice::production no-traffic deploy: keep 100% on ${CURRENT_REV}; new revision -> 0%. Release Wave flip が最新 ready revision に traffic を振る。"
+              # no-traffic (0%) revision に release タグ由来の Cloud Run revision tag を
+              # 付ける (tag は dot 不可なので v1.42.0 -> v1-42-0 にサニタイズ)。admin が
+              # preview-*.ippoan.org (CF Access) 経由でこの tagged URL に到達して flip 前に
+              # E2E 検証する。front↔backend のペアリング/互換は既存の retest
+              # (compat_backend_repo) が担うので別 config は不要。Refs ippoan/ci-dashboard#260。
+              # tag は preview 到達専用 (flip は最新 ready revision を anchor にする)。
+              PREVIEW_TAG="$(printf '%s' "${REF_NAME##*/}" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9' '-' | sed -e 's/-\{2,\}/-/g' -e 's/^-//' -e 's/-$//' | cut -c1-60)"
+              RENDER_ARGS="${RENDER_ARGS} --pending-tag ${PREVIEW_TAG}"
+              echo "::notice::production no-traffic deploy: keep 100% on ${CURRENT_REV}; new revision -> 0% (preview tag=${PREVIEW_TAG}). Release Wave flip が最新 ready revision に traffic を振る。"
             else
               echo "::warning::no current revision for ${PROD_SVC} (first deploy?) — deploying with Cloud Run default traffic (latest 100%)."
             fi
@@ -273,6 +281,23 @@ jobs:
             --region ${{ env.REGION }} --project ${{ env.PROJECT }} \
             --format 'value(status.url)')
           echo "::notice ::${{ matrix.service }} URL: $URL"
+
+      - name: Print preview URL (production no-traffic tag)
+        if: github.event_name != 'pull_request'
+        run: |
+          case "${{ matrix.service }}" in
+            backend) SVC="rust-alc-api" ;;
+            *)       SVC="rust-alc-api-${{ matrix.service }}" ;;
+          esac
+          # tagged (= preview) traffic target の URL を列挙する。pending-* tag が
+          # 付いた 0% revision がここに出る。admin はこの URL を CF Access 配下の
+          # preview-*.ippoan.org にマップして flip 前 E2E に使う (Refs ci-dashboard#260)。
+          gcloud run services describe "$SVC" \
+            --region ${{ env.REGION }} --project ${{ env.PROJECT }} --format=json 2>/dev/null \
+            | jq -r '.status.traffic[]? | select(.tag != null) | "preview tag=\(.tag) url=\(.url)"' \
+            | while IFS= read -r line; do
+                [ -n "$line" ] && echo "::notice ::${{ matrix.service }} $line"
+              done || true
 
   # ---------------------------------------------------------------------------
   # Deploy gateway (after other services, needs their URLs)
@@ -348,7 +373,11 @@ jobs:
             fi
             if [ -n "$CURRENT_REV" ]; then
               GW_RENDER_ARGS="${GW_RENDER_ARGS} --pin-traffic-revision ${CURRENT_REV}"
-              echo "::notice::gateway production no-traffic deploy: keep 100% on ${CURRENT_REV}; new revision -> 0%."
+              # gateway も no-traffic (0%) revision に release タグ由来の revision tag を付ける
+              # (admin が CF Access 経由で flip 前 E2E 検証する。Refs ippoan/ci-dashboard#260)。
+              GW_PREVIEW_TAG="$(printf '%s' "${REF_NAME##*/}" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9' '-' | sed -e 's/-\{2,\}/-/g' -e 's/^-//' -e 's/-$//' | cut -c1-60)"
+              GW_RENDER_ARGS="${GW_RENDER_ARGS} --pending-tag ${GW_PREVIEW_TAG}"
+              echo "::notice::gateway production no-traffic deploy: keep 100% on ${CURRENT_REV}; new revision -> 0% (preview tag=${GW_PREVIEW_TAG})."
             else
               echo "::warning::no current revision for rust-alc-api-gateway (first deploy?) — default traffic (latest 100%)."
             fi
@@ -390,6 +419,18 @@ jobs:
             --region ${{ env.REGION }} --project ${{ env.PROJECT }} \
             --format 'value(status.url)')
           echo "::notice ::Gateway URL: $URL"
+
+      - name: Print gateway preview URL (production no-traffic tag)
+        if: github.event_name != 'pull_request'
+        run: |
+          # gateway の tagged (= preview) traffic target URL を列挙
+          # (Refs ippoan/ci-dashboard#260)。
+          gcloud run services describe rust-alc-api-gateway \
+            --region ${{ env.REGION }} --project ${{ env.PROJECT }} --format=json 2>/dev/null \
+            | jq -r '.status.traffic[]? | select(.tag != null) | "preview tag=\(.tag) url=\(.url)"' \
+            | while IFS= read -r line; do
+                [ -n "$line" ] && echo "::notice ::gateway $line"
+              done || true
 
   # ---------------------------------------------------------------------------
   # Staging: smoke test /api/notify/ingest after staging deploy


### PR DESCRIPTION
## 目的

tag release (`v*`) の production deploy で、no-traffic (0%) で上がる新 revision に
**Cloud Run revision tag** を付け、`https://<tag>---<svc>-<hash>.run.app` の **到達可能な
preview URL** を生やす。これで admin が `preview-*.ippoan.org` (CF Access) 経由で
**flip 前に no-traffic の新 backend を E2E 検証**できるようになる。

Release Wave 機構で「no-traffic front+backend を flip 前にペアで E2E テストしたい」
という要望 (Refs ippoan/ci-dashboard#260) の **block A = backend preview URL** にあたる。

## 変更

`.github/workflows/deploy.yml` のみ:

- production の no-traffic deploy (= `--pin-traffic-revision` を渡す経路) で、release タグを
  Cloud Run revision tag 制約 (`[a-z0-9-]`、dot 不可) に合わせてサニタイズした値
  (`v1.42.0` → `v1-42-0`) を `cloudrun/render.sh --pending-tag` に渡す。
- `render.sh` は既に `--pending-tag` 対応済み (0% revision に `tag:` を emit)。**deploy.yml が
  wire していなかっただけ**。本 PR はその配線。
- backend / 各 service / gateway の deploy ログに tagged preview URL を surface する step を追加。

## 設計上のポイント

- **tag は preview 到達専用**。flip は `release-wave-gcp` proxy が `latestReadyRevision` を
  anchor にする (Refs ci-dashboard#248) ので、揮発する tag に依存しない。
- **front↔backend のペアリング/互換検証は既存の retest (`compat_backend_repo`) が担う**。
  本 PR は新しい pairing config を増やさない (二重実装回避)。
- **後方互換**: tag 無し (初回 deploy で current revision が無い等) の従来挙動は不変。
  staging deploy にも影響しない (production no-traffic 経路のみ)。

## 検証

- `render.sh --pending-tag v1-42-0` で 0% revision に `tag: v1-42-0` が emit されることを確認
  (未指定時は tag 行が出ないことも確認 = 後方互換)。
- 生成 YAML の `spec.traffic` が `[{100% pinned}, {0% latest, tag: v1-42-0}]` になることを
  python で構造検証。
- サニタイズ: `v1.42.0→v1-42-0` / `dev-5→dev-5` / `refs/tags/v1.10.3→v1-10-3`。
- `deploy.yml` の YAML 構文 OK。

Refs ippoan/ci-dashboard#260

---
_Generated by [Claude Code](https://claude.ai/code/session_019vz4Yn4TAGwYaRr3bE3DdM)_