### PR TITLE
feat(dtako-api): inject INTERNAL_SHARED_SECRET for /api/dtako/tickets ingest (Refs email-receiver#1)

### DIFF
--- a/cloudrun/render.sh
+++ b/cloudrun/render.sh
@@ -360,6 +360,15 @@ emit_env_dtako() {
                   name: dtako-r2-secret-key
             - name: SCRAPER_URL
               value: "${ENV_SCRAPER_URL:?ENV_SCRAPER_URL not set (GitHub vars.SCRAPER_URL)}"
+            # email-receiver Worker からの internal ingest (POST /api/dtako/tickets)
+            # 検証用。empty なら dtako-api/src/main.rs:114 で internal route を disable
+            # するので、未投入の prod でも safe fallback。値は ippoan 4 worker と共有
+            # (Refs auth-worker CLAUDE.md "2026-05-24: prod/staging 統合")。
+            - name: INTERNAL_SHARED_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: latest
+                  name: INTERNAL_SHARED_SECRET
             - name: RUST_LOG
               value: "dtako_api=info"
 YAML

--- a/staging/cloudrun-staging.yaml
+++ b/staging/cloudrun-staging.yaml
@@ -244,6 +244,13 @@ spec:
                 secretKeyRef:
                   key: latest
                   name: dtako-r2-secret-key
+            # email-receiver Worker からの internal ingest (POST /api/dtako/tickets)
+            # 用。empty なら dtako-api 側で internal route を disable する safe fallback。
+            - name: INTERNAL_SHARED_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: latest
+                  name: INTERNAL_SHARED_SECRET
             - name: RUST_LOG
               value: "dtako_api=info"
           resources:


### PR DESCRIPTION
## 親 epic

Refs ippoan/email-receiver#1

## 背景

email-receiver Worker は `POST /api/dtako/tickets` (起票) と `PATCH /api/dtako/tickets/{id}/scraped` (反映) を rust-alc-api の dtako-api binary (port 8084) に叩く設計。

dtako-api 側は `crates/dtako-api/src/main.rs:113-125` で env `INTERNAL_SHARED_SECRET` が空なら internal ingest route を **disable する safe fallback** を持つが、staging / prod の Cloud Run service env に未注入だったため email-receiver からの ingest が常に 404 になる状態でした。

## 変更

| file | 変更 |
|---|---|
| `cloudrun/render.sh` | `emit_env_dtako()` に `INTERNAL_SHARED_SECRET` secretKeyRef を追加 (CI deploy の SoT) |
| `staging/cloudrun-staging.yaml` | dtako container env に同じ secretKeyRef を追加 (legacy / local-dev reference) |

値は ippoan 既存 4 consumer (auth-worker / cdp-relay / hcreaderworker / ref-files-worker) と prod / staging で **同一 binding を共有**する規約 (Refs auth-worker CLAUDE.md "2026-05-24: prod/staging 統合") に揃える。今朝 merge した ippoan/email-receiver#4 と一致。

## 前提条件 (merge 前に user 作業必要)

runtime SA `747065218280-compute@developer.gserviceaccount.com` は **project-level `secretAccessor`** を持つ前提 (`ALC_STAGING_API_KEY` と同経路、Refs #391)。万一未付与なら CI staging deploy が次のようなエラーで fail します:

```
Permission denied on secret: projects/cloudsql-sv/secrets/INTERNAL_SHARED_SECRET
```

その場合は user が以下を 1 回実行:

```bash
gcloud secrets add-iam-policy-binding INTERNAL_SHARED_SECRET \
  --project=cloudsql-sv \
  --member="serviceAccount:747065218280-compute@developer.gserviceaccount.com" \
  --role="roles/secretmanager.secretAccessor"
```

(rust-alc-api CLAUDE.md の "新規 secret を secretKeyRef で参照する前に runtime SA へ per-secret grant が必要" 規約に従う。`INTERNAL_SHARED_SECRET` は他 4 consumer 経由で project に存在しているが、Cloud Run 経由のアクセスは初。)

## Test plan

- [ ] CI green (rust + integration test に影響なし、deploy 段で初検証)
- [ ] staging deploy 成功 (`Permission denied` が出たら上記 IAM grant を実行)
- [ ] staging で `email-receiver` 経由 (or curl) で `POST /api/dtako/tickets` が `200 {id}` を返す
- [ ] (確認) staging log に "INTERNAL_SHARED_SECRET not set; /api/dtako/tickets internal routes are disabled" の warn が出なくなる


---
_Generated by [Claude Code](https://claude.ai/code/session_01D8YwZT3a4yJua8JezSQvD4)_