### PR TITLE
ci: auto-merge の needs に deploy を追加し cutover cancel による無音失敗を防ぐ

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -585,13 +585,17 @@ jobs:
 
   auto-merge:
     name: Auto Merge
-    needs: [check, coverage-check, build-image]
+    # deploy (staging cutover) を needs に含める: merge → branch 削除で走行中の
+    # cutover が cancel され deploy 失敗が無音化するのを防ぐ (Refs #405、#391 で
+    # 2 回実害)。トレードオフとして staging 障害時は全 PR が merge 不能になる。
+    needs: [check, coverage-check, build-image, deploy]
     if: >-
       always() &&
       github.event_name == 'pull_request' &&
       needs.check.result == 'success' &&
       needs.coverage-check.result == 'success' &&
-      needs.build-image.result == 'success'
+      needs.build-image.result == 'success' &&
+      needs.deploy.result == 'success'
     uses: ippoan/ci-workflows/.github/workflows/auto-merge.yml@main
     permissions:
       contents: write


### PR DESCRIPTION
Refs #405

## 変更内容

`ci.yml` の `auto-merge` job に `deploy` (staging cutover) を待たせる:

- `needs: [check, coverage-check, build-image]` → `needs: [check, coverage-check, build-image, deploy]`
- `if:` 条件に `needs.deploy.result == 'success'` を追加

## 背景

auto-merge が deploy job の完了を待たずに merge を queue すると、merge → branch 削除で走行中の staging cutover が **cancel** され、deploy 失敗が無音化する (#391 で 2 回実害: PR #403 の STAGING_API_KEY 注入 cutover が cancel → enforce が無音で未適用)。rollback step が旧 revision に traffic を戻すため service は正常に見え、失敗が隠れていた。

issue #405 の **対策案 1** を採用。

## トレードオフ (認識済み)

staging 環境障害 (例: docker.io flaky) 時は全 PR が merge 不能になる (staging が merge gate の SPOF になる)。その場合は deploy job の rerun か手動 merge で回避する。

## 補足

- auto-merge は `github.event_name == 'pull_request'` 限定で、PR event では `deploy` job が必ず実行される (`if` は pull_request を常に通す) ため、`skipped` の考慮は不要
- `report-backend-compat` (deploy 後の compat 記録) は本 PR の `needs` には含めていない — merge との race window は残るが短く、失敗しても staging 反映自体には影響しないため scope 外 (必要なら別 issue で)

https://claude.ai/code/session_01SWN1dXUg4pyPSoQ2xeiZjt

---
_Generated by [Claude Code](https://claude.ai/code/session_01SWN1dXUg4pyPSoQ2xeiZjt)_