### PR TITLE
ci(skills-check): enforce=fail pilot (ci-workflows#118 PR3)

### DIFF
--- a/.github/workflows/skills-check.yml
+++ b/.github/workflows/skills-check.yml
@@ -14,5 +14,6 @@ permissions:
 jobs:
   skills-check:
     uses: ippoan/ci-workflows/.github/workflows/skills-check.yml@main
-    # with:
-    #   enforce: warn        # warn (default) | fail
+    with:
+      # pilot (ci-workflows#118 PR3): map 更新漏れ / deprecated 依存追加で job fail
+      enforce: fail


### PR DESCRIPTION
## 概要

**ci-workflows#118 PR3**（pilot、第 2 弾）。rust-alc-api の skills-check caller を
`enforce: warn` → **`enforce: fail`** に昇格する。`paths`（crates/, src/, migrations/）下に
変更があるのに `rust-alc-api-map` が同 PR で更新されていない、または deprecated 依存を新規追加した
場合に **job を fail させる**。

## 安全性

map は co-located（claude-skills#59 Wave 2）で `generated-from` が現在の commit-sha にあるため、
通常の PR では fail しない。`crates/` 等を触りつつ map を更新しない PR でだけ fail する（意図した gate）。
本 PR 自体は `.github/workflows/` のみ変更で `paths` 未変更のため map-check は pass。

rust-flickr に続く高頻度 repo の pilot 第 2 弾。

Refs ippoan/ci-workflows#118
Refs ippoan/claude-skills#59, ippoan/claude-skills#58, ippoan/claude-hooks#18

https://claude.ai/code/session_014oVWwp7cDCWNGFbJGhRnc6

---
_Generated by [Claude Code](https://claude.ai/code/session_014oVWwp7cDCWNGFbJGhRnc6)_