### PR TITLE
fix(dep-graph): restrict bazel query to workspace crates only

### DIFF
--- a/.github/workflows/dep-graph.yml
+++ b/.github/workflows/dep-graph.yml
@@ -42,10 +42,20 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y graphviz
 
       - name: Query workspace dependency graph
+        # `deps(//crates/...)` をそのまま流すと rules_rust crate_universe の
+        # external 依存 (数百 crate の transitive deps) が全部出て、生成 DOT が
+        # 巨大化して dot -Tsvg が 6 時間 timeout した (run #28321493713 で実測)。
+        # ここで見たいのは workspace 21 crate 間の **相互依存**だけなので
+        # `intersect //crates/...` で graph を workspace 内 target に絞り、
+        # `--noimplicit_deps` で toolchain 等の暗黙依存も除外する。
         run: |
           set -euo pipefail
           mkdir -p out
-          bazel query --output=graph 'deps(//crates/...)' > out/deps.dot
+          bazel query \
+            --noimplicit_deps \
+            --output=graph \
+            'deps(//crates/...) intersect //crates/...' \
+            > out/deps.dot
           dot -Tsvg out/deps.dot -o out/deps.svg
 
       - name: Write metadata


### PR DESCRIPTION
## 問題

#463 で追加した `dep-graph` workflow の初回 main 走行 (run [#28321493713](https://github.com/ippoan/rust-alc-api/actions/runs/28321493713)) が **6 時間 timeout で cancelled** した。

ログ末尾を見ると bazel は 21 packages → 625 packages まで load 完了して `bazel query` を return しているが、その後 `dot -Tsvg` が orphan process として走行し続け runner が GitHub Actions の 6h job limit で kill された:

```
12:00:23 Loading: 625 packages loaded
17:59:27 ##[error]The operation was canceled.
17:59:28 Terminate orphan process: pid (3608) (dot)
```

## 原因

`bazel query 'deps(//crates/...)'` は `deps(...)` の定義上 **推移的依存全部** = rules_rust crate_universe の external crate 群 (数百個の transitive deps を含む) を全部展開する。生成 DOT が巨大化し `dot -Tsvg` がメモリ・CPU を使い切って完走しない。

## 修正

ここで可視化したいのは ippoan workspace 21 crate (`//crates/...`) の **相互依存**だけなので、次の 2 点で query を絞る:

- `intersect //crates/...`: 結果集合を workspace 内 target に限定 (= external crate ノードを除外)
- `--noimplicit_deps`: rust toolchain など暗黙依存も除外

結果 DOT は workspace の 21 crate + rust_library/rust_binary ノード程度の小さなグラフになり、dot 変換も数秒で済む想定。

## Test plan

- [ ] merge 後、新しい `dep-graph` run が **数分以内に** 完走する (cancelled にならない)
- [ ] artifact `dep-graph` の `deps.svg` が生成され、ci-dashboard `/dep-graph/ippoan/rust-alc-api` で 21 crate のグラフが表示される

Refs ippoan/ci-dashboard#443

---
_Generated by [Claude Code](https://claude.ai/code/session_01VcEf8ik2xsBfHE4JghfR3o)_