### PR TITLE
feat(sso): admin SSO config の export endpoint (Refs #434)

### DIFF
--- a/.claude/skills/rust-alc-api-map/SKILL.md
+++ b/.claude/skills/rust-alc-api-map/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rust-alc-api-map
-generated-from: rust-alc-api:5f4dccce01d33e7a8d4006301e3dcf013d40be81
+generated-from: rust-alc-api:364e00672b132071df605fe26830b4ed5622df1f
 paths: [crates/, src/, migrations/]
 description: rust-alc-api (アルコールチェッカー基盤の Rust/Axum Cargo workspace — 13 domain crate + gateway/tenko/carins/dtako/trouble の複数バイナリ、PostgreSQL+RLS、Cloud Run) の構造ナビゲーション。どの crate に何のルートがあるか / monolith(rust-alc-api) と per-domain API + gateway の二系統 / RLS・migration・deploy/release 分離の gotcha を 1 枚にまとめる。トリガー:「rust-alc-api」「alc-api」「alc-notify」「alc-tenko」「alc-trouble」「alc-carins」「alc-dtako」「gateway」「tenko-api」「carins-api」「dtako-api」「trouble-api」「RLS テナント」「sqlx migration」「ts-rs」「Release Wave」「Bazel」等。
 ---

--- a/crates/alc-core/src/repository/sso_admin.rs
+++ b/crates/alc-core/src/repository/sso_admin.rs
@@ -2,12 +2,30 @@ use async_trait::async_trait;
 use ts_rs::TS;
 use uuid::Uuid;
 
+pub use super::bot_admin::TenantInfoForExport;
+
 /// SSO Provider Config の DB 行 (client_secret_encrypted は除外)
 #[derive(Debug, serde::Serialize, Clone, sqlx::FromRow, TS)]
 #[ts(export)]
 pub struct SsoConfigRow {
     pub provider: String,
     pub client_id: String,
+    pub external_org_id: String,
+    pub enabled: bool,
+    pub woff_id: Option<String>,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub updated_at: chrono::DateTime<chrono::Utc>,
+}
+
+/// sso_provider_configs 行 (export 用、暗号化のまま全フィールド)。
+/// staging import の `StagingSsoProviderConfig` と同一シェイプで round-trip 可能。
+#[derive(Debug, Clone, sqlx::FromRow, serde::Serialize)]
+pub struct SsoConfigExportRow {
+    pub id: Uuid,
+    pub tenant_id: Uuid,
+    pub provider: String,
+    pub client_id: String,
+    pub client_secret_encrypted: String,
     pub external_org_id: String,
     pub enabled: bool,
     pub woff_id: Option<String>,
@@ -47,4 +65,16 @@ pub trait SsoAdminRepository: Send + Sync {
 
     /// SSO 設定の削除。削除した行数を返す (0 = 該当なし → handler が 404)
     async fn delete_config(&self, tenant_id: Uuid, provider: &str) -> Result<u64, sqlx::Error>;
+
+    /// 指定テナントの基本情報を取得 (export 用、tenants は RLS なしで OK)
+    async fn get_tenant_for_export(
+        &self,
+        tenant_id: Uuid,
+    ) -> Result<Option<TenantInfoForExport>, sqlx::Error>;
+
+    /// 指定テナントの全 sso_provider_configs を export 用に取得 (暗号化フィールド含む)
+    async fn list_configs_for_export(
+        &self,
+        tenant_id: Uuid,
+    ) -> Result<Vec<SsoConfigExportRow>, sqlx::Error>;
 }

--- a/crates/alc-misc/src/repo/sso_admin.rs
+++ b/crates/alc-misc/src/repo/sso_admin.rs
@@ -145,4 +145,35 @@ impl SsoAdminRepository for PgSsoAdminRepository {
                 .await?;
         Ok(result.rows_affected())
     }
+
+    async fn get_tenant_for_export(
+        &self,
+        tenant_id: Uuid,
+    ) -> Result<Option<TenantInfoForExport>, sqlx::Error> {
+        sqlx::query_as::<_, TenantInfoForExport>(
+            "SELECT id, name, slug, email_domain, created_at FROM tenants WHERE id = $1",
+        )
+        .bind(tenant_id)
+        .fetch_optional(&self.pool)
+        .await
+    }
+
+    async fn list_configs_for_export(
+        &self,
+        tenant_id: Uuid,
+    ) -> Result<Vec<SsoConfigExportRow>, sqlx::Error> {
+        let mut tc = TenantConn::acquire(&self.pool, &tenant_id.to_string()).await?;
+        sqlx::query_as::<_, SsoConfigExportRow>(
+            r#"
+            SELECT id, tenant_id, provider, client_id, client_secret_encrypted,
+                   external_org_id, enabled, woff_id, created_at, updated_at
+            FROM sso_provider_configs
+            WHERE tenant_id = $1
+            ORDER BY provider
+            "#,
+        )
+        .bind(tenant_id)
+        .fetch_all(&mut *tc.conn)
+        .await
+    }
 }

--- a/crates/alc-misc/src/sso_admin.rs
+++ b/crates/alc-misc/src/sso_admin.rs
@@ -1,13 +1,16 @@
 /// SSO Provider Config 管理 REST API
 /// auth-worker の admin/sso ページから呼ばれる
 use axum::{
-    extract::State,
+    extract::{Query, State},
     http::StatusCode,
     routing::{delete, get, post},
     Extension, Json, Router,
 };
+use chrono::Utc;
 use serde::{Deserialize, Serialize};
+use serde_json::json;
 
+use crate::bot_admin::is_developer_email;
 use alc_core::auth_middleware::AuthUser;
 use alc_core::repository::sso_admin::SsoConfigRow;
 use alc_core::AppState;
@@ -32,11 +35,17 @@ struct DeleteRequest {
     provider: String,
 }
 
+#[derive(Debug, Deserialize)]
+struct ExportQuery {
+    tenant_id: uuid::Uuid,
+}
+
 pub fn router() -> Router<AppState> {
     Router::new()
         .route("/admin/sso/configs", get(list_configs))
         .route("/admin/sso/configs", post(upsert_config))
         .route("/admin/sso/configs", delete(delete_config))
+        .route("/admin/sso/configs/export", get(export_configs))
 }
 
 /// GET /admin/sso/configs — テナントの SSO 設定一覧
@@ -150,6 +159,61 @@ async fn delete_config(
     }
 
     Ok(StatusCode::NO_CONTENT)
+}
+
+/// GET /admin/sso/configs/export — developer 限定。
+/// staging import と互換のシェイプ (sso_provider_configs のみ populate) で吐く。
+async fn export_configs(
+    State(state): State<AppState>,
+    Extension(auth_user): Extension<AuthUser>,
+    Query(params): Query<ExportQuery>,
+) -> Result<Json<serde_json::Value>, StatusCode> {
+    if !is_developer_email(&auth_user.email) {
+        tracing::warn!("sso export refused: {}", auth_user.email);
+        return Err(StatusCode::FORBIDDEN);
+    }
+
+    let tid = params.tenant_id;
+
+    let tenant = state
+        .sso_admin
+        .get_tenant_for_export(tid)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to fetch tenant for sso export: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?
+        .ok_or(StatusCode::NOT_FOUND)?;
+
+    let sso_provider_configs = state
+        .sso_admin
+        .list_configs_for_export(tid)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to fetch sso_provider_configs for export: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    Ok(Json(json!({
+        "version": 1,
+        "exported_at": Utc::now().to_rfc3339(),
+        "tenant_id": tid.to_string(),
+        "data": {
+            "tenant": tenant,
+            "users": [],
+            "employees": [],
+            "devices": [],
+            "tenko_schedules": [],
+            "webhook_configs": [],
+            "tenant_allowed_emails": [],
+            "sso_provider_configs": sso_provider_configs,
+            "tenko_call_numbers": [],
+            "tenko_call_drivers": [],
+            "bot_configs": [],
+            "notify_line_configs": [],
+            "notify_recipients": []
+        }
+    })))
 }
 
 /// AES-256-GCM で暗号化（rust-logi と同じ形式）

--- a/tests/mock_helpers/repos_c.rs
+++ b/tests/mock_helpers/repos_c.rs
@@ -5,7 +5,9 @@ use uuid::Uuid;
 
 use rust_alc_api::db::models::*;
 use rust_alc_api::db::repository::nfc_tags::NfcTagRepository;
-use rust_alc_api::db::repository::sso_admin::{SsoAdminRepository, SsoConfigRow};
+use rust_alc_api::db::repository::sso_admin::{
+    SsoAdminRepository, SsoConfigExportRow, SsoConfigRow, TenantInfoForExport,
+};
 use rust_alc_api::db::repository::tenant_users::{TenantUsersRepository, UserRow};
 use rust_alc_api::db::repository::tenko_call::{
     DriverInfo, RegisterDriverResult, TenkoCallDriverRow, TenkoCallNumberRow, TenkoCallRepository,
@@ -114,6 +116,10 @@ pub struct MockSsoAdminRepository {
     pub fail_next: AtomicBool,
     /// true なら delete_config が 0 行 (= 該当なし) を返す
     pub delete_zero: AtomicBool,
+    pub return_tenant_for_export: std::sync::Mutex<Option<TenantInfoForExport>>,
+    pub return_configs_for_export: std::sync::Mutex<Vec<SsoConfigExportRow>>,
+    pub fail_tenant_for_export: AtomicBool,
+    pub fail_configs_for_export: AtomicBool,
 }
 
 impl Default for MockSsoAdminRepository {
@@ -121,6 +127,10 @@ impl Default for MockSsoAdminRepository {
         Self {
             fail_next: AtomicBool::new(false),
             delete_zero: AtomicBool::new(false),
+            return_tenant_for_export: std::sync::Mutex::new(None),
+            return_configs_for_export: std::sync::Mutex::new(Vec::new()),
+            fail_tenant_for_export: AtomicBool::new(false),
+            fail_configs_for_export: AtomicBool::new(false),
         }
     }
 }
@@ -182,6 +192,26 @@ impl SsoAdminRepository for MockSsoAdminRepository {
         } else {
             Ok(1)
         }
+    }
+
+    async fn get_tenant_for_export(
+        &self,
+        _tenant_id: Uuid,
+    ) -> Result<Option<TenantInfoForExport>, sqlx::Error> {
+        if self.fail_tenant_for_export.swap(false, Ordering::SeqCst) {
+            return Err(sqlx::Error::RowNotFound);
+        }
+        Ok(self.return_tenant_for_export.lock().unwrap().clone())
+    }
+
+    async fn list_configs_for_export(
+        &self,
+        _tenant_id: Uuid,
+    ) -> Result<Vec<SsoConfigExportRow>, sqlx::Error> {
+        if self.fail_configs_for_export.swap(false, Ordering::SeqCst) {
+            return Err(sqlx::Error::RowNotFound);
+        }
+        Ok(self.return_configs_for_export.lock().unwrap().clone())
     }
 }
 

--- a/tests/mock_tests/mock_sso_admin_test.rs
+++ b/tests/mock_tests/mock_sso_admin_test.rs
@@ -420,3 +420,223 @@ async fn test_delete_config_db_error() {
         .unwrap();
     assert_eq!(res.status(), 500);
 }
+
+// =========================================================================
+// GET /api/admin/sso/configs/export — developer 限定
+// =========================================================================
+
+fn dev_email() -> &'static str {
+    "m.tama.ramu@gmail.com"
+}
+
+fn set_dev_emails(value: &str) -> Option<String> {
+    let prev = std::env::var("DEVELOPER_EMAILS").ok();
+    std::env::set_var("DEVELOPER_EMAILS", value);
+    prev
+}
+
+fn restore_dev_emails(prev: Option<String>) {
+    match prev {
+        Some(v) => std::env::set_var("DEVELOPER_EMAILS", v),
+        None => std::env::remove_var("DEVELOPER_EMAILS"),
+    }
+}
+
+#[tokio::test]
+async fn test_export_configs_success() {
+    use rust_alc_api::db::repository::sso_admin::{SsoConfigExportRow, TenantInfoForExport};
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    let prev = set_dev_emails(dev_email());
+
+    let mock = Arc::new(MockSsoAdminRepository::default());
+    let tenant_id = uuid::Uuid::new_v4();
+    *mock.return_tenant_for_export.lock().unwrap() = Some(TenantInfoForExport {
+        id: tenant_id,
+        name: "テナント大石".to_string(),
+        slug: Some("ohishi".to_string()),
+        email_domain: None,
+        created_at: chrono::Utc::now(),
+    });
+    *mock.return_configs_for_export.lock().unwrap() = vec![SsoConfigExportRow {
+        id: uuid::Uuid::new_v4(),
+        tenant_id,
+        provider: "lineworks".to_string(),
+        client_id: "cid".to_string(),
+        client_secret_encrypted: "enc-secret".to_string(),
+        external_org_id: "ohishiunyusouko".to_string(),
+        enabled: true,
+        woff_id: None,
+        created_at: chrono::Utc::now(),
+        updated_at: chrono::Utc::now(),
+    }];
+
+    let mut state = crate::mock_helpers::app_state::setup_mock_app_state();
+    state.sso_admin = mock;
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let dev_jwt = crate::common::create_test_jwt_for_user(
+        uuid::Uuid::new_v4(),
+        tenant_id,
+        dev_email(),
+        "admin",
+    );
+    let client = reqwest::Client::new();
+    let res = client
+        .get(format!(
+            "{base_url}/api/admin/sso/configs/export?tenant_id={tenant_id}"
+        ))
+        .header("Authorization", format!("Bearer {dev_jwt}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(body["version"], 1);
+    assert_eq!(body["tenant_id"], tenant_id.to_string());
+    assert_eq!(body["data"]["tenant"]["slug"], "ohishi");
+    let configs = body["data"]["sso_provider_configs"].as_array().unwrap();
+    assert_eq!(configs.len(), 1);
+    assert_eq!(configs[0]["external_org_id"], "ohishiunyusouko");
+    assert_eq!(configs[0]["client_secret_encrypted"], "enc-secret");
+    assert_eq!(body["data"]["bot_configs"].as_array().unwrap().len(), 0);
+
+    restore_dev_emails(prev);
+}
+
+#[tokio::test]
+async fn test_export_configs_forbidden_for_non_developer() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    let prev = set_dev_emails(dev_email());
+
+    let mut state = crate::mock_helpers::app_state::setup_mock_app_state();
+    state.sso_admin = Arc::new(MockSsoAdminRepository::default());
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let tenant_id = uuid::Uuid::new_v4();
+    let attacker_jwt = crate::common::create_test_jwt_for_user(
+        uuid::Uuid::new_v4(),
+        tenant_id,
+        "attacker@example.com",
+        "admin",
+    );
+    let client = reqwest::Client::new();
+    let res = client
+        .get(format!(
+            "{base_url}/api/admin/sso/configs/export?tenant_id={tenant_id}"
+        ))
+        .header("Authorization", format!("Bearer {attacker_jwt}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 403);
+
+    restore_dev_emails(prev);
+}
+
+#[tokio::test]
+async fn test_export_configs_tenant_not_found() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    let prev = set_dev_emails(dev_email());
+
+    // return_tenant_for_export はデフォルト None → handler 側で 404
+    let mut state = crate::mock_helpers::app_state::setup_mock_app_state();
+    state.sso_admin = Arc::new(MockSsoAdminRepository::default());
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let tenant_id = uuid::Uuid::new_v4();
+    let dev_jwt = crate::common::create_test_jwt_for_user(
+        uuid::Uuid::new_v4(),
+        tenant_id,
+        dev_email(),
+        "admin",
+    );
+    let client = reqwest::Client::new();
+    let res = client
+        .get(format!(
+            "{base_url}/api/admin/sso/configs/export?tenant_id={tenant_id}"
+        ))
+        .header("Authorization", format!("Bearer {dev_jwt}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 404);
+
+    restore_dev_emails(prev);
+}
+
+#[tokio::test]
+async fn test_export_configs_tenant_db_error() {
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    let prev = set_dev_emails(dev_email());
+
+    let mock = Arc::new(MockSsoAdminRepository::default());
+    mock.fail_tenant_for_export.store(true, Ordering::SeqCst);
+    let mut state = crate::mock_helpers::app_state::setup_mock_app_state();
+    state.sso_admin = mock;
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let tenant_id = uuid::Uuid::new_v4();
+    let dev_jwt = crate::common::create_test_jwt_for_user(
+        uuid::Uuid::new_v4(),
+        tenant_id,
+        dev_email(),
+        "admin",
+    );
+    let client = reqwest::Client::new();
+    let res = client
+        .get(format!(
+            "{base_url}/api/admin/sso/configs/export?tenant_id={tenant_id}"
+        ))
+        .header("Authorization", format!("Bearer {dev_jwt}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+
+    restore_dev_emails(prev);
+}
+
+#[tokio::test]
+async fn test_export_configs_configs_db_error() {
+    use rust_alc_api::db::repository::sso_admin::TenantInfoForExport;
+    let _guard = crate::common::ENV_LOCK.lock().unwrap();
+    std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    let prev = set_dev_emails(dev_email());
+
+    let mock = Arc::new(MockSsoAdminRepository::default());
+    let tenant_id = uuid::Uuid::new_v4();
+    *mock.return_tenant_for_export.lock().unwrap() = Some(TenantInfoForExport {
+        id: tenant_id,
+        name: "T".to_string(),
+        slug: None,
+        email_domain: None,
+        created_at: chrono::Utc::now(),
+    });
+    mock.fail_configs_for_export.store(true, Ordering::SeqCst);
+    let mut state = crate::mock_helpers::app_state::setup_mock_app_state();
+    state.sso_admin = mock;
+    let base_url = crate::common::spawn_test_server(state).await;
+
+    let dev_jwt = crate::common::create_test_jwt_for_user(
+        uuid::Uuid::new_v4(),
+        tenant_id,
+        dev_email(),
+        "admin",
+    );
+    let client = reqwest::Client::new();
+    let res = client
+        .get(format!(
+            "{base_url}/api/admin/sso/configs/export?tenant_id={tenant_id}"
+        ))
+        .header("Authorization", format!("Bearer {dev_jwt}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 500);
+
+    restore_dev_emails(prev);
+}


### PR DESCRIPTION
## 概要

bot config と同じく developer 限定で SSO config を **staging-import 互換 JSON** で吐く `GET /api/admin/sso/configs/export` を追加する。揮発する staging DB の SSO 設定を export → `/api/staging/import` で round-trip 復元できるようにする (Refs #434)。

別セッション (`claude/github-issue-434-rzaztt`) で push 済みだった `fix/sso-upsert-without-secret` を `origin/main` に rebase し、既に merge 済みの 3-bug 修正 (#449/#450) と重複する 2 commit を落として export endpoint commit のみ残したもの。

## 変更点

- `SsoConfigExportRow` (暗号化フィールド込み、staging import の `StagingSsoProviderConfig` と同一シェイプ) + `get_tenant_for_export` / `list_configs_for_export` を `SsoAdminRepository` trait に追加
- `export_configs` handler: developer email gate → tenant 取得 → configs 取得 → JSON。`is_developer_email` / `TenantInfoForExport` は既存 bot export と共有
- `list_configs_for_export` は `WHERE tenant_id` 明示 (staging は postgres superuser 接続で RLS bypass のため必須、#434 の sso_admin 実害を踏まえる)
- mock + 5 tests (success / forbidden / tenant_not_found / tenant_db_error / configs_db_error)
- `rust-alc-api-map` SKILL.md の `generated-from` sha を現 main に bump (crates 変更に伴う skills-check enforce=fail 対策)

import 側は既存 `/api/staging/import` (`import_sso_configs`) を流用する想定で、本 PR では追加しない。

Refs #434

---
_Generated by [Claude Code](https://claude.ai/code/session_01SRVaeXY89DuETaakvY5HW7)_