### PR TITLE
infra(ci): enable internal-auth OIDC dual-accept on prod (#434 Phase D)

### DIFF
--- a/cloudrun/render.sh
+++ b/cloudrun/render.sh
@@ -143,7 +143,7 @@ emit_env_backend() {
             - name: STAGING_MODE
               value: "$( [[ "$ENV" == "staging" ]] && echo "true" || echo "false" )"
             - name: INTERNAL_AUTH_TRUST_OIDC
-              value: "$( [[ "$ENV" == "staging" ]] && echo "1" || echo "0" )"
+              value: "1"
             - name: RUST_LOG
               value: "info"
 YAML
@@ -509,13 +509,12 @@ if [[ "$ENV" == "staging" && "$SERVICE" != "gateway" ]]; then
     run.googleapis.com/launch-stage: BETA"
 fi
 
-# #434 Phase D 準備: backend に custom audience alc-api-internal を許可する。
+# #434 Phase D: backend に custom audience alc-api-internal を許可する。
 # allUsers 削除後の lockdown で auth-worker が aud=alc-api-internal の OIDC token を
 # mint して invoker 認証する経路に必要 (public のままなら Cloud Run IAM 非強制で無害)。
-# step 1 では INTERNAL_AUTH_TRUST_OIDC で app 側が JWKS 自前検証するため必須ではないが、
-# lockdown 本flip 時の churn を減らすため staging backend のみ先行投入する。
+# staging で実証済み、prod flip に向けて staging/prod 両 env の backend に投入する。
 CUSTOM_AUDIENCES=""
-if [[ "$ENV" == "staging" && "$SERVICE" == "backend" ]]; then
+if [[ "$SERVICE" == "backend" ]]; then
   CUSTOM_AUDIENCES="
     run.googleapis.com/custom-audiences: '[\"alc-api-internal\"]'"
 fi


### PR DESCRIPTION
## 概要

#434 Phase D の prod lockdown に向け、staging で実証した OIDC dual-accept を **prod にも展開**する `cloudrun/render.sh` 変更。`allUsers` 削除(本 lockdown)の**前提**。

## 変更内容(`cloudrun/render.sh`)

- **`INTERNAL_AUTH_TRUST_OIDC` を全 env で `1`**(従来 staging のみ `1` / prod `0`)
  `require_internal_jwt` が HS256 と Google OIDC ID token(`aud=alc-api-internal`、JWKS RS256)を dual-accept。HS256 も受理し続けるので無停止。
- **custom-audiences `alc-api-internal` を staging/prod 両 backend に付与**(従来 staging backend のみ)
  `allUsers` 削除後に auth-worker の `aud=alc-api-internal` OIDC token を Cloud Run IAM が invoker 認証するため必須。gateway 等 backend 以外には付かない。

## なぜ必要か

prod が `INTERNAL_AUTH_TRUST_OIDC=0` / custom-audiences 無しのままだと、`allUsers` 削除時に internal route(`/alc-internal-proxy` 経由)が IAM で 403 になる。データ API(`/alc-proxy`、aud=service URL を常時 mint)は通るが internal が壊れる。

## 順序(無停止)

1. **本 PR(rust)を先に** merge → prod deploy(dual-accept、まだ public、HS256 継続で無停止)
2. auth-worker prod `INTERNAL_AUTH_OIDC=1`(対 PR)を後で deploy(OIDC mint 開始 → rust が dual-accept で受理)
3. `allUsers` 削除(gcloud、staging→prod)

## 検証

- `bash -n` OK / staging・prod 両 backend 出力に custom-audiences + `INTERNAL_AUTH_TRUST_OIDC=1` を確認 / prod gateway は custom-audiences 無しを確認

Refs #434

---
_Generated by [Claude Code](https://claude.ai/code/session_01UioxVnUP66Qp4oVC7VUc7f)_