### PR TITLE
fix(auth): find_user_by_line_user_id を SECURITY DEFINER 化 (Refs #434)

### DIFF
--- a/.claude/skills/rust-alc-api-map/SKILL.md
+++ b/.claude/skills/rust-alc-api-map/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rust-alc-api-map
-generated-from: rust-alc-api:466be820891008db0fb2dac5555e6cbc1f6f87a8
+generated-from: rust-alc-api:9641c4bd31861a675148afdf72f10a3989b5ae85
 paths: [crates/, src/, migrations/]
 description: rust-alc-api (アルコールチェッカー基盤の Rust/Axum Cargo workspace — 13 domain crate + gateway/tenko/carins/dtako/trouble の複数バイナリ、PostgreSQL+RLS、Cloud Run) の構造ナビゲーション。どの crate に何のルートがあるか / monolith(rust-alc-api) と per-domain API + gateway の二系統 / RLS・migration・deploy/release 分離の gotcha を 1 枚にまとめる。トリガー:「rust-alc-api」「alc-api」「alc-notify」「alc-tenko」「alc-trouble」「alc-carins」「alc-dtako」「gateway」「tenko-api」「carins-api」「dtako-api」「trouble-api」「RLS テナント」「sqlx migration」「ts-rs」「Release Wave」「Bazel」等。
 ---
@@ -92,6 +92,13 @@ monolith と per-domain API は同じ domain crate (`alc-tenko` 等) を共有 �
   `notify_line_configs`(#434 migration 118)/`notify_recipients`(119)/`notify_deliveries`+`notify_documents`(120)
   は同じ穴があり `NO FORCE ROW LEVEL SECURITY` で修正済み。新しい pre-auth SECURITY DEFINER 関数を
   追加する時は対象テーブルの RLS ポリシーの cast パターンを確認すること。
+  - **裏の非対称にも注意**: recipient 逆引き (`find_recipient_by_line_user_id`, 076/119) は
+    SECURITY DEFINER 化されていたが、`users` の LINE 逆引きは repo 層が `SELECT * FROM users` を
+    **直接**叩いており (SECURITY DEFINER 無し)、`users` は FORCE 無しでも RLS ENABLE + ポリシーが
+    `current_setting('app.current_tenant_id')::UUID` (**missing_ok 無し**) なので pre-auth では
+    プール接続の残留 GUC 次第で 500/未検出になる非決定バグがあった。migration 121 で
+    `find_user_by_line_user_id(TEXT) RETURNS SETOF users` を SECURITY DEFINER 化して repo を
+    関数経由に変更、recipient と対称化した。
 - **migration 不変条件**: 適用済み `migrations/*.sql` を絶対に変更しない (sqlx が SHA-384 検証、不一致で起動不能)。
   修正は新ファイル追加。migration は **Cloud Run Jobs** (`rust-alc-api-migrate`) で deploy 前に実行
   (`main.rs` から `sqlx::migrate!()` は削除済み = 起動時自動適用なし)。

--- a/crates/alc-core/src/repo/auth.rs
+++ b/crates/alc-core/src/repo/auth.rs
@@ -228,7 +228,10 @@ impl AuthRepository for PgAuthRepository {
         &self,
         line_user_id: &str,
     ) -> Result<Option<User>, sqlx::Error> {
-        sqlx::query_as::<_, User>("SELECT * FROM users WHERE line_user_id = $1")
+        // SECURITY DEFINER 関数経由で RLS をバイパス (migration 121)。LINE ログイン中の
+        // pre-auth 横断逆引きが users RLS + プール接続の残留 tenant GUC に依存して
+        // 500 / 未検出になる非対称を根治 (recipient 側 076/119 と対称)。
+        sqlx::query_as::<_, User>("SELECT * FROM alc_api.find_user_by_line_user_id($1)")
             .bind(line_user_id)
             .fetch_optional(&self.pool)
             .await

--- a/migrations/121_find_user_by_line_id_security_definer.sql
+++ b/migrations/121_find_user_by_line_id_security_definer.sql
@@ -1,0 +1,29 @@
+-- LINE ログイン中の users 逆引きを SECURITY DEFINER でバイパス (Refs #434)
+--
+-- find_recipient_by_line_user_id (migration 076 / 119) と対称の措置。
+-- `find_user_by_line_user_id` は従来 repo 層が `SELECT * FROM users WHERE
+-- line_user_id = $1` を **直接** 実行していた。この経路は LINE ログイン中
+-- (tenant 未確定 = pre-auth) の全テナント横断逆引きだが、実行ロール
+-- `alc_api_app` (NOBYPASSRLS, テーブル非所有者) には users の RLS ポリシー
+--   USING (tenant_id = current_setting('app.current_tenant_id')::UUID)   -- migration 003, missing_ok 無し
+-- が適用される。internal router は tenant context をセットしないため、プール
+-- 接続に残る前リクエストの GUC 次第で:
+--   - GUC 未設定 / '' → current_setting(...)::UUID が例外 → 500
+--   - 別テナントの GUC → 既存 LINE ユーザーを未検出 → 新規扱い → create で
+--     line_user_id UNIQUE 衝突 → 500
+-- と非決定的に壊れる (recipient 側は 076 で SECURITY DEFINER 化済みだが user 側は
+-- 未対応だった非対称)。
+--
+-- 根治: recipient と同じく SECURITY DEFINER 関数で RLS をバイパスして全テナント
+-- 横断で 1 件返す。所有者として実行されるため RLS を回避できる (= 認証前アクセスの
+-- 本来の意図)。通常の tenant スコープ CRUD は alc_api_app に RLS が効いたまま。
+--
+-- splinter 対策として SET search_path = alc_api を付与 (function_search_path_mutable
+-- 回避、既存 find_recipient_by_line_user_id と同形)。
+CREATE OR REPLACE FUNCTION alc_api.find_user_by_line_user_id(p_line_user_id TEXT)
+RETURNS SETOF alc_api.users
+LANGUAGE sql SECURITY DEFINER SET search_path = alc_api AS $$
+  SELECT * FROM alc_api.users WHERE line_user_id = p_line_user_id LIMIT 1;
+$$;
+
+GRANT EXECUTE ON FUNCTION alc_api.find_user_by_line_user_id(TEXT) TO alc_api_app;


### PR DESCRIPTION
## 背景

LINE ログイン（auth.ippoan.org 経由）のデバッグで判明した postgres 側の**非対称な RLS バイパス漏れ**を根治する。

- `find_recipient_by_line_user_id`（migration 076 / 119）は pre-auth 横断逆引き用に **SECURITY DEFINER** 化されている
- 一方 `find_user_by_line_user_id` は repo 層が **`SELECT * FROM users WHERE line_user_id = $1` を直接実行**しており、SECURITY DEFINER バイパスが無い

`users` は migration 003 で RLS 有効、ポリシーは:

```sql
USING (tenant_id = current_setting('app.current_tenant_id')::UUID)  -- missing_ok 無し
```

internal router は tenant context をセットしない（`set_config` 無しを確認）。実行ロール `alc_api_app`（NOBYPASSRLS・非所有者）には RLS が適用されるため、LINE ログイン中（tenant 未確定）の横断 user 逆引きは **プール接続に残る前リクエストの tenant GUC 次第で非決定的に壊れる**:

- GUC 未設定 / `''` → `current_setting(...)::UUID` が例外 → **500**
- 別テナントの GUC → 既存 LINE ユーザーを未検出 → 新規扱い → `create_user_line` で `line_user_id` UNIQUE 衝突 → **500**

（本番ログでは現状プール接続に有効な GUC が残り 200 で動いているが、非決定的で脆い。recipient 側 FORCE RLS は migration 119 で修正済み・v0.0.101 デプロイ済み。本 PR は user 側の対称修正。）

## 変更

- **migration 121**: `CREATE FUNCTION alc_api.find_user_by_line_user_id(TEXT) RETURNS SETOF alc_api.users LANGUAGE sql SECURITY DEFINER SET search_path = alc_api` + `GRANT EXECUTE ... TO alc_api_app`
- **`crates/alc-core/src/repo/auth.rs`**: 直接 SELECT を `SELECT * FROM alc_api.find_user_by_line_user_id($1)` に変更

RLS を無効化するのではなく、pre-auth 横断逆引きという本来の用途に対して所有者実行でバイパスするだけ。通常の tenant スコープ CRUD は `alc_api_app` に RLS が効いたまま。

## splinter

`SET search_path = alc_api` を付与して `function_search_path_mutable` を回避（既存 `find_recipient_by_line_user_id` と同形＝ precedent あり）。migration 検証はローカルで splinter フルセットを回さず、CI の migrate-test + staging 自動デプロイに委譲（CLAUDE.md 方針）。

## ローカル検証

- `cargo fmt -p alc-core` / `cargo check -p alc-core` 通過（ts-rs 警告のみ、無関係）

Refs #434

---
_Generated by [Claude Code](https://claude.ai/code/session_01MgjZBy41zgk9rYMM1NSHpF)_