### PR TITLE
feat(lockdown): LINE webhook / trouble fire を internal 経路へ (Refs #434)

### DIFF
--- a/.claude/skills/rust-alc-api-map/SKILL.md
+++ b/.claude/skills/rust-alc-api-map/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rust-alc-api-map
-generated-from: rust-alc-api:0ddb0d8c40f3f2a48552cff821e4d72267181719
+generated-from: rust-alc-api:7df01c5d1682d9291636b3594b2e46e434ce52ef
 paths: [crates/, src/, migrations/]
 description: rust-alc-api (アルコールチェッカー基盤の Rust/Axum Cargo workspace — 13 domain crate + gateway/tenko/carins/dtako/trouble の複数バイナリ、PostgreSQL+RLS、Cloud Run) の構造ナビゲーション。どの crate に何のルートがあるか / monolith(rust-alc-api) と per-domain API + gateway の二系統 / RLS・migration・deploy/release 分離の gotcha を 1 枚にまとめる。トリガー:「rust-alc-api」「alc-api」「alc-notify」「alc-tenko」「alc-trouble」「alc-carins」「alc-dtako」「gateway」「tenko-api」「carins-api」「dtako-api」「trouble-api」「RLS テナント」「sqlx migration」「ts-rs」「Release Wave」「Bazel」等。
 ---
@@ -35,8 +35,8 @@ monolith と per-domain API は同じ domain crate (`alc-tenko` 等) を共有 �
 | `alc-tenko` | 点呼: tenko_call / tenko_records / tenko_schedules / tenko_sessions / tenko_webhooks / daily_health / equipment_failures / health_baselines |
 | `alc-carins` | 車検証(carins): car_inspections / car_inspection_files / carins_files / nfc_tags |
 | `alc-dtako` | デジタコ: dtako_* (csv_proxy / daily_hours / drivers / logs / operations / restraint_report(_pdf) / scraper / tickets / upload / vehicles / work_times / y_time_export / event_classifications) / vehicle_settings_dumps。`dtako_tickets` は email-receiver Worker から SD カードエラー通知メールを起票し F-VOS3020 設定 ZIP DL → QR で close する pipeline (Refs ippoan/email-receiver#1)。tenant_router (JWT) + internal_router (`INTERNAL_SHARED_SECRET` + `X-Tenant-ID`) + public_close_router (`close_token` のみ) の 3 経路 |
-| `alc-trouble` | トラブル管理: tickets / files / workflow / categories / offices / progress_statuses / schedules / tasks / task_types / task_statuses / notifications / notifier / cloud_tasks / lineworks_members |
-| `alc-notify` | LINE/LINE WORKS 配信: recipients / groups / documents / distribute / ingest / line_config / line_webhook / lineworks_* / read_tracker / viewer / email_documents / extract / redact / background_extract / background_redaction |
+| `alc-trouble` | トラブル管理: tickets / files / workflow / categories / offices / progress_statuses / schedules / tasks / task_types / task_statuses / notifications / notifier / cloud_tasks / lineworks_members。**schedule fire は #434 lockdown で internal 化**: `schedules::internal_fire_router` (`/api/internal/trouble/schedules/{id}/fire`, `require_internal_jwt`) を monolith の internal_protected に集約。旧 bare public `fire_router` は撤去 (現状 `cloud_tasks: None` で未配線)。trouble-api サブサービスは fire を mount しない (gateway が `/api/internal/*` を backend へ振るため) |
+| `alc-notify` | LINE/LINE WORKS 配信: recipients / groups / documents / distribute / ingest / line_config / line_webhook / lineworks_* / read_tracker / viewer / email_documents / extract / redact / background_extract / background_redaction。**`line_webhook` は #434 lockdown で internal_router 併設**: `/api/internal/notify/line/webhook` (`require_internal_jwt`、auth-worker の public 受け口が OIDC mint で forward)。署名検証 (全テナント channel secret 照合) は rust 側。`public_router` (`/notify/line/webhook`) は LINE Console URL 切替 + allUsers 削除までの移行期間 dual-mount |
 | `alc-devices` | デバイス登録 (`devices`) |
 | `alc-storage` | StorageBackend trait + R2 / GCS / HttpProxy 実装 |
 | `alc-csv-parser` / `alc-compare` | CSV パース / 比較ロジック |
@@ -64,8 +64,12 @@ monolith と per-domain API は同じ domain crate (`alc-tenko` 等) を共有 �
   (確定アーキ #4807535677、step 3)。テストは `tests/common/mod.rs` の `test_proxy_inject` が proxy 役で
   Bearer JWT → identity ヘッダーに変換し従来テストを無改修で通す。
 - **gateway**: `crates/gateway/src/{main,routes,proxy,auth,config}.rs`。`is_public_route` に
-  列挙された path (health / auth/* / tenko-call register / devices register / staging / notify line-webhook
-  等) は JWT skip でそのまま proxy。
+  列挙された path (health / auth/* / tenko-call register / devices register / staging /
+  `/notify/line/webhook` / notify read / access-requests 等) は JWT skip でそのまま proxy。
+  **#434 lockdown**: trouble schedule fire は public 列挙から外し internal 化、LINE webhook の
+  判定 path も `/notify/line-webhook` (誤) → `/notify/line/webhook` (実パス) に修正。
+  `resolve_backend` は `/api/internal/*` を **dtako_url (fallback backend)** へ振る = internal
+  ルートは monolith backend が処理する。
 
 ## gotcha (CLAUDE.md / README 由来)
 

--- a/crates/alc-notify/src/line_webhook.rs
+++ b/crates/alc-notify/src/line_webhook.rs
@@ -19,6 +19,19 @@ pub fn public_router() -> Router<AppState> {
     Router::new().route("/notify/line/webhook", axum::routing::post(handle_webhook))
 }
 
+/// lockdown 後の経路 (#434)。LINE platform は Google OIDC を付けられないため、auth-worker
+/// の public 受け口 `POST /line/webhook` が raw body + `x-line-signature` を OIDC mint で
+/// `/api/internal/notify/line/webhook` に forward する。署名検証は rust 側で行う
+/// (`handle_webhook` が全テナント channel secret と照合)。`require_internal_jwt` 配下に
+/// mount する。public_router は LINE Developer Console の webhook URL 切替 + allUsers 削除
+/// までの移行期間に残す (dual-mount)。
+pub fn internal_router() -> Router<AppState> {
+    Router::new().route(
+        "/internal/notify/line/webhook",
+        axum::routing::post(handle_webhook),
+    )
+}
+
 #[derive(serde::Deserialize)]
 struct WebhookBody {
     #[allow(dead_code)]

--- a/crates/alc-trouble/src/schedules.rs
+++ b/crates/alc-trouble/src/schedules.rs
@@ -27,13 +27,17 @@ where
         )
 }
 
-/// Cloud Tasks から呼ばれるルート (認証は別途)
-pub fn fire_router<S>() -> Router<S>
+/// スケジューラ (Cloud Tasks 等) から呼ばれる fire ルートの internal 版 (#434 lockdown)。
+/// `require_internal_jwt` (aud=alc-api-internal) 配下に mount する。スケジューラは Google OIDC を
+/// 直接付けられないため、auth-worker (OIDC mint) 経由で `/api/internal/trouble/schedules/{id}/fire`
+/// を叩く。現状 `cloud_tasks` は未配線 (None) なので caller は居ないが、lockdown 後に経路を
+/// 開けておくための internal mount。bare public は廃止 (IAM + ルート両面で塞ぐ)。
+pub fn internal_fire_router<S>() -> Router<S>
 where
     TroubleState: axum::extract::FromRef<S>,
     S: Clone + Send + Sync + 'static,
 {
-    Router::new().route("/trouble/schedules/{id}/fire", post(fire_schedule))
+    Router::new().route("/internal/trouble/schedules/{id}/fire", post(fire_schedule))
 }
 
 async fn create_schedule(

--- a/crates/gateway/src/routes.rs
+++ b/crates/gateway/src/routes.rs
@@ -14,10 +14,12 @@ pub fn is_public_route(path: &str) -> bool {
         || api_path.starts_with("/devices/register/status/")
         || api_path.starts_with("/devices/register/claim")
         || api_path.starts_with("/staging/")
-        || api_path.starts_with("/notify/line-webhook")
+        || api_path.starts_with("/notify/line/webhook")
         || api_path.starts_with("/notify/read/")
         || api_path.starts_with("/access-requests")
-        || api_path.starts_with("/trouble/schedules/") && api_path.ends_with("/fire")
+    // #434 lockdown: trouble schedule fire は internal 経路 (/api/internal/trouble/...) に移動。
+    // LINE webhook も internal 版を併設 (dual-mount)。internal 経路は public ではないので
+    // ここには列挙しない (gateway は元の Authorization=OIDC をそのまま backend へ forward)。
 }
 
 #[cfg(test)]
@@ -51,17 +53,12 @@ mod tests {
         assert!(is_public_route("/api/staging/export"));
         assert!(is_public_route("/api/staging/import"));
 
-        // notify public
-        assert!(is_public_route("/api/notify/line-webhook"));
+        // notify public (LINE webhook は実パス slash 区切り)
+        assert!(is_public_route("/api/notify/line/webhook"));
         assert!(is_public_route("/api/notify/read/abc"));
 
         // access-requests (public POST)
         assert!(is_public_route("/api/access-requests"));
-
-        // trouble schedule fire (Cloud Tasks callback)
-        assert!(is_public_route(
-            "/api/trouble/schedules/550e8400-e29b-41d4-a716-446655440000/fire"
-        ));
     }
 
     #[test]
@@ -87,5 +84,15 @@ mod tests {
         assert!(!is_public_route("/api/trouble/tickets"));
         assert!(!is_public_route("/api/trouble/notification-prefs"));
         assert!(!is_public_route("/api/trouble/schedules"));
+
+        // #434 lockdown: schedule fire は internal 化 → public ではない
+        assert!(!is_public_route(
+            "/api/trouble/schedules/550e8400-e29b-41d4-a716-446655440000/fire"
+        ));
+        // internal 経路は public 扱いしない (gateway は OIDC をそのまま forward)
+        assert!(!is_public_route("/api/internal/notify/line/webhook"));
+        assert!(!is_public_route(
+            "/api/internal/trouble/schedules/550e8400-e29b-41d4-a716-446655440000/fire"
+        ));
     }
 }

--- a/crates/trouble-api/src/main.rs
+++ b/crates/trouble-api/src/main.rs
@@ -112,9 +112,11 @@ async fn main() {
         .allow_methods(Any)
         .allow_headers(Any);
 
+    // #434 lockdown: schedule fire は backend monolith の internal_protected
+    // (`/api/internal/trouble/schedules/{id}/fire`, require_internal_jwt) に集約。
+    // gateway は `/api/internal/*` を backend へ振るため trouble-api では mount しない。
     let app = Router::new()
         .route("/health", axum::routing::get(|| async { "ok" }))
-        .merge(alc_trouble::schedules::fire_router())
         .merge(tenant_protected)
         .with_state(state)
         .layer(axum::extract::DefaultBodyLimit::max(20 * 1024 * 1024)) // 20MB

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -97,6 +97,8 @@ pub fn router() -> Router<AppState> {
     let internal_protected = Router::new()
         .merge(notify_lineworks_channels::internal_router())
         .merge(notify_viewer::internal_router())
+        .merge(notify_line_webhook::internal_router())
+        .merge(trouble_schedules::internal_fire_router())
         .merge(health_canary::internal_router())
         .merge(auth::internal_router())
         .layer(axum_middleware::from_fn(require_internal_jwt))
@@ -187,8 +189,9 @@ pub fn router() -> Router<AppState> {
         .merge(notify_read_tracker::public_router())
         .merge(notify_viewer::public_router())
         .merge(access_requests::public_router())
-        .merge(dtako_tickets::public_close_router())
-        .merge(trouble_schedules::fire_router());
+        .merge(dtako_tickets::public_close_router());
+    // #434 lockdown: trouble schedule fire は internal_protected へ移動
+    // (`/api/internal/trouble/schedules/{id}/fire`)。bare public 経路は廃止。
 
     Router::new()
         .merge(public_routes)


### PR DESCRIPTION
## 概要

#434 lockdown（`allUsers` / `--allow-unauthenticated` 削除）後に**到達不可になる 2 つの public 経路**を internal 化し、closed-by-default に寄せる。外部 (LINE platform) / スケジューラは Google OIDC を直接付けられないため、auth-worker（OIDC mint, `aud=alc-api-internal`）経由で internal route を叩く設計に揃える（= 既存の `/api/internal/*` 規約と同じ）。

監査で残っていた public route のうち、`tenko-call` / `devices` / `notify viewer/read` / `dtako tickets` / `access-requests` は proxy 化済み。本 PR は **LINE inbound webhook** と **trouble schedule fire** の 2 つ。

## 変更点

### LINE Messaging inbound webhook（使用中）
- `line_webhook::internal_router()`（`POST /api/internal/notify/line/webhook`）を新設し `internal_protected`（`require_internal_jwt`）に mount。
- 署名検証（全テナント channel secret と `X-Line-Signature` 照合）は **rust に残す**（auth-worker は secret を持たない薄い forwarder）。
- `public_router()`（`/notify/line/webhook`）は **dual-mount で残置** — LINE Developer Console の webhook URL を auth-worker 公開受け口へ切替 + `allUsers` 削除までの移行期間用（flag-day 回避）。

### trouble schedule fire（未配線のデッドルート）
- `fire_router` を廃し `internal_fire_router`（`POST /api/internal/trouble/schedules/{id}/fire`）を `internal_protected` に mount。
- bare public 経路を削除（現状 `cloud_tasks: None` で caller 不在）。`trouble-api` サブサービスの public fire mount も撤去（gateway は `/api/internal/*` を backend monolith へ振るため、fire は backend に集約）。
- **IAM は増やさない**（Cloud Tasks SA への `run.invoker` grant はしない）。将来スケジューリングを有効化する際は `CloudTasksClient` を rust 直叩きではなく auth-worker 経由（OIDC mint）に向ける。

### gateway `is_public_route`
- trouble fire エントリを削除。
- LINE webhook の判定パスを `/notify/line-webhook`（誤・ハイフン、実パスと不一致の latent bug）→ `/notify/line/webhook`（実パス）に修正。
- internal 経路（`/api/internal/*`）は public 扱いしない（gateway は元の OIDC `Authorization` をそのまま backend へ forward）。

## 検証
- `cargo fmt` / `cargo check --workspace` / `cargo clippy`（gateway・alc-notify・alc-trouble・trouble-api・rust-alc-api）all green。
- `cargo test -p gateway`（`is_public_route` の public/protected/internal 判定）green。
- 全テスト + カバレッジは CI（DB 必須の integration）に委譲。

## 後続（別作業）
- **auth-worker**: 公開受け口 `POST /line/webhook` を新設し、raw body + `X-Line-Signature` を `internalAuthToken()`（OIDC mint）で `/api/internal/notify/line/webhook` へ forward（`/internal/lineworks/event` と同パターン）。
- **ops**: 上記 2 つを本番反映後に LINE Developer Console の webhook URL を auth-worker 公開 URL へ切替（順序厳守、切替前に rust internal + auth-worker forwarder が本番にいること）。その後 dual-mount の public_router を撤去。

Refs #434

---
_Generated by [Claude Code](https://claude.ai/code/session_01UioxVnUP66Qp4oVC7VUc7f)_