### PR TITLE
ci: report-pending-release に staged_image を載せて flip 前 retest を起動 (Refs ci-dashboard#427)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -534,6 +534,11 @@ jobs:
           RELEASE_WAVE_WEBHOOK_SECRET: ${{ secrets.RELEASE_WAVE_WEBHOOK_SECRET }}
           REPO: ${{ github.repository }}
           TAG: ${{ github.ref_name }}
+          # flip 前 (no-traffic 0%) で上がった production image の識別子。
+          # ci-dashboard が consumer に **flip 前** retest を fan-out する anchor
+          # (Refs ippoan/ci-dashboard#427)。staging report (current_image) と同じく
+          # github.sha = `ghcr.io/ippoan/rust-alc-api:<sha>` を consumer が pull する。
+          STAGED_IMAGE: ${{ github.sha }}
           GCP_PROJECT: cloudsql-sv
           GCP_REGION: asia-northeast1
         run: |
@@ -564,7 +569,8 @@ jobs:
           payload=$(jq -nc \
             --arg repo "$REPO" --arg version_id "$version_id" --arg tag "$TAG" \
             --arg preview_url "${preview_url:-}" \
-            '{repo: $repo, version_id: $version_id, tag: $tag, preview_url: $preview_url}
+            --arg staged_image "${STAGED_IMAGE:-}" \
+            '{repo: $repo, version_id: $version_id, tag: $tag, preview_url: $preview_url, staged_image: $staged_image}
              | with_entries(select(.value != ""))')
           echo "reporting pending release: repo=$REPO tag=$TAG version_id=$version_id"
           # fail-loud: 報告に失敗すると Pending releases に出ず flip できないのに、


### PR DESCRIPTION
## 背景

backend の production release は **no-traffic upload (0% revision) → 明示 flip (100%)** の 2 段。だが consumer (frontend) の retest は staging deploy (PR) と **flip 完了後** (`backend-deploy-report`) でしか走らず、**tag → flip の間に production image の pre-flip 検証が無かった**。flip してから consumer の互換性破壊が分かる手遅れ経路。

## 修正

`report-pending-release` step (v* tag push、production no-traffic upload 成功時に発火) の payload に `staged_image: ${{ github.sha }}` を追加する。ci-dashboard が受けると、その image に対して **flip 前** に consumer retest を fan-out する (受け側はペア PR ippoan/ci-dashboard#437)。

staging report (`current_image: github.sha`) と同じく `ghcr.io/ippoan/rust-alc-api:<sha>` を consumer が pull するので、image 解決の整合は既存と同一。

## 変更 (`.github/workflows/ci.yml`)

- `report-pending-release` step の env に `STAGED_IMAGE: ${{ github.sha }}` を追加 (trusted context、env 経由なので injection なし)。
- pending-release POST payload の jq に `staged_image` を追加。空なら `with_entries(select(.value != ""))` で落ちるので報告経路の backward-compat は維持。

## 効果

これで rust-alc-api の `/tag-release` → no-traffic upload の直後に consumer (alc-app / nuxt-dtako-admin / 他) が production image に対して自動 retest され、**全 green を確認してから flip** できる。

Refs ippoan/ci-dashboard#427

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01L9Whotk2c69w5nPSt8AWyf)_