### PR TITLE
feat(auth): /api/internal/auth/* で認証 DB プリミティブを公開 (Refs #434 Phase 1)

### DIFF
--- a/.claude/skills/rust-alc-api-map/SKILL.md
+++ b/.claude/skills/rust-alc-api-map/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rust-alc-api-map
-generated-from: rust-alc-api:22b14612aa842b69f4b77847d593f3ccff934be0
+generated-from: rust-alc-api:100f8fc08a4af97e990dc50da77e64d897689d69
 paths: [crates/, src/, migrations/]
 description: rust-alc-api (アルコールチェッカー基盤の Rust/Axum Cargo workspace — 13 domain crate + gateway/tenko/carins/dtako/trouble の複数バイナリ、PostgreSQL+RLS、Cloud Run) の構造ナビゲーション。どの crate に何のルートがあるか / monolith(rust-alc-api) と per-domain API + gateway の二系統 / RLS・migration・deploy/release 分離の gotcha を 1 枚にまとめる。トリガー:「rust-alc-api」「alc-api」「alc-notify」「alc-tenko」「alc-trouble」「alc-carins」「alc-dtako」「gateway」「tenko-api」「carins-api」「dtako-api」「trouble-api」「RLS テナント」「sqlx migration」「ts-rs」「Release Wave」「Bazel」等。
 ---
@@ -30,7 +30,7 @@ monolith と per-domain API は同じ domain crate (`alc-tenko` 等) を共有 �
 | crate | 役割 / 主要ルート群 |
 |---|---|
 | `alc-core` | 共通基盤: models / repository trait / `auth_middleware` / `realtime_bus` / `redact_broadcast`。ts-rs 型 export 元 |
-| `alc-auth` | Google / LINE WORKS OAuth、JWT。`routes/mod.rs` で `auth` として re-export。`issue_tokens_for_google_claims` は招待→ドメイン一致の順で tenant 解決し、どちらも無ければ prod は 403 (#332 ゴミテナント防止)。**`STAGING_MODE=true` のときだけ #332 前の `create_tenant_with_domain` 自動作成を復活** (揮発 DB で毎回新規ユーザーになる staging login の救済、Refs #434) |
+| `alc-auth` | Google / LINE WORKS OAuth、JWT。`routes/mod.rs` で `auth` として re-export。`issue_tokens_for_google_claims` は招待→ドメイン一致の順で tenant 解決し、どちらも無ければ prod は 403 (#332 ゴミテナント防止)。**`STAGING_MODE=true` のときだけ #332 前の `create_tenant_with_domain` 自動作成を復活** (揮発 DB で毎回新規ユーザーになる staging login の救済、Refs #434)。`internal.rs` (`internal_router`) は **認証 DB プリミティブを `/api/internal/auth/*` で公開** (sso-config 読み / user upsert-line(works) / recipient、`require_internal_jwt` 配下)。OAuth オーケストレーションを auth-worker に移管するための土台で、token は発行せず user + tenant slug を返すのみ (Refs #434 Phase 1) |
 | `alc-misc` | health (`/health` + `/health/secret-fingerprint?name=&expected=` = 任意 env の sha256[0..8] と `expected` 突合、`{match: bool}` のみ返し oracle 防止。cross-store drift を CI で自動検出、Refs ippoan/rust-alc-api#424 / ippoan/ci-workflows#131) / health_canary / measurements / employees / items / api_tokens / sso_admin / tenant_users / timecard / access_requests / staging / upload / bot_admin / driver_info / members / communication_items / carrying_items / guidance_records |
 | `alc-tenko` | 点呼: tenko_call / tenko_records / tenko_schedules / tenko_sessions / tenko_webhooks / daily_health / equipment_failures / health_baselines |
 | `alc-carins` | 車検証(carins): car_inspections / car_inspection_files / carins_files / nfc_tags |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,34 @@ auth-worker が発行する JWT の `org` クレームは rust-logi の `organiz
 | `OAUTH_STATE_SECRET` | LINE WORKS OAuth state HMAC 署名 | Secret Manager |
 | `API_ORIGIN` | LINE WORKS OAuth callback URL のオリジン | 環境変数 |
 
+### 認証の auth-worker 移管 (#434、移行中)
+
+LINE / LINE WORKS の OAuth オーケストレーションを **auth-worker に移管**し、rust は
+DB プリミティブを `/api/internal/auth/*` (`require_internal_jwt` 配下) で公開する
+だけの dumb backend にする。確定アーキ (Refs #434):
+
+```
+1. browser ──▶ auth.ippoan.org/oauth/line/redirect        (ログイン開始)
+2. auth-worker ──▶ LINE authorize                          (リダイレクト)
+3. user 承認 ──▶ auth-worker/oauth/line/callback?code=…
+4. auth-worker が LINE と code 交換 → profile 取得          (auth-worker が直接)
+5. auth-worker ──OIDC(aud=alc-api-internal)──▶ rust /api/internal/auth/users/…
+                                                           ← ユーザー確認/upsert
+6. rust ──▶ auth-worker に user 情報(id/tenant/role/slug)  ← rust→auth-worker ユーザー情報
+7. auth-worker が JWT を発行(JWT_SECRET で署名)
+8. auth-worker が cookie(logi_auth_token=JWT)をセット + redirect_uri#token=… で戻す ← cookie でログイン保持
+```
+
+- **2 つの OIDC の使い分け**: ログイン中の internal call は `aud=alc-api-internal`
+  (`/api/internal/auth/*`)、ログイン後のデータ API は `aud=service URL`
+  (`require_tenant_header`、tenant/user はヘッダ注入)。`/alc-proxy` は service-URL
+  audience でしか mint しないため、consumer が `/alc-proxy` 経由で internal route に
+  到達しても `aud` 不一致で弾かれる (confused-deputy 防止、Cloud Run custom audiences)。
+- rust は cookie も browser JWT も**一切見ない** (dumb backend)。発行・検証・cookie は
+  auth-worker が持つ。
+- 実装: `crates/alc-auth/src/internal.rs` (`internal_router`)。`require_internal_jwt`
+  は lockdown 時に OIDC custom-audience 検証へ置換予定。
+
 ## ストレージバックエンド切り替え
 
 - `STORAGE_BACKEND=r2` → Cloudflare R2 (`rust-s3` crate)

--- a/crates/alc-auth/src/internal.rs
+++ b/crates/alc-auth/src/internal.rs
@@ -25,7 +25,6 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use alc_core::models::User;
-use alc_core::repository::auth::AuthRepository;
 use alc_core::AppState;
 
 type ErrorResponse = (StatusCode, Json<serde_json::Value>);

--- a/crates/alc-auth/src/internal.rs
+++ b/crates/alc-auth/src/internal.rs
@@ -1,0 +1,296 @@
+//! 内部認証データ API (Refs ippoan/rust-alc-api#434)。
+//!
+//! 認証オーケストレーション (OAuth code 交換 / JWT 発行) を auth-worker に移管する
+//! ための、DB プリミティブを薄く公開する internal endpoint 群。`require_internal_jwt`
+//! 配下に nest され、**auth-worker (= `aud=alc-api-internal` を mint できる唯一の
+//! caller) だけ**が呼べる。
+//!
+//! JWT 発行は呼び出し側 (auth-worker) が `create_access_token` 相当で行うため、本
+//! endpoint は user / recipient / sso-config の read / upsert のみを担い、token は
+//! 発行しない。auth-worker が JWT 組み立てに必要な user フィールド + tenant slug を
+//! 1 度に返す。
+//!
+//! lockdown (`allUsers` 削除) 後は `require_internal_jwt` が OIDC custom audience
+//! (`alc-api-internal`) 検証に置換されるが、本ルート定義は不変。`/alc-proxy` は
+//! service-URL audience でしか OIDC を mint しないため、consumer が `/alc-proxy`
+//! 経由で本 internal route に到達しても `aud` 不一致で弾かれる (confused-deputy 防止)。
+
+use axum::{
+    extract::{Query, State},
+    http::StatusCode,
+    routing::{get, post},
+    Json, Router,
+};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use alc_core::models::User;
+use alc_core::repository::auth::AuthRepository;
+use alc_core::AppState;
+
+type ErrorResponse = (StatusCode, Json<serde_json::Value>);
+type ApiResult<T> = Result<Json<T>, ErrorResponse>;
+
+/// internal レスポンス用に `User` から秘匿フィールド (`password_hash` /
+/// `refresh_token_*`) を除いた DTO。auth-worker は本 DTO + `slug` から access JWT を
+/// 組み立てる。
+#[derive(Debug, Serialize)]
+pub struct InternalUser {
+    pub id: Uuid,
+    pub tenant_id: Uuid,
+    pub email: String,
+    pub name: String,
+    pub role: String,
+    pub google_sub: Option<String>,
+    pub lineworks_id: Option<String>,
+    pub line_user_id: Option<String>,
+}
+
+impl From<User> for InternalUser {
+    fn from(u: User) -> Self {
+        Self {
+            id: u.id,
+            tenant_id: u.tenant_id,
+            email: u.email,
+            name: u.name,
+            role: u.role,
+            google_sub: u.google_sub,
+            lineworks_id: u.lineworks_id,
+            line_user_id: u.line_user_id,
+        }
+    }
+}
+
+/// JWT 発行に必要な user + tenant slug を 1 度に返す。
+#[derive(Debug, Serialize)]
+pub struct InternalUserWithSlug {
+    #[serde(flatten)]
+    pub user: InternalUser,
+    pub slug: Option<String>,
+}
+
+/// SSO 設定 (auth-worker が code 交換に使う)。`client_secret_encrypted` は暗号化
+/// 済みのまま返し、復号は auth-worker 側で行う (lineworks bot-secret と同方針 =
+/// rust は平文 secret を response に echo しない)。
+#[derive(Debug, Serialize)]
+pub struct InternalSsoConfig {
+    pub tenant_id: Uuid,
+    pub client_id: String,
+    pub client_secret_encrypted: String,
+    pub external_org_id: String,
+    pub woff_id: Option<String>,
+}
+
+/// recipient 逆引き 1 件 (tenant_id, name)。
+#[derive(Debug, Serialize)]
+pub struct RecipientTenant {
+    pub tenant_id: Uuid,
+    pub name: String,
+}
+
+fn internal_error(context: &str, err: impl std::fmt::Display) -> ErrorResponse {
+    tracing::error!("internal auth endpoint error ({context}): {err}");
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(serde_json::json!({ "error": "internal_error" })),
+    )
+}
+
+fn not_found(error: &str) -> ErrorResponse {
+    (
+        StatusCode::NOT_FOUND,
+        Json(serde_json::json!({ "error": error })),
+    )
+}
+
+/// `require_internal_jwt` 配下に nest される internal 認証データ route 群。
+pub fn internal_router() -> Router<AppState> {
+    Router::new()
+        .route("/internal/auth/sso-config", get(get_sso_config))
+        .route(
+            "/internal/auth/users/upsert-lineworks",
+            post(upsert_lineworks_user),
+        )
+        .route("/internal/auth/users/upsert-line", post(upsert_line_user))
+        .route("/internal/auth/users/by-line-id", get(user_by_line_id))
+        .route(
+            "/internal/auth/recipients/register-line",
+            post(register_line_recipient),
+        )
+        .route(
+            "/internal/auth/recipients/by-line-id",
+            get(recipients_by_line_id),
+        )
+}
+
+/// tenant slug を解決して `InternalUserWithSlug` を返す共通ヘルパ。
+async fn with_slug(state: &AppState, user: User) -> ApiResult<InternalUserWithSlug> {
+    let slug = state
+        .auth
+        .get_tenant_slug(user.tenant_id)
+        .await
+        .map_err(|e| internal_error("get_tenant_slug", e))?;
+    Ok(Json(InternalUserWithSlug {
+        user: user.into(),
+        slug,
+    }))
+}
+
+// ---------- GET /internal/auth/sso-config?provider=&domain= ----------
+
+#[derive(Debug, Deserialize)]
+struct SsoConfigQuery {
+    provider: String,
+    domain: String,
+}
+
+async fn get_sso_config(
+    State(state): State<AppState>,
+    Query(q): Query<SsoConfigQuery>,
+) -> ApiResult<InternalSsoConfig> {
+    let cfg = state
+        .auth
+        .resolve_sso_config(&q.provider, &q.domain)
+        .await
+        .map_err(|e| internal_error("resolve_sso_config", e))?;
+    match cfg {
+        Some(c) => Ok(Json(InternalSsoConfig {
+            tenant_id: c.tenant_id,
+            client_id: c.client_id,
+            client_secret_encrypted: c.client_secret_encrypted,
+            external_org_id: c.external_org_id,
+            woff_id: c.woff_id,
+        })),
+        None => Err(not_found("sso_config_not_found")),
+    }
+}
+
+// ---------- POST /internal/auth/users/upsert-lineworks ----------
+
+#[derive(Debug, Deserialize)]
+struct UpsertLineworksBody {
+    tenant_id: Uuid,
+    lineworks_id: String,
+    email: String,
+    name: String,
+}
+
+async fn upsert_lineworks_user(
+    State(state): State<AppState>,
+    Json(b): Json<UpsertLineworksBody>,
+) -> ApiResult<InternalUserWithSlug> {
+    let existing = state
+        .auth
+        .find_user_by_lineworks_id(&b.lineworks_id)
+        .await
+        .map_err(|e| internal_error("find_user_by_lineworks_id", e))?;
+    let user = match existing {
+        Some(u) => u,
+        None => state
+            .auth
+            .create_user_lineworks(b.tenant_id, &b.lineworks_id, &b.email, &b.name)
+            .await
+            .map_err(|e| internal_error("create_user_lineworks", e))?,
+    };
+    with_slug(&state, user).await
+}
+
+// ---------- POST /internal/auth/users/upsert-line ----------
+
+#[derive(Debug, Deserialize)]
+struct UpsertLineBody {
+    tenant_id: Uuid,
+    line_user_id: String,
+    name: String,
+}
+
+async fn upsert_line_user(
+    State(state): State<AppState>,
+    Json(b): Json<UpsertLineBody>,
+) -> ApiResult<InternalUserWithSlug> {
+    let existing = state
+        .auth
+        .find_user_by_line_user_id(&b.line_user_id)
+        .await
+        .map_err(|e| internal_error("find_user_by_line_user_id", e))?;
+    let user = match existing {
+        Some(u) => u,
+        None => state
+            .auth
+            .create_user_line(b.tenant_id, &b.line_user_id, &b.name)
+            .await
+            .map_err(|e| internal_error("create_user_line", e))?,
+    };
+    with_slug(&state, user).await
+}
+
+// ---------- GET /internal/auth/users/by-line-id?line_user_id= ----------
+
+#[derive(Debug, Deserialize)]
+struct ByLineIdQuery {
+    line_user_id: String,
+}
+
+async fn user_by_line_id(
+    State(state): State<AppState>,
+    Query(q): Query<ByLineIdQuery>,
+) -> ApiResult<Option<InternalUserWithSlug>> {
+    let user = state
+        .auth
+        .find_user_by_line_user_id(&q.line_user_id)
+        .await
+        .map_err(|e| internal_error("find_user_by_line_user_id", e))?;
+    match user {
+        Some(u) => {
+            let slug = state
+                .auth
+                .get_tenant_slug(u.tenant_id)
+                .await
+                .map_err(|e| internal_error("get_tenant_slug", e))?;
+            Ok(Json(Some(InternalUserWithSlug {
+                user: u.into(),
+                slug,
+            })))
+        }
+        None => Ok(Json(None)),
+    }
+}
+
+// ---------- POST /internal/auth/recipients/register-line ----------
+
+#[derive(Debug, Deserialize)]
+struct RegisterRecipientBody {
+    tenant_id: Uuid,
+    name: String,
+    line_user_id: String,
+}
+
+async fn register_line_recipient(
+    State(state): State<AppState>,
+    Json(b): Json<RegisterRecipientBody>,
+) -> Result<StatusCode, ErrorResponse> {
+    state
+        .auth
+        .register_line_recipient(b.tenant_id, &b.name, &b.line_user_id)
+        .await
+        .map_err(|e| internal_error("register_line_recipient", e))?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+// ---------- GET /internal/auth/recipients/by-line-id?line_user_id= ----------
+
+async fn recipients_by_line_id(
+    State(state): State<AppState>,
+    Query(q): Query<ByLineIdQuery>,
+) -> ApiResult<Vec<RecipientTenant>> {
+    let rows = state
+        .auth
+        .find_recipients_by_line_user_id(&q.line_user_id)
+        .await
+        .map_err(|e| internal_error("find_recipients_by_line_user_id", e))?;
+    Ok(Json(
+        rows.into_iter()
+            .map(|(tenant_id, name)| RecipientTenant { tenant_id, name })
+            .collect(),
+    ))
+}

--- a/crates/alc-auth/src/lib.rs
+++ b/crates/alc-auth/src/lib.rs
@@ -19,6 +19,9 @@ use alc_core::auth_middleware::AuthUser;
 use alc_core::repository::auth::AuthRepository;
 use alc_core::AppState;
 
+mod internal;
+pub use internal::internal_router;
+
 /// `STAGING_MODE=true` かどうか (alc-misc::staging と同判定)。
 /// staging 限定の挙動 (新規ユーザーへの自動テナント作成) の gate に使う。
 fn is_staging_mode() -> bool {

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -95,6 +95,7 @@ pub fn router() -> Router<AppState> {
     let internal_protected = Router::new()
         .merge(notify_lineworks_channels::internal_router())
         .merge(health_canary::internal_router())
+        .merge(auth::internal_router())
         .layer(axum_middleware::from_fn(require_internal_jwt));
 
     // テナント対応ルート — 注入 identity (X-Tenant-ID + 任意 X-User-*) を信頼 (Refs #434)。


### PR DESCRIPTION
## 概要

#434 認証移管の **Phase 1**。LINE / LINE WORKS の OAuth オーケストレーションを auth-worker に移管する前提として、rust 側の DB 操作を `/api/internal/auth/*` (`require_internal_jwt` 配下) として薄く公開する。これにより auth-worker が「code 交換は自前 → DB 操作は rust internal 経由 → JWT 自前発行」の engine になれる。

設計の全体像とフローは issue コメント参照: #434 (確定アーキ + 案B + Cloud Run custom audiences)。

## 変更

- **`crates/alc-auth/src/internal.rs`** (新規): `internal_router` で 6 endpoint
  - `GET  /internal/auth/sso-config?provider=&domain=` — SSO 設定 (client_secret は暗号化のまま返す。復号は auth-worker、lineworks bot-secret と同方針)
  - `POST /internal/auth/users/upsert-lineworks` — lineworks_id で find-or-create
  - `POST /internal/auth/users/upsert-line` — line_user_id で find-or-create
  - `GET  /internal/auth/users/by-line-id?line_user_id=` — line user 逆引き
  - `POST /internal/auth/recipients/register-line` — LINE recipient 自動登録 (204)
  - `GET  /internal/auth/recipients/by-line-id?line_user_id=` — tenant 逆引き (複数テナント)
- **`src/routes/mod.rs`**: `internal_protected` に `auth::internal_router()` を merge
- **`CLAUDE.md`**: 認証の auth-worker 移管 確定フロー図を追記

## 設計上のポイント

- 既存 `AuthRepository` のメソッドを薄く HTTP 公開しただけ (新規 DB ロジック無し)。
- レスポンスは `User` から `password_hash` / `refresh_token_*` を除いた DTO + `tenant slug` (auth-worker が JWT 組み立てに使う)。**token は発行しない**。
- `require_internal_jwt` は移行中は現行の HS256 internal-JWT のまま (非破壊)。lockdown 時に OIDC custom audience (`alc-api-internal`) 検証へ置換予定 (confused-deputy 防止)。
- `client_secret` 平文は response に出さない (暗号化済みのまま返す)。

## まだやらないこと (後続 Phase)

- auth-worker 側の LINE WORKS / LINE engine 内製化 (これらの endpoint を呼ぶ側)
- consumer の向き先変更 / rust 公開 `/api/auth/*` 撤去 / `allUsers` lockdown
- `/alc-proxy` の named WorkerEntrypoint RPC 化 (binding-only ハードニング)

## テスト

- 既存 internal endpoint (lineworks bot-secret 等) と同じ薄い wrapper パターン。CI の fmt/clippy/build + unit に乗せる。

Refs #434

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nn4HQ7wZubMDyhKQ94jRLJ)_