### PR TITLE
fix(auth): LINE WORKS/LINE internal upsert で staging 限定の tenant 自動作成 (Refs #434)

### DIFF
--- a/.claude/skills/rust-alc-api-map/SKILL.md
+++ b/.claude/skills/rust-alc-api-map/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rust-alc-api-map
-generated-from: rust-alc-api:8c1d619a1a7619a16c242f6ea7431194c2cc29c1
+generated-from: rust-alc-api:5f4dccce01d33e7a8d4006301e3dcf013d40be81
 paths: [crates/, src/, migrations/]
 description: rust-alc-api (アルコールチェッカー基盤の Rust/Axum Cargo workspace — 13 domain crate + gateway/tenko/carins/dtako/trouble の複数バイナリ、PostgreSQL+RLS、Cloud Run) の構造ナビゲーション。どの crate に何のルートがあるか / monolith(rust-alc-api) と per-domain API + gateway の二系統 / RLS・migration・deploy/release 分離の gotcha を 1 枚にまとめる。トリガー:「rust-alc-api」「alc-api」「alc-notify」「alc-tenko」「alc-trouble」「alc-carins」「alc-dtako」「gateway」「tenko-api」「carins-api」「dtako-api」「trouble-api」「RLS テナント」「sqlx migration」「ts-rs」「Release Wave」「Bazel」等。
 ---

--- a/crates/alc-auth/src/internal.rs
+++ b/crates/alc-auth/src/internal.rs
@@ -129,6 +129,22 @@ pub fn internal_router() -> Router<AppState> {
         .route("/internal/auth/refresh-token", post(save_refresh_token))
 }
 
+/// staging の揮発 DB では SSO config の tenant_id が dangling になり得る
+/// (`sso_provider_configs.tenant_id` に FK が無い)。その tenant で user を作ると
+/// `users_tenant_id_fkey` 違反で 500 になる。STAGING_MODE 限定で tenant を先に
+/// 冪等作成して救済する (Google login の自動 tenant 作成と同方針)。本番では
+/// tenant が永続なので dangling は起きず、この救済は走らない (no-op)。
+async fn ensure_tenant_for_staging(state: &AppState, tenant_id: Uuid) -> Result<(), ErrorResponse> {
+    if crate::is_staging_mode() {
+        state
+            .auth
+            .ensure_tenant_exists(tenant_id)
+            .await
+            .map_err(|e| internal_error("ensure_tenant_exists", e))?;
+    }
+    Ok(())
+}
+
 /// tenant slug を解決して `InternalUserWithSlug` を返す共通ヘルパ。
 async fn with_slug(state: &AppState, user: User) -> ApiResult<InternalUserWithSlug> {
     let slug = state
@@ -185,6 +201,7 @@ async fn upsert_lineworks_user(
     State(state): State<AppState>,
     Json(b): Json<UpsertLineworksBody>,
 ) -> ApiResult<InternalUserWithSlug> {
+    ensure_tenant_for_staging(&state, b.tenant_id).await?;
     let existing = state
         .auth
         .find_user_by_lineworks_id(&b.lineworks_id)
@@ -214,6 +231,7 @@ async fn upsert_line_user(
     State(state): State<AppState>,
     Json(b): Json<UpsertLineBody>,
 ) -> ApiResult<InternalUserWithSlug> {
+    ensure_tenant_for_staging(&state, b.tenant_id).await?;
     let existing = state
         .auth
         .find_user_by_line_user_id(&b.line_user_id)

--- a/crates/alc-core/src/repo/auth.rs
+++ b/crates/alc-core/src/repo/auth.rs
@@ -104,6 +104,17 @@ impl AuthRepository for PgAuthRepository {
         ))
     }
 
+    async fn ensure_tenant_exists(&self, tenant_id: Uuid) -> Result<(), sqlx::Error> {
+        // short_id は DEFAULT 生成、name は placeholder。既存ならそのまま。
+        sqlx::query(
+            "INSERT INTO tenants (id, name) VALUES ($1, 'LINE WORKS (staging auto)') ON CONFLICT (id) DO NOTHING",
+        )
+        .bind(tenant_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
     async fn get_tenant_by_id(&self, id: Uuid) -> Result<Option<Tenant>, sqlx::Error> {
         sqlx::query_as::<_, Tenant>("SELECT * FROM tenants WHERE id = $1")
             .bind(id)

--- a/crates/alc-core/src/repository/auth.rs
+++ b/crates/alc-core/src/repository/auth.rs
@@ -48,6 +48,10 @@ pub trait AuthRepository: Send + Sync {
 
     async fn create_tenant_with_domain(&self, email_domain: &str) -> Result<Tenant, sqlx::Error>;
 
+    /// 指定 id の tenant が無ければ最小行を作る (冪等)。staging の揮発 DB で
+    /// SSO config の tenant_id が dangling になった時の救済用 (STAGING_MODE 限定)。
+    async fn ensure_tenant_exists(&self, tenant_id: Uuid) -> Result<(), sqlx::Error>;
+
     async fn get_tenant_by_id(&self, id: Uuid) -> Result<Option<Tenant>, sqlx::Error>;
 
     async fn get_tenant_slug(&self, tenant_id: Uuid) -> Result<Option<String>, sqlx::Error>;

--- a/tests/mock_helpers/repos_a.rs
+++ b/tests/mock_helpers/repos_a.rs
@@ -189,6 +189,11 @@ impl AuthRepository for MockAuthRepository {
         })
     }
 
+    async fn ensure_tenant_exists(&self, _tenant_id: Uuid) -> Result<(), sqlx::Error> {
+        check_fail!(self);
+        Ok(())
+    }
+
     async fn get_tenant_by_id(&self, _id: Uuid) -> Result<Option<Tenant>, sqlx::Error> {
         check_fail!(self);
         Ok(self.return_tenant.lock().unwrap().clone())


### PR DESCRIPTION
## 根本原因 (Cloud Run ログで確定)

LINE WORKS ログインの callback で `upsert-lineworks failed: 500`。実エラー (rust-alc-api-staging `00398-qf4`):

```
internal auth endpoint error (create_user_lineworks):
insert or update on table "users" violates foreign key constraint "users_tenant_id_fkey"
```

= SSO config が指す `tenant_id` が `tenants` に存在しないため、その tenant で user を作ると FK 違反。`sso_provider_configs.tenant_id` には **FK が無い**（`tenant_id UUID NOT NULL` のみ）ので、staging の揮発 DB で tenant が wipe されると config の tenant_id が dangling になる。

Google ログインには `STAGING_MODE` 時の auto-tenant 作成があるのに、**LINE WORKS の internal upsert 経路には無かった**。

## 修正

- `AuthRepository` に **`ensure_tenant_exists(tenant_id)`** を追加（`INSERT ... ON CONFLICT (id) DO NOTHING`、冪等）
- `internal.rs` の `upsert_lineworks_user` / `upsert_line_user` で、user 作成前に **`STAGING_MODE` 限定**で tenant を冪等作成（Google login の auto-tenant と同方針）
- **本番**: tenant は永続で dangling は起きないので no-op（`is_staging_mode()` false で skip）

## 確認

- `cargo build -p alc-auth -p alc-core` OK
- mock (`MockAuthRepository`) に `ensure_tenant_exists` 追加済み

Refs #434

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nn4HQ7wZubMDyhKQ94jRLJ)_