### PR TITLE
fix(sso): admin SSO config の upsert/delete/list の 3 バグを修正 (Refs #434)

### DIFF
--- a/.claude/skills/rust-alc-api-map/SKILL.md
+++ b/.claude/skills/rust-alc-api-map/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rust-alc-api-map
-generated-from: rust-alc-api:100f8fc08a4af97e990dc50da77e64d897689d69
+generated-from: rust-alc-api:0d6335910594e41856590e5ff730fb2d0e311fcc
 paths: [crates/, src/, migrations/]
 description: rust-alc-api (アルコールチェッカー基盤の Rust/Axum Cargo workspace — 13 domain crate + gateway/tenko/carins/dtako/trouble の複数バイナリ、PostgreSQL+RLS、Cloud Run) の構造ナビゲーション。どの crate に何のルートがあるか / monolith(rust-alc-api) と per-domain API + gateway の二系統 / RLS・migration・deploy/release 分離の gotcha を 1 枚にまとめる。トリガー:「rust-alc-api」「alc-api」「alc-notify」「alc-tenko」「alc-trouble」「alc-carins」「alc-dtako」「gateway」「tenko-api」「carins-api」「dtako-api」「trouble-api」「RLS テナント」「sqlx migration」「ts-rs」「Release Wave」「Bazel」等。
 ---
@@ -68,6 +68,12 @@ monolith と per-domain API は同じ domain crate (`alc-tenko` 等) を共有 �
 - **DB 接続**: `alc_api_app` ロール (NOBYPASSRLS → RLS 有効) で、**直接接続 port 5432** を使う
   (Supavisor 6543 は `set_config` がリセットされ RLS テナント分離が壊れる)。
   `DATABASE_URL` に `?options=-c search_path=alc_api` 必須。
+- **staging は postgres superuser 接続 → RLS 完全 bypass** (`staging/cloudrun-staging.yaml` の
+  `postgresql://postgres:...`)。superuser は `FORCE ROW LEVEL SECURITY` でも RLS を無視するため、
+  **RLS 頼みで WHERE tenant_id を省いたクエリは staging で全テナント横断に漏れる**。tenant scope は
+  `crates/alc-core/src/tenant.rs::TenantConn` が `set_current_tenant` で `app.current_tenant_id` を
+  立てて RLS に委ねるが、本番 (alc_api_app) でしか効かない。staging も対象にするクエリは
+  **WHERE tenant_id を明示**すること (Refs #434、sso_admin で実害)。
 - **migration 不変条件**: 適用済み `migrations/*.sql` を絶対に変更しない (sqlx が SHA-384 検証、不一致で起動不能)。
   修正は新ファイル追加。migration は **Cloud Run Jobs** (`rust-alc-api-migrate`) で deploy 前に実行
   (`main.rs` から `sqlx::migrate!()` は削除済み = 起動時自動適用なし)。

--- a/crates/alc-core/src/repository/sso_admin.rs
+++ b/crates/alc-core/src/repository/sso_admin.rs
@@ -33,7 +33,8 @@ pub trait SsoAdminRepository: Send + Sync {
         enabled: bool,
     ) -> Result<SsoConfigRow, sqlx::Error>;
 
-    /// SSO 設定の作成/更新 (client_secret_encrypted なし)
+    /// SSO 設定の更新 (client_secret_encrypted なし = UPDATE only)。
+    /// 既存 config が無ければ RowNotFound (= 新規作成には secret 必須)。
     async fn upsert_config_without_secret(
         &self,
         tenant_id: Uuid,
@@ -44,6 +45,6 @@ pub trait SsoAdminRepository: Send + Sync {
         enabled: bool,
     ) -> Result<SsoConfigRow, sqlx::Error>;
 
-    /// SSO 設定の削除
-    async fn delete_config(&self, tenant_id: Uuid, provider: &str) -> Result<(), sqlx::Error>;
+    /// SSO 設定の削除。削除した行数を返す (0 = 該当なし → handler が 404)
+    async fn delete_config(&self, tenant_id: Uuid, provider: &str) -> Result<u64, sqlx::Error>;
 }

--- a/crates/alc-misc/src/repo/sso_admin.rs
+++ b/crates/alc-misc/src/repo/sso_admin.rs
@@ -19,14 +19,19 @@ impl PgSsoAdminRepository {
 #[async_trait]
 impl SsoAdminRepository for PgSsoAdminRepository {
     async fn list_configs(&self, tenant_id: Uuid) -> Result<Vec<SsoConfigRow>, sqlx::Error> {
+        // RLS に依存せず明示的に tenant_id で絞る (defense in depth)。
+        // staging の postgres sidecar は superuser 接続で RLS を bypass するため、
+        // WHERE 句が無いと全テナントの config が漏れる (本番 alc_api_app は NOBYPASSRLS)。
         let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
         sqlx::query_as::<_, SsoConfigRow>(
             r#"
             SELECT provider, client_id, external_org_id, enabled, woff_id, created_at, updated_at
             FROM sso_provider_configs
+            WHERE tenant_id = $1
             ORDER BY provider
             "#,
         )
+        .bind(tenant_id)
         .fetch_all(&mut *tc.conn)
         .await
     }
@@ -76,17 +81,21 @@ impl SsoAdminRepository for PgSsoAdminRepository {
         woff_id: Option<&str>,
         enabled: bool,
     ) -> Result<SsoConfigRow, sqlx::Error> {
+        // secret を渡さない更新は UPDATE only。
+        // client_secret_encrypted は NOT NULL なので INSERT 経路に入れられない
+        // (= 旧コードは ON CONFLICT INSERT で NOT NULL 違反 500 になっていた)。
+        // 既存 config が無ければ RowNotFound を返し、handler が 400 にマップする
+        // (新規作成には client_secret が必須)。
         let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
         sqlx::query_as::<_, SsoConfigRow>(
             r#"
-            INSERT INTO sso_provider_configs (tenant_id, provider, client_id, external_org_id, woff_id, enabled)
-            VALUES ($1, $2, $3, $4, $5, $6)
-            ON CONFLICT (tenant_id, provider) DO UPDATE SET
-                client_id = EXCLUDED.client_id,
-                external_org_id = EXCLUDED.external_org_id,
-                woff_id = EXCLUDED.woff_id,
-                enabled = EXCLUDED.enabled,
+            UPDATE sso_provider_configs SET
+                client_id = $3,
+                external_org_id = $4,
+                woff_id = $5,
+                enabled = $6,
                 updated_at = NOW()
+            WHERE tenant_id = $1 AND provider = $2
             RETURNING provider, client_id, external_org_id, enabled, woff_id, created_at, updated_at
             "#,
         )
@@ -100,13 +109,14 @@ impl SsoAdminRepository for PgSsoAdminRepository {
         .await
     }
 
-    async fn delete_config(&self, tenant_id: Uuid, provider: &str) -> Result<(), sqlx::Error> {
+    async fn delete_config(&self, tenant_id: Uuid, provider: &str) -> Result<u64, sqlx::Error> {
         let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
-        sqlx::query("DELETE FROM sso_provider_configs WHERE tenant_id = $1 AND provider = $2")
-            .bind(tenant_id)
-            .bind(provider)
-            .execute(&mut *tc.conn)
-            .await?;
-        Ok(())
+        let result =
+            sqlx::query("DELETE FROM sso_provider_configs WHERE tenant_id = $1 AND provider = $2")
+                .bind(tenant_id)
+                .bind(provider)
+                .execute(&mut *tc.conn)
+                .await?;
+        Ok(result.rows_affected())
     }
 }

--- a/crates/alc-misc/src/sso_admin.rs
+++ b/crates/alc-misc/src/sso_admin.rs
@@ -115,6 +115,14 @@ async fn upsert_config(
     };
 
     config.map(Json).map_err(|e| {
+        // secret 無し更新で対象 config が無い場合は新規作成不可 → 400
+        if encrypted_secret.is_none() && matches!(e, sqlx::Error::RowNotFound) {
+            tracing::warn!(
+                "SSO upsert without secret but no existing config (provider={})",
+                body.provider
+            );
+            return StatusCode::BAD_REQUEST;
+        }
         tracing::error!("Failed to upsert SSO config: {e}");
         StatusCode::INTERNAL_SERVER_ERROR
     })
@@ -130,7 +138,7 @@ async fn delete_config(
         return Err(StatusCode::FORBIDDEN);
     }
 
-    state
+    let rows = state
         .sso_admin
         .delete_config(auth_user.tenant_id, &body.provider)
         .await
@@ -138,6 +146,11 @@ async fn delete_config(
             tracing::error!("Failed to delete SSO config: {e}");
             StatusCode::INTERNAL_SERVER_ERROR
         })?;
+
+    // 0 行 = 該当テナントに該当 provider の config が無い → 404 で明示
+    if rows == 0 {
+        return Err(StatusCode::NOT_FOUND);
+    }
 
     Ok(StatusCode::NO_CONTENT)
 }

--- a/crates/alc-misc/src/sso_admin.rs
+++ b/crates/alc-misc/src/sso_admin.rs
@@ -117,10 +117,7 @@ async fn upsert_config(
     config.map(Json).map_err(|e| {
         // secret 無し更新で対象 config が無い場合は新規作成不可 → 400
         if encrypted_secret.is_none() && matches!(e, sqlx::Error::RowNotFound) {
-            tracing::warn!(
-                "SSO upsert without secret but no existing config (provider={})",
-                body.provider
-            );
+            tracing::warn!("SSO upsert without secret but config missing");
             return StatusCode::BAD_REQUEST;
         }
         tracing::error!("Failed to upsert SSO config: {e}");

--- a/tests/mock_helpers/repos_c.rs
+++ b/tests/mock_helpers/repos_c.rs
@@ -112,12 +112,15 @@ impl NfcTagRepository for MockNfcTagRepository {
 
 pub struct MockSsoAdminRepository {
     pub fail_next: AtomicBool,
+    /// true なら delete_config が 0 行 (= 該当なし) を返す
+    pub delete_zero: AtomicBool,
 }
 
 impl Default for MockSsoAdminRepository {
     fn default() -> Self {
         Self {
             fail_next: AtomicBool::new(false),
+            delete_zero: AtomicBool::new(false),
         }
     }
 }
@@ -172,9 +175,13 @@ impl SsoAdminRepository for MockSsoAdminRepository {
         })
     }
 
-    async fn delete_config(&self, _tenant_id: Uuid, _provider: &str) -> Result<(), sqlx::Error> {
+    async fn delete_config(&self, _tenant_id: Uuid, _provider: &str) -> Result<u64, sqlx::Error> {
         check_fail!(self);
-        Ok(())
+        if self.delete_zero.load(std::sync::atomic::Ordering::SeqCst) {
+            Ok(0)
+        } else {
+            Ok(1)
+        }
     }
 }
 

--- a/tests/mock_tests/mock_sso_admin_test.rs
+++ b/tests/mock_tests/mock_sso_admin_test.rs
@@ -27,6 +27,19 @@ async fn setup_failing() -> (String, String) {
     (base_url, auth_header)
 }
 
+/// Helper: mock whose delete_config returns 0 rows (= 該当なし).
+async fn setup_delete_zero() -> (String, String) {
+    let mock = Arc::new(MockSsoAdminRepository::default());
+    mock.delete_zero.store(true, Ordering::SeqCst);
+    let mut state = crate::mock_helpers::app_state::setup_mock_app_state();
+    state.sso_admin = mock;
+    let tenant_id = uuid::Uuid::new_v4();
+    let base_url = crate::common::spawn_test_server(state).await;
+    let jwt = crate::common::create_test_jwt(tenant_id, "admin");
+    let auth_header = format!("Bearer {jwt}");
+    (base_url, auth_header)
+}
+
 // =========================================================================
 // GET /api/admin/sso/configs
 // =========================================================================
@@ -247,8 +260,11 @@ async fn test_upsert_config_no_auth() {
     assert_eq!(res.status(), 401);
 }
 
+/// secret 無し upsert は UPDATE only。対象 config が無い (RowNotFound) 場合は
+/// 新規作成不可なので 400。mock の check_fail! は RowNotFound を返すため、この
+/// path の「対象なし」= 400 を検証する (with_secret は同じ RowNotFound でも 500)。
 #[tokio::test]
-async fn test_upsert_config_without_secret_db_error() {
+async fn test_upsert_config_without_secret_missing_returns_400() {
     let (base_url, auth_header) = setup_failing().await;
     let client = reqwest::Client::new();
 
@@ -263,7 +279,7 @@ async fn test_upsert_config_without_secret_db_error() {
         .send()
         .await
         .unwrap();
-    assert_eq!(res.status(), 500);
+    assert_eq!(res.status(), 400);
 }
 
 #[tokio::test]
@@ -372,6 +388,22 @@ async fn test_delete_config_no_auth() {
         .await
         .unwrap();
     assert_eq!(res.status(), 401);
+}
+
+/// delete_config が 0 行 (= 該当テナントに該当 provider なし) → 404
+#[tokio::test]
+async fn test_delete_config_not_found() {
+    let (base_url, auth_header) = setup_delete_zero().await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .delete(format!("{base_url}/api/admin/sso/configs"))
+        .header("Authorization", &auth_header)
+        .json(&serde_json::json!({ "provider": "lineworks" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 404);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## 背景

staging で LINE WORKS SSO 設定の **保存・削除・一覧** が壊れていた。根本原因は staging の postgres sidecar が **`postgres` superuser 接続** で繋いでいること:

```
staging/cloudrun-staging.yaml: DATABASE_URL = postgresql://postgres:staging@localhost:...
```

superuser は `FORCE ROW LEVEL SECURITY` でも **RLS を完全に bypass** する (FORCE はテーブル所有者には効くが superuser/BYPASSRLS ロールには効かない)。本番は `alc_api_app` (NOBYPASSRLS) なので RLS が効くが、staging では RLS 頼みのクエリが全テナント横断で漏れ・誤動作していた。

これにより観測されていた症状:

| 症状 | 原因 |
|---|---|
| 設定が tenant を跨いで list に残る | `list_configs` が WHERE 句なし (RLS 頼み) → bypass で全テナント可視 |
| 削除しても消えない (無音) | `delete_config` が `WHERE tenant_id = $current` だが tenant churn で 0 行 → なのに 200 を返す |
| secret 空で保存すると 500 | `upsert_config_without_secret` の `INSERT...ON CONFLICT` が `client_secret_encrypted NOT NULL` 違反 |

## 変更

- **`list_configs`**: `WHERE tenant_id = $1` を明示。RLS bypass 時の cross-tenant 漏れを防ぐ (本番では冗長だが defense in depth)
- **`upsert_config_without_secret`**: `INSERT...ON CONFLICT` を **UPDATE only** に変更。対象 config が無ければ `RowNotFound` → handler が **400** (新規作成には client_secret 必須)
- **`delete_config`**: `rows_affected()` を返し、0 行なら handler が **404**。従来は tenant 不一致でも 200 NO_CONTENT を返し「削除できない」が無音だった

## テスト

mock test 2 件追加 (`crates/alc-misc/src/sso_admin.rs` は coverage 100% gate 対象):

- `test_delete_config_not_found` — delete 0 行 → 404
- `test_upsert_config_without_secret_missing_returns_400` — 対象 config なし → 400

`cargo test --test mock_misc sso_admin` → 18 passed。

## Note (本 PR scope 外)

staging が superuser 接続なのは volatile DB の都合だが、**他の RLS 頼みクエリも同様に cross-tenant 漏れの risk** がある。staging を `alc_api_app` 接続に切り替えるのが根治だが、影響範囲が広いため別 issue で扱う。本 PR は SSO 系を明示 WHERE で個別に塞いだ。

Refs #434

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nn4HQ7wZubMDyhKQ94jRLJ)_