### PR TITLE
fix(staging): seed default tenant on cold start (Refs email-receiver#1)

### DIFF
--- a/.claude/skills/rust-alc-api-map/SKILL.md
+++ b/.claude/skills/rust-alc-api-map/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rust-alc-api-map
-generated-from: rust-alc-api:42d00a2b380872fac9ca641160d4145d6ecac27f
+generated-from: rust-alc-api:8e3cf5b2d35c8d6d4f1b209069066447846678b1
 paths: [crates/, src/, migrations/]
 description: rust-alc-api (アルコールチェッカー基盤の Rust/Axum Cargo workspace — 13 domain crate + gateway/tenko/carins/dtako/trouble の複数バイナリ、PostgreSQL+RLS、Cloud Run) の構造ナビゲーション。どの crate に何のルートがあるか / monolith(rust-alc-api) と per-domain API + gateway の二系統 / RLS・migration・deploy/release 分離の gotcha を 1 枚にまとめる。トリガー:「rust-alc-api」「alc-api」「alc-notify」「alc-tenko」「alc-trouble」「alc-carins」「alc-dtako」「gateway」「tenko-api」「carins-api」「dtako-api」「trouble-api」「RLS テナント」「sqlx migration」「ts-rs」「Release Wave」「Bazel」等。
 ---

--- a/crates/alc-misc/src/health.rs
+++ b/crates/alc-misc/src/health.rs
@@ -71,10 +71,14 @@ fn sha256_prefix(input: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
+    use tokio::sync::Mutex;
 
     // env vars はプロセス共有なので、本ファイルの env 操作は逐次化する。
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
+    // tokio::sync::Mutex を使うのは、std::sync::Mutex の guard を `.await` 越しに
+    // 保持すると clippy::await_holding_lock (= CI で `-D warnings` により error)
+    // を踏むため。本テストは env 設定 → async handler 呼び出し → assert を
+    // 1 つのロック内で完結させたいので、async-aware mutex が必須。
+    static ENV_LOCK: Mutex<()> = Mutex::const_new(());
 
     #[test]
     fn sha256_prefix_returns_hex_8_chars_and_is_deterministic() {
@@ -99,7 +103,7 @@ mod tests {
     #[tokio::test]
     async fn fingerprints_endpoint_lists_internal_shared_secret_bindings_and_skips_empty_and_unrelated(
     ) {
-        let _g = ENV_LOCK.lock().unwrap();
+        let _g = ENV_LOCK.lock().await;
         std::env::set_var("INTERNAL_SHARED_SECRET_TEST_FP_A", "abc");
         std::env::set_var("INTERNAL_SHARED_SECRET_TEST_FP_B", "xyz");
         std::env::set_var("INTERNAL_SHARED_SECRET_TEST_FP_EMPTY", "");

--- a/staging/entrypoint.sh
+++ b/staging/entrypoint.sh
@@ -15,6 +15,31 @@ echo "Running migrations..."
 DATABASE_URL="postgresql://postgres:staging@localhost:5432/postgres?options=-c search_path=alc_api" \
   /usr/local/bin/migrate
 
+# Seed staging default tenant.
+#
+# Cloud Run staging は揮発 DB (sidecar postgres + emptyDir、`minScale: 0` で
+# アイドル ~15min 後に消える)。コールドスタート時に `tenants` が空になるため、
+# email-receiver 等から固定 `tenant_id` でテーブル INSERT すると FK 違反で 500
+# (Refs ippoan/email-receiver#1 — 2026-06-16 epic e2e で踏んだ)。
+# マイグレーションは 1 回しか走らないので seed には不適、ここで毎 cold start
+# 投入する。`ON CONFLICT DO NOTHING` で idempotent。
+#
+# staging-only: 本 entrypoint.sh は `Dockerfile.app` から build される staging
+# multi-container image でのみ使われるため、本番 (Supabase) には触れない。
+echo "Seeding staging default tenant..."
+PGPASSWORD=staging psql -h localhost -p 5432 -U postgres -d postgres -v ON_ERROR_STOP=1 <<'SQL'
+INSERT INTO alc_api.tenants (id, name, slug, email_domain, created_at)
+VALUES (
+  '11111111-1111-1111-1111-111111111111',
+  'Staging Default',
+  'staging-default',
+  'example.com',
+  NOW()
+)
+ON CONFLICT (id) DO NOTHING;
+SQL
+echo "Staging default tenant seeded"
+
 echo "Migrations completed, starting ${BINARY}..."
 
 # Start the app with DATABASE_URL pointing to local postgres


### PR DESCRIPTION
## 親 epic

Refs ippoan/email-receiver#1

## 背景

email-receiver epic e2e の secret resolve fix (ippoan/email-receiver#16) で Worker fingerprint が `ad24cc83` → `1a9bf89b` に揃って backend ingest middleware を通過する所まで開通したが、**500** で止まった:

```
ERROR: dtako_tickets.create error: insert or update on table "dtako_tickets"
  violates foreign key constraint "dtako_tickets_tenant_id_fkey"
```

= 揮発 DB の cold start で `tenants` テーブルが空になり、固定 `tenant_id = 11111111-1111-1111-1111-111111111111` が消えた状態だった (Refs CLAUDE.md "データ永続性")。

毎回 `/api/staging/import` で手動投入する運用は実用的でないため、**cold start 毎に default tenant が必ず存在する状態を作る**。

## 変更

`staging/entrypoint.sh` の migration 完了直後に `tenants` テーブルへ `ON CONFLICT (id) DO NOTHING` で default tenant を INSERT:

```bash
PGPASSWORD=staging psql -h localhost -p 5432 -U postgres -d postgres -v ON_ERROR_STOP=1 <<'SQL'
INSERT INTO alc_api.tenants (id, name, slug, email_domain, created_at)
VALUES (
  '11111111-1111-1111-1111-111111111111',
  'Staging Default',
  'staging-default',
  'example.com',
  NOW()
)
ON CONFLICT (id) DO NOTHING;
SQL
```

- **staging-only**: 本 entrypoint.sh は `Dockerfile.app` から build される staging multi-container image でのみ使われる。**本番 (Supabase) には触れない**
- 揮発 DB の cold start 毎に走るため idempotent (`ON CONFLICT DO NOTHING`)
- `psql` は既に `apt-get install postgresql-client` 済 (Dockerfile.app L5)

## 効果

1. **email-receiver staging Worker のメール送信 → backend createTicket 200 起票** = epic ippoan/email-receiver#1 e2e 開通 🎉
2. staging-bootstrap E2E (alc-app/web) の wakeUpStaging も同じ tenant_id が常に存在するため import せずに認証経路が動く

完全な Staging Export/Import (`/api/staging/import` 経由の users / employees / devices 等の seed) は従来通り必要時に手動投入する。本 PR は **email-receiver が依存する最小限の tenant 行のみ** を保証する。

## Test plan

- [ ] CI green (Format & Lint / Tests (lib) / Tests (mock-*) / Build backend / Build staging backend)
- [ ] staging deploy 後、Cloud Run revision でメール再送 → `createTicket` が 200 を返す
- [ ] `handler matched (route=prod handler=dtako ticketId=...)` ログが出る
- [ ] staging DB の `dtako_tickets` テーブルに行が追加される

---

_Generated by [Claude Code](https://claude.ai/code) session_

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mp1wG5mvERAPUg6gH5NEWK)_