### PR TITLE
fix(ci): add custom-domain audience to prod backend (lockdown breaker)

### DIFF
--- a/cloudrun/render.sh
+++ b/cloudrun/render.sh
@@ -509,14 +509,23 @@ if [[ "$ENV" == "staging" && "$SERVICE" != "gateway" ]]; then
     run.googleapis.com/launch-stage: BETA"
 fi
 
-# #434 Phase D: backend に custom audience alc-api-internal を許可する。
-# allUsers 削除後の lockdown で auth-worker が aud=alc-api-internal の OIDC token を
-# mint して invoker 認証する経路に必要 (public のままなら Cloud Run IAM 非強制で無害)。
-# staging で実証済み、prod flip に向けて staging/prod 両 env の backend に投入する。
+# #434 Phase D: backend に custom audience を許可する (allUsers 削除後の lockdown 用)。
+#   - `alc-api-internal`: /alc-internal-proxy が internal route を叩く時の aud。両 env 共通。
+#   - `<ALC_API_ORIGIN>`: /alc-proxy がデータ API を叩く時の aud (= auth-worker の
+#     ALC_API_ORIGIN を mint)。prod は **カスタムドメイン** https://alc-api.ippoan.org
+#     を使うため、Cloud Run IAM の default audience (run.app URL) では受理されず
+#     custom-audiences への明示登録が必須。staging は run.app URL = default audience
+#     なので登録不要 (alc-api-internal だけで足りる)。
+# public のままなら IAM 非強制で無害。
 CUSTOM_AUDIENCES=""
 if [[ "$SERVICE" == "backend" ]]; then
+  if [[ "$ENV" == "staging" ]]; then
+    AUDS='["alc-api-internal"]'
+  else
+    AUDS='["alc-api-internal","https://alc-api.ippoan.org"]'
+  fi
   CUSTOM_AUDIENCES="
-    run.googleapis.com/custom-audiences: '[\"alc-api-internal\"]'"
+    run.googleapis.com/custom-audiences: '${AUDS}'"
 fi
 
 cat <<YAML


### PR DESCRIPTION
## 概要

`allUsers` 削除(#434 lockdown 本flip)で **prod の `/alc-proxy` データ API が 403 で全落ちする**不整合の修正。`allUsers` 削除の前提。

## 根本原因

`/alc-proxy`(auth-worker)は `aud = ALC_API_ORIGIN` で OIDC ID token を mint する:
- **staging**: `ALC_API_ORIGIN = https://rust-alc-api-staging-…run.app`(= run.app URL = Cloud Run IAM の **default audience** → 受理 ✓)
- **prod**: `ALC_API_ORIGIN = https://alc-api.ippoan.org`(= **Cloud Run domain mapping** のカスタムドメイン)

Cloud Run IAM が default で受理する aud は run.app URL のみ。カスタムドメインを aud にするには **custom-audiences への明示登録が必須**。現状 prod backend の custom-audiences は `["alc-api-internal"]` だけ(確認済み)で、`allUsers` 削除後は `/alc-proxy`(aud=`https://alc-api.ippoan.org`)が IAM で 403 になる。

staging は run.app aud のため、**staging dry-run ではこの prod 固有の不整合を検出できない**(明示修正が必要な理由)。

## 変更内容(`cloudrun/render.sh`、prod backend のみ)

custom-audiences を env で分岐:
- staging backend: `["alc-api-internal"]`(変更なし。run.app = default aud)
- **prod backend: `["alc-api-internal","https://alc-api.ippoan.org"]`**(カスタムドメイン追加)

`alc-api-internal`(/alc-internal-proxy 用)は両 env 共通。gateway 等 backend 以外には付かない。

## 検証

- `bash -n` OK
- staging backend 出力: `["alc-api-internal"]`
- prod backend 出力: `["alc-api-internal","https://alc-api.ippoan.org"]`
- `alc-api.ippoan.org` は Cloud Run domain mapping → `rust-alc-api`(`gcloud run domain-mappings list` で確認)

## 反映後の手順

merge → **prod rust を再 tag+flip**(custom-audiences が両 aud になる)→ その後で初めて prod backend の `allUsers` 削除が安全。

Refs #434

---
_Generated by [Claude Code](https://claude.ai/code/session_01UioxVnUP66Qp4oVC7VUc7f)_