### PR TITLE
fix(auth): staging 限定で新規ユーザーへの自動テナント作成を復活 (Refs #434)

### DIFF
--- a/.claude/skills/rust-alc-api-map/SKILL.md
+++ b/.claude/skills/rust-alc-api-map/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rust-alc-api-map
-generated-from: rust-alc-api:c1dc0446e29a2a3877bc183bb926e123f11fe640
+generated-from: rust-alc-api:22b14612aa842b69f4b77847d593f3ccff934be0
 paths: [crates/, src/, migrations/]
 description: rust-alc-api (アルコールチェッカー基盤の Rust/Axum Cargo workspace — 13 domain crate + gateway/tenko/carins/dtako/trouble の複数バイナリ、PostgreSQL+RLS、Cloud Run) の構造ナビゲーション。どの crate に何のルートがあるか / monolith(rust-alc-api) と per-domain API + gateway の二系統 / RLS・migration・deploy/release 分離の gotcha を 1 枚にまとめる。トリガー:「rust-alc-api」「alc-api」「alc-notify」「alc-tenko」「alc-trouble」「alc-carins」「alc-dtako」「gateway」「tenko-api」「carins-api」「dtako-api」「trouble-api」「RLS テナント」「sqlx migration」「ts-rs」「Release Wave」「Bazel」等。
 ---
@@ -30,7 +30,7 @@ monolith と per-domain API は同じ domain crate (`alc-tenko` 等) を共有 �
 | crate | 役割 / 主要ルート群 |
 |---|---|
 | `alc-core` | 共通基盤: models / repository trait / `auth_middleware` / `realtime_bus` / `redact_broadcast`。ts-rs 型 export 元 |
-| `alc-auth` | Google / LINE WORKS OAuth、JWT。`routes/mod.rs` で `auth` として re-export |
+| `alc-auth` | Google / LINE WORKS OAuth、JWT。`routes/mod.rs` で `auth` として re-export。`issue_tokens_for_google_claims` は招待→ドメイン一致の順で tenant 解決し、どちらも無ければ prod は 403 (#332 ゴミテナント防止)。**`STAGING_MODE=true` のときだけ #332 前の `create_tenant_with_domain` 自動作成を復活** (揮発 DB で毎回新規ユーザーになる staging login の救済、Refs #434) |
 | `alc-misc` | health (`/health` + `/health/secret-fingerprint?name=&expected=` = 任意 env の sha256[0..8] と `expected` 突合、`{match: bool}` のみ返し oracle 防止。cross-store drift を CI で自動検出、Refs ippoan/rust-alc-api#424 / ippoan/ci-workflows#131) / health_canary / measurements / employees / items / api_tokens / sso_admin / tenant_users / timecard / access_requests / staging / upload / bot_admin / driver_info / members / communication_items / carrying_items / guidance_records |
 | `alc-tenko` | 点呼: tenko_call / tenko_records / tenko_schedules / tenko_sessions / tenko_webhooks / daily_health / equipment_failures / health_baselines |
 | `alc-carins` | 車検証(carins): car_inspections / car_inspection_files / carins_files / nfc_tags |

--- a/crates/alc-auth/src/lib.rs
+++ b/crates/alc-auth/src/lib.rs
@@ -19,6 +19,14 @@ use alc_core::auth_middleware::AuthUser;
 use alc_core::repository::auth::AuthRepository;
 use alc_core::AppState;
 
+/// `STAGING_MODE=true` かどうか (alc-misc::staging と同判定)。
+/// staging 限定の挙動 (新規ユーザーへの自動テナント作成) の gate に使う。
+fn is_staging_mode() -> bool {
+    std::env::var("STAGING_MODE")
+        .map(|v| v == "true")
+        .unwrap_or(false)
+}
+
 /// 公開ルート (認証不要)
 pub fn public_router() -> Router<AppState> {
     Router::new()
@@ -155,6 +163,22 @@ async fn issue_tokens_for_google_claims(
                     .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
                 if let Some(t) = domain_tenant {
+                    (t.id, "admin".to_string())
+                } else if is_staging_mode() {
+                    // staging は揮発 DB で cold start ごとにユーザー/テナントが消えるため、
+                    // 新規 Google ユーザーは毎回「招待もドメイン一致もない」状態になる。
+                    // それを 403 で弾くと staging の login が常に不能になるので、
+                    // STAGING_MODE のときだけ #332 前の自動テナント作成を復活させる
+                    // (prod は下の FORBIDDEN を維持してゴミテナントを作らない)。
+                    // Refs rust-alc-api#434
+                    let t = repo
+                        .create_tenant_with_domain(&email_domain)
+                        .await
+                        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+                    tracing::info!(
+                        "staging auto-provisioned tenant for email={}",
+                        google_claims.email
+                    );
                     (t.id, "admin".to_string())
                 } else {
                     // 3. 招待もドメイン一致もない → ログイン拒否 (テナントを勝手に作らない)


### PR DESCRIPTION
## 背景

#434 の作業中、staging で Google login が常に失敗してループに見える事象を調査。
cdp-relay で手元ブラウザを操作して staging login を再現し、原因を切り分けた。

### 切り分け結果

- auth-worker `google-callback` → rust-alc-api-staging `POST /api/auth/google` が **401/403 + 空ボディ** を返す → auth-worker が `/login?error=`(空) に戻す → ループに見える
- #303 の再署名・`JWT_SECRET`/`GOOGLE_CLIENT_ID`/`WORKER_ENV` 設定・service 配線はすべて正常 (dummy token で綺麗に 401 を確認)
- 真因: **`issue_tokens_for_google_claims` の 403 (FORBIDDEN)**。staging は揮発 DB (Cloud Run `minScale 0` + emptyDir) で cold start ごとにユーザー/テナントが消えるため、新規 Google ユーザーは毎回「招待もドメイン一致もない」状態になる。#332 (`70492c6`) で「テナントを勝手に作らない」に変えたことで、この経路が staging login を恒常的に塞いでいた

> git 履歴で確認: #332 より前は `create_tenant_with_domain` で**新規ユーザーに自動テナント作成**していた (= 「以前は staging で新規 tenant を作っていた」)。

## 変更

`issue_tokens_for_google_claims` の最終分岐を `STAGING_MODE` で gate:

- `STAGING_MODE=true` (= staging) のときだけ `create_tenant_with_domain` で自動テナント作成を復活 (#332 前の挙動)
- prod は従来どおり **403 を維持**し、ゴミテナント作成 (#332 の趣旨) を防ぐ

`create_tenant_with_domain` は既存メソッド (trait + impl 健在、short_id は DB default で採番)。`crates/alc-auth/src/lib.rs` は coverage 100% gate 対象外。

## 検証

- merge → staging 自動 deploy 後、cdp-relay で手元ブラウザから Google login → `/top` 到達を再確認する
- prod は #332 の 403 を維持 (本 PR は staging gate のみ)

Refs #434
Refs #332

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019bihe6n6P8Pds5grZzR4ga)_