### PR TITLE
ci: add dep-graph workflow for crate dependency visualization

### DIFF
--- a/.github/workflows/dep-graph.yml
+++ b/.github/workflows/dep-graph.yml
@@ -1,0 +1,74 @@
+name: dep-graph
+
+# `crates/...` (21 crate) の Bazel 依存グラフを `.dot` / `.svg` で出力し、
+# GitHub Actions artifact として公開する。ci-dashboard の
+# `/dep-graph/rust-alc-api` page から最新 artifact を取得して表示する。
+#
+# Refs ippoan/ci-dashboard#? (ci-dashboard 側 PR で番号確定後に更新)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'crates/**'
+      - 'BUILD.bazel'
+      - 'MODULE.bazel'
+      - '.github/workflows/dep-graph.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dep-graph-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  generate:
+    name: Generate dependency graph
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ippoan/setup-bazel@main
+        with:
+          disk-cache: bazel-depgraph
+          external-cache: true
+          repository-cache: true
+
+      - name: Install graphviz
+        run: sudo apt-get update && sudo apt-get install -y graphviz
+
+      - name: Query workspace dependency graph
+        run: |
+          set -euo pipefail
+          mkdir -p out
+          bazel query --output=graph 'deps(//crates/...)' > out/deps.dot
+          dot -Tsvg out/deps.dot -o out/deps.svg
+
+      - name: Write metadata
+        env:
+          REPO: ${{ github.repository }}
+          COMMIT_SHA: ${{ github.sha }}
+          REF: ${{ github.ref }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          GENERATED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          jq -n \
+            --arg repo "$REPO" \
+            --arg commit_sha "$COMMIT_SHA" \
+            --arg ref "$REF" \
+            --arg generated_at "$GENERATED_AT" \
+            --arg workflow_run_id "$RUN_ID" \
+            '{repo: $repo, commit_sha: $commit_sha, ref: $ref, generated_at: $generated_at, workflow_run_id: $workflow_run_id}' \
+            > out/meta.json
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dep-graph
+          path: out/
+          retention-days: 90
+          if-no-files-found: error


### PR DESCRIPTION
## Summary

- `.github/workflows/dep-graph.yml` を追加。`bazel query --output=graph 'deps(//crates/...)'` で 21 crate の依存グラフを `.dot` で出力し、`dot -Tsvg` で SVG 化、GitHub Actions artifact `dep-graph` にアップロードする
- main push 時 (`Cargo.toml` / `Cargo.lock` / `crates/**` / `BUILD.bazel` / `MODULE.bazel` / 本 workflow 変更時) と `workflow_dispatch` でトリガー
- `meta.json` に `repo` / `commit_sha` / `ref` / `generated_at` / `workflow_run_id` を記録 (ci-dashboard 側の page で「最終更新時刻 / SHA」表示用)
- `ippoan/setup-bazel@main` action + `disk-cache: bazel-depgraph` で既存 CI と同じ cache pattern。query だけなので build より大幅に軽量

## Background

ci-dashboard 側に `/dep-graph/rust-alc-api` page を追加し、本 artifact を取得して inline 表示する別 PR (ci-dashboard 側) と組み合わせて使う。リクエストの背景:
- rust-alc-api の Cargo workspace は 21 crate に膨らんでおり、依存把握が口頭ベース
- 既に Bazel (`MODULE.bazel` + `BUILD.bazel`) が全 crate に揃っているので `bazel query` で機械的に出せる

## Security

`run:` 内で扱う GitHub context 値 (`github.repository` / `github.sha` / `github.ref` / `github.run_id`) は全て `env:` 経由で渡し、`jq -n --arg ...` で安全に JSON 化。コマンドインジェクション対策済み。

## Test plan

- [ ] PR の workflow run 一覧では `dep-graph` は走らない (`branches: [main]` のため)。動作確認は merge 後の main push か `workflow_dispatch` で
- [ ] merge 後、Actions タブで `dep-graph` run の artifact に `deps.dot` / `deps.svg` / `meta.json` の 3 ファイルが存在することを確認
- [ ] `deps.svg` を browser で開いて 21 crate のノードが見えることを確認

Refs ippoan/ci-dashboard#443

---
_Generated by [Claude Code](https://claude.ai/code/session_01VcEf8ik2xsBfHE4JghfR3o)_