### PR TITLE
ci: AR の rust-alc-api image を 3h cadence で能動削除する workflow を追加

### DIFF
--- a/.github/workflows/ar-cleanup.yml
+++ b/.github/workflows/ar-cleanup.yml
@@ -1,0 +1,101 @@
+name: Artifact Registry cleanup (rust-alc-api images)
+
+# `ghcr` は REMOTE_REPOSITORY (GHCR の pull-through cache)。GCP cleanup policy は
+# sweep が ~日次でしか回らず olderThan を短くしても実効保持が縮まないため、
+# rust-alc-api の image だけを 3h cadence で能動的に削除する。
+#
+# 安全性: flip-back (rollback) は GHCR (恒久正本) から digest 単位で再 pull される
+# ため、古い cache version を消しても rollback は壊れない (KEEP=1 で動作中 digest のみ保護)。
+#
+# 前提 (未充足だと削除 step が fail する):
+#   1. `secrets.GCP_SA_KEY` の SA に `roles/artifactregistry.repoAdmin` (または
+#      artifactregistry.versions.delete を含む custom role) を `ghcr` repo に grant 済み。
+#   2. remote repo で `gcloud artifacts docker images delete` が通ること
+#      (通らない場合は GCP cleanup policy + packageNamePrefixes へ切替)。
+
+on:
+  schedule:
+    - cron: '17 */3 * * *' # 3 時間ごと
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: '削除せず対象を列挙するだけ'
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ar-cleanup
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    env:
+      BASE: asia-northeast1-docker.pkg.dev/cloudsql-sv/ghcr/ghcr.io/ippoan
+      KEEP: 1 # 各 image で最新何版を常に残すか (動作中 digest 保護)
+      CUTOFF_EXPR: '3 hours ago'
+      # schedule では必ず削除、workflow_dispatch では input に従う (既定 dry-run)
+      DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || 'false' }}
+    steps:
+      - uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+      - uses: google-github-actions/setup-gcloud@v2
+
+      - name: Delete old cached versions
+        run: |
+          set -uo pipefail
+          CUTOFF=$(date -u -d "$CUTOFF_EXPR" +%Y-%m-%dT%H:%M:%S)
+          echo "Cutoff (UTC): $CUTOFF  / KEEP newest: $KEEP  / dry-run: $DRY_RUN"
+
+          IMAGES="
+            rust-alc-api
+            rust-alc-api-gateway
+            rust-alc-api-tenko
+            rust-alc-api-carins
+            rust-alc-api-dtako
+            rust-alc-api-trouble
+            rust-alc-api-camera
+            rust-alc-api-staging
+            rust-alc-api-tenko-staging
+            rust-alc-api-carins-staging
+            rust-alc-api-dtako-staging
+            rust-alc-api-trouble-staging
+            rust-alc-api-camera-staging
+            rust-alc-api-staging-db
+          "
+
+          deleted=0
+          kept=0
+          for img in $IMAGES; do
+            # 新しい順に列挙 → 最新 KEEP 個を除外 → 残りで cutoff より古いものを削除
+            gcloud artifacts docker images list "$BASE/$img" \
+              --sort-by=~CREATE_TIME \
+              --format='value(version,createTime.date("%Y-%m-%dT%H:%M:%S"))' 2>/dev/null \
+              | tail -n +$((KEEP + 1)) \
+              | while IFS=$'\t' read -r digest ctime; do
+                  [ -z "$digest" ] && continue
+                  if [[ "$ctime" < "$CUTOFF" ]]; then
+                    if [ "$DRY_RUN" = "true" ]; then
+                      echo "[dry-run] would delete $img@$digest ($ctime)"
+                    else
+                      echo "delete $img@$digest ($ctime)"
+                      gcloud artifacts docker images delete "$BASE/$img@$digest" \
+                        --delete-tags --quiet || echo "  !! delete failed for $img@$digest"
+                    fi
+                  fi
+                done
+          done
+
+      - name: Report repository size
+        if: always()
+        run: |
+          SIZE=$(gcloud artifacts repositories describe ghcr \
+            --project=cloudsql-sv --location=asia-northeast1 \
+            --format='value(sizeBytes)' 2>/dev/null || echo 0)
+          echo "## AR cleanup" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "ghcr repo size: $(( SIZE / 1024 / 1024 )) MB" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## 背景

Refs #458

AR の `ghcr` リポジトリ (GHCR の pull-through cache = `REMOTE_REPOSITORY`) が 6.6GB まで肥大化していた件の対処。

調査結果:
- リークではなく、既存 GCP cleanup policy (7日 + keep-recent-1) が効いた**定常サイズ**。6.6GB = 「直近7日分の build/deploy 量」。
- 内訳は **14 image** (本番7 + staging6 + staging-db) × 高頻度デプロイ × コミットごとの可変バイナリ層 + postgres ベースの staging-db。
- 縮めたいが `ghcr` は **daiun-salary / release-wave-gcp / secrets-inventory-gcp とも共有**しているため repo 全体の policy を強くしにくい。また GCP cleanup policy の sweep は ~日次でしか回らず、`olderThan` を 3h にしても実効保持が縮まない。

## 変更内容

`ar-size-audit.yml` の隣に `ar-cleanup.yml` を追加。**rust-alc-api 系 image だけ**を 3h cadence (`cron: '17 */3 * * *'`) で削除する scheduled workflow。

- 各 image を新しい順に列挙 → **最新 `KEEP=1` 版は常に残す** → 残りで cutoff (3h) より古い version を `gcloud artifacts docker images delete --delete-tags` で削除。
- `workflow_dispatch` の `dry_run` input (既定 `true`) で、まず削除対象の列挙だけ確認できる。schedule 実行は必ず削除。
- 最後に `ghcr` repo size を Step Summary に出力。

## rollback 安全性

flip-back (Release Wave の rollback) は **GHCR (恒久正本) から digest 単位で再 pull** される。Cloud Run deploy は digest pin なので、古い cache version を消しても rollback は壊れない (cache miss → GHCR から再取得)。よって `KEEP=1` で動作中 digest のみ保護すれば足りる。

## マージ前に必要な前提 (未充足だと削除 step が fail する)

1. **削除 IAM**: `secrets.GCP_SA_KEY` の SA に `roles/artifactregistry.repoAdmin` (または `artifactregistry.versions.delete` を含む custom role) を `ghcr` repo へ grant。現状 audit 用 SA は read only の可能性が高い。
2. **remote repo での手動 delete 可否**: GCP cleanup policy は remote repo を削除できている (7日実績) が、`gcloud artifacts docker images delete` が remote cache に通るかは別途要確認。まず `workflow_dispatch` を `dry_run=true` で実行 → 続けて手動で 1 digest 削除して通るか確認することを推奨。通らない場合は GCP cleanup policy + `packageNamePrefixes: ["ghcr.io/ippoan/rust-alc-api"]` 方式へ切替。

## 確認

- YAML 構文 OK (`python3 -c "import yaml; yaml.safe_load(...)"`)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019pfLVcVgNuex9E3k2p7YRD)_