### PR TITLE
fix(staging): JWT_SECRET を auth-worker と同 GCP entry に揃え admin 401 を解消

### DIFF
--- a/staging/cloudrun-staging.yaml
+++ b/staging/cloudrun-staging.yaml
@@ -34,7 +34,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   key: latest
-                  name: alc-api-staging-jwt-secret
+                  name: JWT_SECRET
             - name: RUST_LOG
               value: "gateway=info,tower_http=info"
           resources:
@@ -74,11 +74,15 @@ spec:
             - name: RUST_LOG
               value: "info"
             # Secrets — secretKeyRef で Secret Manager から注入
+            # JWT_SECRET は auth-worker (cookie 再署名) と HS256 鍵共有が必要 (#218)。
+            # render.sh は GCP `JWT_SECRET` に統一済みだが staging manifest が
+            # `alc-api-staging-jwt-secret` のまま取り残され、auth-worker 署名 token を
+            # rust /api/admin/* が検証できず 401 になっていた (Refs #434)。同 entry に揃える。
             - name: JWT_SECRET
               valueFrom:
                 secretKeyRef:
                   key: latest
-                  name: alc-api-staging-jwt-secret
+                  name: JWT_SECRET
             - name: GOOGLE_CLIENT_ID
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## 症状

`https://auth-staging.ippoan.org/admin/sso`（および `/admin/users`）が、**role:admin の有効な staging token を持っていても** `/api/sso/list` / `/api/users/list` / `/api/bot-config/list` が全て **401**（body `{"error":""}`）になり、SSO 設定の登録・一覧ができない。

## 原因（二重署名の検証鍵ズレ）

Google ログイン後、auth-worker は cookie 用 JWT を **自身の `JWT_SECRET` で再署名**する（`#218` cross-env 保護 / `#434` dumb-backend 化、`env:"staging"` claim 付与）。admin ページはこの token を `/api/sso/list` 等で **rust `/api/admin/*` に proxy** し、rust が **自身の `JWT_SECRET` で検証**する。

→ 成立条件は「auth-worker と rust が **同じ `JWT_SECRET` 値**を持つこと」。

`cloudrun/render.sh` の `jwt_secret_name()` は既に GCP `JWT_SECRET` に統一済み（`#218` の `jwt_secret_drift` probe 対応コメントあり）だが、**staging の multi-container manifest `staging/cloudrun-staging.yaml` だけが `alc-api-staging-jwt-secret` を参照したまま取り残されていた**。結果、auth-worker（`JWT_SECRET`）署名の token を staging rust（`alc-api-staging-jwt-secret`）が検証できず署名不一致 → 全 admin 401。prod は両者 `JWT_SECRET` で一致するため正常。

ブラウザ実機で token を decode し `env:"staging"` / role:admin / 未失効を確認した上で、`/api/admin/*` が全て 401 を返すことを確認済み。

## 変更

`staging/cloudrun-staging.yaml` の gateway / app 両 container の `JWT_SECRET` secretKeyRef:

```diff
-                  name: alc-api-staging-jwt-secret
+                  name: JWT_SECRET
```

render.sh の統一に staging manifest を揃えるだけ（コードロジック変更なし）。

## デプロイ時の確認事項

staging runtime SA（`747065218280-compute@`）が GCP secret **`JWT_SECRET`** に `secretmanager.secretAccessor` を持っている必要がある。無いと `gcloud run services replace` の cutover が `Permission denied on secret: JWT_SECRET` で fail する。prod が同 entry を使えているので付いている見込みだが、staging cutover ログで要確認（未付与なら per-secret grant を 1 回）。

## 影響

- staging の admin ページ（SSO / users / bot-config）が回復 → LINE WORKS SSO 設定の登録が可能になる。
- `#434` の staging smoke-test（auth-worker 署名 token → rust 検証）の前提も同時に満たす。

Refs #434

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nn4HQ7wZubMDyhKQ94jRLJ)_