### PR TITLE
refactor(auth): require_internal_jwt の HS256 dual-accept を撤去し OIDC 一本化 (Refs #479)

### DIFF
--- a/.claude/skills/rust-alc-api-map/SKILL.md
+++ b/.claude/skills/rust-alc-api-map/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rust-alc-api-map
-generated-from: rust-alc-api:9641c4bd31861a675148afdf72f10a3989b5ae85
+generated-from: rust-alc-api:bb215b961d14a9d3af0c61e6a33af419059d3465
 paths: [crates/, src/, migrations/]
 description: rust-alc-api (アルコールチェッカー基盤の Rust/Axum Cargo workspace — 13 domain crate + gateway/tenko/carins/dtako/trouble の複数バイナリ、PostgreSQL+RLS、Cloud Run) の構造ナビゲーション。どの crate に何のルートがあるか / monolith(rust-alc-api) と per-domain API + gateway の二系統 / RLS・migration・deploy/release 分離の gotcha を 1 枚にまとめる。トリガー:「rust-alc-api」「alc-api」「alc-notify」「alc-tenko」「alc-trouble」「alc-carins」「alc-dtako」「gateway」「tenko-api」「carins-api」「dtako-api」「trouble-api」「RLS テナント」「sqlx migration」「ts-rs」「Release Wave」「Bazel」等。
 ---
@@ -46,14 +46,15 @@ monolith と per-domain API は同じ domain crate (`alc-tenko` 等) を共有 �
 
 - **monolith**: `src/main.rs` — DATABASE_URL で `PgPool`、Storage backend (`STORAGE_BACKEND` = r2/gcs、
   carins/dtako/notify/trouble は別バケット+別 R2 キー)、巨大な `AppState` に全 Pg*Repository を組み立て、
-  `.nest("/api", rust_alc_api::routes::router())`。背景 task: 60s ごと `check_overdue_schedules`。
+  `.nest("/api", rust_alc_api::routes::router(internal_oidc_trust()))`。背景 task: 60s ごと `check_overdue_schedules`。
 - **router 本体**: `src/routes/mod.rs` — 各 domain crate のルートを re-export し `router()` で結線。
   middleware: `require_tenant_header` (tenant/admin 共通、注入 identity 信頼) / `require_internal_jwt`
-  (auth-worker→internal ingest、aud=alc-api-internal。**#434 Phase D で HS256 / Google OIDC の
-  dual-accept 化**: `InternalOidcTrust{enabled,verifier}` Extension (env `INTERNAL_AUTH_TRUST_OIDC=1`
-  で enabled) の時のみ `GoogleTokenVerifier::verify_internal_oidc` が JWKS で RS256 署名検証 +
-  iss + aud=alc-api-internal + exp して OIDC を受理 (Cloud Run IAM に加えた app 層 defense-in-depth)。
-  flag off は HS256 のみ = 非破壊) / `require_internal_shared_secret`
+  (auth-worker→internal ingest、aud=alc-api-internal。**#479 で HS256 dual-accept を撤去し
+  Google OIDC 一本化**: `GoogleTokenVerifier::verify_internal_oidc` が JWKS で RS256 署名検証 +
+  iss + aud=alc-api-internal + exp を検証 (Cloud Run IAM に加えた app 層 defense-in-depth)。
+  `InternalOidcTrust{verifier}` は `router()` の **DI 引数** — prod は `internal_oidc_trust()`
+  (main.rs)、テストは `with_test_claims` verifier を注入。旧 `INTERNAL_AUTH_TRUST_OIDC` env と
+  共有 JWT_SECRET での HS256 受理は削除済み) / `require_internal_shared_secret`
   (email-receiver→`/api/dtako/tickets`)。
   **#434 で monolith のローカル JWT 検証を撤去**: 旧 `require_jwt` / `require_tenant` (bare X-Tenant-ID
   フォールバック) / `TenantProxySecret` gate (#437) / 未配線の `require_tenant_or_device` (#436、device-token)

--- a/cloudrun/render.sh
+++ b/cloudrun/render.sh
@@ -142,8 +142,6 @@ emit_env_backend() {
               value: "alc-fcm"
             - name: STAGING_MODE
               value: "$( [[ "$ENV" == "staging" ]] && echo "true" || echo "false" )"
-            - name: INTERNAL_AUTH_TRUST_OIDC
-              value: "1"
             - name: RUST_LOG
               value: "info"
 YAML

--- a/crates/alc-core/src/auth_middleware.rs
+++ b/crates/alc-core/src/auth_middleware.rs
@@ -4,55 +4,45 @@ use axum::{extract::Request, http::StatusCode, middleware::Next, response::Respo
 use uuid::Uuid;
 
 use crate::auth_google::GoogleTokenVerifier;
-use crate::auth_jwt::{verify_internal_token, JwtSecret};
 
-/// lockdown (`allUsers` 削除) 後に internal-auth の OIDC 経路を有効化する設定
-/// (Refs #434 Phase D)。`require_internal_jwt` 配下に Extension で注入する。
-/// `enabled` が true の時だけ Google OIDC (aud=alc-api-internal) を **署名検証して**受理する
-/// (それまでは HS256 のみ = 非破壊)。`verifier` は `client_id=alc-api-internal` で構築した
-/// `GoogleTokenVerifier` で、enabled に関わらず常時構築する (= 配線を分岐レスにし coverage を
-/// 100% に保つ。enabled=false の間は未使用)。app 配線側で `INTERNAL_AUTH_TRUST_OIDC` env から
-/// `enabled` を解決する (Extension 注入なのでテストは決定的)。
+/// internal-auth の OIDC 検証設定。`require_internal_jwt` 配下に Extension で注入する。
+/// `verifier` は `client_id=alc-api-internal` で構築した `GoogleTokenVerifier`。
+/// app 配線 (`routes::router` の引数経由、prod は main.rs / テストは
+/// `with_test_claims`) で注入するため、テストは決定的。
+///
+/// #479 で #434 Phase D の HS256 dual-accept (`enabled` flag + 共有 `JWT_SECRET`
+/// 検証) を撤去し、Google OIDC (aud=alc-api-internal、JWKS RS256 署名検証) に
+/// 一本化した。全呼び出し元 (auth-worker `internalAuthToken` / Cloud Scheduler)
+/// は OIDC mint 済み。
 #[derive(Clone)]
 pub struct InternalOidcTrust {
-    pub enabled: bool,
     pub verifier: GoogleTokenVerifier,
 }
 
-/// 内部 API 用 JWT 検証ミドルウェア
+/// 内部 API 用 OIDC 検証ミドルウェア
 ///
-/// `Authorization: Bearer <jwt>` を要求し、`aud == "alc-api-internal"` を強制する。
-/// auth-worker が LINE WORKS webhook を受け取って rust-alc-api に転送する際の
-/// `/api/internal/*` ルート保護に使う。通常のユーザー JWT (`AppClaims`) は
-/// `aud` を持たないため弾かれる。
+/// `Authorization: Bearer <token>` を要求し、Google OIDC (aud=alc-api-internal) を
+/// **JWKS で RS256 署名検証**して受理する (`GoogleTokenVerifier::verify_internal_oidc`)。
+/// auth-worker が internal 呼び出し (`/api/internal/*`) に使う。通常のユーザー JWT
+/// (HS256 / aud 無し) は署名検証で弾かれる。
 ///
-/// #434 Phase D の lockdown 移行用に **dual-accept**:
-/// 1. 従来の HS256 internal JWT (`verify_internal_token`) — 移行前/現行。
-/// 2. `InternalOidcTrust.enabled` の時のみ、Google OIDC (aud=alc-api-internal) を
-///    **JWKS で RS256 署名検証**して受理 (`GoogleTokenVerifier::verify_internal_oidc`)。
-///    `enabled=false` の間は完全に dormant (非破壊)。
+/// 旧 HS256 internal JWT (`verify_internal_token` + 共有 `JWT_SECRET`) の受理は
+/// #479 で撤去した — 全呼び出し元が OIDC を mint する (auth-worker#340)。
 pub async fn require_internal_jwt(
-    Extension(jwt_secret): Extension<JwtSecret>,
     Extension(oidc_trust): Extension<InternalOidcTrust>,
     req: Request,
     next: Next,
 ) -> Result<Response, StatusCode> {
     let token = extract_bearer_token(&req).ok_or(StatusCode::UNAUTHORIZED)?;
-    // 1) HS256 internal JWT (移行前/現行)。
-    if verify_internal_token(token, &jwt_secret).is_ok() {
-        return Ok(next.run(req).await);
-    }
-    // 2) lockdown 後の OIDC 経路 (enabled の時のみ、JWKS で署名検証込み)。
-    if oidc_trust.enabled
-        && oidc_trust
-            .verifier
-            .verify_internal_oidc(token)
-            .await
-            .is_ok()
+    if oidc_trust
+        .verifier
+        .verify_internal_oidc(token)
+        .await
+        .is_ok()
     {
         return Ok(next.run(req).await);
     }
-    tracing::warn!("internal JWT verification failed");
+    tracing::warn!("internal OIDC verification failed");
     Err(StatusCode::UNAUTHORIZED)
 }
 
@@ -271,20 +261,12 @@ mod tests {
     }
 
     fn app_internal_jwt() -> Router {
-        app_internal_jwt_with(false)
-    }
-
-    fn app_internal_jwt_with(enabled: bool) -> Router {
         Router::new()
             .route("/i", get(echo_ok))
             .layer(axum_middleware::from_fn(require_internal_jwt))
             .layer(Extension(InternalOidcTrust {
-                enabled,
                 verifier: test_oidc_verifier(),
             }))
-            .layer(Extension(JwtSecret(
-                "test-internal-secret-256-bits!!!".to_string(),
-            )))
     }
 
     /// test_claims モードの verifier (`verify_internal_oidc("test-valid-token")` が Ok)。
@@ -310,8 +292,21 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn internal_jwt_ok() {
-        use crate::auth_jwt::create_internal_token;
+    async fn internal_jwt_oidc_ok() {
+        // OIDC verifier (test_claims モード) の署名検証 OK トークンは受理。
+        let resp = send(
+            app_internal_jwt(),
+            req_with_headers("/i", &[("Authorization", "Bearer test-valid-token")]),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn internal_jwt_hs256_no_longer_accepted() {
+        // #479 regression: 旧 HS256 internal JWT (共有 JWT_SECRET 署名) は
+        // dual-accept 撤去後は拒否されること。
+        use crate::auth_jwt::{create_internal_token, JwtSecret};
         let secret = JwtSecret("test-internal-secret-256-bits!!!".to_string());
         let token = create_internal_token(&secret, "auth-worker", 60).unwrap();
         let resp = send(
@@ -319,7 +314,7 @@ mod tests {
             req_with_headers("/i", &[("Authorization", &format!("Bearer {token}"))]),
         )
         .await;
-        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
     }
 
     #[tokio::test]
@@ -330,8 +325,8 @@ mod tests {
 
     #[tokio::test]
     async fn internal_jwt_user_token_rejected() {
-        // ユーザー JWT は aud を持たないので拒否されること
-        use crate::auth_jwt::create_access_token;
+        // ユーザー JWT (HS256 / aud 無し) は OIDC 署名検証で拒否されること
+        use crate::auth_jwt::{create_access_token, JwtSecret};
         use crate::models::User;
         let secret = JwtSecret("test-internal-secret-256-bits!!!".to_string());
         let user = User {
@@ -359,36 +354,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn internal_jwt_wrong_secret_rejected() {
-        use crate::auth_jwt::create_internal_token;
-        let other = JwtSecret("different-secret-key-256-bits!!".to_string());
-        let token = create_internal_token(&other, "auth-worker", 60).unwrap();
-        // OIDC trust off (既定) なので、HS256 不一致 = 401 (dual-accept の OIDC 経路に入らない)。
+    async fn internal_jwt_oidc_rejected_when_signature_invalid() {
+        // 署名検証に失敗する token は拒否 (署名検証は無効化していない)。
         let resp = send(
             app_internal_jwt(),
-            req_with_headers("/i", &[("Authorization", &format!("Bearer {token}"))]),
-        )
-        .await;
-        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
-    }
-
-    #[tokio::test]
-    async fn internal_jwt_oidc_accepted_when_trust_enabled() {
-        // OIDC verifier 注入 + 署名検証 OK (test_claims モードの "test-valid-token") は受理。
-        // HS256 では通らない token なので OIDC 経路に入る (Refs #434 Phase D)。
-        let resp = send(
-            app_internal_jwt_with(true),
-            req_with_headers("/i", &[("Authorization", "Bearer test-valid-token")]),
-        )
-        .await;
-        assert_eq!(resp.status(), StatusCode::OK);
-    }
-
-    #[tokio::test]
-    async fn internal_jwt_oidc_rejected_when_signature_invalid() {
-        // OIDC verifier 注入でも署名検証に失敗する token は拒否 (署名検証は無効化していない)。
-        let resp = send(
-            app_internal_jwt_with(true),
             req_with_headers("/i", &[("Authorization", "Bearer not-a-valid-token")]),
         )
         .await;

--- a/src/main.rs
+++ b/src/main.rs
@@ -455,9 +455,10 @@ async fn main() -> anyhow::Result<()> {
             "INTERNAL_SHARED_SECRET not set; /api/dtako/tickets internal routes are disabled"
         );
     }
-    let api_router = rust_alc_api::routes::router().merge(
-        rust_alc_api::routes::internal_shared_secret_router(internal_secret),
-    );
+    let api_router = rust_alc_api::routes::router(rust_alc_api::routes::internal_oidc_trust())
+        .merge(rust_alc_api::routes::internal_shared_secret_router(
+            internal_secret,
+        ));
 
     let app = Router::new()
         .nest("/api", api_router)

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -79,7 +79,18 @@ use crate::auth::jwt::INTERNAL_AUD;
 use crate::middleware::auth::{require_internal_jwt, require_tenant_header, InternalOidcTrust};
 use crate::AppState;
 
-pub fn router() -> Router<AppState> {
+/// prod 用の `InternalOidcTrust` を構築する (aud=alc-api-internal、JWKS RS256 検証)。
+/// main.rs から `router()` に渡す。テストは `GoogleTokenVerifier::with_test_claims`
+/// で構築した trust を渡す (Refs #479 — HS256 dual-accept 撤去で OIDC 一本化。
+/// DI 引数化したのは、Extension を router 内部で固定すると外側 layer で上書き
+/// できず、テストが実 JWKS 検証を通せないため)。
+pub fn internal_oidc_trust() -> InternalOidcTrust {
+    InternalOidcTrust {
+        verifier: GoogleTokenVerifier::new(INTERNAL_AUD.to_string(), String::new()),
+    }
+}
+
+pub fn router(internal_oidc: InternalOidcTrust) -> Router<AppState> {
     // 管理者ルート — 注入 identity (X-User-*) を信頼 (Refs #434)。
     // 前段 proxy / gateway が introspect 検証済みの identity を注入する前提。
     // role 判定は各ハンドラが AuthUser から行う。
@@ -102,15 +113,11 @@ pub fn router() -> Router<AppState> {
         .merge(health_canary::internal_router())
         .merge(auth::internal_router())
         .layer(axum_middleware::from_fn(require_internal_jwt))
-        // #434 Phase D: lockdown 後の OIDC dual-accept を有効化する設定 (env 解決、Extension 注入)。
-        // verifier (aud=alc-api-internal) は常時構築し enabled は env で gate する (分岐レス = coverage
-        // 100% を保つ。enabled=false の間は require_internal_jwt が verifier を呼ばない)。OIDC が
-        // enabled の時、require_internal_jwt が JWKS で署名検証して受理する。require_internal_jwt の
-        // 外側に置き、ハンドラ実行時に Extension を解決できるようにする。
-        .layer(Extension(InternalOidcTrust {
-            enabled: std::env::var("INTERNAL_AUTH_TRUST_OIDC").as_deref() == Ok("1"),
-            verifier: GoogleTokenVerifier::new(INTERNAL_AUD.to_string(), String::new()),
-        }));
+        // OIDC 検証設定 (Refs #479 — HS256 dual-accept 撤去で OIDC 一本化)。
+        // require_internal_jwt の外側に置き、ハンドラ実行時に Extension を解決
+        // できるようにする。verifier は呼び出し元 (main.rs = 実 JWKS / テスト =
+        // with_test_claims) が注入する。
+        .layer(Extension(internal_oidc));
 
     // テナント対応ルート — 注入 identity (X-Tenant-ID + 任意 X-User-*) を信頼 (Refs #434)。
     // 旧 require_tenant の bare X-Tenant-ID フォールバック / ローカル JWT 検証は撤去。
@@ -238,5 +245,15 @@ mod tests {
         let _ = internal_shared_secret_router(Some(String::new()));
         // Some(non-empty) → middleware + extension 付き Router (`Some(secret)` ブランチ)
         let _ = internal_shared_secret_router(Some("test-secret".to_string()));
+    }
+
+    /// `internal_oidc_trust()` (prod 用 OIDC trust 構築) のカバレッジテスト
+    /// (Refs #479)。verifier の検証挙動自体は alc-core の auth_middleware /
+    /// auth_google テストがカバーする。ここでは prod 構築 path が panic なく
+    /// 通ることだけを保証する (JWKS fetch は verify 時まで遅延されるため
+    /// ネットワーク非依存)。
+    #[test]
+    fn internal_oidc_trust_builds() {
+        let _ = internal_oidc_trust();
     }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -489,11 +489,13 @@ pub fn create_test_jwt(tenant_id: Uuid, role: &str) -> String {
     create_access_token(&user, &secret, None).expect("Failed to create test JWT")
 }
 
-/// 内部 API 用のテスト JWT を発行 (aud=alc-api-internal)
+/// 内部 API 用のテスト token を返す (aud=alc-api-internal)。
+///
+/// #479 で `require_internal_jwt` は Google OIDC 一本化 (HS256 dual-accept 撤去)
+/// されたため、`spawn_test_server` が注入する test_claims モードの
+/// `GoogleTokenVerifier` が受理する固定 token を返す。
 pub fn create_test_internal_jwt() -> String {
-    let secret = JwtSecret(TEST_JWT_SECRET.to_string());
-    rust_alc_api::auth::jwt::create_internal_token(&secret, "test-auth-worker", 60)
-        .expect("Failed to create test internal JWT")
+    "test-valid-token".to_string()
 }
 
 /// dtako テスト用の最小 ZIP (KUDGURI.csv + KUDGIVT.csv) を生成
@@ -625,6 +627,28 @@ async fn test_proxy_inject(
     next.run(req).await
 }
 
+/// テスト用 `InternalOidcTrust` (test_claims モード)。`create_test_internal_jwt()`
+/// が返す "test-valid-token" だけを受理する (Refs #479 — OIDC 一本化後の
+/// internal route テスト用)。
+fn internal_oidc_trust_for_tests() -> rust_alc_api::middleware::auth::InternalOidcTrust {
+    use rust_alc_api::auth::google::{GoogleClaims, GoogleTokenVerifier};
+    rust_alc_api::middleware::auth::InternalOidcTrust {
+        verifier: GoogleTokenVerifier::with_test_claims(
+            rust_alc_api::auth::jwt::INTERNAL_AUD.to_string(),
+            GoogleClaims {
+                sub: "test-internal-sa".to_string(),
+                email: String::new(),
+                name: String::new(),
+                picture: None,
+                email_verified: false,
+                aud: rust_alc_api::auth::jwt::INTERNAL_AUD.to_string(),
+                iss: "https://accounts.google.com".to_string(),
+                exp: 9999999999,
+            },
+        ),
+    }
+}
+
 pub async fn spawn_test_server(state: AppState) -> String {
     spawn_test_server_with_scraper(state, "http://localhost:9999").await
 }
@@ -658,7 +682,10 @@ pub async fn spawn_test_server_with_scraper(state: AppState, scraper_url: &str) 
         .allow_headers(Any);
 
     let app = Router::new()
-        .nest("/api", rust_alc_api::routes::router())
+        .nest(
+            "/api",
+            rust_alc_api::routes::router(internal_oidc_trust_for_tests()),
+        )
         // テスト用 proxy emulation (Refs #434)。#434 で rust-alc-api は JWT 検証を
         // 撤去し、注入された identity ヘッダー (X-Tenant-ID / X-User-*) を信頼する
         // dumb backend になった。本番では CF proxy が auth-worker introspect で検証


### PR DESCRIPTION
Refs #479 (Stage 1: dual-accept 撤去。JWT_SECRET 撤去は Stage 2 で別 PR)

## 背景

`require_internal_jwt` は #434 Phase D の移行用に **dual-accept** (HS256 internal JWT + 共有 `JWT_SECRET` 検証 / Google OIDC) だった。issue #479 の方針に従い OIDC (aud=`alc-api-internal`、JWKS RS256 署名検証) に一本化する。

## 前提 (揃済み、[調査コメント](https://github.com/ippoan/rust-alc-api/issues/479#issuecomment-4860615024) 参照)

- 最後の HS256 呼び出し元だった auth-worker `lineworks-webhook-do` は **ippoan/auth-worker#340** で `internalAuthToken` (OIDC-aware) に統一済み
- **auth-worker v0.2.89** として prod にも tag release 済み (staging は merge 時点で反映)
- `INTERNAL_AUTH_OIDC=1` + `ALC_API_PROXY_SA_KEY` は auth-worker の prod/staging 両方で設定済み
- `aud=alc-api-internal` の HS256 mint は org 横断 grep で他に存在しない

## 変更内容

- **alc-core `auth_middleware`**: `require_internal_jwt` から HS256 分岐 + `Extension<JwtSecret>` を削除。`InternalOidcTrust` の `enabled` flag も削除 (常時 OIDC 検証)。regression テスト追加: **旧 HS256 internal JWT は 401 になること**
- **`routes/mod.rs`**: `InternalOidcTrust` を `router()` の **DI 引数**に変更 — Extension を router 内部で固定すると外側 layer で上書きできず、統合テストが実 JWKS 検証を通せないため。prod 構築は `internal_oidc_trust()` helper (main.rs から注入)。coverage 100% 登録ファイルなので構築テストも追加
- **`INTERNAL_AUTH_TRUST_OIDC` env を全撤去** (routes / `cloudrun/render.sh`、参照 0 件確認済み)
- **`tests/common`**: `create_test_internal_jwt` を test_claims モード verifier が受理する固定 token に変更、`spawn_test_server` に テスト用 `InternalOidcTrust` (`with_test_claims`) を注入 — mock 統合テスト (notify viewer internal 等) は無変更で通る

## 検証

- `cargo check --workspace --all-targets` ✅ / `cargo clippy --workspace -- -D warnings` (CI 同条件) ✅
- `cargo test -p alc-core --lib auth_middleware` 17 passed (OIDC ok / HS256 拒否 / 署名不正拒否 / header 欠落) ✅
- DB 依存の mock 統合テストは本 PR の CI で検証

## 運用注意

- rust の次回 `v*` release (Release Wave flip) は auth-worker v0.2.89 の prod 反映後であること — v0.2.89 は発行済みなので通常フローで満たされる
- issue #479 AC 3/4 (#436 `require_tenant_or_device` / #437 `TENANT_PROXY_SECRET` の旧実装削除) は grep 0 件 = 既に撤去済みを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q3N7WtyjxVb1fXnMLy1dCL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q3N7WtyjxVb1fXnMLy1dCL)_