### PR TITLE
ci: add cap-catalog extract workflow

### DIFF
--- a/.github/workflows/cap-catalog-extract.yml
+++ b/.github/workflows/cap-catalog-extract.yml
@@ -1,0 +1,13 @@
+name: cap-catalog extract
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+permissions:
+  contents: read
+jobs:
+  extract:
+    uses: ippoan/ci-workflows/.github/workflows/catalog-extract.yml@main
+    with:
+      language: rust


### PR DESCRIPTION
## Summary

- `.github/workflows/cap-catalog-extract.yml` を追加し、`ippoan/ci-workflows/.github/workflows/catalog-extract.yml@main` を caller として呼ぶ
- `language: rust` のみ指定 (workspace root = repo root のため `working_directory` は省略 = default `.`)
- merge 後、cap-catalog builder が本 repo の jsonl を取り込み `v1/latest.jsonl` に集約 → ci-dashboard `/cap-catalog` UI / `cap` CLI から横断検索可能になる

Phase 1 のみ。`@feature:` 注釈 (Phase 2) と doc-comment gate (Phase 3) は後続 issue で。

## Test plan

- [ ] PR push で `cap-catalog extract` workflow が起動し green になる
- [ ] artifact `catalog-extract` が upload される (現状 extractor は empty JSONL を返す stub だが workflow 自体は通る想定 — Refs ippoan/ci-workflows `catalog-extract.yml`)

Refs #431
Refs ippoan/cap-catalog#29

---
_Generated by [Claude Code](https://claude.ai/code/session_017nhvYbgAG11YRxMeSzDwmz)_