### PR TITLE
chore(deploy): trigger backend redeploy after INTERNAL_SHARED_SECRET rotate (Refs email-receiver#1)

### DIFF
--- a/cloudrun/render.sh
+++ b/cloudrun/render.sh
@@ -286,6 +286,9 @@ YAML
             # ippoan auth-worker / cdp-relay / hcreaderworker / ref-files-worker と
             # 同じ INTERNAL_SHARED_SECRET secret を共有 (prod/staging 統合済、
             # Refs auth-worker CLAUDE.md "2026-05-24")。
+            # 2026-06-16: GCP/CF 値 drift で email-receiver から 401 を踏み、rotate 実施
+            # (GCP v2 + CF 上書き)。本コメント更新は新 revision 強制作成のためのトリガー
+            # (= Cloud Run の env キャッシュを invalidate)。
             - name: INTERNAL_SHARED_SECRET
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## 親 epic

Refs ippoan/email-receiver#1

## 背景

PR #419 deploy 後、再送テストメールが依然として `createTicket 401:` で setReject:

```
Mail Delivery Subsystem <mailer-daemon@googlemail.com>
リモート サーバーからの応答:
555 5.7.1 Handler failed: createTicket 401: . uYNPWUFQLYnz
```

backend Cloud Run の `INTERNAL_SHARED_SECRET` env は注入済み (PR #419)、しかし middleware が email-receiver の送る `X-Internal-Shared-Secret` を拒否。

調査結果: **GCP Secret Manager と CF Secrets Store の `INTERNAL_SHARED_SECRET` の値が drift** していた疑い (2026-05-23 に同時投入後、片方が rotate されていない可能性 / trailing newline 等の不一致)。

## 対処

1. `secret-inject --rotate` で `INTERNAL_SHARED_SECRET` を rotate (新 random hex 32 byte):
   - GCP Secret Manager: v2 を追加
   - CF Secrets Store: 同 secret_id を上書き
   - GitHub Actions org secret: 更新
   - = **3 store すべて同一値に統一**
2. CF Secrets Store binding を使う Worker (email-receiver / auth-worker / cdp-relay / hcreaderworker / ref-files-worker) は次の request で新値を読む (自動)
3. Cloud Run rust-alc-api-staging は **container 起動時に env をキャッシュ**するため新 revision 必須 (Refs CLAUDE.md "Secret Manager 更新後は gcloud run deploy で新 revision 強制作成")

## 変更

`cloudrun/render.sh::emit_env_backend()` の `INTERNAL_SHARED_SECRET` セクションに rotate 記録 comment を 3 行追加。**functional change なし** (image / config 内容は不変、PR push による deploy 再走 = 新 revision 強制起動が真の目的)。

## merge 後

1. staging deploy で backend / dtako-api 両方の Cloud Run service が新 revision 起動
2. 新 revision は rotate 後の GCP `INTERNAL_SHARED_SECRET` v2 をキャッシュ
3. email-receiver の CF Secrets Store binding も同値を読む → header 一致
4. テストメール再送 → `email-receiver: handler matched (ticketId=...)` ✅
5. **epic ippoan/email-receiver#1 e2e 開通** 🎉

## Test plan

- [ ] CI green
- [ ] staging deploy 後、テストメール再送 → CF Observability に `handler matched`
- [ ] rust-alc-api staging DB に `dtako_tickets` 行追加


---
_Generated by [Claude Code](https://claude.ai/code/session_01D8YwZT3a4yJua8JezSQvD4)_