### PR TITLE
fix(ci): cache-warm test-shared cmd を --ignore-run-fail で動く形に

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,12 +42,13 @@ jobs:
           # test-matrix 7 並列 (lib + mock-*) が共有する 1 つの cache。
           # rust-flickr#28-#32 の実験で確定した「shared-key 統合 + main warm 1 job
           # だけ save」設計 (Refs #426)。
-          # cmd は --workspace --all-targets --no-run の 1 invocation で、cargo の
-          # jobs server が全 test binary を内部で並列 build → wall time は元の matrix 7
-          # 並列と同等 (~2-3 分)。--no-run で test 実行はせず build artifact のみ作成。
-          # cargo-llvm-cov 0.8.4 で `--no-report` と `--no-run` は併用不可 (Refs #426, run 27612447687 で実機 fail)。
-          # `--no-run` のみで instrumented build artifact を target/ に残せる。
-          - { name: "test-shared", key: "test-shared", cmd: "cargo llvm-cov nextest --no-run --workspace --all-targets" }
+          # cmd は --workspace --all-targets で全 test binary を 1 cargo invocation で
+          # build (cargo の jobs server が内部並列)。--no-report で coverage report
+          # 生成抑制、--ignore-run-fail で DB 必要 test が一部 fail しても許容。
+          # 注意: cargo-llvm-cov 0.8.4 の --no-run は cargo test の --no-run と意味が
+          # 異なる (report subcommand の旧名で profraw 必須)。build only にしたければ
+          # --no-run を使わず、test 実行 + --ignore-run-fail のパターンを使う。
+          - { name: "test-shared", key: "test-shared", cmd: "cargo llvm-cov nextest --no-report --ignore-run-fail --workspace --all-targets" }
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.92.0


### PR DESCRIPTION
## Summary

PR #428 / #429 で導入した `--no-run` 路線が cargo-llvm-cov 0.8.4 の仕様で動かない。元の動作実績ある `--no-report --ignore-run-fail` を 1 invocation 統合に流用 (Refs #426)。

## 失敗履歴

| PR | cmd | run | エラー |
|---|---|---|---|
| #428 | `--no-report --no-run --all-targets` | 27612447687 | `error: --no-report may not be used together with --no-run` |
| #429 | `--no-run --all-targets` (no-report 削除) | 27613060501 | `error: failed to merge profile data: not found *.profraw files` |

## 修正

```diff
- cmd: "cargo llvm-cov nextest --no-run --workspace --all-targets"
+ cmd: "cargo llvm-cov nextest --no-report --ignore-run-fail --workspace --all-targets"
```

cargo-llvm-cov 0.8.4 の `--no-run` は **`cargo test --no-run` とは別物** で、`cargo llvm-cov report` subcommand の旧名 (profraw 必須)。実機検証で初めて判明。

## なぜ Option B (動く形) が良い

- 1 cargo invocation = startup 1 回のみ (PR #427 の 7 直列 cargo startup oncost を解消)
- cargo の jobs server で test binary を**内部並列 build**
- `--no-report` で coverage report 生成抑制 (元 7 invocation も使ってた、確立済挙動)
- `--ignore-run-fail` で DB 必要 test の fail を許容 (mock-* は pass、lib は一部 fail、job 自体は success)
- `--all-targets` で漏れていた top-level test target (`devices_test.rs` 等) も拾う

## 他の Cache Warm jobs は影響なし

run 27613060501 で **`Cache Warm (test-shared)` のみ fail**、`Cache Warm (check)` + `Cache Warm (bazel-*)` 8 jobs は全 success だった。本 PR の修正範囲も test-shared 1 entry のみ。

## Test plan

- [ ] PR push の CI が success
- [ ] merge 後の main run で `Cache Warm (test-shared)` が success で完了
- [ ] その後の PR で `Tests (*)` 7 並列が引き続き sccache 100% hit を維持

Refs #426

---
_Generated by [Claude Code](https://claude.ai/code/session_0156PbSWNDLN4uTv9d6PC2oY)_