### PR TITLE
feat(auth): require_tenant に proxy 共有 secret gate を追加 (Refs #434)

### DIFF
--- a/.claude/skills/rust-alc-api-map/SKILL.md
+++ b/.claude/skills/rust-alc-api-map/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rust-alc-api-map
-generated-from: rust-alc-api:86a6be12d65bacc5c517ada164956c64e01fa98a
+generated-from: rust-alc-api:41beda4b750fb3e3ee01f9b5c5134809a828706b
 paths: [crates/, src/, migrations/]
 description: rust-alc-api (アルコールチェッカー基盤の Rust/Axum Cargo workspace — 13 domain crate + gateway/tenko/carins/dtako/trouble の複数バイナリ、PostgreSQL+RLS、Cloud Run) の構造ナビゲーション。どの crate に何のルートがあるか / monolith(rust-alc-api) と per-domain API + gateway の二系統 / RLS・migration・deploy/release 分離の gotcha を 1 枚にまとめる。トリガー:「rust-alc-api」「alc-api」「alc-notify」「alc-tenko」「alc-trouble」「alc-carins」「alc-dtako」「gateway」「tenko-api」「carins-api」「dtako-api」「trouble-api」「RLS テナント」「sqlx migration」「ts-rs」「Release Wave」「Bazel」等。
 ---
@@ -48,9 +48,10 @@ monolith と per-domain API は同じ domain crate (`alc-tenko` 等) を共有 �
   carins/dtako/notify/trouble は別バケット+別 R2 キー)、巨大な `AppState` に全 Pg*Repository を組み立て、
   `.nest("/api", rust_alc_api::routes::router())`。背景 task: 60s ごと `check_overdue_schedules`。
 - **router 本体**: `src/routes/mod.rs` — 各 domain crate のルートを re-export し `router()` で結線。
-  middleware: `require_jwt` (管理) / `require_tenant` (JWT→`X-Tenant-ID` フォールバック) / `require_internal_jwt` /
-  `require_tenant_or_device` (JWT or `X-Tenant-ID`+`X-Device-Token`、bare `X-Tenant-ID` 単独は 401。
-  device token は migration 116 `verify_device_token` SECURITY DEFINER で fail-closed 検証。#434)。
+  middleware: `require_jwt` (管理) / `require_tenant` (JWT→`X-Tenant-ID` フォールバック) / `require_internal_jwt`。
+  `require_tenant` の X-Tenant-ID 経路は `TenantProxySecret` (env `TENANT_PROXY_SECRET`) 設定時に
+  `X-Tenant-Proxy-Secret` の一致を要求し、信頼できる alc-app proxy 経由のみ許可する (#434、空なら gate off)。
+  `require_tenant_or_device` (#436) は device-token 方式の旧実装で現状未配線 (proxy-secret 方式に転換)。
 - **gateway**: `crates/gateway/src/{main,routes,proxy,auth,config}.rs`。`is_public_route` に
   列挙された path (health / auth/* / tenko-call register / devices register / staging / notify line-webhook
   等) は JWT skip でそのまま proxy。

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,7 +196,7 @@ jobs:
           - { name: "mock-devices", cmd: "--test mock_devices" }
           - { name: "mock-carins", cmd: "--test mock_carins" }
           - { name: "mock-trouble", cmd: "--test mock_trouble --test trouble_test" }
-          - { name: "mock-misc", cmd: "--test mock_misc --test archive_repo_test --test require_tenant_or_device_test" }
+          - { name: "mock-misc", cmd: "--test mock_misc --test archive_repo_test --test require_tenant_or_device_test --test require_tenant_proxy_test" }
     services:
       postgres:
         image: postgres:16

--- a/crates/alc-core/src/auth_middleware.rs
+++ b/crates/alc-core/src/auth_middleware.rs
@@ -14,6 +14,17 @@ use crate::auth_jwt::{verify_access_token, verify_internal_token, JwtSecret};
 #[derive(Clone)]
 pub struct TenantValidationPool(pub Option<sqlx::PgPool>);
 
+/// `require_tenant` の X-Tenant-ID 経路を信頼できる proxy 経由に限定するための共有 secret
+/// (Refs #434)。alc-app server proxy が device JWT を introspect 検証 → `X-Tenant-ID` +
+/// `X-Tenant-Proxy-Secret` を注入して rust-alc-api に転送する。proxy だけが secret を持つので、
+/// **外部からの bare X-Tenant-ID 直叩き (= #434 の無認証アクセス) を拒否できる**。
+///
+/// 値が空文字列 (= env `TENANT_PROXY_SECRET` 未設定) の場合は gate を **無効化** し従来動作
+/// (bare X-Tenant-ID 許可) に倒す。これにより全 consumer が secret 送出に移行するまで
+/// 段階的に有効化できる (= 非破壊な rollout)。JWT 経路には影響しない。
+#[derive(Clone)]
+pub struct TenantProxySecret(pub String);
+
 /// resolve 済みの tenant_id が `tenants` テーブルに実在するか確認する。
 ///
 /// 揮発性 staging DB で tenant が消えると、ブラウザの JWT は古い tenant_id を持つが
@@ -105,6 +116,7 @@ pub async fn require_jwt(
 pub async fn require_tenant(
     jwt_secret: Option<Extension<JwtSecret>>,
     validation_pool: Option<Extension<TenantValidationPool>>,
+    proxy_secret: Option<Extension<TenantProxySecret>>,
     mut req: Request,
     next: Next,
 ) -> Result<Response, StatusCode> {
@@ -139,7 +151,26 @@ pub async fn require_tenant(
         return Ok(next.run(req).await);
     }
 
-    // フォールバック: X-Tenant-ID ヘッダー (キオスクモード)
+    // フォールバック: X-Tenant-ID ヘッダー (proxy 経由キオスクモード)
+    //
+    // proxy secret が設定 (非空) されていれば `X-Tenant-Proxy-Secret` の一致を要求する。
+    // = 信頼できる alc-app proxy 以外からの bare X-Tenant-ID 直叩きを拒否 (#434)。
+    // 空 (env 未設定) なら gate off で従来動作 (= 段階的 rollout 用)。
+    let configured = proxy_secret
+        .as_ref()
+        .map(|Extension(s)| s.0.as_str())
+        .unwrap_or("");
+    if !configured.is_empty() {
+        let provided = req
+            .headers()
+            .get("X-Tenant-Proxy-Secret")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        if !constant_time_eq(configured.as_bytes(), provided.as_bytes()) {
+            return Err(StatusCode::UNAUTHORIZED);
+        }
+    }
+
     let tenant_id = req
         .headers()
         .get("X-Tenant-ID")
@@ -700,6 +731,52 @@ mod tests {
                 &[
                     ("X-Tenant-ID", &Uuid::new_v4().to_string()),
                     ("X-Device-Token", &Uuid::new_v4().to_string()),
+                ],
+            ),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    // -----------------------------------------------------------------
+    // require_tenant の proxy-secret gate (Refs #434) — DB 不要な分岐。
+    // gate 有効 + 正しい secret で通る経路は tests/require_tenant_proxy_test.rs
+    // (実 DB) でカバーする。
+    // -----------------------------------------------------------------
+
+    /// proxy secret を layer した require_tenant 用テストアプリ。JwtSecret も layer する
+    /// (Authorization 無しなら JWT 経路は skip → X-Tenant-ID 経路へ)。
+    fn app_require_tenant_proxy(secret: &str) -> Router {
+        Router::new()
+            .route("/t", get(echo_tenant))
+            .layer(axum_middleware::from_fn(require_tenant))
+            .layer(Extension(TenantProxySecret(secret.to_string())))
+            .layer(Extension(JwtSecret(
+                "unit-test-secret-256-bits-long!!".to_string(),
+            )))
+    }
+
+    #[tokio::test]
+    async fn require_tenant_proxy_secret_missing_header_unauthorized() {
+        // gate 有効 (secret 設定済み) + X-Tenant-ID あり + proxy header 無し → 401 (#434 核心)。
+        let resp = send(
+            app_require_tenant_proxy("proxy-secret"),
+            req_with_headers("/t", &[("X-Tenant-ID", &Uuid::new_v4().to_string())]),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn require_tenant_proxy_secret_wrong_header_unauthorized() {
+        // proxy header が secret と不一致 → 401。
+        let resp = send(
+            app_require_tenant_proxy("proxy-secret"),
+            req_with_headers(
+                "/t",
+                &[
+                    ("X-Tenant-ID", &Uuid::new_v4().to_string()),
+                    ("X-Tenant-Proxy-Secret", "wrong-secret"),
                 ],
             ),
         )

--- a/src/main.rs
+++ b/src/main.rs
@@ -466,6 +466,14 @@ async fn main() -> anyhow::Result<()> {
         .layer(Extension(
             rust_alc_api::middleware::auth::TenantValidationPool(state.pool.clone()),
         ))
+        // require_tenant の X-Tenant-ID 経路を proxy 限定にする共有 secret (Refs #434)。
+        // env `TENANT_PROXY_SECRET` 未設定なら空 = gate off (従来動作)。全 consumer が
+        // secret 送出に移行後、env を入れて有効化する (= 段階的 rollout)。
+        .layer(Extension(
+            rust_alc_api::middleware::auth::TenantProxySecret(
+                std::env::var("TENANT_PROXY_SECRET").unwrap_or_default(),
+            ),
+        ))
         .layer(Extension(rust_alc_api::routes::dtako_scraper::ScraperUrl(
             scraper_url,
         )))

--- a/tests/require_tenant_proxy_test.rs
+++ b/tests/require_tenant_proxy_test.rs
@@ -1,0 +1,56 @@
+//! `require_tenant` の proxy-secret gate (Refs #434) の DB 必須分岐の統合テスト。
+//!
+//! DB 不要な分岐 (gate 有効 + proxy header 欠落/不一致 → 401) は
+//! `crates/alc-core/src/auth_middleware.rs` の unit test 側で確認する。
+//! ここでは実 DB を使い、「gate 有効 + 正しい proxy secret + 実在 tenant → 200」
+//! (= proxy 経由の正規アクセスが通る経路) をカバーする。
+
+#[macro_use]
+mod common;
+
+use axum::{middleware as axum_middleware, routing::get, Extension, Router};
+use rust_alc_api::auth::jwt::JwtSecret;
+use rust_alc_api::middleware::auth::{
+    require_tenant, TenantId, TenantProxySecret, TenantValidationPool,
+};
+use uuid::Uuid;
+
+const PROXY_SECRET: &str = "test-proxy-secret-value-32-bytes";
+
+async fn echo_tenant(Extension(tid): Extension<TenantId>) -> String {
+    tid.0.to_string()
+}
+
+/// gate を有効化した (proxy secret 設定済み) require_tenant をローカル port に spawn。
+async fn spawn(pool: sqlx::PgPool) -> String {
+    let app = Router::new()
+        .route("/t", get(echo_tenant))
+        .layer(axum_middleware::from_fn(require_tenant))
+        .layer(Extension(TenantValidationPool(Some(pool))))
+        .layer(Extension(TenantProxySecret(PROXY_SECRET.to_string())))
+        .layer(Extension(JwtSecret(common::TEST_JWT_SECRET.to_string())));
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    format!("http://{addr}")
+}
+
+#[tokio::test]
+async fn proxy_secret_match_with_existing_tenant_ok() {
+    let state = common::setup_app_state().await;
+    let tenant = common::create_test_tenant(state.pool(), "RTP proxy ok").await;
+    let base = spawn(state.pool().clone()).await;
+
+    let resp = reqwest::Client::new()
+        .get(format!("{base}/t"))
+        .header("X-Tenant-ID", tenant.to_string())
+        .header("X-Tenant-Proxy-Secret", PROXY_SECRET)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    assert_eq!(resp.text().await.unwrap(), tenant.to_string());
+}


### PR DESCRIPTION
## 概要

#434（X-Tenant-ID 単独経路の無認証アクセス）を **「信頼できる alc-app proxy 経由でのみ X-Tenant-ID を受ける」** 方式で塞ぐための **PR 1（rust-alc-api 側の土台、非破壊）**。

方針転換: #436 の device-token (settings_token) 方式ではなく、**alc-app server proxy が device JWT を auth-worker introspect 検証 → `X-Tenant-ID` + `X-Tenant-Proxy-Secret` を注入**する構成（Option ①）。proxy だけが secret を持つので、外部からの bare `X-Tenant-ID` 直叩きを拒否できる。

**この PR 単体では挙動を変えない**（env 未設定 = gate off）。全 consumer が secret 送出に移行後、env を入れて有効化する段階的 rollout。

## 変更

| ファイル | 内容 |
|---|---|
| `crates/alc-core/src/auth_middleware.rs` | `TenantProxySecret` extension + `require_tenant` の X-Tenant-ID 経路に constant-time secret 一致チェック（既存 `constant_time_eq` 流用）+ no-DB unit test |
| `src/main.rs` | env `TENANT_PROXY_SECRET`（default 空）から `TenantProxySecret` を layer |
| `tests/require_tenant_proxy_test.rs` | 正規 proxy 経路（secret 一致 + 実在 tenant → 200）の実 DB 統合テスト |
| `.github/workflows/ci.yml` | 上記統合テストを coverage matrix (mock-misc) に配線 |

## 挙動

`require_tenant` の X-Tenant-ID フォールバック:
- `TENANT_PROXY_SECRET` **空（未設定）** → gate off、従来通り bare X-Tenant-ID 許可（**非破壊**）
- **設定済み** → `X-Tenant-Proxy-Secret` ヘッダの一致を要求。欠落/不一致 → **401**（= #434 の直叩き拒否）
- **JWT (Bearer) 経路には影響しない**（管理者は従来通り直接アクセス可）

## テスト
- unit（DB 不要）: gate 有効 + header 欠落/不一致 → 401
- 統合（実 DB）: gate 有効 + 正しい secret + 実在 tenant → 200
- 空（gate off）経路は既存 `trouble_test` 等で被覆。`auth_middleware.rs` の 100% gate 維持。

## 全体計画（#434 を ① で閉じる）
1. **本 PR** rust-alc-api: proxy-secret gate（gate off で merge）
2. infra: `TENANT_PROXY_SECRET` を GCP Secret Manager + CF Secrets Store に同名投入
3. alc-app: server proxy 新設（device JWT introspect → `X-Tenant-ID` + secret 注入）、キオスク再 pairing（device-kiosk）
4. nuxt-pwa-carins / nuxt-items: 既存 X-Tenant-ID 注入に secret 追加
5. **最終 flip**: 全 consumer 移行確認後に env 投入で gate 有効化 + Cloud Run ingress 制限

> 補足: #436 の `require_tenant_or_device`（device-token 方式）は未配線の旧実装。本方式採用に伴い別 PR で cleanup 予定。

Refs #434

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011vhTKAiiFt7XqtTeF934rE)_