### PR TITLE
fix(line-webhook): RLS バイパス関数で署名照合の 500 を解消 (Refs #434)

### DIFF
--- a/.claude/skills/rust-alc-api-map/SKILL.md
+++ b/.claude/skills/rust-alc-api-map/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rust-alc-api-map
-generated-from: rust-alc-api:7df01c5d1682d9291636b3594b2e46e434ce52ef
+generated-from: rust-alc-api:1b6e030819a1ae6ef2a0e3438bbd410b55ac7809
 paths: [crates/, src/, migrations/]
 description: rust-alc-api (アルコールチェッカー基盤の Rust/Axum Cargo workspace — 13 domain crate + gateway/tenko/carins/dtako/trouble の複数バイナリ、PostgreSQL+RLS、Cloud Run) の構造ナビゲーション。どの crate に何のルートがあるか / monolith(rust-alc-api) と per-domain API + gateway の二系統 / RLS・migration・deploy/release 分離の gotcha を 1 枚にまとめる。トリガー:「rust-alc-api」「alc-api」「alc-notify」「alc-tenko」「alc-trouble」「alc-carins」「alc-dtako」「gateway」「tenko-api」「carins-api」「dtako-api」「trouble-api」「RLS テナント」「sqlx migration」「ts-rs」「Release Wave」「Bazel」等。
 ---
@@ -36,7 +36,7 @@ monolith と per-domain API は同じ domain crate (`alc-tenko` 等) を共有 �
 | `alc-carins` | 車検証(carins): car_inspections / car_inspection_files / carins_files / nfc_tags |
 | `alc-dtako` | デジタコ: dtako_* (csv_proxy / daily_hours / drivers / logs / operations / restraint_report(_pdf) / scraper / tickets / upload / vehicles / work_times / y_time_export / event_classifications) / vehicle_settings_dumps。`dtako_tickets` は email-receiver Worker から SD カードエラー通知メールを起票し F-VOS3020 設定 ZIP DL → QR で close する pipeline (Refs ippoan/email-receiver#1)。tenant_router (JWT) + internal_router (`INTERNAL_SHARED_SECRET` + `X-Tenant-ID`) + public_close_router (`close_token` のみ) の 3 経路 |
 | `alc-trouble` | トラブル管理: tickets / files / workflow / categories / offices / progress_statuses / schedules / tasks / task_types / task_statuses / notifications / notifier / cloud_tasks / lineworks_members。**schedule fire は #434 lockdown で internal 化**: `schedules::internal_fire_router` (`/api/internal/trouble/schedules/{id}/fire`, `require_internal_jwt`) を monolith の internal_protected に集約。旧 bare public `fire_router` は撤去 (現状 `cloud_tasks: None` で未配線)。trouble-api サブサービスは fire を mount しない (gateway が `/api/internal/*` を backend へ振るため) |
-| `alc-notify` | LINE/LINE WORKS 配信: recipients / groups / documents / distribute / ingest / line_config / line_webhook / lineworks_* / read_tracker / viewer / email_documents / extract / redact / background_extract / background_redaction。**`line_webhook` は #434 lockdown で internal_router 併設**: `/api/internal/notify/line/webhook` (`require_internal_jwt`、auth-worker の public 受け口が OIDC mint で forward)。署名検証 (全テナント channel secret 照合) は rust 側。`public_router` (`/notify/line/webhook`) は LINE Console URL 切替 + allUsers 削除までの移行期間 dual-mount |
+| `alc-notify` | LINE/LINE WORKS 配信: recipients / groups / documents / distribute / ingest / line_config / line_webhook / lineworks_* / read_tracker / viewer / email_documents / extract / redact / background_extract / background_redaction。**`line_webhook` は #434 lockdown で internal_router 併設**: `/api/internal/notify/line/webhook` (`require_internal_jwt`、auth-worker の public 受け口が OIDC mint で forward)。署名検証 (全テナント channel secret 照合) は rust 側で、**`list_enabled_line_configs()` SECURITY DEFINER 関数経由で RLS バイパス** (migration 117。生クエリだと未認証パスで `app.current_tenant_id=''` → `''::UUID` キャストが 500 する既知罠)。`public_router` (`/notify/line/webhook`) は LINE Console URL 切替 + allUsers 削除までの移行期間 dual-mount |
 | `alc-devices` | デバイス登録 (`devices`) |
 | `alc-storage` | StorageBackend trait + R2 / GCS / HttpProxy 実装 |
 | `alc-csv-parser` / `alc-compare` | CSV パース / 比較ロジック |

--- a/crates/alc-notify/src/line_webhook.rs
+++ b/crates/alc-notify/src/line_webhook.rs
@@ -156,8 +156,11 @@ async fn find_config_by_signature(
         private_key_encrypted: Option<String>,
     }
 
+    // #434: SECURITY DEFINER 関数で RLS をバイパスして列挙する。生クエリだと未認証パスで
+    // `app.current_tenant_id` が '' のとき RLS の `''::UUID` キャストが 500 する (072/074 の
+    // lookup_line_config_by_channel と同じ認証前アクセス用関数、migration 117)。
     let configs: Vec<ConfigRow> = sqlx::query_as(
-        "SELECT tenant_id, channel_id, channel_secret_encrypted, key_id, private_key_encrypted FROM alc_api.notify_line_configs WHERE enabled = TRUE",
+        "SELECT tenant_id, channel_id, channel_secret_encrypted, key_id, private_key_encrypted FROM alc_api.list_enabled_line_configs()",
     )
     .fetch_all(pool)
     .await

--- a/migrations/117_fix_line_webhook_rls.sql
+++ b/migrations/117_fix_line_webhook_rls.sql
@@ -1,0 +1,27 @@
+-- LINE webhook 署名照合の RLS 500 修正 (Refs #434)
+--
+-- `find_config_by_signature` は LINE webhook の未認証パスで全テナントの enabled config を
+-- 列挙して署名 (X-Line-Signature) を照合する。ところが生クエリ (RLS 対象) で引いていたため、
+-- pooled connection に `app.current_tenant_id` が空文字 ('') で残っていると RLS ポリシー
+-- (`tenant_id = current_setting('app.current_tenant_id', true)::UUID`) の `''::UUID` キャストが
+-- "invalid input syntax for type uuid" で落ち、クエリごと 500 になっていた。
+--
+-- 認証前アクセス用の `lookup_line_config_by_channel` (072/074) と同じく SECURITY DEFINER で
+-- RLS をバイパスして列挙する関数を用意し、handler 側はこれを呼ぶ (devices テーブルの
+-- `lookup_device_tenant` 置換と同パターン)。値の取得は signature 照合に必要な列のみ。
+CREATE OR REPLACE FUNCTION alc_api.list_enabled_line_configs()
+RETURNS TABLE(
+    tenant_id UUID,
+    channel_id TEXT,
+    channel_secret_encrypted TEXT,
+    key_id TEXT,
+    private_key_encrypted TEXT
+)
+LANGUAGE sql SECURITY DEFINER SET search_path = alc_api
+AS $$
+    SELECT tenant_id, channel_id, channel_secret_encrypted, key_id, private_key_encrypted
+    FROM alc_api.notify_line_configs
+    WHERE enabled = TRUE;
+$$;
+
+GRANT EXECUTE ON FUNCTION alc_api.list_enabled_line_configs() TO alc_api_app;


### PR DESCRIPTION
## 概要

LINE Messaging webhook の署名照合が**本番で 500**していた（LINE Console の Webhook URL Verify が「500 Internal Server Error」）。#434 の routing 変更とは**独立した先在バグ**で、public 経路 (`/api/notify/line/webhook`) でも internal 経路 (`/api/internal/notify/line/webhook`) でも 500 になる。

## 原因（Cloud Run ログで確定）

```
ERROR alc_notify::line_webhook
fetch line configs: error returned from database:
  invalid input syntax for type uuid: ""
```

`find_config_by_signature` が全テナントの enabled config を **生クエリ（RLS 対象）**で列挙していた。LINE webhook は未認証パスで、pooled connection に `app.current_tenant_id` が**空文字 `''`** で残っていると、RLS ポリシー `tenant_id = current_setting('app.current_tenant_id', true)::UUID` の `''::UUID` キャストが落ち、クエリごと 500 になる。

同 migration 072/074 は認証前アクセス用に **SECURITY DEFINER 関数 `lookup_line_config_by_channel`** を用意しているのに、署名照合パスはそれを使わず生クエリだった = RLS 未バイパス。

## 修正

- **migration 117**: 全 enabled config を返す SECURITY DEFINER 関数 `list_enabled_line_configs()` を追加（署名照合に必要な列 `tenant_id / channel_id / channel_secret_encrypted / key_id / private_key_encrypted` のみ）。`devices` テーブルの `lookup_device_tenant` 置換（CLAUDE.md「USING(true) を DROP し SECURITY DEFINER 関数に置換」）と同パターン。
- **handler**: `find_config_by_signature` の生クエリを `SELECT ... FROM alc_api.list_enabled_line_configs()` に変更し RLS をバイパス。

fix 後: 署名不一致 → 401、一致 → follow 自動登録が通る。

## 検証
- migration PR 方針に従い、ローカルは `cargo fmt` + `cargo check -p alc-notify` のみ green。RLS/splinter は CI、実適用は staging 自動デプロイで検証。
- staging deploy 後、`POST /api/internal/notify/line/webhook`（dummy 署名）が **500 → 401**（空 body）に変われば fix 確認。

Refs #434

---
_Generated by [Claude Code](https://claude.ai/code/session_01UioxVnUP66Qp4oVC7VUc7f)_