### PR TITLE
fix(ci): include -camera in docker-dev/docker-latest retag loops

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -405,7 +405,7 @@ jobs:
         run: |
           REPO="ghcr.io/${{ github.repository }}"
           SHA="${{ github.sha }}"
-          for suffix in "" "-gateway" "-tenko" "-carins" "-dtako" "-trouble"; do
+          for suffix in "" "-gateway" "-tenko" "-carins" "-dtako" "-trouble" "-camera"; do
             docker pull "${REPO}${suffix}:${SHA}"
             docker tag "${REPO}${suffix}:${SHA}" "${REPO}${suffix}:dev"
             docker push "${REPO}${suffix}:dev"
@@ -430,7 +430,7 @@ jobs:
         run: |
           REPO="ghcr.io/${{ github.repository }}"
           SHA="${{ github.sha }}"
-          for suffix in "" "-gateway" "-tenko" "-carins" "-dtako" "-trouble"; do
+          for suffix in "" "-gateway" "-tenko" "-carins" "-dtako" "-trouble" "-camera"; do
             docker pull "${REPO}${suffix}:dev"
             docker tag "${REPO}${suffix}:dev" "${REPO}${suffix}:${SHA}"
             docker tag "${REPO}${suffix}:dev" "${REPO}${suffix}:latest"


### PR DESCRIPTION
## 症状

`v*` タグの production deploy で `promote-images` job が落ちる。GHCR への push ログ:

```
v0.0.87: digest: sha256:a067... size: 951        # rust-alc-api-trouble:v0.0.87  OK
6c13da4c...: digest: sha256:a067... size: 951    # rust-alc-api-trouble:<sha>    OK
Error response from daemon: manifest unknown
Error: Process completed with exit code 1.
```

`-trouble` の 2 tag は push 成功しているのに、その直後に `manifest unknown` で exit 1。

## 原因

`camera` service は以下 **すべて** の matrix / loop に含まれている:

- `ci.yml` `build-image` matrix (`-camera:<sha>` を build & push)
- `deploy.yml` `staging-images` matrix
- `deploy.yml` `promote-images` loop (`"" -gateway -tenko -carins -dtako -trouble -camera`)
- `deploy.yml` `deploy-services` matrix

ところが `ci.yml` の中間 retag loop **2 箇所だけ** `-camera` が抜けていた:

- `docker-dev` (PR で `:<sha>` → `:dev`)
- `docker-latest` (main push で `:dev` → `:<sha>` + `:latest`)

このため `rust-alc-api-camera:dev` が GHCR に一度も push されず、`v*` タグ時の
`promote-images` loop が `-trouble` を promote した直後の `-camera` イテレーションで
`docker pull ghcr.io/ippoan/rust-alc-api-camera:dev` を叩いて `manifest unknown` →
job 全体が exit 1。

## 修正

`docker-dev` / `docker-latest` 両 loop の suffix リストに `-camera` を追加し、
6 つの matrix / loop すべてで service 集合を一致させる。

Refs #375

---
_Generated by [Claude Code](https://claude.ai/code/session_01TDptUR2JnadwyyTAtv5GiB)_