### PR TITLE
docs: ci-speed-tracking に #482 統合の実測結果を記入 (Refs #482)

### DIFF
--- a/docs/ci-speed-tracking.md
+++ b/docs/ci-speed-tracking.md
@@ -53,10 +53,13 @@ Bazel build + staging deploy を PR CI に含む運用)。改善は「同一ソ�
 - `cache-warm` の check warm cmd を clippy のみに縮小
 - artifact 名 / パス / retention 不変 → `scripts/export-ts-bindings.sh` の契約に影響なし
 
-**実測:**
+**実測 ([run 28550523724](https://github.com/ippoan/rust-alc-api/actions/runs/28550523724)):**
 
 - 変更前: Format & Lint job 141s (うち bindings 生成 ~74s)
-- 変更後: (PR #483 の CI 実測後に記入)
+- 変更後: Format & Lint job **65s (-76s、54% 短縮)**
+- Tests (lib): 129s — bindings upload 追加後も mock shard 群 (161〜192s) より短く、
+  critical path への影響なし。`ts-bindings-*` artifact (19.7 KB) も lib shard から
+  正常に upload されたことを確認
 
 ## 検証済みで「効果薄い / スコープ外」と判断した案 (Refs #482)
 


### PR DESCRIPTION
Refs #482

PR #483 (check job の TS bindings 生成を test-matrix(lib) に統合) の CI 実測結果を `docs/ci-speed-tracking.md` の実測欄に記入する docs-only PR。

- Format & Lint: 141s → **65s (-76s、54% 短縮)** ([run 28550523724](https://github.com/ippoan/rust-alc-api/actions/runs/28550523724))
- Tests (lib): 129s — bindings upload 追加後も mock shard 群 (161〜192s) より短く critical path 影響なし
- `ts-bindings-*` artifact (19.7 KB) も lib shard から正常 upload を確認

issue #482 側にも同内容をコメント済み ([comment](https://github.com/ippoan/rust-alc-api/issues/482#issuecomment-4860436161))。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q3N7WtyjxVb1fXnMLy1dCL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q3N7WtyjxVb1fXnMLy1dCL)_