### PR TITLE
infra(ci): cache-warm test-shared を 1 invocation 並列 build に変更

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,18 +41,11 @@ jobs:
           - { name: "check", key: "check", cmd: "cargo clippy --workspace -- -D warnings && cargo test export_bindings --workspace" }
           # test-matrix 7 並列 (lib + mock-*) が共有する 1 つの cache。
           # rust-flickr#28-#32 の実験で確定した「shared-key 統合 + main warm 1 job
-          # だけ save」設計 (Refs #426)。ここで全 test 系の dep を 1 つの target/ に
-          # 揃えてから save するため、後段の test-matrix 7 並列が exact match で restore できる。
-          - name: "test-shared"
-            key: "test-shared"
-            cmd: |
-              cargo llvm-cov nextest --no-report --ignore-run-fail --lib --workspace
-              cargo llvm-cov nextest --no-report --ignore-run-fail --test mock_tenko
-              cargo llvm-cov nextest --no-report --ignore-run-fail --test mock_dtako
-              cargo llvm-cov nextest --no-report --ignore-run-fail --test mock_devices
-              cargo llvm-cov nextest --no-report --ignore-run-fail --test mock_carins
-              cargo llvm-cov nextest --no-report --ignore-run-fail --test mock_trouble --test trouble_test
-              cargo llvm-cov nextest --no-report --ignore-run-fail --test mock_misc --test archive_repo_test
+          # だけ save」設計 (Refs #426)。
+          # cmd は --workspace --all-targets --no-run の 1 invocation で、cargo の
+          # jobs server が全 test binary を内部で並列 build → wall time は元の matrix 7
+          # 並列と同等 (~2-3 分)。--no-run で test 実行はせず build artifact のみ作成。
+          - { name: "test-shared", key: "test-shared", cmd: "cargo llvm-cov nextest --no-report --no-run --workspace --all-targets" }
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.92.0


### PR DESCRIPTION
## Summary

PR #427 で導入した `cache-warm` の `test-shared` cmd は 7 cargo invocation を直列で並べていて、cargo startup oncost が累積する設計だった。これを **1 invocation の `cargo llvm-cov nextest --no-report --no-run --workspace --all-targets`** に置き換える。cargo の jobs server が全 test binary を内部で並列 build するため wall time は元の matrix 7 並列と同等に戻る。

Refs #426

## 変更内容

```diff
-          - name: "test-shared"
-            key: "test-shared"
-            cmd: |
-              cargo llvm-cov nextest --no-report --ignore-run-fail --lib --workspace
-              cargo llvm-cov nextest --no-report --ignore-run-fail --test mock_tenko
-              cargo llvm-cov nextest --no-report --ignore-run-fail --test mock_dtako
-              cargo llvm-cov nextest --no-report --ignore-run-fail --test mock_devices
-              cargo llvm-cov nextest --no-report --ignore-run-fail --test mock_carins
-              cargo llvm-cov nextest --no-report --ignore-run-fail --test mock_trouble --test trouble_test
-              cargo llvm-cov nextest --no-report --ignore-run-fail --test mock_misc --test archive_repo_test
+          - { name: "test-shared", key: "test-shared",
+              cmd: "cargo llvm-cov nextest --no-report --no-run --workspace --all-targets" }
```

## 期待効果

| 観点 | PR #427 (直列 7 invocation) | 本 PR (1 invocation 並列 build) |
|---|---|---|
| cargo 起動回数 | 7 | 1 |
| dep build | ~3-5 分 (1 回目) | ~3-5 分 |
| test binary link | 直列累積 (各 ~30 秒 × 6 = 3 分) | cargo jobs server で並列 (~1-2 分) |
| **wall time** | **~6-10 分** | **~2-3 分** (= 元の matrix 7 並列同等) |
| test 実行 (warm では無意味) | あり (`--ignore-run-fail`、各 ~15-60 秒) | なし (`--no-run`) |
| カバー範囲 | lib + 列挙された 7 mock_* test | lib + 全 integration test (`tests/devices_test.rs` 等の漏れていた target も拾う) |

## なぜ並列 / 直列の議論より「1 invocation `--all-targets`」が良いか

並列に戻すと shared-key 統合の効果が失われる (cache 8 個 + 並列 save 競合 risk 復活) ため、選択肢は実質「1 job のまま cmd を工夫する」に絞られる。1 cargo invocation で `--all-targets` を渡せば cargo 内部の jobs server が並列 compile するため、結果的に **並列 → 直列の累積 oncost を払わずに済む**。

「1 個変わったら全部やり直しじゃないか」については No。cargo の incremental は変更 crate とその下流のみ rebuild する設計で、shared-key 統合とは無関係。共通 dep / workspace lib 変更で cascade するのは並列 / 直列 / cache 構造いずれでも同じ動作。

## 制約と検証

- `--no-run`: `cargo-llvm-cov` v0.8.4 の long help で対応確認済 (`--no-clean` / `--no-report` / `--no-run` 渡し時は per-invocation clean を抑制)
- `--all-targets`: libs + bins + tests + examples + benches を build。doctests は別 (`--doc` 要)、alc-api coverage gate は doctest 対象外で互換
- llvm-cov instrumented build (`cfg(coverage)`) は test-matrix 側と同 profile → target/ fingerprint 一致

## Test plan

- [ ] PR push の skills-check / CI が success (本 PR 自身は `Cache Warm` を走らせない PR run)
- [ ] merge 後の main run で `Cache Warm (test-shared)` が ~2-3 分で完了 (PR #427 merge 後の run と比較)
- [ ] その後の PR で `Tests (*)` 7 並列が `test-shared` cache を read-only restore し、build 工程が大幅短縮されるか観察

Refs #426

---
_Generated by [Claude Code](https://claude.ai/code/session_0156PbSWNDLN4uTv9d6PC2oY)_