### PR TITLE
feat(notify): 配信リンクを Worker viewer/image へ repoint (PR 4, Refs #434 cutover)

### DIFF
--- a/.claude/skills/rust-alc-api-map/SKILL.md
+++ b/.claude/skills/rust-alc-api-map/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rust-alc-api-map
-generated-from: rust-alc-api:0d97265948b729d6f54cbb5171ef6464dafd5dce
+generated-from: rust-alc-api:a34db468ffbdb4339f6ee2c0e6b10a1de353ef97
 paths: [crates/, src/, migrations/]
 description: rust-alc-api (アルコールチェッカー基盤の Rust/Axum Cargo workspace — 13 domain crate + gateway/tenko/carins/dtako/trouble の複数バイナリ、PostgreSQL+RLS、Cloud Run) の構造ナビゲーション。どの crate に何のルートがあるか / monolith(rust-alc-api) と per-domain API + gateway の二系統 / RLS・migration・deploy/release 分離の gotcha を 1 枚にまとめる。トリガー:「rust-alc-api」「alc-api」「alc-notify」「alc-tenko」「alc-trouble」「alc-carins」「alc-dtako」「gateway」「tenko-api」「carins-api」「dtako-api」「trouble-api」「RLS テナント」「sqlx migration」「ts-rs」「Release Wave」「Bazel」等。
 ---

--- a/crates/alc-notify/src/distribute.rs
+++ b/crates/alc-notify/src/distribute.rs
@@ -328,8 +328,10 @@ async fn distribute(
         }
     }
 
-    let api_origin =
-        std::env::var("API_ORIGIN").unwrap_or_else(|_| "https://localhost:8080".into());
+    // viewer / image のリンク先は **nuxt-notify Worker** (= KV+R2 配信、#434 cutover)。
+    // 旧 rust `/api/notify/read/*` `/api/notify/v/*` は使わない (read-tracking は viewer
+    // ページ表示時に Worker が KV へ記録する)。
+    let frontend = crate::read_tracker::frontend_url();
 
     let line_client = LineClient::new();
     let lw_client = LineworksBotClient::new();
@@ -371,18 +373,21 @@ async fn distribute(
             }
         }
 
-        let read_url = format!("{}/api/notify/read/{}", api_origin, delivery.read_token);
+        // 詳細リンクは Worker の viewer ページ。表示時に Worker が KV へ既読記録する。
+        let view_url = crate::read_tracker::build_view_url(&frontend, delivery.read_token);
         // 画像を併送する場合は本文の「▶ 詳細: {url}」行を省く (画像 inline で見えるので冗長)。
         // 画像なし (テキストのみ) の場合は従来通り URL を入れる。
-        let message_url: Option<&str> = if send_image { None } else { Some(&read_url) };
+        let message_url: Option<&str> = if send_image { None } else { Some(&view_url) };
         let message = build_distribute_message(&doc, message_url);
         // 注: URL を `.jpg` 終わりにするのは必須。LINE Messaging API / LINE WORKS
         // Bot は image message の `originalContentUrl` を **拡張子で** 画像判定
         // するため、`/image` (拡張子なし) だと URL がテキストリンクとして表示される。
+        // Worker の image route は redacted(.jpg) のみ配信 (非 redacted は 415)。
         let image_url = if send_image {
             Some(format!(
                 "{}/api/notify/v/{}/image.jpg",
-                api_origin, delivery.read_token
+                frontend.trim_end_matches('/'),
+                delivery.read_token
             ))
         } else {
             None


### PR DESCRIPTION
## 概要

#434 viewer 移行の **cutover PR (rust 側)**。配信メッセージのリンクを rust から **nuxt-notify Worker** へ向け替える。

- 詳細リンク: `{API_ORIGIN}/api/notify/read/{token}` (rust /read) → **`{NOTIFY_FRONTEND_URL}/v/{token}`** (Worker viewer ページ)
- 画像: `{API_ORIGIN}/api/notify/v/{token}/image.jpg` (rust) → **`{NOTIFY_FRONTEND_URL}/api/notify/v/{token}/image.jpg`** (Worker image route、redacted .jpg のみ)

これで配信〜閲覧の runtime 経路が完全に Worker(KV+R2) になる。**read-tracking は viewer ページ表示時に Worker が KV (`read:{doc}:{rcp}`) へ記録**する（旧 rust `/read` は経由しない）。view データは PR #455 の register で KV に投入済み。

## 変更点 (`crates/alc-notify/src/distribute.rs`)

- `api_origin` (rust 自身) → `frontend` (`read_tracker::frontend_url()`) ベースに変更
- 詳細リンクは `read_tracker::build_view_url(frontend, token)` = `{frontend}/v/{token}`
- 画像 URL は `{frontend}/api/notify/v/{token}/image.jpg`
- 旧 rust public viewer (`/api/notify/v/*`) / read (`/api/notify/read/*`) はコード上は残置（lockdown PR で撤去）

## 補足

- 管理画面「既読」列は現状 rust `read_at` を読むため、本 PR 後の新規配信の既読は KV に入り**管理画面には反映されない**（後続の「管理画面 既読 KV 化」PR で対応）。本番未使用のため移行窓は考慮不要との確認済み
- `build_distribute_message` 等のテストはリテラル URL を使うため影響なし。`cargo fmt`/`clippy -p alc-notify --tests` green
- `rust-alc-api-map` SKILL.md の `generated-from` を現 main に bump

## 後続
- nuxt-notify: 管理画面「既読」を KV 参照へ
- lockdown cutover: 旧 public `/api/notify/v/*` `/read/*` 撤去 + `allUsers` 削除

Refs #434

---
_Generated by [Claude Code](https://claude.ai/code/session_01SRVaeXY89DuETaakvY5HW7)_