### PR TITLE
feat(auth): require_tenant_or_device ミドルウェアを追加 (Refs #434)

### DIFF
--- a/.claude/skills/rust-alc-api-map/SKILL.md
+++ b/.claude/skills/rust-alc-api-map/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rust-alc-api-map
-generated-from: rust-alc-api:1a1e8360f984b15e63d7c956518c0da9cfe7a11a
+generated-from: rust-alc-api:86a6be12d65bacc5c517ada164956c64e01fa98a
 paths: [crates/, src/, migrations/]
 description: rust-alc-api (アルコールチェッカー基盤の Rust/Axum Cargo workspace — 13 domain crate + gateway/tenko/carins/dtako/trouble の複数バイナリ、PostgreSQL+RLS、Cloud Run) の構造ナビゲーション。どの crate に何のルートがあるか / monolith(rust-alc-api) と per-domain API + gateway の二系統 / RLS・migration・deploy/release 分離の gotcha を 1 枚にまとめる。トリガー:「rust-alc-api」「alc-api」「alc-notify」「alc-tenko」「alc-trouble」「alc-carins」「alc-dtako」「gateway」「tenko-api」「carins-api」「dtako-api」「trouble-api」「RLS テナント」「sqlx migration」「ts-rs」「Release Wave」「Bazel」等。
 ---
@@ -48,7 +48,9 @@ monolith と per-domain API は同じ domain crate (`alc-tenko` 等) を共有 �
   carins/dtako/notify/trouble は別バケット+別 R2 キー)、巨大な `AppState` に全 Pg*Repository を組み立て、
   `.nest("/api", rust_alc_api::routes::router())`。背景 task: 60s ごと `check_overdue_schedules`。
 - **router 本体**: `src/routes/mod.rs` — 各 domain crate のルートを re-export し `router()` で結線。
-  middleware: `require_jwt` (管理) / `require_tenant` (JWT→`X-Tenant-ID` フォールバック) / `require_internal_jwt`。
+  middleware: `require_jwt` (管理) / `require_tenant` (JWT→`X-Tenant-ID` フォールバック) / `require_internal_jwt` /
+  `require_tenant_or_device` (JWT or `X-Tenant-ID`+`X-Device-Token`、bare `X-Tenant-ID` 単独は 401。
+  device token は migration 116 `verify_device_token` SECURITY DEFINER で fail-closed 検証。#434)。
 - **gateway**: `crates/gateway/src/{main,routes,proxy,auth,config}.rs`。`is_public_route` に
   列挙された path (health / auth/* / tenko-call register / devices register / staging / notify line-webhook
   等) は JWT skip でそのまま proxy。

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,7 +196,7 @@ jobs:
           - { name: "mock-devices", cmd: "--test mock_devices" }
           - { name: "mock-carins", cmd: "--test mock_carins" }
           - { name: "mock-trouble", cmd: "--test mock_trouble --test trouble_test" }
-          - { name: "mock-misc", cmd: "--test mock_misc --test archive_repo_test" }
+          - { name: "mock-misc", cmd: "--test mock_misc --test archive_repo_test --test require_tenant_or_device_test" }
     services:
       postgres:
         image: postgres:16

--- a/crates/alc-core/src/auth_middleware.rs
+++ b/crates/alc-core/src/auth_middleware.rs
@@ -41,6 +41,33 @@ async fn tenant_exists(pool: Option<&sqlx::PgPool>, tenant_id: Uuid) -> bool {
     }
 }
 
+/// device token (X-Device-Token) を `devices` テーブルで検証する (Refs #434)。
+///
+/// `tenant_exists` (fail-open) と異なり、こちらは **fail-closed**: pool が `None`
+/// (= 検証不能) でも DB エラーでも `false` を返す。device token は署名・所有確認の
+/// 代替なので、検証できないなら通さない (= 無認証アクセスを許さない)。
+///
+/// RLS + SECURITY DEFINER (`alc_api.verify_device_token`, migration 116) 経由で
+/// (tenant_id, settings_token, status='active') の一致を確認する。
+async fn device_token_valid(pool: Option<&sqlx::PgPool>, tenant_id: Uuid, token: Uuid) -> bool {
+    let Some(pool) = pool else {
+        return false;
+    };
+    match sqlx::query_scalar::<_, bool>("SELECT alc_api.verify_device_token($1, $2)")
+        .bind(tenant_id)
+        .bind(token)
+        .fetch_one(pool)
+        .await
+    {
+        Ok(valid) => valid,
+        // 検証クエリ自体が失敗した = 検証不能なので fail-closed (通さない)。
+        Err(e) => {
+            tracing::warn!("device token verification query failed: {e}");
+            false
+        }
+    }
+}
+
 /// JWT 必須ミドルウェア — 管理ページ用
 ///
 /// Authorization: Bearer <jwt> ヘッダーから JWT を検証し、
@@ -123,6 +150,73 @@ pub async fn require_tenant(
     if !tenant_exists(pool, tenant_id).await {
         // 一行に収める (上記 JWT 経路と同理由: 複数行 warn! は llvm-cov で uncovered 計上)。
         tracing::warn!("tenant {tenant_id} not in tenants table (X-Tenant-ID); returning 401");
+        return Err(StatusCode::UNAUTHORIZED);
+    }
+
+    req.extensions_mut().insert(TenantId(tenant_id));
+    Ok(next.run(req).await)
+}
+
+/// テナント認証ミドルウェア — キオスク (device token) 対応版 (Refs #434)
+///
+/// `require_tenant` の bare X-Tenant-ID フォールバック (= 有効な UUID を知るだけで
+/// 通過できる無認証アクセス) を塞いだ版。sensitive route は `require_jwt` へ、
+/// device token を持つキオスクが実際に必要な最小 route だけを本ミドルウェアに乗せる。
+///
+/// 1. Authorization: Bearer <jwt> があれば JWT を検証 (管理者モード)
+/// 2. なければ **X-Tenant-ID + X-Device-Token の両方**を要求し、
+///    `devices` テーブルで device token を検証 (キオスクモード、fail-closed)
+/// 3. X-Tenant-ID 単独 (device token 無し) → 401
+pub async fn require_tenant_or_device(
+    jwt_secret: Option<Extension<JwtSecret>>,
+    validation_pool: Option<Extension<TenantValidationPool>>,
+    mut req: Request,
+    next: Next,
+) -> Result<Response, StatusCode> {
+    let pool = validation_pool
+        .as_ref()
+        .and_then(|Extension(p)| p.0.as_ref());
+
+    // まず JWT を試行 (require_tenant と同じフラット化で llvm-cov 問題回避)
+    if let Some(Ok(claims)) = extract_bearer_token(&req)
+        .zip(jwt_secret.as_ref())
+        .map(|(token, Extension(secret))| verify_access_token(token, secret))
+    {
+        if !tenant_exists(pool, claims.tenant_id).await {
+            let tid = claims.tenant_id;
+            tracing::warn!("tenant {tid} not in tenants table (JWT); returning 401");
+            return Err(StatusCode::UNAUTHORIZED);
+        }
+        let auth_user = AuthUser {
+            user_id: claims.sub,
+            email: claims.email,
+            name: claims.name.clone(),
+            tenant_id: claims.tenant_id,
+            tenant_slug: claims.org_slug,
+            role: claims.role,
+        };
+        req.extensions_mut().insert(TenantId(claims.tenant_id));
+        req.extensions_mut().insert(auth_user);
+        return Ok(next.run(req).await);
+    }
+
+    // キオスク経路: X-Tenant-ID + X-Device-Token の両方を要求 (= bare X-Tenant-ID 拒否)
+    let tenant_id = req
+        .headers()
+        .get("X-Tenant-ID")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| Uuid::parse_str(v).ok())
+        .ok_or(StatusCode::UNAUTHORIZED)?;
+    let device_token = req
+        .headers()
+        .get("X-Device-Token")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| Uuid::parse_str(v).ok())
+        .ok_or(StatusCode::UNAUTHORIZED)?;
+
+    if !device_token_valid(pool, tenant_id, device_token).await {
+        // 一行に収める (llvm-cov で複数行 warn! が uncovered 計上されるため)。
+        tracing::warn!("device token invalid for tenant {tenant_id}; returning 401");
         return Err(StatusCode::UNAUTHORIZED);
     }
 
@@ -541,5 +635,75 @@ mod tests {
         // 長さ違い + 空。
         assert!(!constant_time_eq(b"", b"x"));
         assert!(!constant_time_eq(b"x", b""));
+    }
+
+    // -----------------------------------------------------------------
+    // require_tenant_or_device — DB 不要な分岐 (Refs #434)
+    // DB 必須の分岐 (JWT + 実在 tenant / 実 device token 検証) は
+    // tests/mock_tests/mock_require_tenant_or_device_test.rs (実 DB) でカバーする。
+    // -----------------------------------------------------------------
+
+    /// `pool` 引数で TenantValidationPool を差し替えられる require_tenant_or_device 用
+    /// テストアプリ。JwtSecret は常に layer する (Authorization 無しなら JWT 経路は skip)。
+    fn app_tenant_or_device(pool: Option<sqlx::PgPool>) -> Router {
+        Router::new()
+            .route("/t", get(echo_tenant))
+            .layer(axum_middleware::from_fn(require_tenant_or_device))
+            .layer(Extension(TenantValidationPool(pool)))
+            .layer(Extension(JwtSecret(
+                "unit-test-secret-256-bits-long!!".to_string(),
+            )))
+    }
+
+    #[tokio::test]
+    async fn tenant_or_device_no_headers_unauthorized() {
+        // JWT 無し + X-Tenant-ID 無し → 401 (tenant_id 欠落)。
+        let resp = send(app_tenant_or_device(None), req("/t")).await;
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn tenant_or_device_bare_tenant_id_unauthorized() {
+        // #434 の核心: 有効 UUID を X-Tenant-ID 単独で送っても device token 無しなら 401。
+        let resp = send(
+            app_tenant_or_device(None),
+            req_with_headers("/t", &[("X-Tenant-ID", &Uuid::new_v4().to_string())]),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn tenant_or_device_invalid_device_token_format_unauthorized() {
+        // X-Device-Token が UUID として parse できない → 401 (device_token 欠落扱い)。
+        let resp = send(
+            app_tenant_or_device(None),
+            req_with_headers(
+                "/t",
+                &[
+                    ("X-Tenant-ID", &Uuid::new_v4().to_string()),
+                    ("X-Device-Token", "not-a-uuid"),
+                ],
+            ),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn tenant_or_device_token_present_but_pool_none_fail_closed() {
+        // device token が UUID 形式でも、pool=None (検証不能) なら fail-closed で 401。
+        let resp = send(
+            app_tenant_or_device(None),
+            req_with_headers(
+                "/t",
+                &[
+                    ("X-Tenant-ID", &Uuid::new_v4().to_string()),
+                    ("X-Device-Token", &Uuid::new_v4().to_string()),
+                ],
+            ),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
     }
 }

--- a/migrations/116_add_verify_device_token.sql
+++ b/migrations/116_add_verify_device_token.sql
@@ -1,0 +1,23 @@
+-- require_tenant_or_device ミドルウェア (Refs #434) の device token 検証用関数。
+--
+-- `devices` テーブルは RLS 有効 + SELECT が SECURITY DEFINER 関数経由 (063) のため、
+-- ミドルウェア層 (tenant context 未設定) から素の SELECT では行が見えない。
+-- get_device_settings_by_id (063) と同じく SECURITY DEFINER 関数で RLS を回避し、
+-- (tenant_id, settings_token, status='active') の 3 条件一致を boolean で返す。
+--
+-- - settings_token は approval 時にのみ発行される (114)。NULL の行は決して一致しない。
+-- - status='active' で disabled / rejected / pending な device を除外する
+--   (稼働中 device は INSERT 時 status='active'、enable/disable で 'active'/'disabled' を遷移)。
+-- - 値 (settings_token) は引数で受け取るだけで、関数も呼び出し側も log / response に echo しない。
+CREATE OR REPLACE FUNCTION alc_api.verify_device_token(p_tenant_id UUID, p_token UUID)
+RETURNS BOOLEAN
+LANGUAGE sql SECURITY DEFINER SET search_path = alc_api
+AS $$
+    SELECT EXISTS(
+        SELECT 1 FROM alc_api.devices
+        WHERE tenant_id = p_tenant_id
+          AND settings_token = p_token
+          AND status = 'active'
+    );
+$$;
+GRANT EXECUTE ON FUNCTION alc_api.verify_device_token(UUID, UUID) TO alc_api_app;

--- a/tests/require_tenant_or_device_test.rs
+++ b/tests/require_tenant_or_device_test.rs
@@ -1,0 +1,137 @@
+//! `require_tenant_or_device` ミドルウェア (Refs #434) の DB 必須分岐の統合テスト。
+//!
+//! DB 不要な分岐 (bare X-Tenant-ID → 401 / device token 欠落 → 401 / pool=None
+//! fail-closed) は `crates/alc-core/src/auth_middleware.rs` の unit test 側で確認する。
+//! ここでは実 DB を使い、JWT + 実在 tenant 検証と実 device token 検証
+//! (`alc_api.verify_device_token`, migration 116) を網羅する。
+
+#[macro_use]
+mod common;
+
+use axum::{middleware as axum_middleware, routing::get, Extension, Router};
+use rust_alc_api::auth::jwt::JwtSecret;
+use rust_alc_api::middleware::auth::{require_tenant_or_device, TenantId, TenantValidationPool};
+use uuid::Uuid;
+
+async fn echo_tenant(Extension(tid): Extension<TenantId>) -> String {
+    tid.0.to_string()
+}
+
+/// 指定 pool で require_tenant_or_device を layer した最小アプリをローカル port に
+/// spawn し、base URL を返す。本番 route には配線せず、ミドルウェア単体を検証する。
+async fn spawn(pool: sqlx::PgPool) -> String {
+    let app = Router::new()
+        .route("/t", get(echo_tenant))
+        .layer(axum_middleware::from_fn(require_tenant_or_device))
+        .layer(Extension(TenantValidationPool(Some(pool))))
+        .layer(Extension(JwtSecret(common::TEST_JWT_SECRET.to_string())));
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    format!("http://{addr}")
+}
+
+/// status='active' な device を直接 INSERT して settings_token を仕込む
+/// (テストは postgres superuser = BYPASSRLS なので set_current_tenant 不要)。
+async fn insert_active_device(pool: &sqlx::PgPool, tenant_id: Uuid, token: Uuid) {
+    sqlx::query(
+        "INSERT INTO devices (tenant_id, device_name, device_type, status, settings_token) \
+         VALUES ($1, 'test-kiosk', 'kiosk', 'active', $2)",
+    )
+    .bind(tenant_id)
+    .bind(token)
+    .execute(pool)
+    .await
+    .expect("insert test device");
+}
+
+#[tokio::test]
+async fn jwt_valid_existing_tenant_ok() {
+    let state = common::setup_app_state().await;
+    let tenant = common::create_test_tenant(state.pool(), "RTOD jwt ok").await;
+    let jwt = common::create_test_jwt(tenant, "admin");
+    let base = spawn(state.pool().clone()).await;
+
+    let resp = reqwest::Client::new()
+        .get(format!("{base}/t"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    assert_eq!(resp.text().await.unwrap(), tenant.to_string());
+}
+
+#[tokio::test]
+async fn jwt_valid_missing_tenant_unauthorized() {
+    // JWT は正当だが tenant が DB に存在しない → 401 (揮発性 staging 回復フロー)。
+    let state = common::setup_app_state().await;
+    let jwt = common::create_test_jwt(Uuid::new_v4(), "admin");
+    let base = spawn(state.pool().clone()).await;
+
+    let resp = reqwest::Client::new()
+        .get(format!("{base}/t"))
+        .header("Authorization", format!("Bearer {jwt}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 401);
+}
+
+#[tokio::test]
+async fn valid_device_token_ok() {
+    let state = common::setup_app_state().await;
+    let tenant = common::create_test_tenant(state.pool(), "RTOD dev ok").await;
+    let token = Uuid::new_v4();
+    insert_active_device(state.pool(), tenant, token).await;
+    let base = spawn(state.pool().clone()).await;
+
+    let resp = reqwest::Client::new()
+        .get(format!("{base}/t"))
+        .header("X-Tenant-ID", tenant.to_string())
+        .header("X-Device-Token", token.to_string())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    assert_eq!(resp.text().await.unwrap(), tenant.to_string());
+}
+
+#[tokio::test]
+async fn wrong_device_token_unauthorized() {
+    // tenant は実在し device もあるが、提示された token が一致しない → 401。
+    let state = common::setup_app_state().await;
+    let tenant = common::create_test_tenant(state.pool(), "RTOD dev wrong").await;
+    insert_active_device(state.pool(), tenant, Uuid::new_v4()).await;
+    let base = spawn(state.pool().clone()).await;
+
+    let resp = reqwest::Client::new()
+        .get(format!("{base}/t"))
+        .header("X-Tenant-ID", tenant.to_string())
+        .header("X-Device-Token", Uuid::new_v4().to_string())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 401);
+}
+
+#[tokio::test]
+async fn db_error_fail_closed_unauthorized() {
+    // 検証クエリが失敗 (pool クローズ) しても fail-closed で 401 (Err 分岐)。
+    let state = common::setup_app_state().await;
+    let broken = state.pool().clone();
+    broken.close().await;
+    let base = spawn(broken).await;
+
+    let resp = reqwest::Client::new()
+        .get(format!("{base}/t"))
+        .header("X-Tenant-ID", Uuid::new_v4().to_string())
+        .header("X-Device-Token", Uuid::new_v4().to_string())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 401);
+}


### PR DESCRIPTION
## 概要

#434 (X-Tenant-ID 単独経路が無認証アクセスを許す) の修正シリーズ **step [1] の一部 = 土台**。
合意済みリリース順序のうち「`require_tenant_or_device` 実装」を **追加のみ・非破壊**で入れる。

**この PR は既存挙動を一切変えない**:
- 既存 `require_tenant` の bare X-Tenant-ID フォールバックは**そのまま温存**
- sensitive router の仕分け・bare フォールバック撤去は**含まない**
- 新ミドルウェアは本番 route に**まだ配線していない** (ミドルウェア単体 + テストのみ)

→ 本番・staging のキオスク/管理画面に影響なし。安全に先行 merge できる土台。

## 変更

| ファイル | 内容 |
|---|---|
| `crates/alc-core/src/auth_middleware.rs` | `require_tenant_or_device` ミドルウェア + `device_token_valid` ヘルパー + no-DB 分岐の unit test |
| `migrations/116_add_verify_device_token.sql` | `alc_api.verify_device_token(uuid, uuid)` SECURITY DEFINER 関数 |
| `tests/require_tenant_or_device_test.rs` | JWT / 実 device token 検証の統合テスト (実 DB) |

### `require_tenant_or_device` の挙動

1. `Authorization: Bearer <jwt>` があれば JWT 検証 (管理者モード、`require_tenant` と同等)
2. JWT が無ければ **`X-Tenant-ID` + `X-Device-Token` の両方**を要求し `devices` で検証
3. **`X-Tenant-ID` 単独 (device token 無し) → 401** ← #434 の核心を塞ぐ

### fail-closed の徹底 (レビュー指摘 §2 / D-0 反映)

`device_token_valid` は `tenant_exists` (fail-open) と異なり **pool=None でも DB エラーでも `false`** を返す。device token は署名・所有確認の代替なので、検証不能なら通さない。

### RLS 対応

`devices` は RLS 有効 + SELECT が SECURITY DEFINER 経由 (migration 063) のため、ミドルウェア層 (tenant context 未設定) から素の SELECT では行が見えない。`get_device_settings_by_id` と同じく SECURITY DEFINER 関数 `verify_device_token` で `(tenant_id, settings_token, status='active')` 一致を判定する (`status='active'` で disabled/rejected を除外、値は log/response に echo しない)。

## テスト (B-3 / B-4 相当)

- **unit (DB 不要)**: bare X-Tenant-ID → 401 / device token 欠落 → 401 / 不正 UUID → 401 / pool=None fail-closed → 401
- **integration (実 DB)**: JWT+実在 tenant → 200 / JWT+不在 tenant → 401 / 有効 device token → 200 / 不一致 token → 401 / DB エラー fail-closed → 401

`auth_middleware.rs` は coverage 100% gate 対象。DB 分岐は CI の `--combined` で integration test 経由で被覆される。

## 後続 (本 PR には含まない、合意済み deploy 順序)

1. alc-app: キオスク呼び出しに `X-Device-Token` 付与
2. nuxt-pwa-carins (案A: JWT secret 統一) / nuxt-items: consumer 修正
3. sensitive router を `require_jwt` へ / キオスク最小 router を `require_tenant_or_device` へ仕分け
4. **最終 PR**: `require_tenant` の bare フォールバック撤去 (= 上記 1〜3 の本番反映確認を gate に)

別途起票推奨 (レビュー指摘): `require_tenant_header` の gateway bypass / staging gate 強化。

Refs #434
Refs #388

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011vhTKAiiFt7XqtTeF934rE)_