### PR TITLE
feat(auth): require_internal_jwt を HS256/OIDC dual-accept に (Refs #434 Phase D)

### DIFF
--- a/.claude/skills/rust-alc-api-map/SKILL.md
+++ b/.claude/skills/rust-alc-api-map/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rust-alc-api-map
-generated-from: rust-alc-api:786c7704e7211c64750043a7f7f5518acfbdbdce
+generated-from: rust-alc-api:0ddb0d8c40f3f2a48552cff821e4d72267181719
 paths: [crates/, src/, migrations/]
 description: rust-alc-api (アルコールチェッカー基盤の Rust/Axum Cargo workspace — 13 domain crate + gateway/tenko/carins/dtako/trouble の複数バイナリ、PostgreSQL+RLS、Cloud Run) の構造ナビゲーション。どの crate に何のルートがあるか / monolith(rust-alc-api) と per-domain API + gateway の二系統 / RLS・migration・deploy/release 分離の gotcha を 1 枚にまとめる。トリガー:「rust-alc-api」「alc-api」「alc-notify」「alc-tenko」「alc-trouble」「alc-carins」「alc-dtako」「gateway」「tenko-api」「carins-api」「dtako-api」「trouble-api」「RLS テナント」「sqlx migration」「ts-rs」「Release Wave」「Bazel」等。
 ---
@@ -49,7 +49,10 @@ monolith と per-domain API は同じ domain crate (`alc-tenko` 等) を共有 �
   `.nest("/api", rust_alc_api::routes::router())`。背景 task: 60s ごと `check_overdue_schedules`。
 - **router 本体**: `src/routes/mod.rs` — 各 domain crate のルートを re-export し `router()` で結線。
   middleware: `require_tenant_header` (tenant/admin 共通、注入 identity 信頼) / `require_internal_jwt`
-  (auth-worker→internal ingest、aud=alc-api-internal) / `require_internal_shared_secret`
+  (auth-worker→internal ingest、aud=alc-api-internal。**#434 Phase D で HS256 / Google OIDC の
+  dual-accept 化**: `INTERNAL_AUTH_TRUST_OIDC=1` (`InternalOidcTrust` Extension) の時のみ
+  `verify_internal_oidc_aud` で OIDC を受理、署名は Cloud Run IAM が検証済み前提で aud のみ確認。
+  flag off は HS256 のみ = 非破壊) / `require_internal_shared_secret`
   (email-receiver→`/api/dtako/tickets`)。
   **#434 で monolith のローカル JWT 検証を撤去**: 旧 `require_jwt` / `require_tenant` (bare X-Tenant-ID
   フォールバック) / `TenantProxySecret` gate (#437) / 未配線の `require_tenant_or_device` (#436、device-token)

--- a/crates/alc-auth-jwt/src/lib.rs
+++ b/crates/alc-auth-jwt/src/lib.rs
@@ -195,6 +195,31 @@ pub fn verify_internal_token(
     Ok(token_data.claims)
 }
 
+/// lockdown (`allUsers` 削除) 後の OIDC 経路の検証 (Refs #434 Phase D)。
+///
+/// Cloud Run IAM (`--add-custom-audiences=alc-api-internal`) が **Google 署名を検証済み**で
+/// あることを前提に、本関数は `aud == alc-api-internal` と `exp` のみを確認する
+/// (confused-deputy 防止: `/alc-proxy` が mint する service-URL aud の OIDC を弾く)。
+/// 署名検証は IAM 網層が担保するため行わない。**`require_internal_jwt` 側で
+/// `INTERNAL_AUTH_TRUST_OIDC=1` の時だけ本経路に入る** (= lockdown 後限定。それまでは
+/// HS256 の `verify_internal_token` のみ)。
+pub fn verify_internal_oidc_aud(
+    token: &str,
+) -> Result<InternalClaims, jsonwebtoken::errors::Error> {
+    let mut validation = Validation::new(Algorithm::RS256); // Google OIDC は RS256
+                                                            // 署名は IAM が検証済み。alg header check 用に RS256 (本番) と HS256 (テスト) を許可。
+    validation.algorithms = vec![Algorithm::RS256, Algorithm::HS256];
+    validation.insecure_disable_signature_validation();
+    validation.validate_exp = true;
+    validation.set_audience(&[INTERNAL_AUD]);
+    let token_data = decode::<InternalClaims>(
+        token,
+        &DecodingKey::from_secret(b"unused-iam-verifies-signature"),
+        &validation,
+    )?;
+    Ok(token_data.claims)
+}
+
 pub const INTERNAL_AUD: &str = "alc-api-internal";
 
 /// Refresh token を生成し、(raw_token, hash) を返す
@@ -360,6 +385,83 @@ mod tests {
             )
             .unwrap();
             assert!(verify_internal_token(&token, &secret).is_err());
+        });
+    }
+
+    #[test]
+    fn test_internal_oidc_aud_accepts_correct_aud_without_signature() {
+        test_group!("内部JWT");
+        test_case!(
+            "OIDC: aud=alc-api-internal は署名検証なしで受理 (IAM 検証前提)",
+            {
+                use jsonwebtoken::{encode as jwt_encode, EncodingKey, Header};
+                let now = Utc::now();
+                let claims = InternalClaims {
+                    iss: "https://accounts.google.com".to_string(),
+                    aud: INTERNAL_AUD.to_string(),
+                    iat: now.timestamp(),
+                    exp: (now + Duration::seconds(3600)).timestamp(),
+                    env: None,
+                };
+                // verify_internal_token (HS256) では通らない別 secret で署名 → 署名は無視されることを示す。
+                let token = jwt_encode(
+                    &Header::new(Algorithm::HS256),
+                    &claims,
+                    &EncodingKey::from_secret(b"some-other-key-not-shared-secret"),
+                )
+                .unwrap();
+                let got = verify_internal_oidc_aud(&token).unwrap();
+                assert_eq!(got.aud, INTERNAL_AUD);
+            }
+        );
+    }
+
+    #[test]
+    fn test_internal_oidc_aud_rejects_wrong_aud() {
+        test_group!("内部JWT");
+        test_case!(
+            "OIDC: service-URL 等の別 aud は拒否 (confused-deputy 防止)",
+            {
+                use jsonwebtoken::{encode as jwt_encode, EncodingKey, Header};
+                let now = Utc::now();
+                let claims = InternalClaims {
+                    iss: "https://accounts.google.com".to_string(),
+                    aud: "https://rust-alc-api-xxxx.a.run.app".to_string(),
+                    iat: now.timestamp(),
+                    exp: (now + Duration::seconds(3600)).timestamp(),
+                    env: None,
+                };
+                let token = jwt_encode(
+                    &Header::new(Algorithm::HS256),
+                    &claims,
+                    &EncodingKey::from_secret(b"k"),
+                )
+                .unwrap();
+                assert!(verify_internal_oidc_aud(&token).is_err());
+            }
+        );
+    }
+
+    #[test]
+    fn test_internal_oidc_aud_rejects_expired() {
+        test_group!("内部JWT");
+        test_case!("OIDC: 期限切れは拒否", {
+            use jsonwebtoken::{encode as jwt_encode, EncodingKey, Header};
+            let now = Utc::now();
+            let claims = InternalClaims {
+                iss: "https://accounts.google.com".to_string(),
+                aud: INTERNAL_AUD.to_string(),
+                iat: (now - Duration::seconds(7200)).timestamp(),
+                exp: (now - Duration::seconds(3600)).timestamp(),
+                env: None,
+            };
+            let token = jwt_encode(
+                &Header::new(Algorithm::HS256),
+                &claims,
+                &EncodingKey::from_secret(b"k"),
+            )
+            .unwrap();
+            assert!(verify_internal_oidc_aud(&token).is_err());
         });
     }
 

--- a/crates/alc-core/src/auth_jwt.rs
+++ b/crates/alc-core/src/auth_jwt.rs
@@ -11,8 +11,8 @@
 
 pub use alc_auth_jwt::{
     create_internal_token, create_refresh_token, current_env_label, hash_refresh_token,
-    refresh_token_expires_at, verify_access_token, verify_internal_token, AccessTokenInput,
-    AppClaims, InternalClaims, JwtSecret, ACCESS_TOKEN_EXPIRY_SECS, INTERNAL_AUD,
+    refresh_token_expires_at, verify_access_token, verify_internal_oidc_aud, verify_internal_token,
+    AccessTokenInput, AppClaims, InternalClaims, JwtSecret, ACCESS_TOKEN_EXPIRY_SECS, INTERNAL_AUD,
     REFRESH_TOKEN_EXPIRY_DAYS,
 };
 

--- a/crates/alc-core/src/auth_middleware.rs
+++ b/crates/alc-core/src/auth_middleware.rs
@@ -3,7 +3,14 @@ pub use crate::middleware::{AuthUser, TenantId};
 use axum::{extract::Request, http::StatusCode, middleware::Next, response::Response, Extension};
 use uuid::Uuid;
 
-use crate::auth_jwt::{verify_internal_token, JwtSecret};
+use crate::auth_jwt::{verify_internal_oidc_aud, verify_internal_token, JwtSecret};
+
+/// lockdown (`allUsers` 削除) 後に internal-auth の OIDC 経路を有効化するフラグ
+/// (Refs #434 Phase D)。`require_internal_jwt` 配下に Extension で注入する。
+/// `true` の時だけ Google OIDC (aud=alc-api-internal) を受理 (それまでは HS256 のみ = 非破壊)。
+/// app 配線側で `INTERNAL_AUTH_TRUST_OIDC` env から解決する (Extension 注入なのでテストは決定的)。
+#[derive(Clone, Copy, Debug)]
+pub struct InternalOidcTrust(pub bool);
 
 /// 内部 API 用 JWT 検証ミドルウェア
 ///
@@ -11,17 +18,29 @@ use crate::auth_jwt::{verify_internal_token, JwtSecret};
 /// auth-worker が LINE WORKS webhook を受け取って rust-alc-api に転送する際の
 /// `/api/internal/*` ルート保護に使う。通常のユーザー JWT (`AppClaims`) は
 /// `aud` を持たないため弾かれる。
+///
+/// #434 Phase D の lockdown 移行用に **dual-accept**:
+/// 1. 従来の HS256 internal JWT (`verify_internal_token`) — 移行前/現行。
+/// 2. `INTERNAL_AUTH_TRUST_OIDC=1` の時のみ、Google OIDC (aud=alc-api-internal) を受理
+///    (`verify_internal_oidc_aud`)。署名は Cloud Run IAM が検証済みの前提で aud のみ確認。
+///    flag off の間は完全に dormant (非破壊)。
 pub async fn require_internal_jwt(
     Extension(jwt_secret): Extension<JwtSecret>,
+    Extension(oidc_trust): Extension<InternalOidcTrust>,
     req: Request,
     next: Next,
 ) -> Result<Response, StatusCode> {
     let token = extract_bearer_token(&req).ok_or(StatusCode::UNAUTHORIZED)?;
-    verify_internal_token(token, &jwt_secret).map_err(|e| {
-        tracing::warn!("internal JWT verification failed: {e}");
-        StatusCode::UNAUTHORIZED
-    })?;
-    Ok(next.run(req).await)
+    // 1) HS256 internal JWT (移行前/現行)。
+    if verify_internal_token(token, &jwt_secret).is_ok() {
+        return Ok(next.run(req).await);
+    }
+    // 2) lockdown 後の OIDC 経路 (flag gated)。
+    if oidc_trust.0 && verify_internal_oidc_aud(token).is_ok() {
+        return Ok(next.run(req).await);
+    }
+    tracing::warn!("internal JWT verification failed");
+    Err(StatusCode::UNAUTHORIZED)
 }
 
 /// 注入された identity ヘッダーを信頼するミドルウェア (Refs #434)
@@ -239,9 +258,14 @@ mod tests {
     }
 
     fn app_internal_jwt() -> Router {
+        app_internal_jwt_with(false)
+    }
+
+    fn app_internal_jwt_with(oidc: bool) -> Router {
         Router::new()
             .route("/i", get(echo_ok))
             .layer(axum_middleware::from_fn(require_internal_jwt))
+            .layer(Extension(InternalOidcTrust(oidc)))
             .layer(Extension(JwtSecret(
                 "test-internal-secret-256-bits!!!".to_string(),
             )))
@@ -305,8 +329,55 @@ mod tests {
         use crate::auth_jwt::create_internal_token;
         let other = JwtSecret("different-secret-key-256-bits!!".to_string());
         let token = create_internal_token(&other, "auth-worker", 60).unwrap();
+        // OIDC trust off (既定) なので、HS256 不一致 = 401 (dual-accept の OIDC 経路に入らない)。
         let resp = send(
             app_internal_jwt(),
+            req_with_headers("/i", &[("Authorization", &format!("Bearer {token}"))]),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn internal_jwt_oidc_aud_accepted_when_trust_enabled() {
+        // OIDC trust on + aud=alc-api-internal の OIDC token (別 secret 署名 = HS256 不一致) は
+        // 受理される (Cloud Run IAM が署名検証済みの前提、Refs #434 Phase D)。
+        use crate::auth_jwt::create_internal_token;
+        let other = JwtSecret("different-secret-key-256-bits!!".to_string());
+        let token = create_internal_token(&other, "auth-worker", 60).unwrap(); // aud=alc-api-internal
+        let resp = send(
+            app_internal_jwt_with(true),
+            req_with_headers("/i", &[("Authorization", &format!("Bearer {token}"))]),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn internal_jwt_oidc_wrong_aud_rejected_when_trust_enabled() {
+        // OIDC trust on でも aud が alc-api-internal でなければ拒否 (confused-deputy 防止)。
+        use crate::auth_jwt::create_access_token;
+        use crate::models::User;
+        let secret = JwtSecret("test-internal-secret-256-bits!!!".to_string());
+        let user = User {
+            id: Uuid::new_v4(),
+            tenant_id: Uuid::new_v4(),
+            google_sub: Some("g".to_string()),
+            lineworks_id: None,
+            line_user_id: None,
+            email: "u@e.com".to_string(),
+            name: "u".to_string(),
+            role: "admin".to_string(),
+            username: None,
+            password_hash: None,
+            refresh_token_hash: None,
+            refresh_token_expires_at: None,
+            created_at: chrono::Utc::now(),
+        };
+        // ユーザー JWT は aud を持たない → HS256 でも OIDC でも弾かれる。
+        let token = create_access_token(&user, &secret, None).unwrap();
+        let resp = send(
+            app_internal_jwt_with(true),
             req_with_headers("/i", &[("Authorization", &format!("Bearer {token}"))]),
         )
         .await;

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -72,9 +72,9 @@ pub use alc_trouble::tasks as trouble_tasks;
 pub use alc_trouble::tickets as trouble_tickets;
 pub use alc_trouble::workflow as trouble_workflow;
 
-use axum::{middleware as axum_middleware, Router};
+use axum::{middleware as axum_middleware, Extension, Router};
 
-use crate::middleware::auth::{require_internal_jwt, require_tenant_header};
+use crate::middleware::auth::{require_internal_jwt, require_tenant_header, InternalOidcTrust};
 use crate::AppState;
 
 pub fn router() -> Router<AppState> {
@@ -97,7 +97,12 @@ pub fn router() -> Router<AppState> {
         .merge(notify_viewer::internal_router())
         .merge(health_canary::internal_router())
         .merge(auth::internal_router())
-        .layer(axum_middleware::from_fn(require_internal_jwt));
+        .layer(axum_middleware::from_fn(require_internal_jwt))
+        // #434 Phase D: lockdown 後の OIDC dual-accept を有効化するフラグ (env 解決、Extension 注入)。
+        // require_internal_jwt の外側に置き、ハンドラ実行時に Extension を解決できるようにする。
+        .layer(Extension(InternalOidcTrust(
+            std::env::var("INTERNAL_AUTH_TRUST_OIDC").as_deref() == Ok("1"),
+        )));
 
     // テナント対応ルート — 注入 identity (X-Tenant-ID + 任意 X-User-*) を信頼 (Refs #434)。
     // 旧 require_tenant の bare X-Tenant-ID フォールバック / ローカル JWT 検証は撤去。


### PR DESCRIPTION
## 概要

#434 **Phase D (lockdown flip)** の rust 側コード。lockdown (`allUsers` 削除) 後、internal-auth
(auth-worker → `/api/internal/auth/*`) は Cloud Run IAM が OIDC を要求する。`require_internal_jwt`
を **dual-accept** にして移行を非破壊にする。

## 変更

1. **`crates/alc-auth-jwt`**: `verify_internal_oidc_aud(token)` 追加
   - `insecure_disable_signature_validation()` + `set_audience(["alc-api-internal"])` + `validate_exp`
   - 署名は **Cloud Run IAM (`--add-custom-audiences=alc-api-internal`) が検証済みの前提**で aud + exp のみ確認。confused-deputy 防止 (`/alc-proxy` の service-URL aud OIDC を弾く)
   - alg は RS256 (本番 Google OIDC) + HS256 (テスト) を許可
   - `alc-core::auth_jwt` で re-export
2. **`crates/alc-core/auth_middleware`**: `require_internal_jwt` を dual-accept 化
   - ① HS256 internal JWT (`verify_internal_token`、現行・温存)
   - ② `Extension(InternalOidcTrust(true))` の時のみ Google OIDC (`verify_internal_oidc_aud`)
   - flag off (既定) で **完全に dormant = 非破壊**。Extension 注入なのでテストは決定的 (env race なし)
3. **`src/routes/mod.rs`**: `internal_protected` に `InternalOidcTrust(env INTERNAL_AUTH_TRUST_OIDC=="1")` を layer

## flip 手順 (本 PR は step 1)

1. **本 PR merge → staging 自動 deploy** (flag off = 挙動不変)
2. staging: Cloud Run `--add-custom-audiences=alc-api-internal` + `INTERNAL_AUTH_TRUST_OIDC=1` + auth-worker staging `INTERNAL_AUTH_OIDC=1`
3. staging 検証: **直叩き=403 / proxy=200 / ログイン一連 OK**
4. prod 同様 → `allUsers` 削除 → 確認 → `JWT_SECRET` 撤去 + HS256 分岐削除 → #434 close

## テスト

- alc-auth-jwt 3: aud=alc-api-internal 受理 (別 secret 署名でも = 署名無視を実証) / 別 aud 拒否 / expired 拒否
- alc-core 2: trust on で OIDC 受理 / trust on でも wrong aud (user JWT) 拒否。既存 internal_jwt テストは flag off で挙動不変
- `cargo fmt` + `cargo clippy -p alc-auth-jwt -p alc-core` + 該当 crate `cargo test` green。coverage 100% gate は CI で確認

⚠ **OIDC 経路の runtime 検証は staging が必要** (CCoW では Cloud Run IAM を再現できない)。flag off で merge → staging で step 2-3 を検証してから prod flip すること。

Refs #434

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UioxVnUP66Qp4oVC7VUc7f)_