### PR TITLE
fix(deploy): bootstrap placeholder revision on first production deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -256,6 +256,25 @@ jobs:
               CURRENT_REV=$(printf '%s' "$SVC_JSON" | jq -r \
                 '(([.status.traffic[]? | select((.percent // 0) > 0) | .revisionName] | map(select(. != null)))[0]) // .status.latestReadyRevisionName // ""')
             fi
+            if [ -z "$CURRENT_REV" ]; then
+              # 新規 service の初回 production deploy。Cloud Run は単一 revision を必ず
+              # 100% で配信するため、release revision をそのまま deploy すると 100% に
+              # フリップし release/flip 分離不変条件 (verify-no-traffic) を破る。先に
+              # 使い捨ての placeholder revision (gcr.io/cloudrun/hello) を 100% で立て、
+              # それを anchor に release revision を 0% (no-traffic) で重ねる。placeholder
+              # は実 release image とは別 template なので必ず別 revision として作られ、
+              # 最初の Release Wave flip で release revision に traffic が移るまでの暫定
+              # serving となる。新規 service は flip 前に実トラフィックを受けないので影響なし。
+              echo "::notice::first production deploy for ${PROD_SVC} — bootstrapping a throwaway placeholder revision (gcr.io/cloudrun/hello) so the release revision can land at 0% (no-traffic)."
+              gcloud run deploy "$PROD_SVC" \
+                --image=gcr.io/cloudrun/hello \
+                --region ${{ env.REGION }} --project ${{ env.PROJECT }} \
+                --ingress=all --quiet
+              CURRENT_REV=$(gcloud run services describe "$PROD_SVC" \
+                --region ${{ env.REGION }} --project ${{ env.PROJECT }} \
+                --format='value(status.latestReadyRevisionName)')
+              echo "::notice::placeholder revision ready: ${CURRENT_REV} (serves 100% only until the first Release Wave flip moves traffic to the release revision)."
+            fi
             if [ -n "$CURRENT_REV" ]; then
               RENDER_ARGS="${RENDER_ARGS} --pin-traffic-revision ${CURRENT_REV}"
               # no-traffic (0%) revision に release タグ由来の Cloud Run revision tag を
@@ -268,7 +287,7 @@ jobs:
               RENDER_ARGS="${RENDER_ARGS} --pending-tag ${PREVIEW_TAG}"
               echo "::notice::production no-traffic deploy: keep 100% on ${CURRENT_REV}; new revision -> 0% (preview tag=${PREVIEW_TAG}). Release Wave flip が最新 ready revision に traffic を振る。"
             else
-              echo "::warning::no current revision for ${PROD_SVC} (first deploy?) — deploying with Cloud Run default traffic (latest 100%)."
+              echo "::warning::no current revision for ${PROD_SVC} even after placeholder bootstrap — deploying with Cloud Run default traffic (latest 100%)."
             fi
           fi
 
@@ -598,11 +617,11 @@ jobs:
   # traffic % が 0 か」を確認し、0 でなければ (= release が勝手にフリップした)
   # FAIL する。
   #
-  # 注意: 現状の deploy-services は render.sh (traffic ブロック無し) を
-  # `gcloud run services replace` するため 100% latest にフリップする。よって
-  # 本 check は現状の release では FAIL する想定 — それがまさに検出したい挙動。
-  # release を no-traffic 化する (render.sh に traffic ピン / --no-traffic 相当)
-  # のは別 PR で対応する。
+  # deploy-services は production では --pin-traffic-revision で新 revision を 0%
+  # に固定するため、通常 release ではここを通る。新規 service の初回 deploy だけは
+  # anchor となる旧 revision が無く Cloud Run が latest を 100% にしてしまうので、
+  # deploy-services 側で placeholder revision (gcr.io/cloudrun/hello) を先に立てて
+  # から release を 0% で重ねる (= このガードを新規 service でも満たす)。
   # ---------------------------------------------------------------------------
   verify-no-traffic:
     name: "Verify release did not flip traffic"


### PR DESCRIPTION
## 症状

`v0.0.88` の production deploy で `Deploy / Verify release did not flip traffic` ジョブが FAIL:

```
rust-alc-api-camera: newly released revision (rust-alc-api-camera-00001-rms)
is serving 100% traffic. A tag release must NOT flip traffic — traffic
switching is the Release Wave flip's job. Make the production deploy no-traffic.
```

既存 6 サービスは新 revision が 0%(旧 revision が 100% 維持)で OK。落ちたのは **`rust-alc-api-camera` のみ**で、これは今回が**初デプロイで revision が `-00001` ただ 1 つ**だったため。

> 注: これは直前の PR #383(camera を retag ループに追加)とは別問題。#383 で promote-images / 全 Deploy ジョブは green になっており、今回の failure は traffic 検証ガード側。

## 原因

`verify-no-traffic` ガードは「tag release は traffic を flip しない(flip は Release Wave の仕事)= 新 revision は 0%」を検証する。`deploy-services` の production 分岐は、現在 100% を受けている revision を `--pin-traffic-revision` に渡して新 revision を 0% に固定している。

しかし **新規 service の初回 deploy** では anchor となる旧 revision が存在せず `CURRENT_REV` が空。Cloud Run は単一 revision の service を必ず 100% で配信するため、release revision がそのまま 100% にフリップしてガードが発火する(従来は `::warning::first deploy?` を出して 100% を許してしまっていた)。

## 修正

`deploy-services` の production 分岐で `CURRENT_REV` が空(= service 未作成)の場合、先に使い捨ての **placeholder revision (`gcr.io/cloudrun/hello`)** を 100% で立て、それを anchor に release revision を 0%(no-traffic)で重ねる:

1. `gcloud run deploy <svc> --image=gcr.io/cloudrun/hello` で service + placeholder revision を作成(単一 revision = 100%)。
2. その revision 名を `CURRENT_REV` に取り、続く `render.sh --pin-traffic-revision` の経路へ合流。
3. render.sh が出す実 release revision は **placeholder とは別 image = 別 template** なので必ず新 revision として作られ、`<placeholder>=100% / latest(release)=0%` で landing。
4. `verify-no-traffic` 通過。traffic 切替は従来どおり Release Wave flip が最新 ready revision(= release)へ行う。placeholder は最初の flip までの暫定 serving で、新規 service は flip 前に実トラフィックを受けないため影響なし。

stale だった `verify-no-traffic` のコメント(「現状の release では FAIL する想定」)も実態に合わせて更新。

## camera 自体について

`rust-alc-api-camera` は `v0.0.88` で既に revision `-00001`(100%)が存在するため、**次回 release では `CURRENT_REV` が解決でき**、この placeholder 経路を通らずとも 0% で landing してガードを通過する(= camera の failure は次 release で自然解消)。本 PR は**今後の新規 service**で同じ初回 failure を防ぐためのもの。

Refs #345

---
_Generated by [Claude Code](https://claude.ai/code/session_01TDptUR2JnadwyyTAtv5GiB)_