### PR TITLE
fix(deploy): inject INTERNAL_SHARED_SECRET env to backend Cloud Run (Refs email-receiver#1)

### DIFF
--- a/.claude/skills/rust-alc-api-map/SKILL.md
+++ b/.claude/skills/rust-alc-api-map/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rust-alc-api-map
-generated-from: rust-alc-api:8488c5a7cc58671f73b6aa2f27330c62d8959f7a
+generated-from: rust-alc-api:9831fbf0ec95fb19859722016e525f0d096dbec8
 paths: [crates/, src/, migrations/]
 description: rust-alc-api (アルコールチェッカー基盤の Rust/Axum Cargo workspace — 13 domain crate + gateway/tenko/carins/dtako/trouble の複数バイナリ、PostgreSQL+RLS、Cloud Run) の構造ナビゲーション。どの crate に何のルートがあるか / monolith(rust-alc-api) と per-domain API + gateway の二系統 / RLS・migration・deploy/release 分離の gotcha を 1 枚にまとめる。トリガー:「rust-alc-api」「alc-api」「alc-notify」「alc-tenko」「alc-trouble」「alc-carins」「alc-dtako」「gateway」「tenko-api」「carins-api」「dtako-api」「trouble-api」「RLS テナント」「sqlx migration」「ts-rs」「Release Wave」「Bazel」等。
 ---

--- a/cloudrun/render.sh
+++ b/cloudrun/render.sh
@@ -280,6 +280,17 @@ YAML
                 secretKeyRef:
                   key: latest
                   name: gemini-api-key
+            # email-receiver Worker からの internal ingest (POST /api/dtako/tickets) 用。
+            # empty なら src/routes/mod.rs::internal_shared_secret_router が empty router
+            # を返し、ingest route が disable される safe fallback (Refs ippoan/email-receiver#1)。
+            # ippoan auth-worker / cdp-relay / hcreaderworker / ref-files-worker と
+            # 同じ INTERNAL_SHARED_SECRET secret を共有 (prod/staging 統合済、
+            # Refs auth-worker CLAUDE.md "2026-05-24")。
+            - name: INTERNAL_SHARED_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: latest
+                  name: INTERNAL_SHARED_SECRET
 YAML
 }
 


### PR DESCRIPTION
## 親 epic

Refs ippoan/email-receiver#1

## 背景

PR #418 で backend monolith (`src/routes/mod.rs`) に `dtako_tickets::internal_router()` を mount したが、`cloudrun/render.sh::emit_env_backend()` に `INTERNAL_SHARED_SECRET` env を追加していなかったため、Cloud Run `rust-alc-api-staging` service の env に当該 secret が **無い**。

結果: backend 起動時 `std::env::var("INTERNAL_SHARED_SECRET")` が Err → `internal_shared_secret_router(None)` → empty Router → `POST /api/dtako/tickets` は **405 Method Not Allowed**。

email-receiver のログでは:
```
reason=Handler failed: createTicket 401:
```
(staging staging 経路で 405 が何らかの layer で 401 に変換、`Allow: GET,HEAD` 残存)

実際 curl でも:
```
HTTP/2 401
allow: GET,HEAD
content-length: 0
```

PR #416 は **`emit_env_dtako()` 側だけ**に同じ secretKeyRef を追加した (dtako-api binary 向け)。今 backend monolith に route を mount したので、**`emit_env_backend()` にも同等の inject** が必要。

## 変更

`cloudrun/render.sh::emit_env_backend()` の末尾に `INTERNAL_SHARED_SECRET` の secretKeyRef を追加:

```yaml
- name: INTERNAL_SHARED_SECRET
  valueFrom:
    secretKeyRef:
      key: latest
      name: INTERNAL_SHARED_SECRET
```

ippoan の既存 4 consumer (auth-worker / cdp-relay / hcreaderworker / ref-files-worker) と同じ GCP Secret Manager `INTERNAL_SHARED_SECRET` を共有 (prod/staging 統合済、Refs auth-worker CLAUDE.md "2026-05-24")。

runtime SA `747065218280-compute@developer.gserviceaccount.com` の `secretmanager.secretAccessor` grant は **PR #416 で既に grant 済** (`INTERNAL_SHARED_SECRET` secret に対する per-secret accessor、ユーザーが gcloud で実行)。再 grant 不要。

## merge 後

1. staging deploy で backend Cloud Run env に `INTERNAL_SHARED_SECRET` 注入
2. backend 起動時 `internal_shared_secret_router(Some(secret))` → middleware + extension mount
3. email-receiver の `X-Internal-Shared-Secret` header が backend env と一致 → 200/204 で起票成功
4. **e2e 完成**: epic ippoan/email-receiver#1 開通 🎉

## Test plan

- [ ] CI green
- [ ] staging deploy 後、`curl -X POST /api/dtako/tickets -H "X-Internal-Shared-Secret: dummy"` が 401 (= route mounted、secret mismatch)
- [ ] テストメール送信 → CF Observability `email-receiver: handler matched (ticketId=...)`
- [ ] DB `dtako_tickets` テーブルに行が追加される


---
_Generated by [Claude Code](https://claude.ai/code/session_01D8YwZT3a4yJua8JezSQvD4)_