### PR TITLE
infra(ci): enable internal-auth OIDC dual-accept on staging (#434 step 1)

### DIFF
--- a/cloudrun/render.sh
+++ b/cloudrun/render.sh
@@ -142,6 +142,8 @@ emit_env_backend() {
               value: "alc-fcm"
             - name: STAGING_MODE
               value: "$( [[ "$ENV" == "staging" ]] && echo "true" || echo "false" )"
+            - name: INTERNAL_AUTH_TRUST_OIDC
+              value: "$( [[ "$ENV" == "staging" ]] && echo "1" || echo "0" )"
             - name: RUST_LOG
               value: "info"
 YAML
@@ -507,6 +509,17 @@ if [[ "$ENV" == "staging" && "$SERVICE" != "gateway" ]]; then
     run.googleapis.com/launch-stage: BETA"
 fi
 
+# #434 Phase D 準備: backend に custom audience alc-api-internal を許可する。
+# allUsers 削除後の lockdown で auth-worker が aud=alc-api-internal の OIDC token を
+# mint して invoker 認証する経路に必要 (public のままなら Cloud Run IAM 非強制で無害)。
+# step 1 では INTERNAL_AUTH_TRUST_OIDC で app 側が JWKS 自前検証するため必須ではないが、
+# lockdown 本flip 時の churn を減らすため staging backend のみ先行投入する。
+CUSTOM_AUDIENCES=""
+if [[ "$ENV" == "staging" && "$SERVICE" == "backend" ]]; then
+  CUSTOM_AUDIENCES="
+    run.googleapis.com/custom-audiences: '[\"alc-api-internal\"]'"
+fi
+
 cat <<YAML
 apiVersion: serving.knative.dev/v1
 kind: Service
@@ -514,7 +527,7 @@ metadata:
   name: ${SERVICE_NAME}
   labels:
     cloud.googleapis.com/location: ${REGION}
-  annotations:${LAUNCH_STAGE}
+  annotations:${LAUNCH_STAGE}${CUSTOM_AUDIENCES}
     run.googleapis.com/ingress: ${INGRESS}
 spec:
   template:


### PR DESCRIPTION
## 概要

#434 lockdown の Phase D **step 1**(staging で internal-auth の OIDC 経路を疎通検証する段階)を、CI deploy で durable に効かせるための `cloudrun/render.sh` 変更。

手動 `gcloud run services update` で env / custom-audiences を足しても、staging は PR merge ごとに `gcloud run services replace`(render.sh の YAML 丸ごと置換)で auto-deploy されるため次の deploy で消える。よって config 同梱が唯一 durable。

## 変更内容(`cloudrun/render.sh`、backend service の staging のみ)

- **`INTERNAL_AUTH_TRUST_OIDC=1`**(env var、staging のみ。prod は `0`)
  `require_internal_jwt` が HS256 共有 JWT と Google OIDC ID token(`aud=alc-api-internal`、JWKS RS256 署名検証)を **dual-accept** する。auth-worker 側がまだ HS256 を送っていても動作継続するので無停止。
- **`run.googleapis.com/custom-audiences: '["alc-api-internal"]'`**(metadata annotation、staging backend のみ)
  lockdown 本flip(`allUsers` 削除後)に auth-worker が `aud=alc-api-internal` の OIDC token で Cloud Run invoker 認証する経路で必要。public のままなら Cloud Run IAM は非強制なので**無害**。本flip 時の churn を減らすため先行投入。

## step 1 で GCP 手動操作は不要

`allUsers` 付き(public)のままなので Cloud Run IAM は OIDC token を検証しない。`aud=alc-api-internal` の検証は rust アプリ側が JWKS で自前に行う(`GoogleTokenVerifier::verify_internal_oidc`)。gcloud が要るのは最終 `allUsers` 削除(lockdown 本flip)のみで、これは後続。

## 反映順序(無停止)

rust は dual-accept なので、本 PR(rust 先)→ auth-worker `INTERNAL_AUTH_OIDC=1`(ippoan/auth-worker の対 PR)の順なら順序事故が起きない。

## 検証

- `bash -n cloudrun/render.sh` OK
- staging backend 出力: `custom-audiences` annotation + `INTERNAL_AUTH_TRUST_OIDC=1` を確認
- prod backend 出力: custom-audiences 無し / `INTERNAL_AUTH_TRUST_OIDC=0` を確認

Refs #434

---
_Generated by [Claude Code](https://claude.ai/code/session_01UioxVnUP66Qp4oVC7VUc7f)_