### PR TITLE
feat(notify): viewer 用 internal view/read endpoint (Refs #434)

### DIFF
--- a/.claude/skills/rust-alc-api-map/SKILL.md
+++ b/.claude/skills/rust-alc-api-map/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rust-alc-api-map
-generated-from: rust-alc-api:364e00672b132071df605fe26830b4ed5622df1f
+generated-from: rust-alc-api:563dc68c7d8418a3279a2ad4d451462b785bc292
 paths: [crates/, src/, migrations/]
 description: rust-alc-api (アルコールチェッカー基盤の Rust/Axum Cargo workspace — 13 domain crate + gateway/tenko/carins/dtako/trouble の複数バイナリ、PostgreSQL+RLS、Cloud Run) の構造ナビゲーション。どの crate に何のルートがあるか / monolith(rust-alc-api) と per-domain API + gateway の二系統 / RLS・migration・deploy/release 分離の gotcha を 1 枚にまとめる。トリガー:「rust-alc-api」「alc-api」「alc-notify」「alc-tenko」「alc-trouble」「alc-carins」「alc-dtako」「gateway」「tenko-api」「carins-api」「dtako-api」「trouble-api」「RLS テナント」「sqlx migration」「ts-rs」「Release Wave」「Bazel」等。
 ---

--- a/crates/alc-notify/src/viewer.rs
+++ b/crates/alc-notify/src/viewer.rs
@@ -22,6 +22,22 @@ use uuid::Uuid;
 use alc_core::repository::notify_deliveries::DeliveryViewInfo;
 use alc_core::AppState;
 
+/// auth-worker (= viewer Worker) が OIDC (`aud=alc-api-internal`) で叩く内部 view route。
+/// lockdown (`allUsers` 削除) 後は公開 `/api/notify/v/*` が rust に到達できなくなるため、
+/// Worker が KV cache + R2 直配信するのに必要な r2_key + メタを返す経路を `require_internal_jwt`
+/// 配下で提供する (Refs #434)。値 (r2_key 含む) は trusted caller 限定なので返して良い。
+pub fn internal_router() -> Router<AppState> {
+    Router::new()
+        .route(
+            "/internal/notify/view/{token}",
+            axum::routing::get(internal_view),
+        )
+        .route(
+            "/internal/notify/view/{token}/read",
+            axum::routing::post(internal_mark_read),
+        )
+}
+
 pub fn public_router() -> Router<AppState> {
     Router::new()
         .route("/notify/v/{token}", axum::routing::get(view_metadata))
@@ -225,6 +241,71 @@ async fn view_image(
     Ok((StatusCode::OK, headers, jpeg_bytes).into_response())
 }
 
+/// internal view 経路の応答。公開 `ViewMetadata` と違い **r2_key を含む**
+/// (trusted caller = viewer Worker が R2 直 fetch するのに使う)。
+#[derive(serde::Serialize, Debug, PartialEq)]
+pub struct InternalViewInfo {
+    pub r2_key: String,
+    pub file_name: Option<String>,
+    pub file_size_bytes: Option<i64>,
+    pub source_subject: Option<String>,
+    pub source_sender: Option<String>,
+    pub source_received_at: Option<chrono::DateTime<chrono::Utc>>,
+    pub expire_at: chrono::DateTime<chrono::Utc>,
+}
+
+pub(crate) fn build_internal_view_info(info: &DeliveryViewInfo) -> InternalViewInfo {
+    InternalViewInfo {
+        r2_key: info.r2_key.clone(),
+        file_name: info.file_name.clone(),
+        file_size_bytes: info.file_size_bytes,
+        source_subject: info.source_subject.clone(),
+        source_sender: info.source_sender.clone(),
+        source_received_at: info.source_received_at,
+        expire_at: info.expire_at,
+    }
+}
+
+/// GET /api/internal/notify/view/{token} — viewer Worker 用。
+/// r2_key + メタを返す。期限切れは 410、存在しなければ 404。既読化はしない
+/// (`/read` の責務)。
+async fn internal_view(
+    State(state): State<AppState>,
+    Path(token): Path<Uuid>,
+) -> Result<Json<InternalViewInfo>, StatusCode> {
+    let info = state
+        .notify_deliveries
+        .get_for_view(token)
+        .await
+        .map_err(|e| {
+            tracing::error!("internal_view get_for_view: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?
+        .ok_or(StatusCode::NOT_FOUND)?;
+
+    check_not_expired(info.expire_at, chrono::Utc::now())?;
+    Ok(Json(build_internal_view_info(&info)))
+}
+
+/// POST /api/internal/notify/view/{token}/read — viewer Worker が viewer ページ
+/// 表示時に 1 回だけ叩いて既読化する (旧 public `/api/notify/read/{token}` の置換)。
+/// 既読済みでも 204 (idempotent)、存在しなければ 404。
+async fn internal_mark_read(
+    State(state): State<AppState>,
+    Path(token): Path<Uuid>,
+) -> Result<StatusCode, StatusCode> {
+    state
+        .notify_deliveries
+        .mark_read(token)
+        .await
+        .map_err(|e| {
+            tracing::error!("internal_mark_read: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?
+        .ok_or(StatusCode::NOT_FOUND)?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -255,6 +336,25 @@ mod tests {
         assert_eq!(m.expire_at, info.expire_at);
         let json = serde_json::to_string(&m).unwrap();
         assert!(!json.contains("r2_key"));
+        assert!(!json.contains("document_id"));
+        assert!(!json.contains("tenant_id"));
+    }
+
+    #[test]
+    fn build_internal_view_info_includes_r2_key() {
+        let info = sample_info(24);
+        let v = build_internal_view_info(&info);
+        assert_eq!(v.r2_key, info.r2_key);
+        assert_eq!(v.file_name, info.file_name);
+        assert_eq!(v.file_size_bytes, info.file_size_bytes);
+        assert_eq!(v.source_subject, info.source_subject);
+        assert_eq!(v.source_sender, info.source_sender);
+        assert_eq!(v.source_received_at, info.source_received_at);
+        assert_eq!(v.expire_at, info.expire_at);
+        // 公開 ViewMetadata と違い internal は r2_key を JSON に含む
+        let json = serde_json::to_string(&v).unwrap();
+        assert!(json.contains("r2_key"));
+        // document_id / tenant_id は internal でも露出しない
         assert!(!json.contains("document_id"));
         assert!(!json.contains("tenant_id"));
     }

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -94,6 +94,7 @@ pub fn router() -> Router<AppState> {
     // 内部 API ルート (auth-worker 等の信頼できる呼び出し元のみ、aud=alc-api-internal)
     let internal_protected = Router::new()
         .merge(notify_lineworks_channels::internal_router())
+        .merge(notify_viewer::internal_router())
         .merge(health_canary::internal_router())
         .merge(auth::internal_router())
         .layer(axum_middleware::from_fn(require_internal_jwt));

--- a/tests/mock_helpers/repos_d.rs
+++ b/tests/mock_helpers/repos_d.rs
@@ -433,12 +433,20 @@ impl NotifyDocumentRepository for MockNotifyDocumentRepository {
 
 pub struct MockNotifyDeliveryRepository {
     pub fail_next: AtomicBool,
+    /// Some(x) で get_for_view の戻り値を上書き (内側 None = 404 を再現)。
+    /// None なら下記 default の Some(...) を返す。
+    pub view_override: Mutex<Option<Option<DeliveryViewInfo>>>,
+    /// true で mark_read が Ok(None) を返す (404 を再現)。ReadResult は
+    /// Clone 非対応なので値上書きではなく bool で None だけ再現する。
+    pub mark_read_none: AtomicBool,
 }
 
 impl Default for MockNotifyDeliveryRepository {
     fn default() -> Self {
         Self {
             fail_next: AtomicBool::new(false),
+            view_override: Mutex::new(None),
+            mark_read_none: AtomicBool::new(false),
         }
     }
 }
@@ -490,6 +498,9 @@ impl NotifyDeliveryRepository for MockNotifyDeliveryRepository {
     }
     async fn mark_read(&self, _read_token: Uuid) -> Result<Option<ReadResult>, sqlx::Error> {
         check_fail!(self);
+        if self.mark_read_none.load(Ordering::SeqCst) {
+            return Ok(None);
+        }
         Ok(Some(ReadResult {
             document_id: Uuid::new_v4(),
             tenant_id: Uuid::new_v4(),
@@ -502,6 +513,9 @@ impl NotifyDeliveryRepository for MockNotifyDeliveryRepository {
         _read_token: Uuid,
     ) -> Result<Option<DeliveryViewInfo>, sqlx::Error> {
         check_fail!(self);
+        if let Some(ov) = self.view_override.lock().unwrap().clone() {
+            return Ok(ov);
+        }
         Ok(Some(DeliveryViewInfo {
             document_id: Uuid::new_v4(),
             tenant_id: Uuid::new_v4(),

--- a/tests/mock_misc/main.rs
+++ b/tests/mock_misc/main.rs
@@ -29,6 +29,8 @@ mod mock_lineworks_internal_test;
 mod mock_measurements_test;
 #[path = "../mock_tests/mock_members_test.rs"]
 mod mock_members_test;
+#[path = "../mock_tests/mock_notify_view_internal_test.rs"]
+mod mock_notify_view_internal_test;
 #[path = "../mock_tests/mock_sso_admin_test.rs"]
 mod mock_sso_admin_test;
 #[path = "../mock_tests/mock_tenant_users_test.rs"]

--- a/tests/mock_tests/mock_notify_view_internal_test.rs
+++ b/tests/mock_tests/mock_notify_view_internal_test.rs
@@ -1,0 +1,231 @@
+//! Internal viewer endpoints (`/api/internal/notify/view/*`) のモックテスト。
+//!
+//! lockdown 後の viewer Worker (OIDC `aud=alc-api-internal`) 用に、r2_key + メタを
+//! 返す internal view と既読化 internal read を `require_internal_jwt` 配下で提供する
+//! 経路 (Refs #434)。実 DB は使わず MockNotifyDeliveryRepository で振る舞いを固定する。
+
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+use serde_json::Value;
+use uuid::Uuid;
+
+use rust_alc_api::db::repository::notify_deliveries::DeliveryViewInfo;
+
+use crate::mock_helpers::app_state::setup_mock_app_state;
+use crate::mock_helpers::MockNotifyDeliveryRepository;
+
+fn install_mock(state: &mut rust_alc_api::AppState) -> Arc<MockNotifyDeliveryRepository> {
+    let mock = Arc::new(MockNotifyDeliveryRepository::default());
+    state.notify_deliveries = mock.clone();
+    mock
+}
+
+fn sample_view(expire_in_hours: i64) -> DeliveryViewInfo {
+    DeliveryViewInfo {
+        document_id: Uuid::new_v4(),
+        tenant_id: Uuid::new_v4(),
+        r2_key: "tenant/email/msg/file.pdf".into(),
+        file_name: Some("file.pdf".into()),
+        file_size_bytes: Some(2048),
+        source_subject: Some("件名".into()),
+        source_sender: Some("from@example.com".into()),
+        source_received_at: Some(chrono::Utc::now()),
+        expire_at: chrono::Utc::now() + chrono::Duration::hours(expire_in_hours),
+    }
+}
+
+// ============================================================
+// GET /api/internal/notify/view/{token}
+// ============================================================
+
+#[tokio::test]
+async fn test_internal_view_success() {
+    test_group!("Internal: notify view success");
+    test_case!("有効な token は r2_key + メタを返す", {
+        let _guard = crate::common::ENV_LOCK.lock().unwrap();
+        std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        let mut state = setup_mock_app_state();
+        let _mock = install_mock(&mut state);
+        let base_url = crate::common::spawn_test_server(state).await;
+
+        let token = Uuid::new_v4();
+        let jwt = crate::common::create_test_internal_jwt();
+        let res = reqwest::Client::new()
+            .get(format!("{base_url}/api/internal/notify/view/{token}"))
+            .header("Authorization", format!("Bearer {jwt}"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(res.status(), 200);
+        let body: Value = res.json().await.unwrap();
+        // internal は公開 metadata と違い r2_key を含む
+        assert_eq!(body["r2_key"], "mock/key");
+        assert_eq!(body["file_name"], "mock.pdf");
+        assert_eq!(body["file_size_bytes"], 1024);
+        // document_id / tenant_id は露出しない
+        assert!(body.get("document_id").is_none());
+        assert!(body.get("tenant_id").is_none());
+    });
+}
+
+#[tokio::test]
+async fn test_internal_view_not_found() {
+    test_group!("Internal: notify view not found");
+    test_case!("存在しない token は 404", {
+        let _guard = crate::common::ENV_LOCK.lock().unwrap();
+        std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        let mut state = setup_mock_app_state();
+        let mock = install_mock(&mut state);
+        *mock.view_override.lock().unwrap() = Some(None);
+        let base_url = crate::common::spawn_test_server(state).await;
+
+        let token = Uuid::new_v4();
+        let jwt = crate::common::create_test_internal_jwt();
+        let res = reqwest::Client::new()
+            .get(format!("{base_url}/api/internal/notify/view/{token}"))
+            .header("Authorization", format!("Bearer {jwt}"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(res.status(), 404);
+    });
+}
+
+#[tokio::test]
+async fn test_internal_view_expired() {
+    test_group!("Internal: notify view expired");
+    test_case!("期限切れ token は 410 Gone", {
+        let _guard = crate::common::ENV_LOCK.lock().unwrap();
+        std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        let mut state = setup_mock_app_state();
+        let mock = install_mock(&mut state);
+        *mock.view_override.lock().unwrap() = Some(Some(sample_view(-1)));
+        let base_url = crate::common::spawn_test_server(state).await;
+
+        let token = Uuid::new_v4();
+        let jwt = crate::common::create_test_internal_jwt();
+        let res = reqwest::Client::new()
+            .get(format!("{base_url}/api/internal/notify/view/{token}"))
+            .header("Authorization", format!("Bearer {jwt}"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(res.status(), 410);
+    });
+}
+
+#[tokio::test]
+async fn test_internal_view_db_error() {
+    test_group!("Internal: notify view db error");
+    test_case!("get_for_view が失敗すると 500", {
+        let _guard = crate::common::ENV_LOCK.lock().unwrap();
+        std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        let mut state = setup_mock_app_state();
+        let mock = install_mock(&mut state);
+        mock.fail_next.store(true, Ordering::SeqCst);
+        let base_url = crate::common::spawn_test_server(state).await;
+
+        let token = Uuid::new_v4();
+        let jwt = crate::common::create_test_internal_jwt();
+        let res = reqwest::Client::new()
+            .get(format!("{base_url}/api/internal/notify/view/{token}"))
+            .header("Authorization", format!("Bearer {jwt}"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(res.status(), 500);
+    });
+}
+
+#[tokio::test]
+async fn test_internal_view_requires_internal_jwt() {
+    test_group!("Internal: notify view auth required");
+    test_case!("internal JWT なしは 401", {
+        let _guard = crate::common::ENV_LOCK.lock().unwrap();
+        std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        let mut state = setup_mock_app_state();
+        let _mock = install_mock(&mut state);
+        let base_url = crate::common::spawn_test_server(state).await;
+
+        let token = Uuid::new_v4();
+        let res = reqwest::Client::new()
+            .get(format!("{base_url}/api/internal/notify/view/{token}"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(res.status(), 401);
+    });
+}
+
+// ============================================================
+// POST /api/internal/notify/view/{token}/read
+// ============================================================
+
+#[tokio::test]
+async fn test_internal_mark_read_success() {
+    test_group!("Internal: notify mark read success");
+    test_case!("有効な token の既読化は 204", {
+        let _guard = crate::common::ENV_LOCK.lock().unwrap();
+        std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        let mut state = setup_mock_app_state();
+        let _mock = install_mock(&mut state);
+        let base_url = crate::common::spawn_test_server(state).await;
+
+        let token = Uuid::new_v4();
+        let jwt = crate::common::create_test_internal_jwt();
+        let res = reqwest::Client::new()
+            .post(format!("{base_url}/api/internal/notify/view/{token}/read"))
+            .header("Authorization", format!("Bearer {jwt}"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(res.status(), 204);
+    });
+}
+
+#[tokio::test]
+async fn test_internal_mark_read_not_found() {
+    test_group!("Internal: notify mark read not found");
+    test_case!("存在しない token の既読化は 404", {
+        let _guard = crate::common::ENV_LOCK.lock().unwrap();
+        std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        let mut state = setup_mock_app_state();
+        let mock = install_mock(&mut state);
+        mock.mark_read_none.store(true, Ordering::SeqCst);
+        let base_url = crate::common::spawn_test_server(state).await;
+
+        let token = Uuid::new_v4();
+        let jwt = crate::common::create_test_internal_jwt();
+        let res = reqwest::Client::new()
+            .post(format!("{base_url}/api/internal/notify/view/{token}/read"))
+            .header("Authorization", format!("Bearer {jwt}"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(res.status(), 404);
+    });
+}
+
+#[tokio::test]
+async fn test_internal_mark_read_db_error() {
+    test_group!("Internal: notify mark read db error");
+    test_case!("mark_read が失敗すると 500", {
+        let _guard = crate::common::ENV_LOCK.lock().unwrap();
+        std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        let mut state = setup_mock_app_state();
+        let mock = install_mock(&mut state);
+        mock.fail_next.store(true, Ordering::SeqCst);
+        let base_url = crate::common::spawn_test_server(state).await;
+
+        let token = Uuid::new_v4();
+        let jwt = crate::common::create_test_internal_jwt();
+        let res = reqwest::Client::new()
+            .post(format!("{base_url}/api/internal/notify/view/{token}/read"))
+            .header("Authorization", format!("Bearer {jwt}"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(res.status(), 500);
+    });
+}


### PR DESCRIPTION
## 概要

#434 lockdown (`allUsers` / `--allow-unauthenticated` 削除) の caller 移行のうち、**notify 公開 viewer** を Worker 側 (nuxt-notify) に寄せるための **rust 側土台 (PR 1/N)**。

lockdown 後は公開 `/api/notify/v/*` (viewer 本体) と `/api/notify/read/*` (既読化) が rust に **public 到達できなくなる**。viewer Worker が OIDC (`aud=alc-api-internal`) で叩ける internal 経路を `require_internal_jwt` 配下に追加し、Worker が **KV cache + R2 直配信** + **既読化維持** できるようにする。

確定設計 (issue #434 で user と確認):
- token は既存 opaque `read_token` (UUID) を継続。件名等は URL に載せず Worker **KV** に保持 (recall 可)
- 既読化は viewer Worker が rust internal (OIDC) を叩いて維持
- inline 画像 (`image.jpg`) は redacted(.jpg) のみ Worker が R2 直配信、非 redacted は画像送信しない (後続 PR)

## 変更点

- `crates/alc-notify/src/viewer.rs`:
  - `internal_router()` を追加
  - `GET /api/internal/notify/view/{token}` → `InternalViewInfo` (公開 `ViewMetadata` と違い **r2_key を含む** = trusted caller が R2 fetch に使う)。期限切れ 410 / 不在 404 / 既読化しない
  - `POST /api/internal/notify/view/{token}/read` → 既読化 (旧 public `/read` の置換)。既読済みも 204 idempotent / 不在 404
  - 既存 `get_for_view` / `mark_read` (両方 SECURITY DEFINER、tenant 不要) を再利用
- `src/routes/mod.rs`: `internal_protected` に `notify_viewer::internal_router()` を merge
- `tests/mock_helpers/repos_d.rs`: `MockNotifyDeliveryRepository` に `view_override` / `mark_read_none` を追加 (既存 default 挙動は不変)
- `tests/mock_tests/mock_notify_view_internal_test.rs` (新規): view success / 404 / 410 / 500 / 401 + read success / 404 / 500 の 8 mock test
- viewer.rs unit test に `build_internal_view_info` の pure test を追加 (r2_key 含む / document_id・tenant_id 非露出)

## 検証

- `cargo fmt` 済み
- `cargo check -p alc-notify` / `cargo check -p rust-alc-api --lib --test mock_misc` green

## 後続 (このPRには含めない)

- nuxt-notify: R2 + KV binding + server route で viewer Worker 実装、rust internal を OIDC で叩く配線
- distribute.rs: viewer URL を Worker origin へ向ける + KV publish
- 旧 public `/api/notify/v/*` `/api/notify/read/*` の撤去 (lockdown cutover 時)

Refs #434

---
_Generated by [Claude Code](https://claude.ai/code/session_01SRVaeXY89DuETaakvY5HW7)_