### PR TITLE
fix(notify): extract-recompute で extraction_status を pending にリセット (Refs ippoan/nuxt-notify#66)

### DIFF
--- a/crates/alc-core/src/repository/notify_documents.rs
+++ b/crates/alc-core/src/repository/notify_documents.rs
@@ -136,4 +136,11 @@ pub trait NotifyDocumentRepository: Send + Sync {
     /// force re-redact 用: redaction_status='pending' に戻し、redacted_* を NULL に。
     /// R2 オブジェクトは消さない (固定キーで上書きされる)。
     async fn reset_redaction(&self, tenant_id: Uuid, id: Uuid) -> Result<(), sqlx::Error>;
+
+    /// force re-extract 用: extraction_status='pending' に戻し、extraction_error
+    /// を NULL に、updated_at を NOW() に倒す (Refs ippoan/nuxt-notify#66)。
+    /// background が完走するまで「処理中」を truthful に保ち、stuck 検知の
+    /// 経過時間タイマー (updated_at 起点) もリセットする。extracted_data は
+    /// 触らない (background が completed 時に上書きするまで旧値を保持)。
+    async fn reset_extraction(&self, tenant_id: Uuid, id: Uuid) -> Result<(), sqlx::Error>;
 }

--- a/crates/alc-notify/src/background_extract.rs
+++ b/crates/alc-notify/src/background_extract.rs
@@ -424,6 +424,9 @@ mod tests {
         async fn reset_redaction(&self, _t: Uuid, _id: Uuid) -> Result<(), sqlx::Error> {
             unimplemented!()
         }
+        async fn reset_extraction(&self, _t: Uuid, _id: Uuid) -> Result<(), sqlx::Error> {
+            unimplemented!()
+        }
     }
 
     struct StubStorage {

--- a/crates/alc-notify/src/background_redaction.rs
+++ b/crates/alc-notify/src/background_redaction.rs
@@ -473,6 +473,9 @@ mod tests {
         async fn reset_redaction(&self, _t: Uuid, _id: Uuid) -> Result<(), sqlx::Error> {
             Ok(())
         }
+        async fn reset_extraction(&self, _t: Uuid, _id: Uuid) -> Result<(), sqlx::Error> {
+            Ok(())
+        }
     }
 
     struct StubStorage {

--- a/crates/alc-notify/src/documents.rs
+++ b/crates/alc-notify/src/documents.rs
@@ -359,9 +359,16 @@ async fn extract_recompute(
         })?
         .ok_or(StatusCode::NOT_FOUND)?;
 
-    // 既存 extraction_status / extraction_error は保持して上書きする (background が
-    // 完走時に completed/failed を再設定する)。明示的なリセット関数がないので
-    // background 内で update_extraction が走った時点で最新化される。
+    // extraction_status を 'pending' に戻し、extraction_error を NULL、updated_at
+    // を NOW() に倒してから再 spawn (Refs ippoan/nuxt-notify#66)。これにより:
+    //   - 前回 stuck (pending のまま固まった) / failed の状態が truthful にリセット
+    //   - frontend の stuck 検知 (updated_at 起点の経過時間) も 0 に戻る
+    // reset 失敗は致命ではない (background が完走時に上書きする) ので、エラーでも
+    // spawn は続行し、ログだけ残す。
+    if let Err(e) = state.notify_documents.reset_extraction(tenant.0, id).await {
+        tracing::warn!("extract_recompute: reset_extraction failed (continuing): {e}");
+    }
+
     crate::background_extract::spawn_extract_document(state.clone(), tenant.0, id);
     Ok(StatusCode::ACCEPTED)
 }

--- a/crates/alc-notify/src/repo/notify_documents.rs
+++ b/crates/alc-notify/src/repo/notify_documents.rs
@@ -260,4 +260,21 @@ impl NotifyDocumentRepository for PgNotifyDocumentRepository {
         .await?;
         Ok(())
     }
+
+    async fn reset_extraction(&self, tenant_id: Uuid, id: Uuid) -> Result<(), sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        sqlx::query(
+            r#"
+            UPDATE notify_documents SET
+                extraction_status = 'pending',
+                extraction_error = NULL,
+                updated_at = NOW()
+            WHERE id = $1
+            "#,
+        )
+        .bind(id)
+        .execute(&mut *tc.conn)
+        .await?;
+        Ok(())
+    }
 }

--- a/tests/mock_helpers/repos_d.rs
+++ b/tests/mock_helpers/repos_d.rs
@@ -421,6 +421,10 @@ impl NotifyDocumentRepository for MockNotifyDocumentRepository {
         check_fail!(self);
         Ok(())
     }
+    async fn reset_extraction(&self, _tenant_id: Uuid, _id: Uuid) -> Result<(), sqlx::Error> {
+        check_fail!(self);
+        Ok(())
+    }
 }
 
 // ============================================================


### PR DESCRIPTION
## 概要

nuxt-notify の運送情報抽出が **「🔍 運送情報を抽出中…」のまま固まる** 問題
(ippoan/nuxt-notify#66) の **backend 側対応**。frontend 側の stuck 検知導線
(ippoan/nuxt-notify#84、merged) と対になる。

## root cause

extract は fire-and-forget の `tokio::spawn` (`spawn_extract_document`) で
動くため、Cloud Run の CPU throttling 等で background task が静かに死ぬと
`extraction_status` が `pending` のまま止まり、自動復旧しない
(本 repo CLAUDE.md「長時間 compute と Cloud Run の罠」で既知のパターン)。

frontend で stuck を検知して「🔄 再抽出」導線を出したが、従来の
`extract-recompute` は **status を一切触らず再 spawn するだけ** だったため、
再キックしても状態が truthful にならず、frontend の stuck タイマー
(`updated_at` 起点) もリセットされなかった。

## 変更

- `NotifyDocumentRepository` に `reset_extraction(tenant_id, id)` を追加:
  `extraction_status='pending'` / `extraction_error=NULL` / `updated_at=NOW()`。
  `extracted_data` は触らない (background が completed 時に上書きするまで
  旧値を保持)。既存 `reset_redaction` と対称な実装
- `extract_recompute` handler が再 spawn 前に `reset_extraction` を呼ぶ。
  これで「stuck 検知 → 再抽出 → status が pending にリセット + updated_at
  リセット」のループが閉じる。reset 失敗は致命でない (background が完走時に
  上書きする) ので log だけ残して spawn は続行
- 全 `NotifyDocumentRepository` impl を更新 (Pg 本体 / background_extract /
  background_redaction の test stub / 統合テスト mock_helpers)

## スコープ外 (将来の別 PR)

issue が挙げた **起動時 / 定期の自動 stuck recovery sweep** は本 PR に含めない:

- repo は `TenantConn` で **per-tenant RLS**。全テナント横断の sweep は接続
  モデルの変更が必要 (RLS bypass or テナント走査) でリスクが高い
- そもそも fire-and-forget の根治には Cloud Tasks / `--no-cpu-throttling`
  等の別アーキテクチャ判断 (コスト発生) が必要

本 PR は **ユーザー操作 (再抽出) による復旧を truthful にする** ことに絞り、
これで #66 の主訴「pending のまま固まって復旧手段がない」は解消する
(frontend が stuck を可視化 → ワンクリックで確実にリセット & 再実行)。

## 検証

`cargo fmt --all` + `cargo check -p alc-notify` + `cargo check --tests` が
green (ts-rs / unused macro の既存 warning のみ)。全テスト実行は CI に委譲。

Refs ippoan/nuxt-notify#66

https://claude.ai/code/session_01ELcPDvD5gWcbdGiJiQpcSY

---
_Generated by [Claude Code](https://claude.ai/code/session_01ELcPDvD5gWcbdGiJiQpcSY)_