### PR TITLE
ci: TS bindings 生成を check job から test-matrix(lib) に統合 (Refs #482)

### DIFF
--- a/.claude/skills/rust-alc-api-map/SKILL.md
+++ b/.claude/skills/rust-alc-api-map/SKILL.md
@@ -106,7 +106,10 @@ monolith と per-domain API は同じ domain crate (`alc-tenko` 等) を共有 �
   `scope:rust-alc-api` plan Issue を作り `npm run snapshot` で `manifests/production.snapshot.json` 更新。
   pre-commit (`.githooks`) + CI `snapshot-check` job が drift/stale-sha を検出。`SKIP_CLIPPY=1` で commit 時 clippy skip 可。
 - **ts-rs**: 各 crate が `#[ts(export)]` で TS 型を生成 (`cargo test export_bindings`)。フロント
-  (nuxt-*) が型同期する。型変更時は export_bindings を回す。
+  (nuxt-*) が型同期する。型変更時は export_bindings を回す。生成元は alc-core / alc-misc /
+  alc-carins の 3 crate のみ (alc-auth は ts-rs 依存だけあって derive 未使用)。CI での
+  `ts-bindings-${sha}` artifact は **test-matrix(lib) shard が生成** する (check job ではない、
+  Refs #482 / 下記 CI 節)。
 - **長時間 compute と Cloud Run**: `tokio::spawn` で background compute → fire-and-forget broadcast は
   やらない (Cloud Run は応答後に CPU を絞る)。`RealtimeBus` / `RedactBroadcaster` で対処。CLAUDE.md 該当節参照。
 
@@ -126,6 +129,11 @@ monolith と per-domain API は同じ domain crate (`alc-tenko` 等) を共有 �
   domain 別 (`tests/mock_tenko` `mock_dtako` `mock_carins` `mock_trouble` `mock_devices` `mock_misc`)。
 - **その他 workflow**: `migration-safety-check.yml` (適用済み migration の破壊的変更検査) /
   `release-wave.yml` (Release Wave caller、`repository_dispatch` で cloudrun flip を受ける)。
+- **CI 速度の tracking**: [`docs/ci-speed-tracking.md`](../../../docs/ci-speed-tracking.md) が SoT
+  (Refs #482)。PR CI は同一ソースに対し「coverage 計装 (test-matrix)」と「Bazel fastbuild
+  (build-image)」の 2 profile ビルドが走る (プロファイル統合は原理的に不可)。check job の
+  test profile 重複ビルド (TS bindings 生成) は #482 で test-matrix(lib) に統合済み。
+  Bazel remote cache は健全 (実測済み) — 遅く見えても cache 設定を疑う前にこの doc を読む。
 
 ## 関連 skill
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,9 @@ jobs:
       matrix:
         target:
           # check job 用 (test と build profile が違うため別 cache に分離)。
-          - { name: "check", key: "check", cmd: "cargo clippy --workspace -- -D warnings && cargo test export_bindings --workspace" }
+          # TS bindings 生成は test-matrix(lib) に統合済み (Refs #482) なので
+          # ここは clippy のみ warm する。
+          - { name: "check", key: "check", cmd: "cargo clippy --workspace -- -D warnings" }
           # test-matrix 7 並列 (lib + mock-*) が共有する 1 つの cache。
           # rust-flickr#28-#32 の実験で確定した「shared-key 統合 + main warm 1 job
           # だけ save」設計 (Refs #426)。
@@ -170,16 +172,12 @@ jobs:
         env:
           SCCACHE_GHA_ENABLED: "true"
           RUSTC_WRAPPER: "sccache"
-      - name: Generate TypeScript bindings
-        run: cargo test export_bindings --workspace
-        env:
-          SCCACHE_GHA_ENABLED: "true"
-          RUSTC_WRAPPER: "sccache"
-      - uses: actions/upload-artifact@v4
-        with:
-          name: ts-bindings-${{ github.sha }}
-          path: crates/*/bindings/**/*.ts
-          retention-days: 90
+      # TS bindings 生成 (cargo test export_bindings --workspace) はここから削除し
+      # test-matrix(lib) に統合した (Refs #482)。ts-rs の export_bindings_* は
+      # 各 crate の lib target 内 #[test] なので、lib shard の
+      # `cargo llvm-cov nextest --lib --workspace` が同じ .ts を生成する
+      # (coverage 計装は出力内容に影響しない、diff 検証済み)。check job で
+      # test profile のビルドを重複させない。
 
   test-matrix:
     name: Tests (${{ matrix.group.name }})
@@ -259,6 +257,20 @@ jobs:
           name: coverage-${{ matrix.group.name }}
           path: /tmp/llvm-cov-output.txt
           retention-days: 1
+
+      # ts-rs の export_bindings_* テスト (lib target 内 #[test]) が上の lib shard
+      # 実行で .ts を生成するので、ここで artifact 化する (check job から移設、
+      # Refs #482)。scripts/export-ts-bindings.sh がこの artifact 名で download
+      # する契約は不変。将来 nextest filter 等で export テストが走らなくなった
+      # 場合に無音で空 artifact にならないよう if-no-files-found: error で
+      # loud fail させる。
+      - uses: actions/upload-artifact@v4
+        if: matrix.group.name == 'lib'
+        with:
+          name: ts-bindings-${{ github.sha }}
+          path: crates/*/bindings/**/*.ts
+          retention-days: 90
+          if-no-files-found: error
 
   coverage-check:
     name: Coverage Check

--- a/docs/ci-speed-tracking.md
+++ b/docs/ci-speed-tracking.md
@@ -1,0 +1,82 @@
+# CI 速度改善 tracking
+
+rust-alc-api の PR CI (~214s 実測 / 45 jobs) の速度改善の調査・施策・実測を追跡する doc。
+発端は rust-ichibanboshi (72s / 3 jobs) との比較調査 (Refs #482)。
+
+結論の先出し: **速度差は技術選定ミスではなくスコープの差** (7 マイクロサービスの
+Bazel build + staging deploy を PR CI に含む運用)。改善は「同一ソースの重複ビルドの排除」
+を中心に進める。
+
+## 確定した事実 (2026-07-01 調査、Refs #482)
+
+### Bazel remote cache は健全
+
+- `Build backend` job (106s) 実測: `1832 processes: 1375 disk cache hit, 443 internal,
+  14 processwrapper-sandbox` / `Elapsed 103.4s, Critical Path 36.1s`
+- cache miss ではなく PR 差分 (alc-core 79 files 等) による正当な差分ビルド
+- `gateway` job は `1 process: 1 internal` で完全 cache hit
+- **Bazel の技術選定・cache 設定に問題はない**
+
+### 同一ソースに対して 3 つの独立ビルドが走っていた
+
+| # | job | ツール | profile | cache key |
+|---|---|---|---|---|
+| 1 | `check` (Format & Lint) | `cargo test export_bindings --workspace` | test/debug | rust-cache `check` |
+| 2 | `test-matrix` ×7 | `cargo llvm-cov nextest` | coverage 計装 | rust-cache `test-shared` |
+| 3 | `build-image` ×7 | `bazel build -c fastbuild` | fastbuild | bazel disk-cache |
+
+プロファイルが違うため sccache / rust-cache のキャッシュキーは一切共有されず、
+`alc-core` 等の変更のたびに実質フルリコンパイルが 3 回走る。
+
+## 施策 log
+
+### #482: check job の TS bindings 生成を test-matrix(lib) に統合 (PR #483)
+
+上表 #1 の `cargo test export_bindings --workspace` (~74s) は #2 の lib shard と
+丸ごと重複していた。検証と統合の内容:
+
+**検証 (ローカル、cargo-llvm-cov 0.8.4 = CI 同版 + cargo-nextest):**
+
+- ts-rs の `export_bindings_*` は全て各 crate の **lib target 内 `#[test]`**。
+  `cargo llvm-cov nextest --lib -E 'test(export_bindings)'` で 47 テスト実行、
+  51 .ts が生成された (生成元は alc-core / alc-misc / alc-carins の 3 crate のみ。
+  alc-auth は Cargo.toml に ts-rs 依存があるが `#[derive(TS)]` 未使用)
+- coverage 計装 (`-Cinstrument-coverage`) の有無で .ts 出力を sha256 diff →
+  **完全一致**。nextest のプロセス並列書き込みでも 3 回連続で決定的
+
+**変更 (PR #483):**
+
+- `check` job から `Generate TypeScript bindings` step + `ts-bindings-${sha}`
+  artifact upload を削除 (check は fmt + clippy のみに)
+- `test-matrix` の lib shard 完了後に `ts-bindings-${sha}` を upload
+  (`if-no-files-found: error` で将来の生成漏れを loud fail 化)
+- `cache-warm` の check warm cmd を clippy のみに縮小
+- artifact 名 / パス / retention 不変 → `scripts/export-ts-bindings.sh` の契約に影響なし
+
+**実測:**
+
+- 変更前: Format & Lint job 141s (うち bindings 生成 ~74s)
+- 変更後: (PR #483 の CI 実測後に記入)
+
+## 検証済みで「効果薄い / スコープ外」と判断した案 (Refs #482)
+
+- **FROM scratch image 化**: docker build は既に軽い (3-9s、Bazel がコンパイルを担い、
+  PDFium curl レイヤーも GHA cache でヒット済み)。PDFium が動的 .so 依存のため
+  scratch 化は musl 静的リンク作業が必要でリスク高、CI 速度目的の優先度は低い
+- **バイナリ + main のみ image 化 (rust-ichibanboshi 方式)**: PR ごとの staging deploy
+  検証という CLAUDE.md 明記の運用ポリシー変更を伴う大きな決断のため別途相談
+- **cargo-llvm-cov の RUSTC_WRAPPER 干渉**: ci.yml 側で `RUSTC_WRAPPER: "sccache"` を
+  明示指定しているため `RUSTFLAGS` 経由の注入にフォールバックしているはず
+  (ドキュメント通りなら協調動作)。実害の証跡なし
+
+## 今後の候補 (未着手)
+
+- 上表 #2 (coverage 計装) と #3 (Bazel fastbuild) のプロファイル統合は原理的に不可能
+  (計装バイナリと配布バイナリは別物)。残る余地は shard 分割の見直し・cache 世代管理の
+  チューニング程度で、いずれも計測してから判断する
+
+## 関連
+
+- 調査 issue: [#482](https://github.com/ippoan/rust-alc-api/issues/482)
+- cache 設計の経緯: #426 (shared-key 統合 + 非対称 save-if、rust-flickr#28-#32 の実験由来)
+- auto-merge と deploy の race: #405 / #391 (ci.yml の needs 設計の背景)


### PR DESCRIPTION
Refs #482

## 背景

`check` (Format & Lint) job の `cargo test export_bindings --workspace` は、テスト名フィルタで export_bindings 系だけを実行するために **test profile で workspace 全体を再コンパイル**しており (~74s)、`test-matrix(lib)` shard の `cargo llvm-cov nextest --lib --workspace` と丸ごと重複していた (issue #482 の疑い)。

## ローカル検証結果 (完了条件 1/2)

| 検証 | 結果 |
|---|---|
| export_bindings テストが lib target に含まれるか | ✅ `export_bindings_*` は全て各 crate の lib target 内 `#[test]`。`cargo llvm-cov nextest --lib -E 'test(export_bindings)'` で **47 テスト実行、51 .ts 生成** (alc-core / alc-misc / alc-carins の `bindings/`) |
| coverage 計装が .ts 出力に影響しないか | ✅ 非計装 `cargo test export_bindings` の出力と sha256 diff で**完全一致**。nextest のプロセス並列書き込みでも **3 回連続で決定的** |

補足:
- bindings を生成するのは alc-core / alc-misc / alc-carins の 3 crate のみ (alc-auth は Cargo.toml に ts-rs 依存があるが `#[derive(TS)]` 未使用)
- 検証環境: cargo-llvm-cov 0.8.4 (CI と同版) + cargo-nextest、`-Cinstrument-coverage` は codegen のみに作用し ts-rs の文字列出力には無関係

## 変更内容

- **check job**: `Generate TypeScript bindings` step と `ts-bindings-${sha}` artifact upload を削除 → check は fmt + clippy のみに (test profile ビルドが丸ごと消える)
- **test-matrix**: `lib` shard 完了後に `ts-bindings-${sha}` を upload (`if: matrix.group.name == 'lib'`)。`if-no-files-found: error` を追加し、将来 nextest filter 等で export テストが走らなくなった場合に無音で空 artifact にならないよう loud fail 化
- **cache-warm**: `check` warm cmd から `cargo test export_bindings --workspace` を削除 (clippy のみ) — main push 時の warm も軽くなる

## 互換性

- artifact 名 (`ts-bindings-${sha}`) / パス (`crates/*/bindings/**/*.ts`) / retention (90d) は不変 — `scripts/export-ts-bindings.sh` は artifact 名で download するだけなので契約に影響なし
- check job / test-matrix は同一条件 (PR run のみ) で走るため、artifact が生成されるタイミングも従来と同じ

## 実測 (完了条件 4)

本 PR の CI 実行で Format & Lint job の所要時間を変更前 (141s) と比較する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q3N7WtyjxVb1fXnMLy1dCL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q3N7WtyjxVb1fXnMLy1dCL)_