### PR TITLE
fix(gateway): route /api/dtako/* to dtako-api (Refs email-receiver#1)

### DIFF
--- a/.claude/skills/rust-alc-api-map/SKILL.md
+++ b/.claude/skills/rust-alc-api-map/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rust-alc-api-map
-generated-from: rust-alc-api:f9fd8e991119cde81d9e4181052bd91b82d6735d
+generated-from: rust-alc-api:6ea5525063cd7da955e4023b6b104d93a1d7cf9a
 paths: [crates/, src/, migrations/]
 description: rust-alc-api (アルコールチェッカー基盤の Rust/Axum Cargo workspace — 13 domain crate + gateway/tenko/carins/dtako/trouble の複数バイナリ、PostgreSQL+RLS、Cloud Run) の構造ナビゲーション。どの crate に何のルートがあるか / monolith(rust-alc-api) と per-domain API + gateway の二系統 / RLS・migration・deploy/release 分離の gotcha を 1 枚にまとめる。トリガー:「rust-alc-api」「alc-api」「alc-notify」「alc-tenko」「alc-trouble」「alc-carins」「alc-dtako」「gateway」「tenko-api」「carins-api」「dtako-api」「trouble-api」「RLS テナント」「sqlx migration」「ts-rs」「Release Wave」「Bazel」等。
 ---

--- a/crates/gateway/src/proxy.rs
+++ b/crates/gateway/src/proxy.rs
@@ -32,6 +32,7 @@ fn resolve_backend<'a>(path: &str, state: &'a ProxyState) -> &'a str {
     {
         state.carins_url.as_deref().unwrap_or(&state.backend_url)
     } else if api_path.starts_with("/dtako-")
+        || api_path.starts_with("/dtako/")
         || api_path.starts_with("/upload")
         || api_path.starts_with("/uploads")
         || api_path.starts_with("/recalculate")
@@ -262,6 +263,16 @@ mod tests {
         );
         assert_eq!(
             resolve_backend("/api/internal/pending", &state),
+            "http://dtako:8084"
+        );
+        // dtako tickets routes (alc-dtako::dtako_tickets, Refs ippoan/email-receiver#1)
+        // — `/api/dtako/...` (スラッシュ) を dtako-api に振る。
+        assert_eq!(
+            resolve_backend("/api/dtako/tickets", &state),
+            "http://dtako:8084"
+        );
+        assert_eq!(
+            resolve_backend("/api/dtako/tickets/abc/scraped", &state),
             "http://dtako:8084"
         );
     }


### PR DESCRIPTION
## 親 epic

Refs ippoan/email-receiver#1

## 根本原因

PR #415 で `alc-dtako::dtako_tickets::internal_router` を `/api/dtako/tickets` (スラッシュ) に mount したが、**gateway の `resolve_backend()` (`crates/gateway/src/proxy.rs:25-57`) は dtako-api への振り分け prefix を明示 list 化**しており、`/dtako-` (ハイフン) しか含まれていなかった:

```rust
} else if api_path.starts_with("/dtako-")   // dtako-logs / dtako-restraint-report
    || api_path.starts_with("/upload")
    || ... {
    state.dtako_url...
} else {
    &state.backend_url   // ← /api/dtako/tickets はここ (alc-api 本体 port 8081)
}
```

→ `/api/dtako/tickets` (スラッシュ) は **fallback の `backend_url` (alc-api 本体) に転送され 404** に。

## ground truth

email-receiver の diagnostic log:
```
reason=Handler failed: createTicket 404:
```

staging endpoint に直接 curl:
```bash
curl -X POST 'https://rust-alc-api-staging-566bls5vfq-an.a.run.app/api/dtako/tickets' \
  -H "X-Internal-Shared-Secret: dummy" -H "X-Tenant-ID: ..." -d '{}'
# HTTP/2 404, content-length: 0, server: Google Frontend
```

## 変更

`resolve_backend()` の dtako 振り分けに `/dtako/` (スラッシュ) prefix を追加:

```diff
 } else if api_path.starts_with("/dtako-")
+    || api_path.starts_with("/dtako/")
     || api_path.starts_with("/upload")
     ...
```

これで `/api/dtako/tickets` および `/api/dtako/tickets/{id}/scraped` が **dtako-api (port 8084)** に転送され、PR #415 で実装された internal_router が応答する。

unit test を 2 ケース追加して回帰防止 (`test_resolve_backend_dtako`)。

## merge 後

1. staging deploy で gateway が新コードに切り替わる
2. email-receiver からの `POST /api/dtako/tickets` が dtako-api に届き、internal_router が `X-Internal-Shared-Secret` を検証して起票処理
3. テストメール再送で `email-receiver: handler matched (route=prod handler=dtako ticketId=...)` が CF Observability に出る → epic e2e 開通

## Test plan

- [ ] CI green (unit + integration)
- [ ] staging deploy 後、curl で `POST /api/dtako/tickets` が 404 ではなく 401 (X-Internal-Shared-Secret 不正) or 200 を返す
- [ ] email-receiver staging で `handler matched` ログ + ticketId 確認
- [ ] rust-alc-api staging DB の `dtako_tickets` に行が入る


---
_Generated by [Claude Code](https://claude.ai/code/session_01D8YwZT3a4yJua8JezSQvD4)_