### PR TITLE
feat(devices): OTA trigger FCM data に download_url を forward

### DIFF
--- a/crates/alc-devices/src/devices.rs
+++ b/crates/alc-devices/src/devices.rs
@@ -1550,6 +1550,10 @@ struct TriggerUpdateBody {
     /// true: dev端末のみ, false/省略: 全端末
     #[serde(default)]
     dev_only: Option<bool>,
+    /// 指定時はアプリがこの URL から APK を DL する (PR dev build の prerelease asset 等)。
+    /// 省略時はアプリ側が releases/latest に fallback。
+    #[serde(default)]
+    download_url: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -1627,6 +1631,9 @@ async fn send_update_fcm(
         }
         if let Some(ref vn) = body.version_name {
             data.insert("version_name".to_string(), vn.clone());
+        }
+        if let Some(ref url) = body.download_url {
+            data.insert("download_url".to_string(), url.clone());
         }
 
         match fcm.send_data_message(&device.fcm_token, data).await {

--- a/tests/mock_tests/mock_devices_test.rs
+++ b/tests/mock_tests/mock_devices_test.rs
@@ -3313,6 +3313,82 @@ async fn test_trigger_update_dev_with_tenants() {
 }
 
 // ============================================================
+// trigger_update_dev: download_url passthrough (Refs #406)
+// ============================================================
+
+#[tokio::test]
+async fn test_trigger_update_dev_download_url_passthrough() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("FCM_INTERNAL_SECRET", "dev-secret-3");
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    mock.return_dev_tenants.store(true, Ordering::SeqCst);
+    mock.return_data.store(true, Ordering::SeqCst);
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    let fcm_mock = Arc::new(crate::common::MockFcmSender::new());
+    state.fcm = Some(fcm_mock.clone());
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let url =
+        "https://github.com/ippoan/AlcoholChecker/releases/download/dev-pr2-10/app-release.apk";
+    let client = reqwest::Client::new();
+    let res = client
+        .post(format!("{base_url}/api/devices/trigger-update-dev"))
+        .header("X-Internal-Secret", "dev-secret-3")
+        .json(&serde_json::json!({ "version_code": 100, "download_url": url }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    let body: Value = res.json().await.unwrap();
+    assert_eq!(body["sent"], 1);
+
+    // FCM data に download_url がそのまま forward される
+    let sent = fcm_mock.sent.lock().unwrap();
+    assert_eq!(sent.len(), 1);
+    assert_eq!(sent[0].1.get("download_url"), Some(&url.to_string()));
+    assert_eq!(sent[0].1.get("type"), Some(&"app_update".to_string()));
+    drop(sent);
+    std::env::remove_var("FCM_INTERNAL_SECRET");
+}
+
+// ============================================================
+// trigger_update: download_url 省略時は FCM data に乗らない (Refs #406)
+// ============================================================
+
+#[tokio::test]
+async fn test_trigger_update_without_download_url() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+
+    let mock = Arc::new(MockDeviceRepository::default());
+    mock.return_data.store(true, Ordering::SeqCst);
+    let mut state = setup_mock_app_state();
+    state.devices = mock;
+    let fcm_mock = Arc::new(crate::common::MockFcmSender::new());
+    state.fcm = Some(fcm_mock.clone());
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let tenant_id = Uuid::new_v4();
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let client = reqwest::Client::new();
+    let res = client
+        .post(format!("{base_url}/api/devices/trigger-update"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .json(&serde_json::json!({ "version_code": 100 }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+
+    let sent = fcm_mock.sent.lock().unwrap();
+    assert_eq!(sent.len(), 1);
+    assert!(sent[0].1.get("download_url").is_none());
+}
+
+// ============================================================
 // trigger_update_dev: DB error on list_dev_device_tenant_ids
 // ============================================================
 


### PR DESCRIPTION
Refs #406, Refs ippoan/AlcoholChecker#2

## 変更内容

AlcoholChecker の dev/prod 配信分離 (dev 端末は PR build を即 OTA、prod 端末は Release Wave / 管理画面トリガー) のための backend 対応:

- `TriggerUpdateBody` に `download_url: Option<String>` を追加
- `send_update_fcm` が `download_url` を FCM `app_update` data にそのまま forward

アプリ側 (ippoan/AlcoholChecker#2) は FCM data の `download_url` を `OtaUpdateService` に passthrough し (allowlist: `https://github.com/ippoan/AlcoholChecker/releases/download/` のみ)、未指定なら従来どおり `releases/latest` に fallback する。

## テスト

- `test_trigger_update_dev_download_url_passthrough` — `MockFcmSender` の記録から `download_url` / `type` を直接 assert
- `test_trigger_update_without_download_url` — 省略時に FCM data に乗らないこと

## 互換性

- `download_url` 未指定の caller は挙動不変
- serde は unknown field を無視するので、旧 backend に新 caller (AlcoholChecker CI) が `download_url` を送っても 200 (無視されるだけ)

---
_Generated by [Claude Code](https://claude.ai/code/session_019STQEmTfAqCGkrKvv4bGrL)_