### PR TITLE
fix(security): constant-time compares / error disclosure / headers / filename / switch_org

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,6 +103,7 @@ dependencies = [
  "tokio",
  "tracing",
  "ts-rs",
+ "urlencoding",
  "uuid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sqlx = { version = "0.8", features = ["runtime-tokio", "tls-rustls", "postgres", "chrono", "uuid"] }
 tokio = { version = "1", features = ["full"] }
-tower-http = { version = "0.6", features = ["cors", "trace"] }
+tower-http = { version = "0.6", features = ["cors", "trace", "set-header"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 

--- a/crates/alc-auth/src/lib.rs
+++ b/crates/alc-auth/src/lib.rs
@@ -336,11 +336,12 @@ async fn switch_org(
     let target_tenant_id =
         Uuid::parse_str(&body.organization_id).map_err(|_| StatusCode::BAD_REQUEST)?;
 
-    // ターゲットテナントで同一ユーザーを検索 (email でフォールバック)
-    // 現在の JWT から email を取得し、ターゲットテナントのユーザーを探す
+    // ターゲットテナントで同一ユーザーを検索。email 一致のみでは切り替えを許可
+    // せず、current user と同じ verified identity (google_sub / lineworks_id /
+    // line_user_id) を持つ row を要求する (Refs #393 M-4)。
     let target_user = state
         .auth
-        .find_user_in_tenant(target_tenant_id, None, None, None, &auth_user.email)
+        .find_user_in_tenant(target_tenant_id, auth_user.user_id)
         .await
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
         .ok_or(StatusCode::FORBIDDEN)?;

--- a/crates/alc-carins/Cargo.toml
+++ b/crates/alc-carins/Cargo.toml
@@ -18,6 +18,7 @@ uuid = { version = "1", features = ["v4", "serde"] }
 tokio = { version = "1", features = ["rt"] }
 pdf-extract = "0.7"
 regex = "1"
+urlencoding = "2"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt"] }

--- a/crates/alc-carins/src/carins_files.rs
+++ b/crates/alc-carins/src/carins_files.rs
@@ -112,6 +112,18 @@ async fn get_file(
     Ok(Json(row))
 }
 
+/// Content-Disposition 用に user 由来 filename をサニタイズする。`"` は disposition
+/// の構造を操作できるため `_` に落とし、非 ASCII は RFC 5987 `filename*=UTF-8''`
+/// で渡す (Refs #394 L-3。参考: alc-notify viewer の `build_inline_disposition`)。
+fn build_attachment_disposition(filename: &str) -> String {
+    let encoded = urlencoding::encode(filename);
+    format!(
+        "attachment; filename=\"{}\"; filename*=UTF-8''{}",
+        filename.replace('"', "_"),
+        encoded
+    )
+}
+
 async fn download_file(
     State(state): State<CarinsState>,
     Extension(tenant_id): Extension<TenantId>,
@@ -140,7 +152,7 @@ async fn download_file(
                 (header::CONTENT_TYPE, content_type),
                 (
                     header::CONTENT_DISPOSITION,
-                    format!("attachment; filename=\"{}\"", filename),
+                    build_attachment_disposition(&filename),
                 ),
             ],
             data,
@@ -159,7 +171,7 @@ async fn download_file(
                 (header::CONTENT_TYPE, content_type),
                 (
                     header::CONTENT_DISPOSITION,
-                    format!("attachment; filename=\"{}\"", filename),
+                    build_attachment_disposition(&filename),
                 ),
             ],
             data,
@@ -596,6 +608,30 @@ fn spawn_verify_unverified(state: &CarinsState, tenant_id: Uuid, rows: &[FileRow
 mod tests {
     use super::*;
     use std::sync::Mutex;
+
+    #[test]
+    fn attachment_disposition_basic() {
+        let cd = build_attachment_disposition("hello.pdf");
+        assert!(cd.starts_with("attachment; "));
+        assert!(cd.contains("filename=\"hello.pdf\""));
+        assert!(cd.contains("filename*=UTF-8''hello.pdf"));
+    }
+
+    #[test]
+    fn attachment_disposition_sanitizes_quote() {
+        // `"` で disposition 構造を操作できないこと (Refs #394 L-3)
+        let cd = build_attachment_disposition("evil\"; foo=\"bar.pdf");
+        assert!(!cd.contains("evil\";"));
+        assert!(cd.contains("filename=\"evil_; foo=_bar.pdf\""));
+    }
+
+    #[test]
+    fn attachment_disposition_utf8() {
+        let cd = build_attachment_disposition("車検証.pdf");
+        // ASCII fallback はそのまま、RFC 5987 側は URL エンコード
+        assert!(cd.contains("filename*=UTF-8''"));
+        assert!(cd.contains("%E8%BB%8A"));
+    }
 
     struct MockRepo {
         pending_pdf_uuid: Mutex<Option<String>>,

--- a/crates/alc-core/src/constant_time.rs
+++ b/crates/alc-core/src/constant_time.rs
@@ -1,0 +1,31 @@
+//! shared secret / 署名の定数時間比較ヘルパ。
+//!
+//! 文字列 `==` 比較は不一致バイトで早期 return するためタイミング側チャネルの
+//! 余地がある。ヘッダ shared secret (X-Internal-Secret 等) の検証はこちらを使う
+//! (Refs #393 M-2)。HMAC 署名の検証は `Mac::verify_slice` を直接使うこと。
+
+/// 定数時間比較。タイミング攻撃で長さや位置を漏らさないため、長さ一致時は最後まで XOR する。
+pub fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff: u8 = 0;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn constant_time_eq_basic() {
+        assert!(constant_time_eq(b"abc", b"abc"));
+        assert!(!constant_time_eq(b"abc", b"abd"));
+        assert!(!constant_time_eq(b"abc", b"abcd"));
+        assert!(!constant_time_eq(b"", b"x"));
+        assert!(constant_time_eq(b"", b""));
+    }
+}

--- a/crates/alc-core/src/lib.rs
+++ b/crates/alc-core/src/lib.rs
@@ -9,6 +9,7 @@ pub mod auth_line;
 pub mod auth_lineworks;
 pub mod auth_middleware;
 
+pub mod constant_time;
 pub mod fcm;
 pub mod middleware;
 pub mod models;

--- a/crates/alc-core/src/repo/auth.rs
+++ b/crates/alc-core/src/repo/auth.rs
@@ -192,27 +192,25 @@ impl AuthRepository for PgAuthRepository {
     async fn find_user_in_tenant(
         &self,
         target_tenant_id: Uuid,
-        google_sub: Option<&str>,
-        lineworks_id: Option<&str>,
-        line_user_id: Option<&str>,
-        email: &str,
+        current_user_id: Uuid,
     ) -> Result<Option<User>, sqlx::Error> {
-        // google_sub, lineworks_id, line_user_id のいずれかでマッチ、またはメールでフォールバック
+        // email 一致のみで別テナントの user row にマッチさせない。同一 email が
+        // 複数テナントに存在すると意図しない role での JWT 発行につながるため、
+        // verified identity (google_sub / lineworks_id / line_user_id) の一致を
+        // 要求する (Refs #393 M-4)。verified ID を持たないユーザーは switch 不可。
         sqlx::query_as::<_, User>(
-            r#"SELECT * FROM users WHERE tenant_id = $1
+            r#"SELECT t.* FROM users t
+               JOIN users c ON c.id = $2
+               WHERE t.tenant_id = $1
                AND (
-                 (google_sub IS NOT NULL AND google_sub = $2)
-                 OR (lineworks_id IS NOT NULL AND lineworks_id = $3)
-                 OR (line_user_id IS NOT NULL AND line_user_id = $4)
-                 OR email = $5
+                 (t.google_sub IS NOT NULL AND t.google_sub = c.google_sub)
+                 OR (t.lineworks_id IS NOT NULL AND t.lineworks_id = c.lineworks_id)
+                 OR (t.line_user_id IS NOT NULL AND t.line_user_id = c.line_user_id)
                )
                LIMIT 1"#,
         )
         .bind(target_tenant_id)
-        .bind(google_sub.unwrap_or(""))
-        .bind(lineworks_id.unwrap_or(""))
-        .bind(line_user_id.unwrap_or(""))
-        .bind(email)
+        .bind(current_user_id)
         .fetch_optional(&self.pool)
         .await
     }

--- a/crates/alc-core/src/repository/auth.rs
+++ b/crates/alc-core/src/repository/auth.rs
@@ -118,13 +118,13 @@ pub trait AuthRepository: Send + Sync {
 
     // --- Switch org ---
 
+    /// switch-org 用: current user (`current_user_id`) と同じ verified identity
+    /// (google_sub / lineworks_id / line_user_id) を持つ user を target tenant から
+    /// 探す。email のみの一致では別テナントの JWT を発行しない (Refs #393 M-4)。
     async fn find_user_in_tenant(
         &self,
         target_tenant_id: Uuid,
-        google_sub: Option<&str>,
-        lineworks_id: Option<&str>,
-        line_user_id: Option<&str>,
-        email: &str,
+        current_user_id: Uuid,
     ) -> Result<Option<User>, sqlx::Error>;
 
     // --- Password login ---

--- a/crates/alc-devices/src/devices.rs
+++ b/crates/alc-devices/src/devices.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use alc_core::auth_middleware::{AuthUser, TenantId};
+use alc_core::constant_time::constant_time_eq;
 use alc_core::repository::devices::{
     DeviceRow, DeviceSettingsRow, FcmDeviceRow, RegistrationRequestRow,
 };
@@ -84,7 +85,8 @@ fn check_internal_secret(headers: &HeaderMap) -> Result<(), StatusCode> {
         .get("X-Internal-Secret")
         .and_then(|v| v.to_str().ok())
         .unwrap_or("");
-    if provided == expected {
+    // 文字列 `==` は非 constant-time でタイミング側チャネルの余地がある (Refs #393 M-2)
+    if constant_time_eq(provided.as_bytes(), expected.as_bytes()) {
         Ok(())
     } else {
         Err(StatusCode::UNAUTHORIZED)
@@ -1638,7 +1640,8 @@ async fn trigger_update_dev(
         .get("X-Internal-Secret")
         .and_then(|v| v.to_str().ok())
         .unwrap_or("");
-    if provided != expected_secret {
+    // 文字列 `!=` は非 constant-time でタイミング側チャネルの余地がある (Refs #393 M-2)
+    if !constant_time_eq(provided.as_bytes(), expected_secret.as_bytes()) {
         return Err(StatusCode::UNAUTHORIZED);
     }
 

--- a/crates/alc-dtako/src/dtako_event_classifications.rs
+++ b/crates/alc-dtako/src/dtako_event_classifications.rs
@@ -55,11 +55,12 @@ async fn update_classification(
 
     let tenant_id = tenant.0 .0;
 
+    // 生の sqlx エラー (SQL 片 / テーブル名等) を 500 body に echo しない (Refs #393 M-1)
     let row = state
         .dtako_event_classifications
         .update(tenant_id, id, &body.classification)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        .map_err(crate::dtako_upload::internal_err)?;
 
     match row {
         Some(r) => Ok(Json(r)),

--- a/crates/alc-dtako/src/dtako_upload.rs
+++ b/crates/alc-dtako/src/dtako_upload.rs
@@ -977,6 +977,7 @@ async fn internal_download(
     let r2_zip_key = record.r2_zip_key;
     let filename = record.filename;
 
+    // storage エラー詳細 (bucket / key / 認証情報) は log のみ、body には出さない (Refs #393 M-1)
     let zip_bytes = state
         .dtako_storage
         .as_ref()
@@ -984,9 +985,10 @@ async fn internal_download(
         .download(&r2_zip_key)
         .await
         .map_err(|e| {
+            tracing::error!("R2 download failed: {e}");
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                format!("R2 download failed: {e}"),
+                "R2 download failed".to_string(),
             )
         })?;
 
@@ -1034,6 +1036,7 @@ async fn internal_rerun(
     let filename = record.filename;
 
     // R2 から ZIP をダウンロード
+    // storage エラー詳細 (bucket / key / 認証情報) は log のみ、body には出さない (Refs #393 M-1)
     let zip_bytes = state
         .dtako_storage
         .as_ref()
@@ -1041,9 +1044,10 @@ async fn internal_rerun(
         .download(&r2_zip_key)
         .await
         .map_err(|e| {
+            tracing::error!("R2 download failed: {e}");
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                format!("R2 download failed: {e}"),
+                "R2 download failed".to_string(),
             )
         })?;
 
@@ -1576,9 +1580,10 @@ async fn split_csv_handler(
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
     tracing::info!("split-csv (auth) called: upload_id={}", upload_id);
 
+    // 生の anyhow エラー (内部パス / SQL 片等) を 500 body に echo しない (Refs #393 M-1)
     split_csv_from_r2(&state, upload_id)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        .map_err(internal_err)?;
 
     Ok(Json(
         serde_json::json!({ "status": "ok", "upload_id": upload_id }),

--- a/crates/alc-notify/src/line_webhook.rs
+++ b/crates/alc-notify/src/line_webhook.rs
@@ -77,14 +77,18 @@ async fn handle_webhook(
                         resolved.tenant_id
                     );
 
+                    // フォールバック表示名用の短縮 ID。`&user_id[..8]` は user_id が
+                    // 8 バイト未満 / UTF-8 境界を割ると panic するため、char ベースで
+                    // 安全に先頭 8 文字を取る (Refs #394 L-4)。
+                    let short_id: String = user_id.chars().take(8).collect();
                     // JWT でアクセストークン取得 → プロフィール取得
                     let name = match line_client.get_access_token(&line_config).await {
                         Ok(token) => get_user_display_name(&token, user_id)
                             .await
-                            .unwrap_or_else(|_| format!("LINE User {}", &user_id[..8])),
+                            .unwrap_or_else(|_| format!("LINE User {short_id}")),
                         Err(e) => {
                             tracing::warn!("LINE token error, using default name: {e}");
-                            format!("LINE User {}", &user_id[..8])
+                            format!("LINE User {short_id}")
                         }
                     };
 
@@ -190,8 +194,13 @@ fn verify_signature(body: &[u8], channel_secret: &str, signature: &str) -> bool 
         return false;
     };
     mac.update(body);
-    let expected = base64::engine::general_purpose::STANDARD.encode(mac.finalize().into_bytes());
-    expected == signature
+    // LINE の x-line-signature は base64(HMAC-SHA256(body))。文字列 `==` 比較は
+    // 非 constant-time でタイミング側チャネルの余地があるため、署名を decode して
+    // `mac.verify_slice` (内部で constant-time 比較) で検証する (Refs #393 M-2)。
+    let Ok(decoded) = base64::engine::general_purpose::STANDARD.decode(signature) else {
+        return false;
+    };
+    mac.verify_slice(&decoded).is_ok()
 }
 
 use base64::Engine;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,14 @@
 use std::sync::Arc;
 
+use axum::http::header::{
+    HeaderValue, REFERRER_POLICY, STRICT_TRANSPORT_SECURITY, X_CONTENT_TYPE_OPTIONS,
+    X_FRAME_OPTIONS,
+};
 use axum::http::Method;
 use axum::{Extension, Router};
 use sqlx::postgres::PgPoolOptions;
 use tower_http::cors::{AllowOrigin, Any, CorsLayer};
+use tower_http::set_header::SetResponseHeaderLayer;
 use tower_http::trace::TraceLayer;
 use tracing_subscriber::EnvFilter;
 
@@ -449,6 +454,25 @@ async fn main() -> anyhow::Result<()> {
         .layer(Extension(lw_client))
         .layer(axum::extract::DefaultBodyLimit::max(20 * 1024 * 1024)) // 20MB
         .layer(cors)
+        // セキュリティレスポンスヘッダ (Refs #394 L-2)。JSON API のため XSS 面は
+        // 小さいが、HSTS / nosniff / clickjacking 抑止は安価に効く。ハンドラが
+        // 個別に設定した値は尊重する (if_not_present)。
+        .layer(SetResponseHeaderLayer::if_not_present(
+            STRICT_TRANSPORT_SECURITY,
+            HeaderValue::from_static("max-age=31536000; includeSubDomains"),
+        ))
+        .layer(SetResponseHeaderLayer::if_not_present(
+            X_CONTENT_TYPE_OPTIONS,
+            HeaderValue::from_static("nosniff"),
+        ))
+        .layer(SetResponseHeaderLayer::if_not_present(
+            X_FRAME_OPTIONS,
+            HeaderValue::from_static("DENY"),
+        ))
+        .layer(SetResponseHeaderLayer::if_not_present(
+            REFERRER_POLICY,
+            HeaderValue::from_static("no-referrer"),
+        ))
         .layer(TraceLayer::new_for_http())
         .with_state(state);
 

--- a/tests/mock_helpers/repos_a.rs
+++ b/tests/mock_helpers/repos_a.rs
@@ -280,10 +280,7 @@ impl AuthRepository for MockAuthRepository {
     async fn find_user_in_tenant(
         &self,
         _target_tenant_id: Uuid,
-        _google_sub: Option<&str>,
-        _lineworks_id: Option<&str>,
-        _line_user_id: Option<&str>,
-        _email: &str,
+        _current_user_id: Uuid,
     ) -> Result<Option<User>, sqlx::Error> {
         check_fail!(self);
         Ok(self.return_switch_user.lock().unwrap().clone())


### PR DESCRIPTION
セキュリティ監査の引き継ぎ (Refs #396) のうち、フロント契約に影響しない範囲を一括適用。

Refs #393, Refs #394, Refs #396

## 変更内容

### #393 M-2: 非 constant-time 比較の排除
- `crates/alc-notify/src/line_webhook.rs` — LINE webhook の HMAC 署名検証を文字列 `==` から `mac.verify_slice` (内部 constant-time) に変更 (#396 の WIP diff を再適用)
- `crates/alc-core/src/constant_time.rs` **新設** — `constant_time_eq` 共有ヘルパ (ingest.rs の実装と同等 + テスト)
- `crates/alc-devices/src/devices.rs` — `X-Internal-Secret` の比較 2 箇所 (`check_internal_secret` / `trigger_update_dev`) を `constant_time_eq` に変更

### #393 M-1: 生エラー文字列の 500 body への漏洩排除
- `dtako_event_classifications.rs` — `update` の sqlx エラーを `internal_err` (log + generic body) に
- `dtako_upload.rs` — `split_csv_handler` の anyhow エラーを `internal_err` に、`R2 download failed: {e}` 2 箇所は `{e}` を log のみに (body は `"R2 download failed"` 固定 = 既存テストの `contains` assert はそのまま通る)

### #393 M-4: switch_org の email fallback 排除
- `find_user_in_tenant` を `(target_tenant_id, current_user_id)` signature に変更し、SQL を self-JOIN で **verified identity (google_sub / lineworks_id / line_user_id) の一致必須** に。email のみの一致では別テナント JWT を発行しない
- verified ID を持たないユーザー (username/password のみ等) は switch 不可 (403) になる挙動変更

### #394 L-2: セキュリティレスポンスヘッダ
- `src/main.rs` — `SetResponseHeaderLayer::if_not_present` で `Strict-Transport-Security` / `X-Content-Type-Options: nosniff` / `X-Frame-Options: DENY` / `Referrer-Policy: no-referrer` を付与 (tower-http に `set-header` feature 追加)

### #394 L-3: Content-Disposition filename injection (carins)
- `carins_files.rs` — `build_attachment_disposition` ヘルパ追加 (`"`→`_` サニタイズ + RFC 5987 `filename*=UTF-8''`、alc-notify viewer の `build_inline_disposition` と同パターン)。テスト 3 件追加
- 注: issue #396 で言及されていた「巨大行問題」は現 main では解消済み (最大 167 文字) だった

### #394 L-4: LINE webhook user_id slicing の panic 経路除去
- `&user_id[..8]` (8 バイト未満 / UTF-8 境界で panic) を `chars().take(8).collect()` に (#396 WIP 再適用)

## カバレッジ 100% gate への配慮

gate 対象 (`devices.rs` / `dtako_event_classifications.rs` / `dtako_upload.rs`) の変更は既存行の置換のみで、既存のエラーパステスト (status / `R2 download failed` prefix assert) で全行到達を維持。`repos_a.rs` mock は新 signature に追従済み。

## 残作業 (本 PR スコープ外、#396 参照)

- #393 M-3 (OAuth state expiry、`auth_lineworks.rs` gated で変更量大)
- #394 L-1 (rsa crate、低優先) / L-5 (無認証テナント作成、usage 調査要)
- #388 / #391 (フロント契約に影響するため user 確認の上で)

## 検証

- `cargo fmt --all` 済み / `cargo clippy --workspace -- -D warnings` green (CI と同一条件)
- `cargo check --workspace --all-targets` green
- 新規ユニットテスト 4 件 (constant_time 1 + attachment_disposition 3) pass

https://claude.ai/code/session_01Y62YGiPFyFQ7LkamqjdAaQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y62YGiPFyFQ7LkamqjdAaQ)_