### PR TITLE
fix(sso): cross-tenant takeover を排除し staging churn を STAGING_MODE 限定削除に (Refs #434)

### DIFF
--- a/.claude/skills/rust-alc-api-map/SKILL.md
+++ b/.claude/skills/rust-alc-api-map/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rust-alc-api-map
-generated-from: rust-alc-api:0d6335910594e41856590e5ff730fb2d0e311fcc
+generated-from: rust-alc-api:8c1d619a1a7619a16c242f6ea7431194c2cc29c1
 paths: [crates/, src/, migrations/]
 description: rust-alc-api (アルコールチェッカー基盤の Rust/Axum Cargo workspace — 13 domain crate + gateway/tenko/carins/dtako/trouble の複数バイナリ、PostgreSQL+RLS、Cloud Run) の構造ナビゲーション。どの crate に何のルートがあるか / monolith(rust-alc-api) と per-domain API + gateway の二系統 / RLS・migration・deploy/release 分離の gotcha を 1 枚にまとめる。トリガー:「rust-alc-api」「alc-api」「alc-notify」「alc-tenko」「alc-trouble」「alc-carins」「alc-dtako」「gateway」「tenko-api」「carins-api」「dtako-api」「trouble-api」「RLS テナント」「sqlx migration」「ts-rs」「Release Wave」「Bazel」等。
 ---

--- a/crates/alc-misc/src/repo/sso_admin.rs
+++ b/crates/alc-misc/src/repo/sso_admin.rs
@@ -47,22 +47,40 @@ impl SsoAdminRepository for PgSsoAdminRepository {
         enabled: bool,
     ) -> Result<SsoConfigRow, sqlx::Error> {
         let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
-        // 競合 key は (provider, external_org_id) = resolve_sso_config の引き key に揃える。
-        // 同じ LW org (external_org_id) の config は 1 つだけ存在し、保存した tenant が
-        // 所有者になる (tenant_id も EXCLUDED で付け替え)。これにより staging の tenant
-        // churn で別 tenant に orphan が残っても「最新の保存が引き取る」で 500 を避ける。
-        // 本番 (alc_api_app + RLS) では他 tenant の行は RLS で不可視 = ON CONFLICT の
-        // UPDATE 対象にならず、他人の LW org を乗っ取れない (= cross-tenant 防御は維持)。
-        // 旧 (tenant_id, provider) / (provider, client_id) UNIQUE と衝突しうるが、
-        // 1 tenant = 1 LW org の運用では発生しない (将来 migration で整理予定)。
+        // cross-tenant UNIQUE (provider, external_org_id / client_id) は「1 LW org =
+        // 1 tenant」を保証する所有権境界。これを跨いで tenant_id を付け替えると別
+        // tenant の config を乗っ取れてしまう (cross-tenant takeover) ため絶対にしない。
+        //
+        // staging の揮発 DB は tenant churn で「同じ人間の別 tenant」に orphan を残し、
+        // それが cross-tenant UNIQUE に衝突して保存を 500 にする。これは staging 固有の
+        // 事故なので **STAGING_MODE のときだけ** orphan を明示削除して解消する。
+        // 本番 (STAGING_MODE 無効 + alc_api_app/RLS) では削除しない = tenant は永続で
+        // cross-tenant 衝突は「別の実テナント」= 正当な境界。衝突時は下の INSERT が
+        // UNIQUE 違反を返し、勝手な付け替え/削除はしない。
+        if std::env::var("STAGING_MODE").as_deref() == Ok("true") {
+            sqlx::query(
+                r#"
+                DELETE FROM sso_provider_configs
+                WHERE provider = $1
+                  AND tenant_id <> $2
+                  AND (external_org_id = $3 OR client_id = $4)
+                "#,
+            )
+            .bind(provider)
+            .bind(tenant_id)
+            .bind(external_org_id)
+            .bind(client_id)
+            .execute(&mut *tc.conn)
+            .await?;
+        }
         sqlx::query_as::<_, SsoConfigRow>(
             r#"
             INSERT INTO sso_provider_configs (tenant_id, provider, client_id, client_secret_encrypted, external_org_id, woff_id, enabled)
             VALUES ($1, $2, $3, $4, $5, $6, $7)
-            ON CONFLICT (provider, external_org_id) DO UPDATE SET
-                tenant_id = EXCLUDED.tenant_id,
+            ON CONFLICT (tenant_id, provider) DO UPDATE SET
                 client_id = EXCLUDED.client_id,
                 client_secret_encrypted = EXCLUDED.client_secret_encrypted,
+                external_org_id = EXCLUDED.external_org_id,
                 woff_id = EXCLUDED.woff_id,
                 enabled = EXCLUDED.enabled,
                 updated_at = NOW()


### PR DESCRIPTION
## 🔒 セキュリティ修正（直前マージの #450 の回帰を是正）

#450 でマージした upsert は:

```sql
ON CONFLICT (provider, external_org_id) DO UPDATE SET
    tenant_id = EXCLUDED.tenant_id, ...
```

これは **別 tenant が所有する LW org config を無言で乗っ取れる (cross-tenant takeover)**。`(provider, external_org_id)` UNIQUE は「1 LW org = 1 tenant」の所有権境界なのに、`tenant_id` を `EXCLUDED` で付け替えてしまう。staging は postgres superuser 接続で RLS を bypass するため、この乗っ取りが**実際に成立**する（自動セキュリティレビューで CRITICAL 指摘）。

## 修正

- **`ON CONFLICT (tenant_id, provider)` に戻し、`tenant_id` の付け替えを削除** → cross-tenant の所有権境界を維持。別 tenant の config は触れない。
- staging の tenant churn 由来 orphan（同じ人間の別 tenant に残った同一 `external_org_id`/`client_id`）は、**`STAGING_MODE=true` のときだけ明示 DELETE** してから upsert（レビュアー option (a)）。
  - **本番**（`STAGING_MODE` 無効 + `alc_api_app`/RLS）: 削除しない。tenant は永続なので cross-tenant 衝突は「別の実テナント」= 正当な境界 → INSERT が UNIQUE 違反を返す（勝手な付け替え/削除はしない）。
  - **staging**（superuser）: churn orphan を消してから保存 → 揮発 DB でも保存が通る。

## 確認

- `cargo build -p alc-misc` OK / `cargo test --test mock_misc sso_admin` 18 passed。
- handler の挙動（200/400/404/500）は不変、mock test 維持。

Refs #434

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nn4HQ7wZubMDyhKQ94jRLJ)_