### PR TITLE
perf(ci): 依存を opt-level=2 にして crypto テストの unoptimized 激遅を解消 (Refs #438)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,13 @@
 members = [".", "crates/alc-auth", "crates/alc-auth-jwt", "crates/alc-camera", "crates/alc-camera-api", "crates/alc-carins", "crates/alc-core", "crates/alc-csv-parser", "crates/alc-compare", "crates/alc-devices", "crates/alc-dtako", "crates/alc-misc", "crates/alc-notify", "crates/alc-pdf", "crates/alc-storage", "crates/alc-tenko", "crates/alc-trouble", "crates/carins-api", "crates/dtako-api", "crates/gateway", "crates/tenko-api", "crates/trouble-api"]
 resolver = "2"
 
+# 依存クレートだけ opt-level=2 で最適化 (Refs #438)。RSA/JWT/TLS 等の暗号処理を
+# unoptimized (debug) で実行すると release の数十倍遅く、CI の `Tests (lib)` shard の
+# 律速 (run 90s) だった。自前コード (= 計装対象) は opt-level 0 のまま据え置くので、
+# 計装コンパイル速度も coverage 100% gate も維持される。
+[profile.dev.package."*"]
+opt-level = 2
+
 [package]
 name = "rust-alc-api"
 version = "0.1.0"


### PR DESCRIPTION
## 概要

[#438](https://github.com/ippoan/rust-alc-api/issues/438) の対応。root `Cargo.toml` に依存クレートだけ最適化する profile を 1 ブロック追加する。

```toml
[profile.dev.package."*"]
opt-level = 2
```

## 背景（issue #438 の実測）

CI の wall-clock 律速は `Tests (lib)` shard（run 90s）で、その正体は **RSA / JWT / TLS 等の暗号処理を debug(unoptimized) プロファイルで実行している**こと（Rust の既知の罠：crypto は unoptimized だと release の数十倍遅い）。DB でも shard 不足でもない。

依存だけ opt-level=2 にした実測（issue より）:

| テスト | before | after | 倍率 |
|---|---|---|---|
| `line::push_text_failure_returns_send_failed` | 11.34s | 0.181s | 63× |
| `line::get_access_token_400_returns_error` | 8.45s | 0.169s | 50× |
| `auth_google::test_verify_success` | 8.97s | sub-second | ~30× |

alc-core + alc-notify の全テスト実行: 数十秒 → `Summary [4.546s]`。

## なぜ安全か

- **自前コード（= 計装対象）は opt-level 0 のまま据え置く** → 計装コンパイル速度も **coverage 100% gate も維持**される
- アーキ / CI 構造 / shard / AR 変更は一切不要。`Cargo.toml` 7 行のみ
- 依存の compile は増えるが、swatinem の main cache-warm → PR restore で amortize される

## 検証

- `cargo metadata --no-deps` で manifest parse 確認（OK）
- `Tests (lib)` shard の wall-clock 短縮（90s → 推定 20〜30s）と coverage gate 維持は CI で確認

Refs #438

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017ZG256rYG5A2FGeUB4dXNP)_