### PR TITLE
ci: deploy chain の直列 hop を削減 — staging image build を ci.yml に統合 + gateway 並列化 (Refs #482)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,13 +78,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # targets は build-image matrix と揃える (staging image 用に各 service
+          # job が //:migrate も build するため、warm 側にも含める。Refs #482)。
           - { name: backend, targets: "//:rust-alc-api //:migrate //:archive" }
           - { name: gateway, targets: "//crates/gateway" }
-          - { name: tenko, targets: "//crates/tenko-api" }
-          - { name: carins, targets: "//crates/carins-api" }
-          - { name: dtako, targets: "//crates/dtako-api" }
-          - { name: trouble, targets: "//crates/trouble-api" }
-          - { name: camera, targets: "//crates/alc-camera-api" }
+          - { name: tenko, targets: "//crates/tenko-api //:migrate" }
+          - { name: carins, targets: "//crates/carins-api //:migrate" }
+          - { name: dtako, targets: "//crates/dtako-api //:migrate" }
+          - { name: trouble, targets: "//crates/trouble-api //:migrate" }
+          - { name: camera, targets: "//crates/alc-camera-api //:migrate" }
     steps:
       - uses: actions/checkout@v4
       - uses: ippoan/setup-bazel@main
@@ -324,6 +326,13 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
+        # staging-bin が非空の service は、prod image に加えて staging image
+        # (staging/Dockerfile.app + entrypoint) もこの job で build/push する。
+        # 旧 deploy.yml の staging-images job は prod image から docker create/cp
+        # でバイナリを取り出して再パッケージしていたが、この job は bazel-bin に
+        # バイナリを既に持っているため直接 build できる (= deploy chain の直列
+        # hop を 1 個削減、Refs #482)。staging entrypoint が migrate を実行する
+        # ため、staging 対象 service は //:migrate も targets に含める。
         include:
           - name: backend
             targets: "//:rust-alc-api //:migrate //:archive"
@@ -332,6 +341,7 @@ jobs:
             dockerfile: Dockerfile
             tag-suffix: ""
             extra-copy: "migrations"
+            staging-bin: "rust-alc-api"
           - name: gateway
             targets: "//crates/gateway"
             binaries: "gateway"
@@ -339,41 +349,47 @@ jobs:
             dockerfile: Dockerfile.gateway
             tag-suffix: "-gateway"
             extra-copy: ""
+            staging-bin: ""
           - name: tenko
-            targets: "//crates/tenko-api"
+            targets: "//crates/tenko-api //:migrate"
             binaries: "tenko-api"
             bin-paths: "bazel-bin/crates/tenko-api/tenko-api"
             dockerfile: Dockerfile.tenko
             tag-suffix: "-tenko"
             extra-copy: ""
+            staging-bin: "tenko-api"
           - name: carins
-            targets: "//crates/carins-api"
+            targets: "//crates/carins-api //:migrate"
             binaries: "carins-api"
             bin-paths: "bazel-bin/crates/carins-api/carins-api"
             dockerfile: Dockerfile.carins
             tag-suffix: "-carins"
             extra-copy: ""
+            staging-bin: "carins-api"
           - name: dtako
-            targets: "//crates/dtako-api"
+            targets: "//crates/dtako-api //:migrate"
             binaries: "dtako-api"
             bin-paths: "bazel-bin/crates/dtako-api/dtako-api"
             dockerfile: Dockerfile.dtako
             tag-suffix: "-dtako"
             extra-copy: ""
+            staging-bin: "dtako-api"
           - name: trouble
-            targets: "//crates/trouble-api"
+            targets: "//crates/trouble-api //:migrate"
             binaries: "trouble-api"
             bin-paths: "bazel-bin/crates/trouble-api/trouble-api"
             dockerfile: Dockerfile.trouble
             tag-suffix: "-trouble"
             extra-copy: ""
+            staging-bin: "trouble-api"
           - name: camera
-            targets: "//crates/alc-camera-api"
+            targets: "//crates/alc-camera-api //:migrate"
             binaries: "alc-camera-api"
             bin-paths: "bazel-bin/crates/alc-camera-api/alc-camera-api"
             dockerfile: Dockerfile.camera
             tag-suffix: "-camera"
             extra-copy: ""
+            staging-bin: "alc-camera-api"
     steps:
       - uses: actions/checkout@v4
 
@@ -417,6 +433,58 @@ jobs:
           tags: "ghcr.io/${{ github.repository }}${{ matrix.tag-suffix }}:${{ github.sha }}"
           cache-from: "type=gha,scope=${{ matrix.name }}"
           cache-to: "type=gha,mode=max,scope=${{ matrix.name }}"
+
+      # staging image (postgres sidecar 前提の entrypoint + migrate + migrations 同梱)。
+      # 旧 staging-images job (deploy.yml) からの移設 (Refs #482)。バイナリは
+      # bazel-bin から直接取る (prod image からの docker create/cp 再抽出を廃止)。
+      - name: Prepare staging context
+        if: matrix.staging-bin != ''
+        run: |
+          mkdir -p ctx-staging/staging
+          cp "ctx/${{ matrix.staging-bin }}" ctx-staging/
+          cp bazel-bin/migrate ctx-staging/
+          chmod u+w ctx-staging/migrate
+          strip ctx-staging/migrate
+          cp -r migrations ctx-staging/
+          cp staging/Dockerfile.app ctx-staging/Dockerfile
+          cp staging/entrypoint.sh ctx-staging/staging/
+
+      - name: Build and push staging image
+        if: matrix.staging-bin != ''
+        uses: docker/build-push-action@v6
+        with:
+          context: ctx-staging
+          push: true
+          build-args: "BINARY_NAME=${{ matrix.staging-bin }}"
+          tags: "ghcr.io/${{ github.repository }}${{ matrix.tag-suffix }}-staging:${{ github.sha }}"
+          cache-from: "type=gha,scope=${{ matrix.name }}-staging"
+          cache-to: "type=gha,mode=max,scope=${{ matrix.name }}-staging"
+
+  # staging の postgres sidecar image。旧 deploy.yml の staging-db job からの
+  # 移設 (Refs #482)。build-image と並列に走らせることで、deploy workflow 側の
+  # 直列 hop (staging-db → deploy-services) を消す。staging/ 配下は変更頻度が
+  # 低く docker layer cache で数十秒で終わるため、deploy の critical path
+  # (build-image + coverage-check 待ち) には乗らない。
+  staging-db:
+    name: Build staging-db
+    needs: [pr-limit]
+    if: "always() && github.event_name == 'pull_request' && (needs.pr-limit.result == 'success' || needs.pr-limit.result == 'skipped')"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push staging-db
+        run: |
+          docker build -f staging/Dockerfile.postgres \
+            -t ghcr.io/${{ github.repository }}-staging-db:latest .
+          docker push ghcr.io/${{ github.repository }}-staging-db:latest
 
   docker-dev:
     name: Tag dev
@@ -472,11 +540,12 @@ jobs:
 
   deploy:
     name: Deploy
-    needs: [build-image, coverage-check]
+    needs: [build-image, staging-db, coverage-check]
     if: >-
       always() &&
       (github.event_name == 'pull_request' || (startsWith(github.ref, 'refs/tags/v') && github.event_name == 'push')) &&
       (needs.build-image.result == 'success' || needs.build-image.result == 'skipped') &&
+      (needs.staging-db.result == 'success' || needs.staging-db.result == 'skipped') &&
       needs.coverage-check.result == 'success'
     uses: ./.github/workflows/deploy.yml
     permissions:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,79 +27,14 @@ env:
 
 jobs:
   # ---------------------------------------------------------------------------
-  # Staging: build staging images (entrypoint.sh + sidecar)
+  # NOTE (Refs #482): staging image (app / db) の build は ci.yml 側に移設した。
+  #   - staging app image → ci.yml build-image job (bazel-bin から直接 build)
+  #   - staging-db image  → ci.yml staging-db job
+  # 本 workflow が呼ばれる時点 (ci.yml deploy job の needs 充足後) で
+  # ${REPO}${suffix}-staging:${sha} / ${REPO}-staging-db:latest は push 済み。
+  # これにより deploy leg の直列 hop が staging-images → deploy-services →
+  # deploy-gateway の 3 段から deploy-services ∥ deploy-gateway の 1 段になる。
   # ---------------------------------------------------------------------------
-  staging-db:
-    name: "Build staging-db"
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push staging-db
-        run: |
-          docker build -f staging/Dockerfile.postgres \
-            -t ${{ env.REPO }}-staging-db:latest .
-          docker push ${{ env.REPO }}-staging-db:latest
-
-  staging-images:
-    name: "Build staging ${{ matrix.service }}"
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    strategy:
-      fail-fast: true
-      matrix:
-        include:
-          - { service: backend, suffix: "",       binary: rust-alc-api }
-          - { service: tenko,   suffix: "-tenko", binary: tenko-api }
-          - { service: carins,  suffix: "-carins", binary: carins-api }
-          - { service: dtako,   suffix: "-dtako",   binary: dtako-api }
-          - { service: trouble, suffix: "-trouble", binary: trouble-api }
-          - { service: camera,  suffix: "-camera",  binary: alc-camera-api }
-    steps:
-      - uses: actions/checkout@v4
-      - uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build staging image
-        run: |
-          SHA="${{ inputs.image_sha }}"
-          REPO="${{ env.REPO }}"
-          SUFFIX="${{ matrix.suffix }}"
-          BIN="${{ matrix.binary }}"
-
-          mkdir -p ctx/staging
-
-          # Extract service binary
-          docker create --name extract-svc "${REPO}${SUFFIX}:${SHA}"
-          docker cp "extract-svc:/usr/local/bin/${BIN}" ctx/
-          docker rm extract-svc
-
-          # Extract migrate + migrations from backend image
-          docker create --name extract-mig "${REPO}:${SHA}"
-          docker cp extract-mig:/usr/local/bin/migrate ctx/
-          docker cp extract-mig:/app/migrations ctx/
-          docker rm extract-mig
-
-          cp staging/Dockerfile.app ctx/Dockerfile
-          cp staging/entrypoint.sh ctx/staging/
-
-          docker build --build-arg "BINARY_NAME=${BIN}" \
-            -t "${REPO}${SUFFIX}-staging:${SHA}" ctx/
-          docker push "${REPO}${SUFFIX}-staging:${SHA}"
-
   # ---------------------------------------------------------------------------
   # Production: promote dev → version tag
   # ---------------------------------------------------------------------------
@@ -175,10 +110,12 @@ jobs:
   # ---------------------------------------------------------------------------
   deploy-services:
     name: "Deploy ${{ matrix.service }}"
-    needs: [staging-db, staging-images, promote-images, migrate]
+    # PR (staging): staging image 群は ci.yml (build-image / staging-db) で
+    # push 済みなので待つものが無く、即 deploy に入る (Refs #482)。
+    needs: [promote-images, migrate]
     if: >-
       always() && (
-        (github.event_name == 'pull_request' && needs.staging-images.result == 'success' && needs.staging-db.result == 'success') ||
+        github.event_name == 'pull_request' ||
         (startsWith(github.ref, 'refs/tags/v') && needs.migrate.result == 'success')
       )
     runs-on: ubuntu-latest
@@ -365,9 +302,19 @@ jobs:
   # ---------------------------------------------------------------------------
   deploy-gateway:
     name: "Deploy gateway"
-    needs: [deploy-services]
+    # deploy-services と並列 (Refs #482)。gateway が必要とするのは各 service の
+    # `status.url` だけで、Cloud Run の URL は revision が変わっても不変のため
+    # deploy-services の完了を待つ理由がない (service が存在しさえすればよい)。
+    # 例外は完全新規環境の bootstrap (service 未作成で describe が空を返す) のみ
+    # — その場合は deploy-services 完走後に re-run すれば正しい URL で render
+    # される。旧 needs: [deploy-services] は直列 hop ~1 分を deploy leg に
+    # 追加していた。
+    needs: [promote-images, migrate]
     if: >-
-      always() && needs.deploy-services.result == 'success'
+      always() && (
+        github.event_name == 'pull_request' ||
+        (startsWith(github.ref, 'refs/tags/v') && needs.migrate.result == 'success')
+      )
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -43,8 +43,15 @@ rust_binary(
     name = "migrate",
     srcs = ["src/bin/migrate.rs"],
     compile_data = glob(["migrations/**"]),
-    deps = all_crate_deps(normal = True),
-    proc_macro_deps = all_crate_deps(proc_macro = True),
+    # migrate.rs は sqlx/tokio/anyhow しか使わない。all_crate_deps(normal) だと
+    # root package の全 external deps を要求し、staging image 用に //:migrate を
+    # 全 build-image matrix job (per-service bazel cache) で build する際に
+    # monolith の dep closure を抱え込むため、明示 deps に絞る (Refs #482)。
+    deps = [
+        "@crates//:anyhow",
+        "@crates//:sqlx",
+        "@crates//:tokio",
+    ],
 )
 
 rust_binary(

--- a/docs/ci-speed-tracking.md
+++ b/docs/ci-speed-tracking.md
@@ -61,6 +61,37 @@ Bazel build + staging deploy を PR CI に含む運用)。改善は「同一ソ�
   critical path への影響なし。`ts-bindings-*` artifact (19.7 KB) も lib shard から
   正常に upload されたことを確認
 
+### deploy chain の直列 hop 削減 (staging image 統合 + gateway 並列化)
+
+PR CI の deploy leg (~4 分実測) は `staging-images (max 46s) → deploy-services
+(max 60s) → deploy-gateway (56s)` の 3 直列 hop で、hop ごとに runner 起動 +
+checkout + gcloud auth/setup (~20-40s) が乗ることが支配要因だった (service 数の
+matrix は並列なので支配要因ではない)。変更:
+
+- **staging app image の build を ci.yml build-image job に統合** — 旧
+  staging-images job は「prod image から `docker create/cp` でバイナリ抽出 →
+  再パッケージ」だったが、build-image は bazel-bin にバイナリを既に持つので
+  直接 build できる。staging entrypoint が使う `migrate` は各 service job で
+  `//:migrate` を追加 build (BUILD.bazel で deps を sqlx/tokio/anyhow に slim 化
+  済みなので増分はほぼ migrate 本体のみ)。buildx gha cache (scope:
+  `<name>-staging`) で apt/PDFium layer もキャッシュされる (旧 job は cache 無しで
+  毎回 apt-get + PDFium DL していた)
+- **staging-db image build を ci.yml の並列 job に移設** — deploy の needs に
+  入るが build-image / coverage-check より速く終わるため critical path に乗らない
+- **deploy-gateway を deploy-services と並列化** — gateway が必要なのは各 service
+  の `status.url` のみで、Cloud Run の URL は revision が変わっても不変。
+  完全新規環境の bootstrap (service 未作成) のみ re-run が必要
+
+**image レベルの検証の位置は不変**: staging deploy (deploy-services) → 
+smoke-staging-ingest → drift-check-staging → auto-merge gate という「PR ごと
+staging deploy 検証」の運用ポリシー・順序・merge gate はそのまま。むしろ staging
+image の build 失敗は CI 前半 (build-image) で早く検出されるようになる。
+
+**実測:**
+
+- 変更前: deploy leg ~4 分 (3 直列 hop)
+- 変更後: (PR の CI 実測後に記入。見込み ~1.5 分 = deploy-services 1 hop 分)
+
 ## 検証済みで「効果薄い / スコープ外」と判断した案 (Refs #482)
 
 - **FROM scratch image 化**: docker build は既に軽い (3-9s、Bazel がコンパイルを担い、


### PR DESCRIPTION
Refs #482

## 背景

PR CI の deploy leg は実測 ~4 分かかっており、内訳は 3 つの直列 hop:

```
staging-images (max 46s) → deploy-services (max 60s) → deploy-gateway (56s)
```

実作業の合計は ~2.7 分だが、hop ごとに runner 起動 + checkout + gcloud auth/setup (~20-40s) が乗る。matrix の service 数は並列なので支配要因ではなく、**直列 hop 数が支配要因**。

## 変更内容

### A. staging image build を ci.yml に統合 (hop 1 個削減)

- **staging app image**: 旧 `deploy.yml` の `staging-images` job は「prod image から `docker create/cp` でバイナリ抽出 → 再パッケージ」だったが、`ci.yml` の `build-image` job は bazel-bin にバイナリを既に持つため直接 build できる。matrix に `staging-bin` key を追加し、staging 対象 6 service で prod image に続けて staging image も build/push
- **`//:migrate` の bazel deps を slim 化** (`BUILD.bazel`): staging entrypoint が使う migrate バイナリを各 service job で build するため、`all_crate_deps(normal)` (= root package の全 external deps) から `sqlx` / `tokio` / `anyhow` の明示 deps に絞った。sqlx/tokio の閉包は各 *-api が既に持つため、増分はほぼ migrate 本体のコンパイルのみ
- **buildx gha cache** (scope: `<name>-staging`) を導入 — 旧 job は cache 無しで毎 PR apt-get + PDFium DL していた
- **staging-db image**: ci.yml の並列 job に移設。deploy の needs に入るが build-image / coverage-check より速く終わるため critical path に乗らない
- cache-warm-bazel の targets も build-image と揃えた (main push warm で //:migrate も per-service cache に入る)

### B. deploy-gateway を deploy-services と並列化 (hop もう 1 個削減)

gateway の render が必要とするのは各 service の `status.url` のみで、**Cloud Run の URL は revision が変わっても不変** (service が存在すれば deploy 前の describe でも同じ値)。よって deploy-services の完了を待つ理由がない。

- 例外: 完全新規環境の bootstrap (service 未作成で describe が空) のみ、deploy-services 完走後の re-run が必要 (コメントに明記)

## image レベルの検証の位置は不変

「PR ごと staging deploy 検証」の運用ポリシーはそのまま:

- staging deploy (deploy-services) → smoke-staging-ingest → drift-check-staging → auto-merge gate の順序・merge gate は不変 (#405/#391 の教訓を維持)
- staging image の build 失敗はむしろ CI 前半 (build-image) で早く検出されるようになる

## 見込みと実測

- 見込み: deploy leg ~4 分 → **~1.5 分** (deploy-services ∥ deploy-gateway の 1 hop 分)
- 実測は本 PR の CI で確認し `docs/ci-speed-tracking.md` に記入する

## 注意 (初回のみのコスト)

- 各 service の bazel disk-cache (`bazel-tenko` 等) に `//:migrate` の成果物が無い初回は Build job が数十秒〜伸びる (次回以降 cache hit)
- buildx `<name>-staging` scope の初回は cold (apt + PDFium DL ~30s)、次回以降 layer cache hit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q3N7WtyjxVb1fXnMLy1dCL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q3N7WtyjxVb1fXnMLy1dCL)_