### PR TITLE
feat(notify): register body に tenant_id を追加 (PR 6, Refs #434)

### DIFF
--- a/.claude/skills/rust-alc-api-map/SKILL.md
+++ b/.claude/skills/rust-alc-api-map/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rust-alc-api-map
-generated-from: rust-alc-api:a34db468ffbdb4339f6ee2c0e6b10a1de353ef97
+generated-from: rust-alc-api:efcdfe12ff41236585e2e028c4da5aa5f50240a6
 paths: [crates/, src/, migrations/]
 description: rust-alc-api (アルコールチェッカー基盤の Rust/Axum Cargo workspace — 13 domain crate + gateway/tenko/carins/dtako/trouble の複数バイナリ、PostgreSQL+RLS、Cloud Run) の構造ナビゲーション。どの crate に何のルートがあるか / monolith(rust-alc-api) と per-domain API + gateway の二系統 / RLS・migration・deploy/release 分離の gotcha を 1 枚にまとめる。トリガー:「rust-alc-api」「alc-api」「alc-notify」「alc-tenko」「alc-trouble」「alc-carins」「alc-dtako」「gateway」「tenko-api」「carins-api」「dtako-api」「trouble-api」「RLS テナント」「sqlx migration」「ts-rs」「Release Wave」「Bazel」等。
 ---

--- a/crates/alc-notify/src/distribute.rs
+++ b/crates/alc-notify/src/distribute.rs
@@ -358,6 +358,7 @@ async fn distribute(
         if let Some(rc) = viewer_register.as_ref() {
             let body = build_register_body(
                 delivery.read_token,
+                tenant_id,
                 &view_r2_key,
                 document_id,
                 delivery.recipient_id,

--- a/crates/alc-notify/src/viewer_register.rs
+++ b/crates/alc-notify/src/viewer_register.rs
@@ -57,9 +57,13 @@ impl ViewerRegisterClient {
 }
 
 /// register-view へ送る JSON body を組み立てる (pure)。
+/// `tenant_id` は viewer Worker が既読を `read:{tenant_id}:{document_id}:{recipient_id}` に
+/// テナント前置で記録し、管理画面 read-status をサーバ側でテナント分離するために要る
+/// (KV multi-tenant の定石 = tenant prefix。Refs #434)。
 #[allow(clippy::too_many_arguments)]
 pub fn build_register_body(
     token: Uuid,
+    tenant_id: Uuid,
     r2_key: &str,
     document_id: Uuid,
     recipient_id: Uuid,
@@ -72,6 +76,7 @@ pub fn build_register_body(
 ) -> serde_json::Value {
     json!({
         "token": token.to_string(),
+        "tenant_id": tenant_id.to_string(),
         "r2_key": r2_key,
         "document_id": document_id.to_string(),
         "recipient_id": recipient_id.to_string(),
@@ -97,10 +102,12 @@ mod tests {
     #[test]
     fn build_register_body_shape() {
         let token = Uuid::nil();
+        let tenant = Uuid::nil();
         let doc = Uuid::nil();
         let rcp = Uuid::nil();
         let body = build_register_body(
             token,
+            tenant,
             "tenant/m/file.pdf",
             doc,
             rcp,
@@ -112,6 +119,7 @@ mod tests {
             ts("2026-07-04T00:00:00Z"),
         );
         assert_eq!(body["token"], token.to_string());
+        assert_eq!(body["tenant_id"], tenant.to_string());
         assert_eq!(body["r2_key"], "tenant/m/file.pdf");
         assert_eq!(body["document_id"], doc.to_string());
         assert_eq!(body["recipient_id"], rcp.to_string());
@@ -126,6 +134,7 @@ mod tests {
     #[test]
     fn build_register_body_nulls() {
         let body = build_register_body(
+            Uuid::nil(),
             Uuid::nil(),
             "k",
             Uuid::nil(),
@@ -160,6 +169,7 @@ mod tests {
             "sek".into(),
         );
         let body = build_register_body(
+            Uuid::nil(),
             Uuid::nil(),
             "k",
             Uuid::nil(),


### PR DESCRIPTION
## 概要

#434 viewer 移行の下準備。viewer Worker が**既読をテナント前置キー** `read:{tenant_id}:{document_id}:{recipient_id}` で記録できるよう、register body に `tenant_id` を追加する。

これにより後続 (nuxt-notify) の管理画面 read-status を **サーバ側でテナント分離**できる（KV multi-tenant の定石 = tenant prefix。`document_id` の秘匿に頼らない）。

**additive**: 現行 nuxt-notify の `register-view` は未知 field を無視するので非破壊。順序は本 PR (rust が tenant_id を送る) → nuxt-notify PR (tenant-aware read key + read-status)。

## 変更点

- `viewer_register.rs::build_register_body` に `tenant_id: Uuid` 引数 + JSON `tenant_id` を追加
- `distribute.rs`: register 呼び出しに `tenant_id` (= `tenant.0`) を渡す
- tests 更新（`tenant_id` assertion）
- `rust-alc-api-map` SKILL.md `generated-from` bump

## 検証
- `cargo fmt` / `cargo clippy -p alc-notify --tests` green

## 後続
- nuxt-notify: `read:{tenant_id}:{doc}:{rcp}` 化 + `GET /api/notify/read-status/{documentId}` (`requireAuth` で tenant_id 取得 → tenant scope list) + 管理画面「既読」マージ

設計根拠の web 調査: Worker+R2 binding 配信 / opaque token / KV tenant-prefix いずれも Cloudflare best practice に合致。

Refs #434

---
_Generated by [Claude Code](https://claude.ai/code/session_01SRVaeXY89DuETaakvY5HW7)_