### PR TITLE
feat(camera): 監視カメラ死活管理ドメイン + 障害自動起票 (Refs #345)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,7 @@ jobs:
           - { name: carins, targets: "//crates/carins-api" }
           - { name: dtako, targets: "//crates/dtako-api" }
           - { name: trouble, targets: "//crates/trouble-api" }
+          - { name: camera, targets: "//crates/alc-camera-api" }
     steps:
       - uses: actions/checkout@v4
       - uses: ippoan/setup-bazel@main
@@ -333,6 +334,13 @@ jobs:
             bin-paths: "bazel-bin/crates/trouble-api/trouble-api"
             dockerfile: Dockerfile.trouble
             tag-suffix: "-trouble"
+            extra-copy: ""
+          - name: camera
+            targets: "//crates/alc-camera-api"
+            binaries: "alc-camera-api"
+            bin-paths: "bazel-bin/crates/alc-camera-api/alc-camera-api"
+            dockerfile: Dockerfile.camera
+            tag-suffix: "-camera"
             extra-copy: ""
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,6 +65,7 @@ jobs:
           - { service: carins,  suffix: "-carins", binary: carins-api }
           - { service: dtako,   suffix: "-dtako",   binary: dtako-api }
           - { service: trouble, suffix: "-trouble", binary: trouble-api }
+          - { service: camera,  suffix: "-camera",  binary: alc-camera-api }
     steps:
       - uses: actions/checkout@v4
       - uses: docker/login-action@v3
@@ -121,7 +122,7 @@ jobs:
           REPO="${{ env.REPO }}"
           TAG="${{ inputs.ref_name }}"
           SHA="${{ inputs.image_sha }}"
-          for suffix in "" "-gateway" "-tenko" "-carins" "-dtako" "-trouble"; do
+          for suffix in "" "-gateway" "-tenko" "-carins" "-dtako" "-trouble" "-camera"; do
             docker pull "${REPO}${suffix}:dev"
             docker tag "${REPO}${suffix}:dev" "${REPO}${suffix}:${TAG}"
             docker tag "${REPO}${suffix}:dev" "${REPO}${suffix}:${SHA}"
@@ -186,7 +187,7 @@ jobs:
       # 独立してロールバックする (Refs #375)。
       fail-fast: false
       matrix:
-        service: [backend, tenko, carins, dtako, trouble]
+        service: [backend, tenko, carins, dtako, trouble, camera]
     steps:
       - uses: actions/checkout@v4
 
@@ -401,6 +402,9 @@ jobs:
             TROUBLE_URL=$(gcloud run services describe rust-alc-api-staging-trouble \
               --region ${{ env.REGION }} --project ${{ env.PROJECT }} \
               --format 'value(status.url)' 2>/dev/null || echo "")
+            CAMERA_URL=$(gcloud run services describe rust-alc-api-staging-camera \
+              --region ${{ env.REGION }} --project ${{ env.PROJECT }} \
+              --format 'value(status.url)' 2>/dev/null || echo "")
           else
             BACKEND_URL=$(gcloud run services describe rust-alc-api \
               --region ${{ env.REGION }} --project ${{ env.PROJECT }} \
@@ -415,6 +419,9 @@ jobs:
               --region ${{ env.REGION }} --project ${{ env.PROJECT }} \
               --format 'value(status.url)' 2>/dev/null || echo "")
             TROUBLE_URL=$(gcloud run services describe rust-alc-api-trouble \
+              --region ${{ env.REGION }} --project ${{ env.PROJECT }} \
+              --format 'value(status.url)' 2>/dev/null || echo "")
+            CAMERA_URL=$(gcloud run services describe rust-alc-api-camera \
               --region ${{ env.REGION }} --project ${{ env.PROJECT }} \
               --format 'value(status.url)' 2>/dev/null || echo "")
           fi
@@ -452,6 +459,7 @@ jobs:
             -e "s|PLACEHOLDER_CARINS_URL|${CARINS_URL}|" \
             -e "s|PLACEHOLDER_DTAKO_URL|${DTAKO_URL}|" \
             -e "s|PLACEHOLDER_TROUBLE_URL|${TROUBLE_URL}|" \
+            -e "s|PLACEHOLDER_CAMERA_URL|${CAMERA_URL}|" \
             /tmp/gateway.yaml
 
           echo "=== Gateway YAML ==="
@@ -617,7 +625,7 @@ jobs:
       - name: Assert latest revision receives 0% traffic
         run: |
           set -euo pipefail
-          SERVICES="rust-alc-api rust-alc-api-gateway rust-alc-api-tenko rust-alc-api-carins rust-alc-api-dtako rust-alc-api-trouble"
+          SERVICES="rust-alc-api rust-alc-api-gateway rust-alc-api-tenko rust-alc-api-carins rust-alc-api-dtako rust-alc-api-trouble rust-alc-api-camera"
           fail=0
           for SVC in $SERVICES; do
             echo "::group::$SVC traffic split"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "alc-camera"
+version = "0.1.0"
+dependencies = [
+ "alc-core",
+ "async-trait",
+ "axum",
+ "chrono",
+ "serde",
+ "serde_json",
+ "sqlx",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "alc-camera-api"
+version = "0.1.0"
+dependencies = [
+ "alc-camera",
+ "alc-core",
+ "alc-trouble",
+ "axum",
+ "sqlx",
+ "tokio",
+ "tower-http",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "alc-carins"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = [".", "crates/alc-auth", "crates/alc-carins", "crates/alc-core", "crates/alc-csv-parser", "crates/alc-compare", "crates/alc-devices", "crates/alc-dtako", "crates/alc-misc", "crates/alc-notify", "crates/alc-pdf", "crates/alc-storage", "crates/alc-tenko", "crates/alc-trouble", "crates/carins-api", "crates/dtako-api", "crates/gateway", "crates/tenko-api", "crates/trouble-api"]
+members = [".", "crates/alc-auth", "crates/alc-camera", "crates/alc-camera-api", "crates/alc-carins", "crates/alc-core", "crates/alc-csv-parser", "crates/alc-compare", "crates/alc-devices", "crates/alc-dtako", "crates/alc-misc", "crates/alc-notify", "crates/alc-pdf", "crates/alc-storage", "crates/alc-tenko", "crates/alc-trouble", "crates/carins-api", "crates/dtako-api", "crates/gateway", "crates/tenko-api", "crates/trouble-api"]
 resolver = "2"
 
 [package]

--- a/Dockerfile.camera
+++ b/Dockerfile.camera
@@ -1,0 +1,10 @@
+FROM debian:trixie-slim
+
+RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+
+COPY alc-camera-api /usr/local/bin/
+
+ENV PORT=8080
+EXPOSE 8080
+
+CMD ["alc-camera-api"]

--- a/cloudrun/render.sh
+++ b/cloudrun/render.sh
@@ -3,7 +3,7 @@
 # Generates a Cloud Run service YAML for any service × environment combination.
 #
 # Usage: bash cloudrun/render.sh <service> <environment> <image_sha> [options]
-#   service:     backend | gateway | tenko | carins | dtako
+#   service:     backend | gateway | tenko | carins | dtako | trouble | camera
 #   environment: staging | production
 #   image_sha:   Docker image SHA tag
 #
@@ -59,6 +59,7 @@ case "$SERVICE" in
   carins)   SUFFIX="-carins";  BIN="carins-api" ;;
   dtako)    SUFFIX="-dtako";   BIN="dtako-api" ;;
   trouble)  SUFFIX="-trouble"; BIN="trouble-api" ;;
+  camera)   SUFFIX="-camera";  BIN="alc-camera-api" ;;
   *) echo "Unknown service: $SERVICE" >&2; exit 1 ;;
 esac
 
@@ -287,6 +288,8 @@ emit_env_gateway() {
               value: "PLACEHOLDER_DTAKO_URL"
             - name: TROUBLE_API_URL
               value: "PLACEHOLDER_TROUBLE_URL"
+            - name: CAMERA_API_URL
+              value: "PLACEHOLDER_CAMERA_URL"
             - name: JWT_SECRET
               valueFrom:
                 secretKeyRef:
@@ -377,6 +380,14 @@ YAML
   emit_database_url
 }
 
+emit_env_camera() {
+  cat <<YAML
+            - name: RUST_LOG
+              value: "alc_camera_api=info,alc_camera=info"
+YAML
+  emit_database_url
+}
+
 # Shared helper: emit DATABASE_URL (staging=localhost, production=Secret Manager)
 emit_database_url() {
   if [[ "$ENV" == "staging" ]]; then
@@ -428,6 +439,7 @@ case "$SERVICE" in
   carins)  MEMORY="256Mi"; CPU="1"   ;;
   dtako)   MEMORY="512Mi"; CPU="1"   ;;
   trouble) MEMORY="256Mi"; CPU="1"   ;;
+  camera)  MEMORY="256Mi"; CPU="1"   ;;
 esac
 
 # Port

--- a/crates/alc-camera-api/BUILD.bazel
+++ b/crates/alc-camera-api/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@rules_rust//rust:defs.bzl", "rust_binary")
+load("@crates//:defs.bzl", "all_crate_deps")
+
+rust_binary(
+    name = "alc-camera-api",
+    srcs = glob(["src/**/*.rs"]),
+    deps = all_crate_deps(normal = True) + [
+        "//crates/alc-core",
+        "//crates/alc-camera",
+        "//crates/alc-trouble",
+    ],
+    proc_macro_deps = all_crate_deps(proc_macro = True),
+    visibility = ["//visibility:public"],
+)

--- a/crates/alc-camera-api/Cargo.toml
+++ b/crates/alc-camera-api/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "alc-camera-api"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "alc-camera-api"
+path = "src/main.rs"
+
+[dependencies]
+alc-core = { path = "../alc-core" }
+alc-camera = { path = "../alc-camera" }
+alc-trouble = { path = "../alc-trouble" }
+axum = "0.8"
+sqlx = { version = "0.8", features = ["runtime-tokio", "tls-rustls", "postgres"] }
+tokio = { version = "1", features = ["full"] }
+tower-http = { version = "0.6", features = ["cors", "trace"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/crates/alc-camera-api/src/main.rs
+++ b/crates/alc-camera-api/src/main.rs
@@ -1,0 +1,77 @@
+//! 監視カメラ死活管理 API バイナリ (Refs #345)。
+//!
+//! gateway が `/cameras*` をこのサービスへ proxy する。カメラマスタの CRUD、
+//! device からのヘルスログ受信、ステータス集計を提供し、連続失敗を alc-trouble に
+//! 自動起票する。
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use axum::{middleware as axum_middleware, Router};
+use sqlx::postgres::PgPoolOptions;
+use tower_http::{
+    cors::{Any, CorsLayer},
+    trace::TraceLayer,
+};
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+use alc_camera::repo::PgCamerasRepository;
+use alc_camera::{CameraState, DEFAULT_DOWN_THRESHOLD};
+use alc_core::auth_middleware::require_tenant_header;
+use alc_trouble::repo::trouble_tickets::PgTroubleTicketsRepository;
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::registry()
+        .with(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "alc_camera_api=info,alc_camera=info,tower_http=info".into()),
+        )
+        .with(tracing_subscriber::fmt::layer())
+        .init();
+
+    let database_url = std::env::var("DATABASE_URL").expect("DATABASE_URL is required");
+    let port: u16 = std::env::var("PORT")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(8080);
+    let down_threshold: usize = std::env::var("CAMERA_DOWN_THRESHOLD")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .filter(|n| *n >= 1)
+        .unwrap_or(DEFAULT_DOWN_THRESHOLD);
+
+    let pool = PgPoolOptions::new()
+        .max_connections(10)
+        .connect(&database_url)
+        .await
+        .expect("Failed to connect to database");
+
+    let state = CameraState {
+        cameras: Arc::new(PgCamerasRepository::new(pool.clone())),
+        trouble_tickets: Arc::new(PgTroubleTicketsRepository::new(pool.clone())),
+        down_threshold,
+    };
+
+    let tenant_protected = Router::new()
+        .merge(alc_camera::handlers::tenant_router())
+        .layer(axum_middleware::from_fn(require_tenant_header));
+
+    let cors = CorsLayer::new()
+        .allow_origin(Any)
+        .allow_methods(Any)
+        .allow_headers(Any);
+
+    let app = Router::new()
+        .route("/health", axum::routing::get(|| async { "ok" }))
+        .merge(tenant_protected)
+        .with_state(state)
+        .layer(cors)
+        .layer(TraceLayer::new_for_http());
+
+    let addr = SocketAddr::from(([0, 0, 0, 0], port));
+    tracing::info!("alc-camera-api listening on {addr} (down_threshold={down_threshold})");
+
+    let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
+    axum::serve(listener, app).await.unwrap();
+}

--- a/crates/alc-camera/BUILD.bazel
+++ b/crates/alc-camera/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
+load("@crates//:defs.bzl", "all_crate_deps")
+
+rust_library(
+    name = "alc-camera",
+    srcs = glob(["src/**/*.rs"]),
+    crate_name = "alc_camera",
+    deps = all_crate_deps(normal = True) + [
+        "//crates/alc-core",
+    ],
+    proc_macro_deps = all_crate_deps(proc_macro = True),
+    visibility = ["//visibility:public"],
+)
+
+rust_test(
+    name = "alc-camera_test",
+    crate = ":alc-camera",
+)

--- a/crates/alc-camera/Cargo.toml
+++ b/crates/alc-camera/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "alc-camera"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+alc-core = { path = "../alc-core" }
+async-trait = "0.1"
+axum = "0.8"
+chrono = { version = "0.4", features = ["serde"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+sqlx = { version = "0.8", features = ["postgres", "chrono", "uuid"] }
+tracing = "0.1"
+uuid = { version = "1", features = ["v4", "serde"] }

--- a/crates/alc-camera/src/handlers.rs
+++ b/crates/alc-camera/src/handlers.rs
@@ -1,0 +1,161 @@
+//! 監視カメラ HTTP layer (tenant スコープ、Refs #345)。
+//!
+//! `require_tenant_header` 配下にマウントする前提。device (拠点タブレット) は
+//! X-Tenant-ID ヘッダーで health-log を書き込み、管理画面は JWT でマスタを CRUD する。
+
+use axum::{
+    extract::{Path, Query, State},
+    http::StatusCode,
+    routing::{get, post},
+    Extension, Json, Router,
+};
+use serde::Deserialize;
+use uuid::Uuid;
+
+use alc_core::auth_middleware::TenantId;
+use alc_core::repository::cameras::{
+    Camera, CameraHealthLog, CameraStatusRow, CreateCamera, CreateCameraHealthLog, UpdateCamera,
+};
+
+use crate::CameraState;
+
+pub fn tenant_router() -> Router<CameraState> {
+    Router::new()
+        .route("/cameras", get(list_cameras).post(create_camera))
+        .route("/cameras/status", get(camera_statuses))
+        .route(
+            "/cameras/{id}",
+            get(get_camera).patch(update_camera).delete(delete_camera),
+        )
+        .route(
+            "/cameras/{id}/health-logs",
+            post(create_health_log).get(list_health_logs),
+        )
+}
+
+async fn list_cameras(
+    State(state): State<CameraState>,
+    tenant: Extension<TenantId>,
+) -> Result<Json<Vec<Camera>>, StatusCode> {
+    let tenant_id = tenant.0 .0;
+    state
+        .cameras
+        .list(tenant_id)
+        .await
+        .map(Json)
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)
+}
+
+async fn create_camera(
+    State(state): State<CameraState>,
+    tenant: Extension<TenantId>,
+    Json(body): Json<CreateCamera>,
+) -> Result<(StatusCode, Json<Camera>), StatusCode> {
+    let tenant_id = tenant.0 .0;
+    state
+        .cameras
+        .create(tenant_id, &body)
+        .await
+        .map(|c| (StatusCode::CREATED, Json(c)))
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)
+}
+
+async fn get_camera(
+    State(state): State<CameraState>,
+    tenant: Extension<TenantId>,
+    Path(id): Path<Uuid>,
+) -> Result<Json<Camera>, StatusCode> {
+    let tenant_id = tenant.0 .0;
+    match state.cameras.get(tenant_id, id).await {
+        Ok(Some(c)) => Ok(Json(c)),
+        Ok(None) => Err(StatusCode::NOT_FOUND),
+        Err(_) => Err(StatusCode::INTERNAL_SERVER_ERROR),
+    }
+}
+
+async fn update_camera(
+    State(state): State<CameraState>,
+    tenant: Extension<TenantId>,
+    Path(id): Path<Uuid>,
+    Json(body): Json<UpdateCamera>,
+) -> Result<Json<Camera>, StatusCode> {
+    let tenant_id = tenant.0 .0;
+    match state.cameras.update(tenant_id, id, &body).await {
+        Ok(Some(c)) => Ok(Json(c)),
+        Ok(None) => Err(StatusCode::NOT_FOUND),
+        Err(_) => Err(StatusCode::INTERNAL_SERVER_ERROR),
+    }
+}
+
+async fn delete_camera(
+    State(state): State<CameraState>,
+    tenant: Extension<TenantId>,
+    Path(id): Path<Uuid>,
+) -> Result<StatusCode, StatusCode> {
+    let tenant_id = tenant.0 .0;
+    match state.cameras.delete(tenant_id, id).await {
+        Ok(true) => Ok(StatusCode::NO_CONTENT),
+        Ok(false) => Err(StatusCode::NOT_FOUND),
+        Err(_) => Err(StatusCode::INTERNAL_SERVER_ERROR),
+    }
+}
+
+async fn camera_statuses(
+    State(state): State<CameraState>,
+    tenant: Extension<TenantId>,
+) -> Result<Json<Vec<CameraStatusRow>>, StatusCode> {
+    let tenant_id = tenant.0 .0;
+    state
+        .cameras
+        .statuses(tenant_id)
+        .await
+        .map(Json)
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)
+}
+
+async fn create_health_log(
+    State(state): State<CameraState>,
+    tenant: Extension<TenantId>,
+    Path(id): Path<Uuid>,
+    Json(body): Json<CreateCameraHealthLog>,
+) -> Result<(StatusCode, Json<CameraHealthLog>), StatusCode> {
+    let tenant_id = tenant.0 .0;
+    // カメラの存在 (= テナント所属) を確認してから記録する。
+    match state.cameras.get(tenant_id, id).await {
+        Ok(Some(_)) => {}
+        Ok(None) => return Err(StatusCode::NOT_FOUND),
+        Err(_) => return Err(StatusCode::INTERNAL_SERVER_ERROR),
+    }
+    crate::health::record_health_and_maybe_ticket(
+        state.cameras.as_ref(),
+        state.trouble_tickets.as_ref(),
+        tenant_id,
+        id,
+        &body,
+        state.down_threshold,
+    )
+    .await
+    .map(|log| (StatusCode::CREATED, Json(log)))
+    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)
+}
+
+#[derive(Debug, Deserialize)]
+pub struct HealthLogQuery {
+    pub limit: Option<i64>,
+}
+
+async fn list_health_logs(
+    State(state): State<CameraState>,
+    tenant: Extension<TenantId>,
+    Path(id): Path<Uuid>,
+    Query(q): Query<HealthLogQuery>,
+) -> Result<Json<Vec<CameraHealthLog>>, StatusCode> {
+    let tenant_id = tenant.0 .0;
+    let limit = q.limit.unwrap_or(100).clamp(1, 1000);
+    state
+        .cameras
+        .recent_health_logs(tenant_id, id, limit)
+        .await
+        .map(Json)
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)
+}

--- a/crates/alc-camera/src/health.rs
+++ b/crates/alc-camera/src/health.rs
@@ -1,0 +1,188 @@
+//! ヘルスログ記録 + 連続失敗判定 → alc-trouble 自動起票 usecase (Refs #345)。
+//!
+//! Cloud Run の CPU throttling 対策として `tokio::spawn` の background 化はせず、
+//! health-log POST のリクエスト内で同期的に判定・起票する (1 query 数件で軽量)。
+
+use uuid::Uuid;
+
+use alc_core::models::CreateTroubleTicket;
+use alc_core::repository::cameras::{CameraHealthLog, CreateCameraHealthLog};
+use alc_core::repository::{CamerasRepository, TroubleTicketsRepository};
+
+/// camera の障害自動起票で使う trouble category。
+const CAMERA_TROUBLE_CATEGORY: &str = "その他";
+
+/// ヘルスログを 1 件記録し、必要なら障害の自動起票 / 復旧リンク解除を行う。
+///
+/// - `alive == false` が連続 `down_threshold` 回続き、かつ未解決の自動 ticket が
+///   無ければ alc-trouble に起票して `cameras.active_down_ticket_id` にリンクする。
+/// - `alive == true` (復旧) でリンクがあればリンクをクリアする (ticket は自動
+///   クローズせず手動クローズに委ねる)。
+///
+/// 起票やステータス更新で失敗しても **ログ記録自体は成功扱い** で返す
+/// (監視ログの欠損を避けるため、副作用の失敗は warning に留める)。
+pub async fn record_health_and_maybe_ticket(
+    cameras: &dyn CamerasRepository,
+    tickets: &dyn TroubleTicketsRepository,
+    tenant_id: Uuid,
+    camera_id: Uuid,
+    input: &CreateCameraHealthLog,
+    down_threshold: usize,
+) -> Result<CameraHealthLog, sqlx::Error> {
+    let log = cameras
+        .insert_health_log(tenant_id, camera_id, input)
+        .await?;
+
+    // カメラマスタが消えている等で取れなければ副作用はスキップ。
+    let camera = match cameras.get(tenant_id, camera_id).await? {
+        Some(c) => c,
+        None => return Ok(log),
+    };
+
+    if input.alive {
+        // 復旧: 自動起票リンクがあればクリア (ticket は手動クローズ)。
+        if camera.active_down_ticket_id.is_some() {
+            if let Err(e) = cameras
+                .set_active_down_ticket(tenant_id, camera_id, None)
+                .await
+            {
+                tracing::warn!(
+                    camera_id = %camera_id,
+                    tenant_id = %tenant_id,
+                    error = %e,
+                    "camera recovered but failed to clear active_down_ticket"
+                );
+            }
+        }
+        return Ok(log);
+    }
+
+    // down 系: 既に未解決 ticket があれば冪等に何もしない。
+    if camera.active_down_ticket_id.is_some() {
+        return Ok(log);
+    }
+
+    // 直近 down_threshold 件が全て alive=false なら連続失敗とみなす。
+    let recent = cameras
+        .recent_health_logs(tenant_id, camera_id, down_threshold as i64)
+        .await?;
+    let consecutive_down = recent.len() >= down_threshold && recent.iter().all(|l| !l.alive);
+    if !consecutive_down {
+        return Ok(log);
+    }
+
+    let ticket_input = build_camera_down_ticket(&camera.name, &camera.ip, camera_id, &log);
+    match tickets.create(tenant_id, &ticket_input, None, None).await {
+        Ok(ticket) => {
+            if let Err(e) = cameras
+                .set_active_down_ticket(tenant_id, camera_id, Some(ticket.id))
+                .await
+            {
+                tracing::warn!(
+                    camera_id = %camera_id,
+                    ticket_id = %ticket.id,
+                    error = %e,
+                    "auto-ticketed camera down but failed to link active_down_ticket"
+                );
+            }
+            tracing::info!(
+                camera_id = %camera_id,
+                tenant_id = %tenant_id,
+                ticket_id = %ticket.id,
+                "camera down auto-ticketed"
+            );
+        }
+        Err(e) => {
+            tracing::warn!(
+                camera_id = %camera_id,
+                tenant_id = %tenant_id,
+                error = %e,
+                "failed to auto-ticket camera down"
+            );
+        }
+    }
+
+    Ok(log)
+}
+
+/// 自動起票する trouble ticket のペイロードを組み立てる (純粋関数、テスト容易)。
+pub fn build_camera_down_ticket(
+    camera_name: &str,
+    camera_ip: &str,
+    camera_id: Uuid,
+    log: &CameraHealthLog,
+) -> CreateTroubleTicket {
+    let title = format!("監視カメラ異常: {camera_name}");
+    let description = format!(
+        "監視カメラ「{name}」({ip}) が連続して応答しません。\n直近エラー: {err}",
+        name = camera_name,
+        ip = camera_ip,
+        err = log.error.as_deref().unwrap_or("(なし)"),
+    );
+    CreateTroubleTicket {
+        category: CAMERA_TROUBLE_CATEGORY.to_string(),
+        title: Some(title),
+        occurred_at: Some(log.checked_at),
+        occurred_date: None,
+        company_name: None,
+        office_name: None,
+        department: None,
+        person_name: None,
+        person_id: None,
+        person_is_external: None,
+        registration_number: None,
+        location: Some(camera_ip.to_string()),
+        description: Some(description),
+        assigned_to: None,
+        damage_amount: None,
+        compensation_amount: None,
+        road_service_cost: None,
+        counterparty: None,
+        counterparty_insurance: None,
+        // 自動起票である事を識別するマーカー (UI の出所表示 / 集計用)。
+        custom_fields: Some(serde_json::json!({
+            "source": "camera_auto",
+            "camera_id": camera_id,
+        })),
+        due_date: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn log_fixture(alive: bool, err: Option<&str>) -> CameraHealthLog {
+        CameraHealthLog {
+            id: 1,
+            tenant_id: Uuid::new_v4(),
+            camera_id: Uuid::new_v4(),
+            alive,
+            latency_ms: None,
+            error: err.map(|s| s.to_string()),
+            checked_at: chrono::Utc::now(),
+            source_device_id: None,
+        }
+    }
+
+    #[test]
+    fn build_ticket_sets_camera_auto_marker_and_title() {
+        let cid = Uuid::new_v4();
+        let log = log_fixture(false, Some("timeout"));
+        let t = build_camera_down_ticket("正門", "192.168.1.10", cid, &log);
+        assert_eq!(t.category, "その他");
+        assert_eq!(t.title.as_deref(), Some("監視カメラ異常: 正門"));
+        assert_eq!(t.location.as_deref(), Some("192.168.1.10"));
+        assert!(t.description.as_deref().unwrap().contains("timeout"));
+        let cf = t.custom_fields.unwrap();
+        assert_eq!(cf["source"], "camera_auto");
+        assert_eq!(cf["camera_id"], serde_json::json!(cid));
+    }
+
+    #[test]
+    fn build_ticket_handles_missing_error() {
+        let log = log_fixture(false, None);
+        let t = build_camera_down_ticket("裏口", "10.0.0.2", Uuid::new_v4(), &log);
+        assert!(t.description.as_deref().unwrap().contains("(なし)"));
+    }
+}

--- a/crates/alc-camera/src/lib.rs
+++ b/crates/alc-camera/src/lib.rs
@@ -1,0 +1,31 @@
+//! 監視カメラ死活管理ドメイン (Refs #345)。
+//!
+//! 事業所の ONVIF カメラ (Tapo 等) の死活監視。alc-app (拠点タブレット) が
+//! ONVIF GetSystemDateAndTime を周期実行し、結果を `camera_health_logs` に記録。
+//! 連続失敗を集約して alc-trouble に障害を自動起票する。
+//!
+//! - CRUD / health-log / status の HTTP layer は `handlers` (tenant スコープ)。
+//! - 連続失敗判定 + 自動起票 usecase は `health`。alc-core の
+//!   `TroubleTicketsRepository` trait だけに依存し、alc-trouble 本体には依存しない
+//!   (binary 側で Pg 実装を注入する)。
+
+pub mod handlers;
+pub mod health;
+pub mod repo;
+
+use std::sync::Arc;
+
+use alc_core::repository::{CamerasRepository, TroubleTicketsRepository};
+
+/// down 判定に必要な連続失敗回数のデフォルト (約 15 分周期 × 3 = 45 分)。
+pub const DEFAULT_DOWN_THRESHOLD: usize = 3;
+
+/// camera-api 用の最小 State。
+#[derive(Clone)]
+pub struct CameraState {
+    pub cameras: Arc<dyn CamerasRepository>,
+    /// 自動起票先。alc-trouble の Pg 実装を binary が注入する。
+    pub trouble_tickets: Arc<dyn TroubleTicketsRepository>,
+    /// 連続失敗 down 判定のしきい値。
+    pub down_threshold: usize,
+}

--- a/crates/alc-camera/src/repo/cameras.rs
+++ b/crates/alc-camera/src/repo/cameras.rs
@@ -1,0 +1,188 @@
+//! `CamerasRepository` の PostgreSQL 実装 (RLS テナント分離)。
+
+use async_trait::async_trait;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use alc_core::repository::cameras::*;
+use alc_core::tenant::TenantConn;
+
+pub struct PgCamerasRepository {
+    pool: PgPool,
+}
+
+impl PgCamerasRepository {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl CamerasRepository for PgCamerasRepository {
+    async fn list(&self, tenant_id: Uuid) -> Result<Vec<Camera>, sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        sqlx::query_as::<_, Camera>("SELECT * FROM cameras ORDER BY name, created_at")
+            .fetch_all(&mut *tc.conn)
+            .await
+    }
+
+    async fn get(&self, tenant_id: Uuid, id: Uuid) -> Result<Option<Camera>, sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        sqlx::query_as::<_, Camera>("SELECT * FROM cameras WHERE id = $1")
+            .bind(id)
+            .fetch_optional(&mut *tc.conn)
+            .await
+    }
+
+    async fn create(&self, tenant_id: Uuid, input: &CreateCamera) -> Result<Camera, sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        sqlx::query_as::<_, Camera>(
+            r#"
+            INSERT INTO cameras (tenant_id, office_id, name, ip, onvif_port, model)
+            VALUES ($1, $2, $3, $4, COALESCE($5, 2020), $6)
+            RETURNING *
+            "#,
+        )
+        .bind(tenant_id)
+        .bind(input.office_id)
+        .bind(&input.name)
+        .bind(&input.ip)
+        .bind(input.onvif_port)
+        .bind(&input.model)
+        .fetch_one(&mut *tc.conn)
+        .await
+    }
+
+    async fn update(
+        &self,
+        tenant_id: Uuid,
+        id: Uuid,
+        input: &UpdateCamera,
+    ) -> Result<Option<Camera>, sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        // COALESCE で「指定された項目だけ更新」する (NULL 引数は既存値を維持)。
+        sqlx::query_as::<_, Camera>(
+            r#"
+            UPDATE cameras SET
+                office_id = COALESCE($2, office_id),
+                name = COALESCE($3, name),
+                ip = COALESCE($4, ip),
+                onvif_port = COALESCE($5, onvif_port),
+                model = COALESCE($6, model),
+                active = COALESCE($7, active),
+                updated_at = now()
+            WHERE id = $1
+            RETURNING *
+            "#,
+        )
+        .bind(id)
+        .bind(input.office_id)
+        .bind(input.name.as_ref())
+        .bind(input.ip.as_ref())
+        .bind(input.onvif_port)
+        .bind(input.model.as_ref())
+        .bind(input.active)
+        .fetch_optional(&mut *tc.conn)
+        .await
+    }
+
+    async fn delete(&self, tenant_id: Uuid, id: Uuid) -> Result<bool, sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        let res = sqlx::query("DELETE FROM cameras WHERE id = $1")
+            .bind(id)
+            .execute(&mut *tc.conn)
+            .await?;
+        Ok(res.rows_affected() > 0)
+    }
+
+    async fn insert_health_log(
+        &self,
+        tenant_id: Uuid,
+        camera_id: Uuid,
+        input: &CreateCameraHealthLog,
+    ) -> Result<CameraHealthLog, sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        sqlx::query_as::<_, CameraHealthLog>(
+            r#"
+            INSERT INTO camera_health_logs
+                (tenant_id, camera_id, alive, latency_ms, error, source_device_id)
+            VALUES ($1, $2, $3, $4, $5, $6)
+            RETURNING *
+            "#,
+        )
+        .bind(tenant_id)
+        .bind(camera_id)
+        .bind(input.alive)
+        .bind(input.latency_ms)
+        .bind(input.error.as_ref())
+        .bind(input.source_device_id.as_ref())
+        .fetch_one(&mut *tc.conn)
+        .await
+    }
+
+    async fn recent_health_logs(
+        &self,
+        tenant_id: Uuid,
+        camera_id: Uuid,
+        limit: i64,
+    ) -> Result<Vec<CameraHealthLog>, sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        sqlx::query_as::<_, CameraHealthLog>(
+            r#"
+            SELECT * FROM camera_health_logs
+            WHERE camera_id = $1
+            ORDER BY checked_at DESC
+            LIMIT $2
+            "#,
+        )
+        .bind(camera_id)
+        .bind(limit)
+        .fetch_all(&mut *tc.conn)
+        .await
+    }
+
+    async fn statuses(&self, tenant_id: Uuid) -> Result<Vec<CameraStatusRow>, sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        // 各カメラの最新ログを DISTINCT ON で 1 件取り、マスタと LEFT JOIN する。
+        sqlx::query_as::<_, CameraStatusRow>(
+            r#"
+            SELECT
+                c.id AS camera_id,
+                c.name AS name,
+                c.active AS active,
+                l.alive AS last_alive,
+                l.latency_ms AS last_latency_ms,
+                l.checked_at AS last_checked_at,
+                c.active_down_ticket_id AS active_down_ticket_id
+            FROM cameras c
+            LEFT JOIN LATERAL (
+                SELECT alive, latency_ms, checked_at
+                FROM camera_health_logs hl
+                WHERE hl.camera_id = c.id
+                ORDER BY hl.checked_at DESC
+                LIMIT 1
+            ) l ON true
+            ORDER BY c.name, c.created_at
+            "#,
+        )
+        .fetch_all(&mut *tc.conn)
+        .await
+    }
+
+    async fn set_active_down_ticket(
+        &self,
+        tenant_id: Uuid,
+        camera_id: Uuid,
+        ticket_id: Option<Uuid>,
+    ) -> Result<(), sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        sqlx::query(
+            "UPDATE cameras SET active_down_ticket_id = $2, updated_at = now() WHERE id = $1",
+        )
+        .bind(camera_id)
+        .bind(ticket_id)
+        .execute(&mut *tc.conn)
+        .await?;
+        Ok(())
+    }
+}

--- a/crates/alc-camera/src/repo/mod.rs
+++ b/crates/alc-camera/src/repo/mod.rs
@@ -1,0 +1,3 @@
+pub mod cameras;
+
+pub use cameras::PgCamerasRepository;

--- a/crates/alc-core/src/repository/cameras.rs
+++ b/crates/alc-core/src/repository/cameras.rs
@@ -1,0 +1,125 @@
+//! 監視カメラ死活管理ドメインの repository trait + 値型 (Refs #345)。
+//!
+//! `cameras` (マスタ) と `camera_health_logs` (ヘルスチェック結果) を扱う。
+//! 連続失敗判定 → alc-trouble 自動起票の usecase は alc-camera 側に置き、
+//! ここは永続化の抽象だけを定義する。
+
+use async_trait::async_trait;
+use uuid::Uuid;
+
+#[derive(Debug, Clone, sqlx::FromRow, serde::Serialize)]
+pub struct Camera {
+    pub id: Uuid,
+    pub tenant_id: Uuid,
+    pub office_id: Option<Uuid>,
+    pub name: String,
+    pub ip: String,
+    pub onvif_port: i32,
+    pub model: String,
+    pub active: bool,
+    /// down 検知で自動起票した未解決 ticket。down 中の重複起票防止に使う。
+    pub active_down_ticket_id: Option<Uuid>,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub updated_at: chrono::DateTime<chrono::Utc>,
+}
+
+#[derive(Debug, Clone, sqlx::FromRow, serde::Serialize)]
+pub struct CameraHealthLog {
+    pub id: i64,
+    pub tenant_id: Uuid,
+    pub camera_id: Uuid,
+    pub alive: bool,
+    pub latency_ms: Option<i32>,
+    pub error: Option<String>,
+    pub checked_at: chrono::DateTime<chrono::Utc>,
+    pub source_device_id: Option<String>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct CreateCamera {
+    pub office_id: Option<Uuid>,
+    #[serde(default)]
+    pub name: String,
+    #[serde(default)]
+    pub ip: String,
+    pub onvif_port: Option<i32>,
+    #[serde(default)]
+    pub model: String,
+}
+
+#[derive(Debug, Clone, Default, serde::Deserialize)]
+pub struct UpdateCamera {
+    pub office_id: Option<Uuid>,
+    pub name: Option<String>,
+    pub ip: Option<String>,
+    pub onvif_port: Option<i32>,
+    pub model: Option<String>,
+    pub active: Option<bool>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct CreateCameraHealthLog {
+    pub alive: bool,
+    pub latency_ms: Option<i32>,
+    pub error: Option<String>,
+    pub source_device_id: Option<String>,
+}
+
+/// 各カメラの最新ステータス集計 1 行 (`GET /cameras/status` 用)。
+#[derive(Debug, Clone, sqlx::FromRow, serde::Serialize)]
+pub struct CameraStatusRow {
+    pub camera_id: Uuid,
+    pub name: String,
+    pub active: bool,
+    /// 直近ログの alive。ログが 1 件も無ければ NULL。
+    pub last_alive: Option<bool>,
+    pub last_latency_ms: Option<i32>,
+    pub last_checked_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// 自動起票済みの未解決 ticket があれば。
+    pub active_down_ticket_id: Option<Uuid>,
+}
+
+#[async_trait]
+pub trait CamerasRepository: Send + Sync {
+    async fn list(&self, tenant_id: Uuid) -> Result<Vec<Camera>, sqlx::Error>;
+
+    async fn get(&self, tenant_id: Uuid, id: Uuid) -> Result<Option<Camera>, sqlx::Error>;
+
+    async fn create(&self, tenant_id: Uuid, input: &CreateCamera) -> Result<Camera, sqlx::Error>;
+
+    async fn update(
+        &self,
+        tenant_id: Uuid,
+        id: Uuid,
+        input: &UpdateCamera,
+    ) -> Result<Option<Camera>, sqlx::Error>;
+
+    /// 物理削除 (health_logs は ON DELETE CASCADE で消える)。
+    async fn delete(&self, tenant_id: Uuid, id: Uuid) -> Result<bool, sqlx::Error>;
+
+    async fn insert_health_log(
+        &self,
+        tenant_id: Uuid,
+        camera_id: Uuid,
+        input: &CreateCameraHealthLog,
+    ) -> Result<CameraHealthLog, sqlx::Error>;
+
+    /// 直近 `limit` 件を checked_at 降順で返す (連続失敗判定 / 管理画面表示の両用)。
+    async fn recent_health_logs(
+        &self,
+        tenant_id: Uuid,
+        camera_id: Uuid,
+        limit: i64,
+    ) -> Result<Vec<CameraHealthLog>, sqlx::Error>;
+
+    /// 各カメラの最新ステータスを集計して返す。
+    async fn statuses(&self, tenant_id: Uuid) -> Result<Vec<CameraStatusRow>, sqlx::Error>;
+
+    /// 自動起票した未解決 ticket のリンクを設定 / クリア (冪等性管理)。
+    async fn set_active_down_ticket(
+        &self,
+        tenant_id: Uuid,
+        camera_id: Uuid,
+        ticket_id: Option<Uuid>,
+    ) -> Result<(), sqlx::Error>;
+}

--- a/crates/alc-core/src/repository/mod.rs
+++ b/crates/alc-core/src/repository/mod.rs
@@ -1,6 +1,7 @@
 pub mod api_tokens;
 pub mod auth;
 pub mod bot_admin;
+pub mod cameras;
 pub mod car_inspections;
 pub mod carins_files;
 pub mod carrying_items;
@@ -59,6 +60,10 @@ pub mod webhook;
 pub use api_tokens::{ApiTokenRow, ApiTokensRepository};
 pub use auth::AuthRepository;
 pub use bot_admin::BotAdminRepository;
+pub use cameras::{
+    Camera, CameraHealthLog, CameraStatusRow, CamerasRepository, CreateCamera,
+    CreateCameraHealthLog, UpdateCamera,
+};
 pub use car_inspections::CarInspectionRepository;
 pub use carins_files::CarinsFilesRepository;
 pub use carrying_items::CarryingItemsRepository;

--- a/crates/gateway/src/config.rs
+++ b/crates/gateway/src/config.rs
@@ -12,6 +12,8 @@ pub struct Config {
     pub dtako_url: Option<String>,
     /// trouble-api の URL。未設定時は backend_url にフォールバック。
     pub trouble_url: Option<String>,
+    /// alc-camera-api の URL。未設定時は backend_url にフォールバック。
+    pub camera_url: Option<String>,
 }
 
 impl Config {
@@ -27,6 +29,7 @@ impl Config {
             carins_url: env::var("CARINS_API_URL").ok(),
             dtako_url: env::var("DTAKO_API_URL").ok(),
             trouble_url: env::var("TROUBLE_API_URL").ok(),
+            camera_url: env::var("CAMERA_API_URL").ok(),
         }
     }
 }

--- a/crates/gateway/src/main.rs
+++ b/crates/gateway/src/main.rs
@@ -47,6 +47,9 @@ async fn main() {
     if let Some(ref trouble_url) = config.trouble_url {
         tracing::info!("trouble-api: {trouble_url}");
     }
+    if let Some(ref camera_url) = config.camera_url {
+        tracing::info!("alc-camera-api: {camera_url}");
+    }
 
     let proxy_state = ProxyState {
         client,
@@ -56,6 +59,7 @@ async fn main() {
         carins_url: config.carins_url,
         dtako_url: config.dtako_url,
         trouble_url: config.trouble_url,
+        camera_url: config.camera_url,
     };
 
     let cors = CorsLayer::new()

--- a/crates/gateway/src/proxy.rs
+++ b/crates/gateway/src/proxy.rs
@@ -172,6 +172,7 @@ mod tests {
             carins_url: Some("http://carins:8083".to_string()),
             dtako_url: Some("http://dtako:8084".to_string()),
             trouble_url: Some("http://trouble:8085".to_string()),
+            camera_url: Some("http://camera:8086".to_string()),
         }
     }
 
@@ -288,6 +289,7 @@ mod tests {
             carins_url: None,
             dtako_url: None,
             trouble_url: None,
+            camera_url: None,
         };
         assert_eq!(
             resolve_backend("/api/tenko/sessions", &state),

--- a/crates/gateway/src/proxy.rs
+++ b/crates/gateway/src/proxy.rs
@@ -18,6 +18,7 @@ pub struct ProxyState {
     pub carins_url: Option<String>,
     pub dtako_url: Option<String>,
     pub trouble_url: Option<String>,
+    pub camera_url: Option<String>,
 }
 
 /// パスに応じてバックエンド URL を選択する
@@ -48,6 +49,8 @@ fn resolve_backend<'a>(path: &str, state: &'a ProxyState) -> &'a str {
         state.dtako_url.as_deref().unwrap_or(&state.backend_url)
     } else if api_path.starts_with("/trouble") {
         state.trouble_url.as_deref().unwrap_or(&state.backend_url)
+    } else if api_path.starts_with("/cameras") {
+        state.camera_url.as_deref().unwrap_or(&state.backend_url)
     } else {
         &state.backend_url
     }

--- a/migrations/113_create_cameras.sql
+++ b/migrations/113_create_cameras.sql
@@ -1,0 +1,62 @@
+-- 監視カメラ死活管理ドメイン (Refs #345)。
+-- 事業所に設置された Tapo 等の ONVIF カメラの死活監視。alc-app (拠点タブレット) が
+-- ONVIF GetSystemDateAndTime を周期実行し、結果を camera_health_logs に記録する。
+-- 連続失敗を alc-camera-api が集約して alc-trouble に障害を自動起票する。
+--
+-- 設計判断 (issue の「未検討事項」への回答):
+-- * ONVIF 認証情報 (user/pass) は保持しない。GetSystemDateAndTime のみなら認証不要。
+--   将来 PTZ/stream を扱う際に Secret Manager 連携で別途設計する。
+-- * 障害自動起票の冪等性は cameras.active_down_ticket_id で担保 (down 中の重複起票防止)。
+--   復旧 (alive) 時はリンクをクリアするのみで ticket は自動クローズしない (手動クローズ)。
+-- * office は既存の alc_api.trouble_offices を参照する (専用 offices テーブルは作らない)。
+
+-- カメラマスタ
+CREATE TABLE alc_api.cameras (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id UUID NOT NULL REFERENCES alc_api.tenants(id),
+    office_id UUID REFERENCES alc_api.trouble_offices(id),
+    name TEXT NOT NULL DEFAULT '',
+    -- LAN 内アドレス。検証は軽いが sqlx の ipnetwork feature を workspace 全体に
+    -- 波及させないため INET ではなく TEXT で保持する。
+    ip TEXT NOT NULL DEFAULT '',
+    onvif_port INTEGER NOT NULL DEFAULT 2020,
+    model TEXT NOT NULL DEFAULT '',
+    active BOOLEAN NOT NULL DEFAULT TRUE,
+    -- down 検知で自動起票した未解決 ticket。down 中の重複起票防止 + 復旧でクリア。
+    active_down_ticket_id UUID REFERENCES alc_api.trouble_tickets(id),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_cameras_tenant ON alc_api.cameras(tenant_id);
+CREATE INDEX idx_cameras_tenant_active ON alc_api.cameras(tenant_id, active) WHERE active = TRUE;
+
+ALTER TABLE alc_api.cameras ENABLE ROW LEVEL SECURITY;
+CREATE POLICY tenant_isolation ON alc_api.cameras
+    FOR ALL USING (tenant_id = current_setting('app.current_tenant_id', true)::uuid)
+    WITH CHECK (tenant_id = current_setting('app.current_tenant_id', true)::uuid);
+GRANT SELECT, INSERT, UPDATE, DELETE ON alc_api.cameras TO alc_api_app;
+
+-- ヘルスチェックログ (件数が伸びるので checked_at で retention 削除する想定)
+CREATE TABLE alc_api.camera_health_logs (
+    id BIGSERIAL PRIMARY KEY,
+    tenant_id UUID NOT NULL REFERENCES alc_api.tenants(id),
+    camera_id UUID NOT NULL REFERENCES alc_api.cameras(id) ON DELETE CASCADE,
+    alive BOOLEAN NOT NULL,
+    latency_ms INTEGER,
+    error TEXT,
+    checked_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    source_device_id TEXT
+);
+
+-- 「直近 N 件」を引く + retention 削除に効くインデックス
+CREATE INDEX idx_camera_health_logs_camera_checked
+    ON alc_api.camera_health_logs(tenant_id, camera_id, checked_at DESC);
+CREATE INDEX idx_camera_health_logs_checked ON alc_api.camera_health_logs(checked_at);
+
+ALTER TABLE alc_api.camera_health_logs ENABLE ROW LEVEL SECURITY;
+CREATE POLICY tenant_isolation ON alc_api.camera_health_logs
+    FOR ALL USING (tenant_id = current_setting('app.current_tenant_id', true)::uuid)
+    WITH CHECK (tenant_id = current_setting('app.current_tenant_id', true)::uuid);
+GRANT SELECT, INSERT, UPDATE, DELETE ON alc_api.camera_health_logs TO alc_api_app;
+GRANT USAGE, SELECT ON SEQUENCE alc_api.camera_health_logs_id_seq TO alc_api_app;


### PR DESCRIPTION
Refs #345。事業所 ONVIF カメラ (Tapo 等) の死活監視ドメインを新設。alc-app (拠点タブレット) が ONVIF `GetSystemDateAndTime` を周期実行して `camera_health_logs` に記録し、連続失敗を `alc-camera-api` が集約して `alc-trouble` に障害を自動起票する。

## 追加内容 (issue マイルストーン全項目)

| 項目 | 実装 |
|---|---|
| crate 骨格 (domain/usecase/infra) | `crates/alc-camera` (`repo`/`handlers`/`health`) + alc-core に `CamerasRepository` trait + 値型 |
| migration + RLS | `migrations/113_create_cameras.sql` (`cameras` / `camera_health_logs` + tenant_isolation RLS + GRANT) |
| CRUD API バイナリ | `crates/alc-camera-api` (新 Cloud Run service `camera`) |
| gateway ルーティング | `/cameras*` → `CAMERA_API_URL` proxy |
| 連続失敗判定 → alc-trouble 起票 | `health::record_health_and_maybe_ticket` (down_threshold 連続失敗で起票) |
| 冪等性チェック | `cameras.active_down_ticket_id` で down 中の重複起票を防止 |
| CI に新バイナリ | `BUILD.bazel` ×2 + `Dockerfile.camera` + ci.yml の cache-warm / build-image matrix |
| deploy 配線 | render.sh の camera service + deploy.yml の全 matrix / gateway URL / verify-no-traffic |

## エンドポイント (gateway 経由)

`GET/POST /cameras` · `GET /cameras/status` · `GET/PATCH/DELETE /cameras/{id}` · `POST/GET /cameras/{id}/health-logs`

## 設計判断 (issue「未検討事項」への回答)

- **ONVIF 認証情報は保持しない** — `GetSystemDateAndTime` のみなら認証不要。将来 PTZ/stream 時に Secret Manager 連携で別設計。
- **障害自動クローズはしない** — 復旧 (alive) 時は `active_down_ticket_id` リンクをクリアするのみ。ticket は手動クローズ (誤クローズ防止)。
- **office は既存 `trouble_offices` を参照** (専用 offices テーブルは作らない)。
- **判定・起票は health-log POST 内で同期実行** — Cloud Run の CPU throttling で `tokio::spawn` background が完走しない罠を回避 (CLAUDE.md 既知事項)。
- `ip` は INET ではなく TEXT — sqlx の ipnetwork feature を workspace 全体に波及させないため。

## 検証

- `cargo check -p alc-core -p alc-camera -p alc-camera-api` green (ローカル)。`build_camera_down_ticket` に unit test 付き。
- migration / 全テスト / Bazel ビルドは CI に委ねる。

## 別途必要 (本 PR スコープ外)

- [ ] **新 Cloud Run service の初回作成** (user 手動): `gcloud run deploy rust-alc-api-staging-camera` / `rust-alc-api-camera`。未作成だと deploy job の `gcloud run services replace` が失敗するため、merge 前後に作成が必要。
- [ ] Supabase Realtime → nuxt-notify 通知の疎通確認 (`troubles` テーブル変更が流れること)。
- [ ] alc-app 側ヘルスチェッカー実装 (ippoan/alc-app#27、別 repo)。

---
_Generated by [Claude Code](https://claude.ai/code/session_01HpWzPz611r4FqRKPxEkCy9)_