### PR TITLE
feat(notify): distribute 時に viewer KV を満たす register-view (PR 2, Refs #434)

### DIFF
--- a/.claude/skills/rust-alc-api-map/SKILL.md
+++ b/.claude/skills/rust-alc-api-map/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rust-alc-api-map
-generated-from: rust-alc-api:563dc68c7d8418a3279a2ad4d451462b785bc292
+generated-from: rust-alc-api:0d97265948b729d6f54cbb5171ef6464dafd5dce
 paths: [crates/, src/, migrations/]
 description: rust-alc-api (アルコールチェッカー基盤の Rust/Axum Cargo workspace — 13 domain crate + gateway/tenko/carins/dtako/trouble の複数バイナリ、PostgreSQL+RLS、Cloud Run) の構造ナビゲーション。どの crate に何のルートがあるか / monolith(rust-alc-api) と per-domain API + gateway の二系統 / RLS・migration・deploy/release 分離の gotcha を 1 枚にまとめる。トリガー:「rust-alc-api」「alc-api」「alc-notify」「alc-tenko」「alc-trouble」「alc-carins」「alc-dtako」「gateway」「tenko-api」「carins-api」「dtako-api」「trouble-api」「RLS テナント」「sqlx migration」「ts-rs」「Release Wave」「Bazel」等。
 ---

--- a/crates/alc-notify/src/distribute.rs
+++ b/crates/alc-notify/src/distribute.rs
@@ -16,6 +16,7 @@ use alc_core::AppState;
 
 use crate::clients::line::{LineClient, LineConfig};
 use crate::clients::lineworks::{LineworksBotClient, LineworksBotConfig};
+use crate::viewer_register::{build_register_body, ViewerRegisterClient};
 
 pub fn tenant_router() -> Router<AppState> {
     Router::new()
@@ -333,6 +334,16 @@ async fn distribute(
     let line_client = LineClient::new();
     let lw_client = LineworksBotClient::new();
 
+    // viewer Worker (nuxt-notify) の KV へ view:{token} を登録する client (Refs #434)。
+    // env 未設定なら None (= 非破壊)。viewer が配信する r2_key は redacted 優先
+    // (= rust viewer の COALESCE(redacted_r2_key, r2_key) と一致させる)。
+    let viewer_register = ViewerRegisterClient::from_env();
+    let view_r2_key = doc
+        .redacted_r2_key
+        .clone()
+        .unwrap_or_else(|| doc.r2_key.clone());
+    let view_expire = chrono::Utc::now() + chrono::Duration::days(retention_days as i64);
+
     // image メッセージは PDF + extracted_data.logistics がある時のみ送る
     // (PDF 以外、または配車手配票でない PDF は画像送信しない)
     let send_image = should_send_image(&doc);
@@ -341,6 +352,25 @@ async fn distribute(
     let mut failed = 0;
 
     for (delivery, recipient) in deliveries.iter().zip(recipients.iter()) {
+        // KV 登録は best-effort。失敗しても配信は止めない (旧 viewer / 再配信が fallback)。
+        if let Some(rc) = viewer_register.as_ref() {
+            let body = build_register_body(
+                delivery.read_token,
+                &view_r2_key,
+                document_id,
+                delivery.recipient_id,
+                doc.file_name.as_deref(),
+                doc.file_size_bytes,
+                doc.source_subject.as_deref(),
+                doc.source_sender.as_deref(),
+                Some(doc.created_at),
+                view_expire,
+            );
+            if let Err(e) = rc.register(&body).await {
+                tracing::warn!("register-view: {e}");
+            }
+        }
+
         let read_url = format!("{}/api/notify/read/{}", api_origin, delivery.read_token);
         // 画像を併送する場合は本文の「▶ 詳細: {url}」行を省く (画像 inline で見えるので冗長)。
         // 画像なし (テキストのみ) の場合は従来通り URL を入れる。

--- a/crates/alc-notify/src/lib.rs
+++ b/crates/alc-notify/src/lib.rs
@@ -17,3 +17,4 @@ pub mod redact;
 pub mod repo;
 pub mod test_endpoints;
 pub mod viewer;
+pub mod viewer_register;

--- a/crates/alc-notify/src/viewer_register.rs
+++ b/crates/alc-notify/src/viewer_register.rs
@@ -1,0 +1,202 @@
+//! viewer Worker (nuxt-notify) の KV に `view:{token}` を登録する client (Refs #434)。
+//!
+//! lockdown 後の公開 viewer は Worker(KV+R2) だけで完結する。rust は配信 (distribute) 時に
+//! token→{r2_key, メタ} を nuxt-notify の `/api/notify/register-view` に **best-effort** で
+//! POST し KV を満たすだけ。失敗しても配信は止めない (旧 rust viewer / 再 distribute が fallback)。
+//!
+//! 認証は `INTERNAL_SHARED_SECRET` (全 stack 同値、`x-notify-internal-secret` header)。
+//! 外部 API なのでテスト可能性のため endpoint を struct field 化 (wiremock で差し替え)。
+
+use chrono::{DateTime, Utc};
+use serde_json::json;
+use uuid::Uuid;
+
+pub struct ViewerRegisterClient {
+    endpoint: String,
+    secret: String,
+    http: reqwest::Client,
+}
+
+impl ViewerRegisterClient {
+    /// env から構築。`NOTIFY_FRONTEND_URL` + `INTERNAL_SHARED_SECRET` の両方が無ければ
+    /// `None` (= register 無効、非破壊)。
+    pub fn from_env() -> Option<Self> {
+        let frontend = std::env::var("NOTIFY_FRONTEND_URL").ok()?;
+        let secret = std::env::var("INTERNAL_SHARED_SECRET").ok()?;
+        let endpoint = format!(
+            "{}/api/notify/register-view",
+            frontend.trim_end_matches('/')
+        );
+        Some(Self::with_endpoint(endpoint, secret))
+    }
+
+    pub fn with_endpoint(endpoint: String, secret: String) -> Self {
+        Self {
+            endpoint,
+            secret,
+            http: reqwest::Client::new(),
+        }
+    }
+
+    /// KV に view レコードを登録。2xx 以外 / 通信失敗は `Err` (呼び出し側は warn して継続)。
+    pub async fn register(&self, body: &serde_json::Value) -> Result<(), String> {
+        let resp = self
+            .http
+            .post(&self.endpoint)
+            .header("x-notify-internal-secret", &self.secret)
+            .json(body)
+            .send()
+            .await
+            .map_err(|e| format!("register-view request failed: {e}"))?;
+        if resp.status().is_success() {
+            Ok(())
+        } else {
+            Err(format!("register-view status {}", resp.status()))
+        }
+    }
+}
+
+/// register-view へ送る JSON body を組み立てる (pure)。
+#[allow(clippy::too_many_arguments)]
+pub fn build_register_body(
+    token: Uuid,
+    r2_key: &str,
+    document_id: Uuid,
+    recipient_id: Uuid,
+    file_name: Option<&str>,
+    file_size_bytes: Option<i64>,
+    source_subject: Option<&str>,
+    source_sender: Option<&str>,
+    source_received_at: Option<DateTime<Utc>>,
+    expire_at: DateTime<Utc>,
+) -> serde_json::Value {
+    json!({
+        "token": token.to_string(),
+        "r2_key": r2_key,
+        "document_id": document_id.to_string(),
+        "recipient_id": recipient_id.to_string(),
+        "file_name": file_name,
+        "file_size_bytes": file_size_bytes,
+        "source_subject": source_subject,
+        "source_sender": source_sender,
+        "source_received_at": source_received_at.map(|t| t.to_rfc3339()),
+        "expire_at": expire_at.to_rfc3339(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wiremock::matchers::{header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn ts(s: &str) -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339(s).unwrap().with_timezone(&Utc)
+    }
+
+    #[test]
+    fn build_register_body_shape() {
+        let token = Uuid::nil();
+        let doc = Uuid::nil();
+        let rcp = Uuid::nil();
+        let body = build_register_body(
+            token,
+            "tenant/m/file.pdf",
+            doc,
+            rcp,
+            Some("file.pdf"),
+            Some(2048),
+            Some("件名"),
+            Some("from@example.com"),
+            Some(ts("2026-06-27T00:00:00Z")),
+            ts("2026-07-04T00:00:00Z"),
+        );
+        assert_eq!(body["token"], token.to_string());
+        assert_eq!(body["r2_key"], "tenant/m/file.pdf");
+        assert_eq!(body["document_id"], doc.to_string());
+        assert_eq!(body["recipient_id"], rcp.to_string());
+        assert_eq!(body["file_name"], "file.pdf");
+        assert_eq!(body["file_size_bytes"], 2048);
+        assert_eq!(body["source_subject"], "件名");
+        assert_eq!(body["source_sender"], "from@example.com");
+        assert_eq!(body["source_received_at"], "2026-06-27T00:00:00+00:00");
+        assert_eq!(body["expire_at"], "2026-07-04T00:00:00+00:00");
+    }
+
+    #[test]
+    fn build_register_body_nulls() {
+        let body = build_register_body(
+            Uuid::nil(),
+            "k",
+            Uuid::nil(),
+            Uuid::nil(),
+            None,
+            None,
+            None,
+            None,
+            None,
+            ts("2026-07-04T00:00:00Z"),
+        );
+        assert!(body["file_name"].is_null());
+        assert!(body["file_size_bytes"].is_null());
+        assert!(body["source_subject"].is_null());
+        assert!(body["source_sender"].is_null());
+        assert!(body["source_received_at"].is_null());
+    }
+
+    #[tokio::test]
+    async fn register_success_sends_secret_header() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/notify/register-view"))
+            .and(header("x-notify-internal-secret", "sek"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({"ok": true})))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = ViewerRegisterClient::with_endpoint(
+            format!("{}/api/notify/register-view", server.uri()),
+            "sek".into(),
+        );
+        let body = build_register_body(
+            Uuid::nil(),
+            "k",
+            Uuid::nil(),
+            Uuid::nil(),
+            None,
+            None,
+            None,
+            None,
+            None,
+            ts("2026-07-04T00:00:00Z"),
+        );
+        assert!(client.register(&body).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn register_non_2xx_is_err() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(401))
+            .mount(&server)
+            .await;
+        let client = ViewerRegisterClient::with_endpoint(
+            format!("{}/api/notify/register-view", server.uri()),
+            "sek".into(),
+        );
+        let err = client.register(&json!({})).await.unwrap_err();
+        assert!(err.contains("401"));
+    }
+
+    #[tokio::test]
+    async fn register_unreachable_is_err() {
+        // 即座に閉じている port に向けて通信失敗を起こす
+        let client = ViewerRegisterClient::with_endpoint(
+            "http://127.0.0.1:1/api/notify/register-view".into(),
+            "sek".into(),
+        );
+        let err = client.register(&json!({})).await.unwrap_err();
+        assert!(err.contains("request failed"));
+    }
+}


### PR DESCRIPTION
## 概要

#434 lockdown 後の公開 viewer を Worker(KV+R2) だけで配信する移行の **PR 2** (rust 側、非破壊)。

distribute がデリバリ作成後、各 `read_token` を nuxt-notify の `/api/notify/register-view` (PR ippoan/nuxt-notify#99 で merge 済) に **best-effort** で POST し、KV に `view:{token}` → `{r2_key, メタ}` を登録する。これで Worker が runtime に rust を呼ばず viewer 配信できる土台が満ちる。

**まだトラフィックは切り替えない** (viewer ページ・message URL は従来どおり rust 経由)。本 PR は KV を満たすだけ = 非破壊。

## 変更点

- `crates/alc-notify/src/viewer_register.rs` (新規):
  - `ViewerRegisterClient` — endpoint 注入可 (wiremock テスト用)、`x-notify-internal-secret` header に `INTERNAL_SHARED_SECRET` を載せて POST。`from_env` は `NOTIFY_FRONTEND_URL` + `INTERNAL_SHARED_SECRET` 両方揃った時だけ `Some` (未設定は `None` = 非破壊)
  - `build_register_body` (pure) — token/r2_key/document_id/recipient_id/メタ/expire を JSON 化
  - tests: body shape (full / nulls) + register success(secret header 検証) / 4xx / unreachable
- `crates/alc-notify/src/distribute.rs`:
  - 送信ループで best-effort register (失敗は `warn`、配信は継続)
  - viewer が配信する `r2_key` は **redacted 優先** (`COALESCE(redacted_r2_key, r2_key)` = rust viewer と一致)
  - `expire_at = now + retention_days` (DB の `NOW() + retention` と整合)
  - `source_received_at` は `doc.created_at` で代用 (NotifyDocument に専用 field 無し)
- 認証 secret は既存 `INTERNAL_SHARED_SECRET` (rust に `render.sh`/staging yaml で注入済、全 stack 同値)
- `rust-alc-api-map` SKILL.md の `generated-from` を現 main に bump (skills-check 対策)

## 検証

- `cargo fmt` / `cargo check -p alc-notify --tests` / `cargo clippy -p alc-notify --tests` green

## 後続

- viewer ページ `/v/[token].vue` を同一オリジン fetch + `content_type` 利用に切替 / message の viewer URL・image URL を Worker へ repoint
- 管理画面「既読」列を KV (`read:{doc}:{rcp}`) から読む
- lockdown cutover で旧 public `/api/notify/v/*` `/read/*` 撤去

Refs #434

---
_Generated by [Claude Code](https://claude.ai/code/session_01SRVaeXY89DuETaakvY5HW7)_