### PR TITLE
fix(migrate): pre-auth SECURITY DEFINER 関数の FORCE RLS 500 を修正 (LINE ログイン他)

### DIFF
--- a/.claude/skills/rust-alc-api-map/SKILL.md
+++ b/.claude/skills/rust-alc-api-map/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rust-alc-api-map
-generated-from: rust-alc-api:ed66bfb4f0a14fe68bba8f8eafe5104e3fadef14
+generated-from: rust-alc-api:466be820891008db0fb2dac5555e6cbc1f6f87a8
 paths: [crates/, src/, migrations/]
 description: rust-alc-api (アルコールチェッカー基盤の Rust/Axum Cargo workspace — 13 domain crate + gateway/tenko/carins/dtako/trouble の複数バイナリ、PostgreSQL+RLS、Cloud Run) の構造ナビゲーション。どの crate に何のルートがあるか / monolith(rust-alc-api) と per-domain API + gateway の二系統 / RLS・migration・deploy/release 分離の gotcha を 1 枚にまとめる。トリガー:「rust-alc-api」「alc-api」「alc-notify」「alc-tenko」「alc-trouble」「alc-carins」「alc-dtako」「gateway」「tenko-api」「carins-api」「dtako-api」「trouble-api」「RLS テナント」「sqlx migration」「ts-rs」「Release Wave」「Bazel」等。
 ---
@@ -82,6 +82,16 @@ monolith と per-domain API は同じ domain crate (`alc-tenko` 等) を共有 �
   `crates/alc-core/src/tenant.rs::TenantConn` が `set_current_tenant` で `app.current_tenant_id` を
   立てて RLS に委ねるが、本番 (alc_api_app) でしか効かない。staging も対象にするクエリは
   **WHERE tenant_id を明示**すること (Refs #434、sso_admin で実害)。
+- **pre-auth SECURITY DEFINER + FORCE ROW LEVEL SECURITY の罠**: 未認証経路 (LINE webhook /
+  LINE login / notify viewer `/v/{token}` 等) が cross-tenant 検索用の SECURITY DEFINER 関数
+  を叩く時、対象テーブルに `FORCE ROW LEVEL SECURITY` が有効かつポリシーが
+  `current_setting('app.current_tenant_id', true)::UUID` を `NULLIF` でガードせず直接キャストして
+  いると、tenant context 未設定 (空文字) で `invalid input syntax for type uuid: ""` 500 になる
+  (テーブル所有者 = SECURITY DEFINER 実行ロールにも FORCE 下では RLS が適用されるため)。
+  `devices`/`bot_configs`/carins 系は `NULLIF(..., '')::UUID` でガード済みで安全、
+  `notify_line_configs`(#434 migration 118)/`notify_recipients`(119)/`notify_deliveries`+`notify_documents`(120)
+  は同じ穴があり `NO FORCE ROW LEVEL SECURITY` で修正済み。新しい pre-auth SECURITY DEFINER 関数を
+  追加する時は対象テーブルの RLS ポリシーの cast パターンを確認すること。
 - **migration 不変条件**: 適用済み `migrations/*.sql` を絶対に変更しない (sqlx が SHA-384 検証、不一致で起動不能)。
   修正は新ファイル追加。migration は **Cloud Run Jobs** (`rust-alc-api-migrate`) で deploy 前に実行
   (`main.rs` から `sqlx::migrate!()` は削除済み = 起動時自動適用なし)。

--- a/migrations/119_notify_recipients_no_force_rls.sql
+++ b/migrations/119_notify_recipients_no_force_rls.sql
@@ -1,0 +1,18 @@
+-- LINE ログイン中の recipients 検索 500 の真因修正 (Refs #434, follow-up to migration 118)
+--
+-- `find_recipient_by_line_user_id()` (migration 081) は SECURITY DEFINER 関数で
+-- `notify_recipients` を line_user_id で全テナント横断検索する (ログイン中は
+-- まだ tenant context が確立していないため)。069 で `FORCE ROW LEVEL SECURITY` が
+-- 有効なため **テーブル所有者 (= SECURITY DEFINER 関数の実行ロール) にも RLS が
+-- 適用され**、未認証経路の空 tenant context (`app.current_tenant_id = ''`) で RLS
+-- ポリシー `current_setting(...)::UUID` が '' を uuid キャストして 500 していた
+-- (Cloud Run ログ: alc_auth::internal "invalid input syntax for type uuid")。
+-- #434 lockdown 実地検証 (prod flip) で LINE ログイン時に実害が発覚。
+--
+-- 118 (notify_line_configs) と同じ根治: FORCE を外すと、所有者として実行される
+-- SECURITY DEFINER 関数 (`find_recipient_by_line_user_id`) が RLS をバイパスして
+-- 全テナントの recipient を検索できる (= 認証前アクセスの本来の意図)。
+--
+-- app ロール (`alc_api_app`, NOBYPASSRLS, テーブル非所有者) には RLS が引き続き
+-- 適用されるため、通常の tenant スコープ CRUD のテナント分離は維持される。
+ALTER TABLE alc_api.notify_recipients NO FORCE ROW LEVEL SECURITY;

--- a/migrations/120_notify_deliveries_documents_no_force_rls.sql
+++ b/migrations/120_notify_deliveries_documents_no_force_rls.sql
@@ -1,0 +1,24 @@
+-- notify 公開 viewer (/v/{token}) の同種 RLS 500 を事前修正 (Refs #434, follow-up to 118/119)
+--
+-- `lookup_delivery_for_view()` (migration 107) は SECURITY DEFINER 関数で
+-- `notify_deliveries` と `notify_documents` を read_token だけで JOIN 検索する
+-- (viewer ページは未認証、まだ tenant context が確立していない)。071/070 で
+-- `FORCE ROW LEVEL SECURITY` が有効かつ、両テーブルのポリシーは
+-- `tenant_id = current_setting('app.current_tenant_id', true)::UUID` を
+-- NULLIF でガードせずに直接キャストしているため、空 tenant context
+-- (`app.current_tenant_id = ''`) では他の SECURITY DEFINER 関数
+-- (list_enabled_line_configs / find_recipient_by_line_user_id) と同じ
+-- "invalid input syntax for type uuid" で 500 になる。
+--
+-- #434 lockdown 実地検証で LINE ログイン (notify_recipients, migration 119) の
+-- 実害が見つかったのを機に、同一パターンを静的に洗い出して先行修正する
+-- (viewer ページはまだ実害が出ていないが、pre-auth cross-tenant lookup という
+-- 構造は完全に同じでいつでも起こり得る)。
+--
+-- 118/119 と同じ根治: FORCE を外すことで、所有者として実行される
+-- SECURITY DEFINER 関数が RLS をバイパスして全テナントの delivery/document を
+-- 検索できる (= 認証前アクセスの本来の意図)。app ロール (`alc_api_app`,
+-- NOBYPASSRLS、テーブル非所有者) には引き続き RLS が適用されるため、通常の
+-- tenant スコープ CRUD のテナント分離は維持される。
+ALTER TABLE alc_api.notify_deliveries NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE alc_api.notify_documents NO FORCE ROW LEVEL SECURITY;


### PR DESCRIPTION
## Summary

- prod で #434 lockdown flip 後の実地検証中、LINE ログインが `GET /api/internal/auth/recipients/by-line-id` の 500 で失敗した
- 原因: `find_recipient_by_line_user_id()` (migration 081) が SECURITY DEFINER 関数で `notify_recipients` を pre-auth (tenant context 無し) で cross-tenant 検索するが、migration 069 の `FORCE ROW LEVEL SECURITY` によりテーブル所有者 (= SECURITY DEFINER 実行ロール) にも RLS ポリシーが適用され、`current_setting('app.current_tenant_id', true)::UUID` の `''::UUID` キャストで例外になっていた
- これは migration 117/118 (LINE webhook 500 の真因) と完全に同一のバグクラス
- **同じパターンを全 migration に対して静的に洗い出し**、もう1件の同種リスクを予防的に修正:
  - `notify_deliveries` / `notify_documents` — notify 公開 viewer (`/v/{token}`) が使う `lookup_delivery_for_view()` (migration 107) が同じ pre-auth cross-tenant JOIN 検索をしており、同じ 500 を起こし得る (実害は未報告だが構造は同一)
- 洗い出したが対象外と判断したもの (PR 本文に詳細): `notify_ingest_keys` (dead code、tenant_short_id 方式に移行済み)、`notify_groups` (pre-auth アクセサ無し)、`bot_configs`/`lineworks_channels`/`devices`/carins 系 (`NULLIF` ガード済みで空文字キャストは発生しない)、`trouble_schedules` (Cloud Tasks 未配線)

## Changes

- `migrations/119_notify_recipients_no_force_rls.sql` — `notify_recipients` の `NO FORCE ROW LEVEL SECURITY`
- `migrations/120_notify_deliveries_documents_no_force_rls.sql` — `notify_deliveries` / `notify_documents` の `NO FORCE ROW LEVEL SECURITY`

いずれも `NO FORCE` は SECURITY DEFINER 関数 (テーブル所有者コンテキスト) のみに影響し、`alc_api_app` (NOBYPASSRLS、テーブル非所有者) には引き続き RLS が適用されるため、通常の tenant スコープ CRUD のテナント分離は維持される (migration 118 で確立済みの根治パターンを踏襲)。

## Test plan

- [x] SQL 構文はコードレビューで確認 (`NO FORCE ROW LEVEL SECURITY` は migration 118 で prod 実績あり)
- [ ] push → CI の `migrate-test` (splinter / RLS) job で検証
- [ ] staging 自動デプロイ後、LINE ログインで recipients 検索が 200 になることを確認
- [ ] merge + `/tag-release patch` で prod 反映後、再度 LINE ログイン確認

Refs ippoan/rust-alc-api#434


---
_Generated by [Claude Code](https://claude.ai/code/session_014xtN6mfkamjWJRFTDPJrhu)_