### PR TITLE
fix(ci): cache-warm test-shared から --no-report を削除 (--no-run と併用不可)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,9 @@ jobs:
           # cmd は --workspace --all-targets --no-run の 1 invocation で、cargo の
           # jobs server が全 test binary を内部で並列 build → wall time は元の matrix 7
           # 並列と同等 (~2-3 分)。--no-run で test 実行はせず build artifact のみ作成。
-          - { name: "test-shared", key: "test-shared", cmd: "cargo llvm-cov nextest --no-report --no-run --workspace --all-targets" }
+          # cargo-llvm-cov 0.8.4 で `--no-report` と `--no-run` は併用不可 (Refs #426, run 27612447687 で実機 fail)。
+          # `--no-run` のみで instrumented build artifact を target/ に残せる。
+          - { name: "test-shared", key: "test-shared", cmd: "cargo llvm-cov nextest --no-run --workspace --all-targets" }
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.92.0


### PR DESCRIPTION
## Summary

PR #428 で導入した cmd が main run 27612447687 で fail。`--no-report` を削除して fix (Refs #426)。

## エラー (実機実測)

```
$ cargo llvm-cov nextest --no-report --no-run --workspace --all-targets
warning: --no-run is deprecated, use `cargo llvm-cov report` subcommand instead
error: --no-report may not be used together with --no-run
##[error]Process completed with exit code 1.
```

[Cache Warm (test-shared) job 81639984893](https://github.com/ippoan/rust-alc-api/actions/runs/27612447687/job/81639984893): 48 秒で exit 1。

## 原因

cargo-llvm-cov 0.8.4 の仕様で `--no-report` と `--no-run` は併用不可。Plan agent と私が「long help にあるから動く」と仮定して実機検証しなかったミス。

## 修正

```diff
- cmd: "cargo llvm-cov nextest --no-report --no-run --workspace --all-targets"
+ cmd: "cargo llvm-cov nextest --no-run --workspace --all-targets"
```

`--no-report` を削除。`--no-run` のみで:
- instrumented build artifact が target/ に残る (warm の目的達成)
- test 実行は skip される
- `--no-run` は deprecated warning が出るが動作する

## 残課題 (本 PR の外)

`--no-run` は deprecated。将来 cargo-llvm-cov 更新で消える可能性あり。その時は `cargo llvm-cov report` subcommand 移行を検討。

## Test plan

- [ ] PR push の skills-check / CI が success
- [ ] merge 後の main run で `Cache Warm (test-shared)` が成功し、wall time を実測
- [ ] その値を PR #427 merge 後の 10:17 (直列 7 invocation) と比較

Refs #426

---
_Generated by [Claude Code](https://claude.ai/code/session_0156PbSWNDLN4uTv9d6PC2oY)_