### PR TITLE
ci(ar-cleanup): size レポートの整数演算バグを修正し job を落とさない

### DIFF
--- a/.github/workflows/ar-cleanup.yml
+++ b/.github/workflows/ar-cleanup.yml
@@ -120,14 +120,15 @@ jobs:
 
       - name: Report repository size
         if: always()
+        continue-on-error: true # size 表示の失敗で cleanup job を落とさない
         run: |
-          # sizeBytes は `repositories list` でのみ返る。集計に lag があり削除直後は旧値の場合あり。
-          SIZE=$(gcloud artifacts repositories list \
-            --project="$PROJECT" --location="$REGION" \
-            --filter='name~/ghcr$' --format='value(sizeBytes)' 2>/dev/null | head -1)
-          SIZE=${SIZE:-0}
+          # `value(sizeBytes)` は gcloud が MB float に整形して返すことがあり整数演算が壊れる。
+          # ar-size-audit と同じく json から sizeBytes(bytes) を取り python で MB 換算する。
+          MB=$(gcloud artifacts repositories list \
+                 --project="$PROJECT" --location="$REGION" --format='json' 2>/dev/null \
+               | python3 -c 'import json,sys; r=[x for x in json.load(sys.stdin) if x["name"].endswith("/ghcr")]; print(round(int(r[0].get("sizeBytes",0))/1024/1024,1) if r else "unknown")' 2>/dev/null)
           {
             echo "## AR cleanup"
             echo ""
-            echo "ghcr repo size: $(( SIZE / 1024 / 1024 )) MB (集計 lag あり)"
+            echo "ghcr repo size: ${MB:-unknown} MB (集計 lag あり、削除直後は旧値の場合あり)"
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## 背景

Refs #458

#461 の `ar-cleanup.yml` を `dry_run=true` で実機検証したところ:

- ✅ **keep-set 構築 = success**（空でない → 安全装置 OK）
- ✅ `[would delete]` が古い版を正しく列挙（cleanup ロジック自体は正常）
- ❌ **size レポート step が job を red にしていた**:
  ```
  7591.749: syntax error: invalid arithmetic operator (error token is ".749")
  ##[error]Process completed with exit code 1
  ```

原因: `gcloud artifacts repositories list --format='value(sizeBytes)'` が **MB の float（例 `7591.749`）** を返し、`$(( SIZE / 1024 / 1024 ))` の整数演算が壊れて exit 1。cleanup 本体が成功しても job 全体が失敗扱いになっていた。

## 変更内容

- size 取得を **json から `sizeBytes`（bytes 整数）を読み python で MB 換算**する方式に変更（`ar-size-audit.yml` と同じ実績ある方法）。
- report step に **`continue-on-error: true`** を付与（size 表示の失敗で cleanup job を落とさない）。

cleanup の keep-set / multi-pass ロジックは #461 のまま無変更。

## 確認

- YAML 構文 OK。
- dry-run で keep-set 非空・削除対象列挙は確認済み。本 PR merge 後に再度 `dry_run=true` → 実 run で size 表示まで通ることを確認予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019pfLVcVgNuex9E3k2p7YRD)_