### PR TITLE
fix(sso): upsert を (provider, external_org_id) key で reassign し cross-tenant 500 を解消 (Refs #434)

### DIFF
--- a/crates/alc-auth/src/internal.rs
+++ b/crates/alc-auth/src/internal.rs
@@ -89,11 +89,16 @@ pub struct RecipientTenant {
 }
 
 fn internal_error(context: &str, err: impl std::fmt::Display) -> ErrorResponse {
-    tracing::error!("internal auth endpoint error ({context}): {err}");
-    (
-        StatusCode::INTERNAL_SERVER_ERROR,
-        Json(serde_json::json!({ "error": "internal_error" })),
-    )
+    let detail = err.to_string();
+    tracing::error!("internal auth endpoint error ({context}): {detail}");
+    // staging (揮発 DB) でのみ DB エラー詳細を response に載せて診断を高速化する。
+    // 本番は内部エラー文言を隠す (情報漏洩防止)。
+    let body = if std::env::var("STAGING_MODE").as_deref() == Ok("true") {
+        serde_json::json!({ "error": "internal_error", "context": context, "detail": detail })
+    } else {
+        serde_json::json!({ "error": "internal_error" })
+    };
+    (StatusCode::INTERNAL_SERVER_ERROR, Json(body))
 }
 
 fn not_found(error: &str) -> ErrorResponse {

--- a/crates/alc-misc/src/repo/sso_admin.rs
+++ b/crates/alc-misc/src/repo/sso_admin.rs
@@ -47,14 +47,22 @@ impl SsoAdminRepository for PgSsoAdminRepository {
         enabled: bool,
     ) -> Result<SsoConfigRow, sqlx::Error> {
         let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        // 競合 key は (provider, external_org_id) = resolve_sso_config の引き key に揃える。
+        // 同じ LW org (external_org_id) の config は 1 つだけ存在し、保存した tenant が
+        // 所有者になる (tenant_id も EXCLUDED で付け替え)。これにより staging の tenant
+        // churn で別 tenant に orphan が残っても「最新の保存が引き取る」で 500 を避ける。
+        // 本番 (alc_api_app + RLS) では他 tenant の行は RLS で不可視 = ON CONFLICT の
+        // UPDATE 対象にならず、他人の LW org を乗っ取れない (= cross-tenant 防御は維持)。
+        // 旧 (tenant_id, provider) / (provider, client_id) UNIQUE と衝突しうるが、
+        // 1 tenant = 1 LW org の運用では発生しない (将来 migration で整理予定)。
         sqlx::query_as::<_, SsoConfigRow>(
             r#"
             INSERT INTO sso_provider_configs (tenant_id, provider, client_id, client_secret_encrypted, external_org_id, woff_id, enabled)
             VALUES ($1, $2, $3, $4, $5, $6, $7)
-            ON CONFLICT (tenant_id, provider) DO UPDATE SET
+            ON CONFLICT (provider, external_org_id) DO UPDATE SET
+                tenant_id = EXCLUDED.tenant_id,
                 client_id = EXCLUDED.client_id,
                 client_secret_encrypted = EXCLUDED.client_secret_encrypted,
-                external_org_id = EXCLUDED.external_org_id,
                 woff_id = EXCLUDED.woff_id,
                 enabled = EXCLUDED.enabled,
                 updated_at = NOW()


### PR DESCRIPTION
## 根本原因 (Cloud Run ログで確定)

staging で SSO config 保存が 500。実エラー (rust-alc-api-staging `00396-cbj`):

```
Failed to upsert SSO config: error returned from database:
duplicate key value violates unique constraint "sso_provider_configs_provider_client_id_key"
```

揮発 staging DB の **tenant churn** で、別 tenant に同一 lineworks config (`client_id` / `external_org_id`) が **orphan** として残る。新 tenant での保存は `ON CONFLICT (tenant_id, provider)` では捕捉できず、テナント跨ぎ UNIQUE `(provider, client_id)` 違反で 500。`#449` で list が tenant スコープになったため orphan は画面から見えず「未設定なのに保存できない」デッドロックになっていた。

## 修正

- **`upsert_config_with_secret` の競合 key を `(tenant_id, provider)` → `(provider, external_org_id)` に変更**し、`tenant_id` も `EXCLUDED` で UPDATE。
  - = 同じ LW org (`external_org_id`) の config は最新の保存 tenant が所有者になる。`resolve_sso_config` の引き key と一致するので routing とも整合
  - **staging (superuser)**: orphan を現 tenant に付け替えて保存成功 → churn しても通る
  - **本番 (alc_api_app + RLS)**: 他 tenant の行は RLS で不可視 → `ON CONFLICT` の UPDATE 対象にならず、他人の LW org を乗っ取れない (cross-tenant 防御を維持)
- `internal_error` が `STAGING_MODE=true` 時に DB エラー詳細を response body に載せる (揮発 staging の診断高速化、本番は内部文言を隠す)

## 残課題 (別 PR)

- `(provider, client_id)` の cross-tenant UNIQUE は resolve に不要 (resolve は `external_org_id` で引く)。orphan の `external_org_id` が一致する今回のケースでは ON CONFLICT が同じ行を更新するので発火しないが、`client_id` だけ衝突する edge では残る。将来 migration で `(provider, client_id)` / `(tenant_id, provider)` UNIQUE を整理する。

Refs #434

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nn4HQ7wZubMDyhKQ94jRLJ)_