### PR TITLE
refactor(crypto): 保存 secret 暗号鍵の JWT_SECRET fallback を撤去し SSO_ENCRYPTION_KEY 必須化 (Refs #479)

### DIFF
--- a/.claude/skills/rust-alc-api-map/SKILL.md
+++ b/.claude/skills/rust-alc-api-map/SKILL.md
@@ -74,6 +74,13 @@ monolith と per-domain API は同じ domain crate (`alc-tenko` 等) を共有 �
 
 ## gotcha (CLAUDE.md / README 由来)
 
+- **保存 secret の暗号鍵は `SSO_ENCRYPTION_KEY` 必須** (Refs #479 PR-1)。LINE channel
+  secret / LINE WORKS bot secret / SSO client_secret の AES-256-GCM 鍵素材
+  (`SHA-256(SSO_ENCRYPTION_KEY)`、`alc-core::auth_lineworks::{encrypt,decrypt}_secret`)。
+  旧 `or_else(JWT_SECRET)` の env-presence fallback は撤去済み — 未設定は loud に 500。
+  復号側は auth-worker (同 secret の CF binding) と共有。render.sh は backend にのみ注入
+  (暗号化経路を実行するのは monolith だけ。trouble-api は notifier: None)。
+
 - **DB 接続**: `alc_api_app` ロール (NOBYPASSRLS → RLS 有効) で、**直接接続 port 5432** を使う
   (Supavisor 6543 は `set_config` がリセットされ RLS テナント分離が壊れる)。
   `DATABASE_URL` に `?options=-c search_path=alc_api` 必須。

--- a/crates/alc-misc/src/bot_admin.rs
+++ b/crates/alc-misc/src/bot_admin.rs
@@ -268,9 +268,7 @@ async fn upsert_config(
         return Err(StatusCode::FORBIDDEN);
     }
 
-    let key = std::env::var("SSO_ENCRYPTION_KEY")
-        .or_else(|_| std::env::var("JWT_SECRET"))
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let key = std::env::var("SSO_ENCRYPTION_KEY").map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
     let provider = body.provider.as_deref().unwrap_or("lineworks");
     let enabled = body.enabled.unwrap_or(true);
@@ -409,9 +407,7 @@ async fn get_config_secrets(
         return Err(StatusCode::FORBIDDEN);
     }
 
-    let key = std::env::var("SSO_ENCRYPTION_KEY")
-        .or_else(|_| std::env::var("JWT_SECRET"))
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let key = std::env::var("SSO_ENCRYPTION_KEY").map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
     let row = state
         .bot_admin

--- a/crates/alc-misc/src/sso_admin.rs
+++ b/crates/alc-misc/src/sso_admin.rs
@@ -86,7 +86,6 @@ async fn upsert_config(
             None
         } else {
             let key = std::env::var("SSO_ENCRYPTION_KEY")
-                .or_else(|_| std::env::var("JWT_SECRET"))
                 .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
             Some(encrypt_secret(secret, &key).expect("AES-256-GCM encrypt infallible"))
         }

--- a/crates/alc-notify/src/distribute.rs
+++ b/crates/alc-notify/src/distribute.rs
@@ -31,12 +31,10 @@ pub fn tenant_router() -> Router<AppState> {
 }
 
 fn encryption_key() -> Result<String, StatusCode> {
-    std::env::var("SSO_ENCRYPTION_KEY")
-        .or_else(|_| std::env::var("JWT_SECRET"))
-        .map_err(|_| {
-            tracing::error!("SSO_ENCRYPTION_KEY or JWT_SECRET not set");
-            StatusCode::INTERNAL_SERVER_ERROR
-        })
+    std::env::var("SSO_ENCRYPTION_KEY").map_err(|_| {
+        tracing::error!("SSO_ENCRYPTION_KEY not set");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })
 }
 
 async fn resolve_line_config(state: &AppState, tenant_id: Uuid) -> Result<LineConfig, String> {

--- a/crates/alc-notify/src/line_config.rs
+++ b/crates/alc-notify/src/line_config.rs
@@ -31,12 +31,10 @@ async fn upsert_config(
     Extension(tenant): Extension<TenantId>,
     Json(input): Json<UpsertLineConfig>,
 ) -> Result<Json<serde_json::Value>, StatusCode> {
-    let key = std::env::var("SSO_ENCRYPTION_KEY")
-        .or_else(|_| std::env::var("JWT_SECRET"))
-        .map_err(|_| {
-            tracing::error!("SSO_ENCRYPTION_KEY or JWT_SECRET not set");
-            StatusCode::INTERNAL_SERVER_ERROR
-        })?;
+    let key = std::env::var("SSO_ENCRYPTION_KEY").map_err(|_| {
+        tracing::error!("SSO_ENCRYPTION_KEY not set");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
 
     let channel_secret_encrypted = encrypt_secret(&input.channel_secret, &key).map_err(|e| {
         tracing::error!("encrypt channel_secret: {e}");

--- a/crates/alc-notify/src/line_webhook.rs
+++ b/crates/alc-notify/src/line_webhook.rs
@@ -169,12 +169,10 @@ async fn find_config_by_signature(
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
 
-    let enc_key = std::env::var("SSO_ENCRYPTION_KEY")
-        .or_else(|_| std::env::var("JWT_SECRET"))
-        .map_err(|_| {
-            tracing::error!("SSO_ENCRYPTION_KEY or JWT_SECRET not set");
-            StatusCode::INTERNAL_SERVER_ERROR
-        })?;
+    let enc_key = std::env::var("SSO_ENCRYPTION_KEY").map_err(|_| {
+        tracing::error!("SSO_ENCRYPTION_KEY not set");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
 
     for cfg in &configs {
         let Ok(channel_secret) = decrypt_secret(&cfg.channel_secret_encrypted, &enc_key) else {

--- a/crates/alc-notify/src/lineworks_channels.rs
+++ b/crates/alc-notify/src/lineworks_channels.rs
@@ -55,12 +55,10 @@ fn internal_error(msg: &str) -> (StatusCode, Json<serde_json::Value>) {
 }
 
 fn encryption_key() -> Result<String, (StatusCode, Json<serde_json::Value>)> {
-    std::env::var("SSO_ENCRYPTION_KEY")
-        .or_else(|_| std::env::var("JWT_SECRET"))
-        .map_err(|_| {
-            tracing::error!("SSO_ENCRYPTION_KEY or JWT_SECRET not set");
-            internal_error("encryption_key_missing")
-        })
+    std::env::var("SSO_ENCRYPTION_KEY").map_err(|_| {
+        tracing::error!("SSO_ENCRYPTION_KEY not set");
+        internal_error("encryption_key_missing")
+    })
 }
 
 // ---------- admin: list ----------

--- a/crates/alc-notify/src/lineworks_directory.rs
+++ b/crates/alc-notify/src/lineworks_directory.rs
@@ -28,12 +28,10 @@ pub struct DirectoryUser {
 }
 
 fn encryption_key() -> Result<String, (StatusCode, Json<serde_json::Value>)> {
-    std::env::var("SSO_ENCRYPTION_KEY")
-        .or_else(|_| std::env::var("JWT_SECRET"))
-        .map_err(|_| {
-            tracing::error!("SSO_ENCRYPTION_KEY or JWT_SECRET not set");
-            internal_error("encryption_key_missing")
-        })
+    std::env::var("SSO_ENCRYPTION_KEY").map_err(|_| {
+        tracing::error!("SSO_ENCRYPTION_KEY not set");
+        internal_error("encryption_key_missing")
+    })
 }
 
 fn internal_error(msg: &str) -> (StatusCode, Json<serde_json::Value>) {

--- a/crates/alc-trouble/src/notifier.rs
+++ b/crates/alc-trouble/src/notifier.rs
@@ -20,9 +20,7 @@ pub trait TroubleNotifier: Send + Sync {
 }
 
 fn encryption_key() -> Result<String, String> {
-    std::env::var("SSO_ENCRYPTION_KEY")
-        .or_else(|_| std::env::var("JWT_SECRET"))
-        .map_err(|_| "SSO_ENCRYPTION_KEY or JWT_SECRET not set".to_string())
+    std::env::var("SSO_ENCRYPTION_KEY").map_err(|_| "SSO_ENCRYPTION_KEY not set".to_string())
 }
 
 pub async fn resolve_lineworks_config(

--- a/tests/mock_tests/mock_auth_test.rs
+++ b/tests/mock_tests/mock_auth_test.rs
@@ -20,6 +20,7 @@ use rust_alc_api::db::repository::auth::SsoConfigRow;
 async fn test_require_jwt_invalid_token_returns_401() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockAuthRepository::default());
     let mut state = setup_mock_app_state();
@@ -47,6 +48,7 @@ async fn test_require_jwt_invalid_token_returns_401() {
 async fn test_google_login_existing_user() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let tenant_id = Uuid::new_v4();
     let user = mock_user(tenant_id);
@@ -84,6 +86,7 @@ async fn test_google_login_existing_user() {
 async fn test_google_login_new_user_no_invitation_rejected() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     // return_user = None → no invitation → no domain tenant
     // → 勝手に新テナントを作らず 403 で拒否する (Refs #332)
@@ -111,6 +114,7 @@ async fn test_google_login_new_user_no_invitation_rejected() {
 async fn test_google_login_new_user_via_invitation() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let tenant_id = Uuid::new_v4();
     let mock = Arc::new(MockAuthRepository::default());
@@ -148,6 +152,7 @@ async fn test_google_login_new_user_via_invitation() {
 async fn test_google_login_new_user_via_email_domain() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let tenant_id = Uuid::new_v4();
     let mock = Arc::new(MockAuthRepository::default());
@@ -187,6 +192,7 @@ async fn test_google_login_new_user_via_email_domain() {
 async fn test_google_login_invalid_token() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockAuthRepository::default());
     let mut state = setup_mock_app_state();
@@ -212,6 +218,7 @@ async fn test_google_login_invalid_token() {
 async fn test_google_login_db_error() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockAuthRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
@@ -238,6 +245,7 @@ async fn test_google_login_db_error() {
 async fn test_refresh_token_success() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let tenant_id = Uuid::new_v4();
     let user = mock_user(tenant_id);
@@ -271,6 +279,7 @@ async fn test_refresh_token_success() {
 async fn test_refresh_token_invalid() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     // return_refresh_user = None → user not found → 401
     let mock = Arc::new(MockAuthRepository::default());
@@ -297,6 +306,7 @@ async fn test_refresh_token_invalid() {
 async fn test_refresh_token_db_error() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockAuthRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
@@ -323,6 +333,7 @@ async fn test_refresh_token_db_error() {
 async fn test_me_success() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let tenant_id = Uuid::new_v4();
     let mock = Arc::new(MockAuthRepository::default());
@@ -354,6 +365,7 @@ async fn test_me_success() {
 async fn test_me_unauthorized() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockAuthRepository::default());
     let mut state = setup_mock_app_state();
@@ -378,6 +390,7 @@ async fn test_me_unauthorized() {
 async fn test_logout_success() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let tenant_id = Uuid::new_v4();
     let mock = Arc::new(MockAuthRepository::default());
@@ -405,6 +418,7 @@ async fn test_logout_success() {
 async fn test_logout_unauthorized() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockAuthRepository::default());
     let mut state = setup_mock_app_state();
@@ -429,6 +443,7 @@ async fn test_logout_unauthorized() {
 async fn test_logout_db_error() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let tenant_id = Uuid::new_v4();
     let mock = Arc::new(MockAuthRepository::default());
@@ -457,6 +472,7 @@ async fn test_logout_db_error() {
 async fn test_my_orgs_success() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let tenant_id = Uuid::new_v4();
     let mock = Arc::new(MockAuthRepository::default());
@@ -499,6 +515,7 @@ async fn test_my_orgs_success() {
 async fn test_my_orgs_empty() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let tenant_id = Uuid::new_v4();
     // return_tenant = None → empty organizations
@@ -530,6 +547,7 @@ async fn test_my_orgs_empty() {
 async fn test_my_orgs_db_error() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let tenant_id = Uuid::new_v4();
     let mock = Arc::new(MockAuthRepository::default());
@@ -558,6 +576,7 @@ async fn test_my_orgs_db_error() {
 async fn test_my_orgs_unauthorized() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockAuthRepository::default());
     let mut state = setup_mock_app_state();
@@ -583,6 +602,7 @@ async fn test_my_orgs_unauthorized() {
 async fn test_woff_config_success() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockAuthRepository::default());
     *mock.return_sso_config.lock().unwrap() = Some(SsoConfigRow {
@@ -619,6 +639,7 @@ async fn test_woff_config_success() {
 async fn test_woff_config_not_found() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     // return_sso_config = None → 404
     let mock = Arc::new(MockAuthRepository::default());
@@ -646,6 +667,7 @@ async fn test_woff_config_not_found() {
 async fn test_woff_config_no_woff_id() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockAuthRepository::default());
     *mock.return_sso_config.lock().unwrap() = Some(SsoConfigRow {
@@ -680,6 +702,7 @@ async fn test_woff_config_no_woff_id() {
 async fn test_woff_config_db_error() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockAuthRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
@@ -707,6 +730,7 @@ async fn test_woff_config_db_error() {
 async fn test_woff_config_missing_domain() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockAuthRepository::default());
     let mut state = setup_mock_app_state();
@@ -732,6 +756,7 @@ async fn test_woff_config_missing_domain() {
 async fn test_google_code_login_valid_code() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     // GoogleTokenVerifier in test mode accepts "test-valid-code"
     let mock = Arc::new(MockAuthRepository::default());
@@ -773,6 +798,7 @@ async fn test_google_code_login_valid_code() {
 async fn test_google_code_login_invalid_code() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockAuthRepository::default());
     let mut state = setup_mock_app_state();
@@ -801,6 +827,7 @@ async fn test_google_code_login_invalid_code() {
 async fn test_lineworks_redirect_missing_domain() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     std::env::set_var("OAUTH_STATE_SECRET", "test-state-secret");
 
     let mock = Arc::new(MockAuthRepository::default());
@@ -832,6 +859,7 @@ async fn test_lineworks_redirect_missing_domain() {
 async fn test_lineworks_redirect_sso_not_found() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     std::env::set_var("OAUTH_STATE_SECRET", "test-state-secret");
 
     // return_sso_config = None → 404
@@ -863,6 +891,7 @@ async fn test_lineworks_redirect_sso_not_found() {
 async fn test_lineworks_redirect_success() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     std::env::set_var("OAUTH_STATE_SECRET", "test-state-secret");
 
     let mock = Arc::new(MockAuthRepository::default());
@@ -904,6 +933,7 @@ async fn test_lineworks_redirect_success() {
 async fn test_lineworks_redirect_with_address() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     std::env::set_var("OAUTH_STATE_SECRET", "test-state-secret");
 
     let mock = Arc::new(MockAuthRepository::default());
@@ -943,6 +973,7 @@ async fn test_lineworks_redirect_with_address() {
 async fn test_lineworks_redirect_db_error() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     std::env::set_var("OAUTH_STATE_SECRET", "test-state-secret");
 
     let mock = Arc::new(MockAuthRepository::default());
@@ -974,6 +1005,7 @@ async fn test_lineworks_redirect_db_error() {
 async fn test_google_redirect_success() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     std::env::set_var("OAUTH_STATE_SECRET", "test-state-secret");
 
     let mock = Arc::new(MockAuthRepository::default());
@@ -1007,6 +1039,7 @@ async fn test_google_redirect_success() {
 async fn test_google_redirect_missing_state_secret() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     std::env::remove_var("OAUTH_STATE_SECRET");
 
     let mock = Arc::new(MockAuthRepository::default());
@@ -1073,6 +1106,7 @@ fn encrypt_secret_for_test(plaintext: &str, key_material: &str) -> String {
 async fn test_google_callback_success() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     std::env::set_var("OAUTH_STATE_SECRET", "test-state-secret");
     std::env::set_var("API_ORIGIN", "http://localhost:0");
 
@@ -1129,6 +1163,7 @@ async fn test_google_callback_success() {
 async fn test_google_callback_missing_state_secret() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     std::env::remove_var("OAUTH_STATE_SECRET");
 
     let mock = Arc::new(MockAuthRepository::default());
@@ -1159,6 +1194,7 @@ async fn test_google_callback_missing_state_secret() {
 async fn test_google_callback_invalid_state() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     std::env::set_var("OAUTH_STATE_SECRET", "test-state-secret");
 
     let mock = Arc::new(MockAuthRepository::default());
@@ -1189,6 +1225,7 @@ async fn test_google_callback_invalid_state() {
 async fn test_google_callback_invalid_code() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     std::env::set_var("OAUTH_STATE_SECRET", "test-state-secret");
 
     let mock = Arc::new(MockAuthRepository::default());
@@ -1229,6 +1266,7 @@ async fn test_google_callback_invalid_code() {
 async fn test_google_callback_new_user() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     std::env::set_var("OAUTH_STATE_SECRET", "test-state-secret");
 
     // return_user = None → new user。招待もドメイン一致もないと #332 で 403 に
@@ -1285,6 +1323,7 @@ async fn test_google_callback_new_user() {
 async fn test_lineworks_redirect_missing_state_secret() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     std::env::remove_var("OAUTH_STATE_SECRET");
 
     let mock = Arc::new(MockAuthRepository::default());
@@ -1315,6 +1354,7 @@ async fn test_lineworks_redirect_missing_state_secret() {
 async fn test_lineworks_callback_success() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     let oauth_secret = "test-state-secret";
     std::env::set_var("OAUTH_STATE_SECRET", oauth_secret);
 
@@ -1424,6 +1464,7 @@ async fn test_lineworks_callback_success() {
 async fn test_lineworks_callback_existing_user() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     let oauth_secret = "test-state-secret";
     std::env::set_var("OAUTH_STATE_SECRET", oauth_secret);
 
@@ -1532,6 +1573,7 @@ async fn test_lineworks_callback_existing_user() {
 async fn test_lineworks_callback_missing_state_secret() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     std::env::remove_var("OAUTH_STATE_SECRET");
 
     let mock = Arc::new(MockAuthRepository::default());
@@ -1562,6 +1604,7 @@ async fn test_lineworks_callback_missing_state_secret() {
 async fn test_lineworks_callback_invalid_state() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     std::env::set_var("OAUTH_STATE_SECRET", "test-state-secret");
 
     let mock = Arc::new(MockAuthRepository::default());
@@ -1592,6 +1635,7 @@ async fn test_lineworks_callback_invalid_state() {
 async fn test_lineworks_callback_sso_not_found() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     let oauth_secret = "test-state-secret";
     std::env::set_var("OAUTH_STATE_SECRET", oauth_secret);
 
@@ -1634,6 +1678,7 @@ async fn test_lineworks_callback_sso_not_found() {
 async fn test_lineworks_callback_decrypt_fails() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     let oauth_secret = "test-state-secret";
     std::env::set_var("OAUTH_STATE_SECRET", oauth_secret);
 
@@ -1684,6 +1729,7 @@ async fn test_lineworks_callback_decrypt_fails() {
 async fn test_lineworks_callback_token_exchange_fails() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     let oauth_secret = "test-state-secret";
     std::env::set_var("OAUTH_STATE_SECRET", oauth_secret);
 
@@ -1756,6 +1802,7 @@ async fn test_lineworks_callback_token_exchange_fails() {
 async fn test_lineworks_callback_profile_fetch_fails() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     let oauth_secret = "test-state-secret";
     std::env::set_var("OAUTH_STATE_SECRET", oauth_secret);
 
@@ -1846,6 +1893,7 @@ async fn test_lineworks_callback_profile_fetch_fails() {
 async fn test_lineworks_callback_create_user_fails() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     let oauth_secret = "test-state-secret";
     std::env::set_var("OAUTH_STATE_SECRET", oauth_secret);
 
@@ -1946,6 +1994,7 @@ async fn test_lineworks_callback_create_user_fails() {
 async fn test_woff_auth_success() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock_server = wiremock::MockServer::start().await;
     std::env::set_var(
@@ -2007,6 +2056,7 @@ async fn test_woff_auth_success() {
 async fn test_woff_auth_existing_user() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock_server = wiremock::MockServer::start().await;
     std::env::set_var(
@@ -2081,6 +2131,7 @@ async fn test_woff_auth_existing_user() {
 async fn test_woff_auth_sso_not_found() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     // return_sso_config = None → 404
     let mock = Arc::new(MockAuthRepository::default());
@@ -2110,6 +2161,7 @@ async fn test_woff_auth_sso_not_found() {
 async fn test_woff_auth_profile_fails() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock_server = wiremock::MockServer::start().await;
     std::env::set_var(
@@ -2165,6 +2217,7 @@ async fn test_woff_auth_profile_fails() {
 async fn test_woff_auth_db_error() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockAuthRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
@@ -2194,6 +2247,7 @@ async fn test_woff_auth_db_error() {
 async fn test_google_callback_two_part_domain() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     std::env::set_var("OAUTH_STATE_SECRET", "test-state-secret");
 
     let mock = Arc::new(MockAuthRepository::default());
@@ -2247,6 +2301,7 @@ async fn test_google_callback_two_part_domain() {
 async fn test_google_callback_http_redirect_uri() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     std::env::set_var("OAUTH_STATE_SECRET", "test-state-secret");
 
     let mock = Arc::new(MockAuthRepository::default());
@@ -2303,6 +2358,7 @@ async fn test_google_callback_http_redirect_uri() {
 async fn test_switch_org_success() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let current_tenant_id = Uuid::new_v4();
     let target_tenant_id = Uuid::new_v4();
@@ -2357,6 +2413,7 @@ async fn test_switch_org_success() {
 async fn test_switch_org_user_not_found() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let current_tenant_id = Uuid::new_v4();
     let target_tenant_id = Uuid::new_v4();
@@ -2388,6 +2445,7 @@ async fn test_switch_org_user_not_found() {
 async fn test_switch_org_invalid_uuid() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let tenant_id = Uuid::new_v4();
     let mock = Arc::new(MockAuthRepository::default());
@@ -2416,6 +2474,7 @@ async fn test_switch_org_invalid_uuid() {
 async fn test_switch_org_db_error() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let tenant_id = Uuid::new_v4();
     let target_tenant_id = Uuid::new_v4();
@@ -2447,6 +2506,7 @@ async fn test_switch_org_db_error() {
 async fn test_switch_org_unauthorized() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockAuthRepository::default());
     let mut state = setup_mock_app_state();
@@ -2472,6 +2532,7 @@ async fn test_switch_org_unauthorized() {
 async fn test_line_redirect_success() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     std::env::set_var("OAUTH_STATE_SECRET", "test-state-secret");
     std::env::set_var("LINE_LOGIN_CHANNEL_ID", "test-line-channel-id");
     std::env::set_var("API_ORIGIN", "http://localhost:0");
@@ -2509,6 +2570,7 @@ async fn test_line_redirect_success() {
 async fn test_line_redirect_with_tenant_id() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     std::env::set_var("OAUTH_STATE_SECRET", "test-state-secret");
     std::env::set_var("LINE_LOGIN_CHANNEL_ID", "test-line-channel-id");
     std::env::set_var("API_ORIGIN", "http://localhost:0");
@@ -2547,6 +2609,7 @@ async fn test_line_redirect_with_tenant_id() {
 async fn test_line_redirect_missing_state_secret() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     std::env::remove_var("OAUTH_STATE_SECRET");
     std::env::set_var("LINE_LOGIN_CHANNEL_ID", "test-line-channel-id");
 
@@ -2580,6 +2643,7 @@ async fn test_line_redirect_missing_state_secret() {
 async fn test_line_redirect_missing_channel_id() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     std::env::set_var("OAUTH_STATE_SECRET", "test-state-secret");
     std::env::remove_var("LINE_LOGIN_CHANNEL_ID");
 
@@ -2611,6 +2675,7 @@ async fn test_line_redirect_missing_channel_id() {
 async fn test_line_select_tenant_success() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let tenant_id = Uuid::new_v4();
     let user = User {
@@ -2666,6 +2731,7 @@ async fn test_line_select_tenant_success() {
 async fn test_line_select_tenant_new_user() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let tenant_id = Uuid::new_v4();
 
@@ -2703,6 +2769,7 @@ async fn test_line_select_tenant_new_user() {
 async fn test_line_select_tenant_forbidden() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let tenant_id = Uuid::new_v4();
     let other_tenant_id = Uuid::new_v4();
@@ -2739,6 +2806,7 @@ async fn test_line_select_tenant_forbidden() {
 async fn test_line_select_tenant_db_error() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let tenant_id = Uuid::new_v4();
 
@@ -2771,6 +2839,7 @@ async fn test_line_select_tenant_db_error() {
 async fn test_password_login_success() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let tenant_id = Uuid::new_v4();
 
@@ -2837,6 +2906,7 @@ async fn test_password_login_success() {
 async fn test_password_login_wrong_password() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let tenant_id = Uuid::new_v4();
 
@@ -2895,6 +2965,7 @@ async fn test_password_login_wrong_password() {
 async fn test_password_login_user_not_found() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let tenant_id = Uuid::new_v4();
 
@@ -2927,6 +2998,7 @@ async fn test_password_login_user_not_found() {
 async fn test_password_login_no_hash() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let tenant_id = Uuid::new_v4();
 
@@ -2977,6 +3049,7 @@ async fn test_password_login_no_hash() {
 async fn test_password_login_invalid_org_id() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockAuthRepository::default());
     let mut state = setup_mock_app_state();
@@ -3006,6 +3079,7 @@ async fn test_password_login_invalid_org_id() {
 async fn test_password_login_db_error() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let tenant_id = Uuid::new_v4();
 
@@ -3083,6 +3157,7 @@ async fn test_line_callback_existing_user() {
     std::env::set_var("LINE_LOGIN_CHANNEL_SECRET", "s");
     std::env::set_var("LINE_API_BASE", mock_server.uri());
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let p = lineworks::state::StatePayload {
         redirect_uri: "https://e.com/cb".into(),
@@ -3148,6 +3223,7 @@ async fn test_line_callback_zero_tenants() {
     std::env::set_var("LINE_LOGIN_CHANNEL_SECRET", "s");
     std::env::set_var("LINE_API_BASE", mock_server.uri());
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let p = lineworks::state::StatePayload {
         redirect_uri: "https://e.com/cb".into(),
@@ -3219,6 +3295,7 @@ async fn test_line_callback_one_tenant() {
     std::env::set_var("LINE_LOGIN_CHANNEL_SECRET", "s");
     std::env::set_var("LINE_API_BASE", mock_server.uri());
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let p = lineworks::state::StatePayload {
         redirect_uri: "https://e.com/cb".into(),
@@ -3289,6 +3366,7 @@ async fn test_line_callback_multiple_tenants() {
     std::env::set_var("LINE_LOGIN_CHANNEL_SECRET", "s");
     std::env::set_var("LINE_API_BASE", mock_server.uri());
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let p = lineworks::state::StatePayload {
         redirect_uri: "https://e.com/s".into(),
@@ -3330,6 +3408,7 @@ async fn test_line_callback_invalid_state_param() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("OAUTH_STATE_SECRET", "s");
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     let state = setup_mock_app_state();
     let base_url = crate::common::spawn_test_server(state).await;
     let client = reqwest::Client::builder()
@@ -3368,6 +3447,7 @@ async fn test_line_callback_token_exchange_fails() {
     std::env::set_var("LINE_LOGIN_CHANNEL_SECRET", "s");
     std::env::set_var("LINE_API_BASE", mock_server.uri());
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let p = lineworks::state::StatePayload {
         redirect_uri: "https://e.com/cb".into(),
@@ -3423,6 +3503,7 @@ async fn test_line_callback_profile_fetch_fails() {
     std::env::set_var("LINE_LOGIN_CHANNEL_SECRET", "s");
     std::env::set_var("LINE_API_BASE", mock_server.uri());
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let p = lineworks::state::StatePayload {
         redirect_uri: "https://e.com/cb".into(),
@@ -3458,6 +3539,7 @@ async fn test_line_callback_missing_channel_id() {
     let ss = "ss-ch-missing";
     std::env::set_var("OAUTH_STATE_SECRET", ss);
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     std::env::remove_var("LINE_LOGIN_CHANNEL_ID");
     std::env::remove_var("LINE_LOGIN_CHANNEL_SECRET");
 
@@ -3524,6 +3606,7 @@ async fn test_line_callback_qr_invite() {
     std::env::set_var("LINE_LOGIN_CHANNEL_SECRET", "s");
     std::env::set_var("LINE_API_BASE", mock_server.uri());
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let p = lineworks::state::StatePayload {
         redirect_uri: "https://e.com/cb".into(),

--- a/tests/mock_tests/mock_bot_admin_test.rs
+++ b/tests/mock_tests/mock_bot_admin_test.rs
@@ -19,6 +19,7 @@ async fn test_list_configs_success() {
     test_case!("管理者は空のリストを取得できる", {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
         let mock = Arc::new(MockBotAdminRepository::default());
         let mut state = setup_mock_app_state();
@@ -47,6 +48,7 @@ async fn test_list_configs_forbidden_for_viewer() {
     test_case!("viewer ロールは FORBIDDEN", {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
         let mock = Arc::new(MockBotAdminRepository::default());
         let mut state = setup_mock_app_state();
@@ -73,6 +75,7 @@ async fn test_list_configs_db_error() {
     test_case!("DB エラー時に 500 を返す", {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
         let mock = Arc::new(MockBotAdminRepository::default());
         mock.fail_next.store(true, Ordering::SeqCst);
@@ -104,6 +107,7 @@ async fn test_create_config_success() {
     test_case!("新規作成が成功する", {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
         let mock = Arc::new(MockBotAdminRepository::default());
         let mut state = setup_mock_app_state();
@@ -146,6 +150,7 @@ async fn test_create_config_with_explicit_provider_and_disabled() {
     test_case!("provider を明示指定、enabled=false で作成", {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
         let mock = Arc::new(MockBotAdminRepository::default());
         let mut state = setup_mock_app_state();
@@ -183,6 +188,7 @@ async fn test_create_config_forbidden_for_viewer() {
     test_case!("viewer ロールは FORBIDDEN", {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
         let mock = Arc::new(MockBotAdminRepository::default());
         let mut state = setup_mock_app_state();
@@ -215,6 +221,7 @@ async fn test_create_config_db_error() {
     test_case!("DB エラー時に 500 を返す", {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
         let mock = Arc::new(MockBotAdminRepository::default());
         mock.fail_next.store(true, Ordering::SeqCst);
@@ -252,6 +259,7 @@ async fn test_update_config_success() {
     test_case!("既存設定の更新が成功する", {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
         let mock = Arc::new(MockBotAdminRepository::default());
         let mut state = setup_mock_app_state();
@@ -291,6 +299,7 @@ async fn test_update_config_with_secrets() {
     test_case!("client_secret と private_key を同時に更新", {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
         let mock = Arc::new(MockBotAdminRepository::default());
         let mut state = setup_mock_app_state();
@@ -329,6 +338,7 @@ async fn test_create_config_with_bot_secret() {
         {
             let _guard = crate::common::ENV_LOCK.lock().unwrap();
             std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+            std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
             let mock = Arc::new(MockBotAdminRepository::default());
             let mut state = setup_mock_app_state();
@@ -365,6 +375,7 @@ async fn test_update_config_with_bot_secret() {
         {
             let _guard = crate::common::ENV_LOCK.lock().unwrap();
             std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+            std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
             let mock = Arc::new(MockBotAdminRepository::default());
             let mut state = setup_mock_app_state();
@@ -401,6 +412,7 @@ async fn test_update_config_with_empty_bot_secret_skipped() {
     test_case!("空文字の bot_secret は更新スキップ", {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
         let mock = Arc::new(MockBotAdminRepository::default());
         let mut state = setup_mock_app_state();
@@ -438,6 +450,7 @@ async fn test_create_config_with_bot_secret_update_fails() {
         {
             let _guard = crate::common::ENV_LOCK.lock().unwrap();
             std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+            std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
             // create_config は成功させ、update_bot_secret だけを失敗させる
             let mock = Arc::new(MockBotAdminRepository::default());
@@ -475,6 +488,7 @@ async fn test_update_bot_secret_db_error() {
     test_case!("update_bot_secret 失敗時に 500", {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
         // fail_next を 1 回だけ true → 最初の呼び出しが失敗。
         // update_config よりも先に update_bot_secret が呼ばれることを期待。
@@ -515,6 +529,7 @@ async fn test_update_config_with_empty_secrets() {
         {
             let _guard = crate::common::ENV_LOCK.lock().unwrap();
             std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+            std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
             let mock = Arc::new(MockBotAdminRepository::default());
             let mut state = setup_mock_app_state();
@@ -552,6 +567,7 @@ async fn test_update_config_invalid_uuid() {
     test_case!("不正な UUID は BAD_REQUEST", {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
         let mock = Arc::new(MockBotAdminRepository::default());
         let mut state = setup_mock_app_state();
@@ -585,6 +601,7 @@ async fn test_update_config_forbidden_for_viewer() {
     test_case!("viewer ロールは FORBIDDEN", {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
         let mock = Arc::new(MockBotAdminRepository::default());
         let mut state = setup_mock_app_state();
@@ -618,6 +635,7 @@ async fn test_update_config_db_error() {
     test_case!("update_config の DB エラーで 500", {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
         let mock = Arc::new(MockBotAdminRepository::default());
         mock.fail_next.store(true, Ordering::SeqCst);
@@ -700,6 +718,7 @@ async fn test_delete_config_success() {
     test_case!("設定の削除が成功する", {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
         let mock = Arc::new(MockBotAdminRepository::default());
         let mut state = setup_mock_app_state();
@@ -729,6 +748,7 @@ async fn test_delete_config_invalid_uuid() {
     test_case!("不正な UUID は BAD_REQUEST", {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
         let mock = Arc::new(MockBotAdminRepository::default());
         let mut state = setup_mock_app_state();
@@ -758,6 +778,7 @@ async fn test_delete_config_forbidden_for_viewer() {
     test_case!("viewer ロールは FORBIDDEN", {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
         let mock = Arc::new(MockBotAdminRepository::default());
         let mut state = setup_mock_app_state();
@@ -787,6 +808,7 @@ async fn test_delete_config_db_error() {
     test_case!("DB エラー時に 500 を返す", {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
         let mock = Arc::new(MockBotAdminRepository::default());
         mock.fail_next.store(true, Ordering::SeqCst);
@@ -860,6 +882,7 @@ async fn test_get_config_secrets_success() {
             let _guard = crate::common::ENV_LOCK.lock().unwrap();
             let key = "test-encryption-key-for-secrets";
             std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+            std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
             std::env::set_var("SSO_ENCRYPTION_KEY", key);
 
             let config_id = Uuid::new_v4();
@@ -918,6 +941,7 @@ async fn test_get_config_secrets_with_bot_secret() {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         let key = "test-encryption-key-bot-secret";
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
         std::env::set_var("SSO_ENCRYPTION_KEY", key);
 
         let config_id = Uuid::new_v4();
@@ -966,6 +990,7 @@ async fn test_get_config_secrets_bot_secret_decrypt_error() {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         let key = "test-key-bot-secret-fail";
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
         std::env::set_var("SSO_ENCRYPTION_KEY", key);
 
         let config_id = Uuid::new_v4();
@@ -1011,6 +1036,7 @@ async fn test_get_config_secrets_forbidden_viewer() {
     test_case!("viewer ロールは FORBIDDEN", {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
         let mock = Arc::new(MockBotAdminRepository::default());
         let mut state = setup_mock_app_state();
@@ -1040,6 +1066,7 @@ async fn test_get_config_secrets_not_found() {
     test_case!("存在しない config は 404", {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
         let mock = Arc::new(MockBotAdminRepository::default());
         // return_config_with_secrets is None by default -> 404
@@ -1070,6 +1097,7 @@ async fn test_get_config_secrets_db_error() {
     test_case!("DB エラー時に 500 を返す", {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
         let mock = Arc::new(MockBotAdminRepository::default());
         mock.fail_next.store(true, Ordering::SeqCst);
@@ -1101,6 +1129,7 @@ async fn test_get_config_secrets_decrypt_error() {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         let key = "test-key-for-decrypt-fail";
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
         std::env::set_var("SSO_ENCRYPTION_KEY", key);
 
         let config_id = Uuid::new_v4();
@@ -1147,6 +1176,7 @@ async fn test_get_config_secrets_short_ciphertext() {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         let key = "test-key-short";
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
         std::env::set_var("SSO_ENCRYPTION_KEY", key);
 
         let config_id = Uuid::new_v4();
@@ -1196,6 +1226,7 @@ async fn test_get_config_secrets_private_key_decrypt_error() {
             let _guard = crate::common::ENV_LOCK.lock().unwrap();
             let key = "test-key-pk-fail";
             std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+            std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
             std::env::set_var("SSO_ENCRYPTION_KEY", key);
 
             let config_id = Uuid::new_v4();
@@ -1305,6 +1336,7 @@ async fn test_export_configs_success() {
     test_case!("developer email + tenant + 1 config", {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
         let prev = set_dev_emails(dev_email());
 
         let mock = Arc::new(MockBotAdminRepository::default());
@@ -1379,6 +1411,7 @@ async fn test_export_configs_forbidden_for_non_developer() {
     test_case!("DEVELOPER_EMAILS に含まれない user は 403", {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
         let prev = set_dev_emails(dev_email());
 
         let mock = Arc::new(MockBotAdminRepository::default());
@@ -1414,6 +1447,7 @@ async fn test_export_configs_tenant_not_found() {
     test_case!("テナントが存在しない場合は 404", {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
         let prev = set_dev_emails(dev_email());
 
         let mock = Arc::new(MockBotAdminRepository::default());
@@ -1450,6 +1484,7 @@ async fn test_export_configs_tenant_db_error() {
     test_case!("tenant 取得時の DB エラーで 500", {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
         let prev = set_dev_emails(dev_email());
 
         let mock = Arc::new(MockBotAdminRepository::default());
@@ -1486,6 +1521,7 @@ async fn test_export_configs_configs_db_error() {
     test_case!("bot_configs 取得時の DB エラーで 500", {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
         let prev = set_dev_emails(dev_email());
 
         let mock = Arc::new(MockBotAdminRepository::default());

--- a/tests/mock_tests/mock_devices_test.rs
+++ b/tests/mock_tests/mock_devices_test.rs
@@ -16,6 +16,7 @@ use crate::mock_helpers::MockDeviceRepository;
 async fn test_register_request_success() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     let mut state = setup_mock_app_state();
@@ -39,6 +40,7 @@ async fn test_register_request_success() {
 async fn test_register_request_code_collision_retry() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_code_exists_once
@@ -63,6 +65,7 @@ async fn test_register_request_code_collision_retry() {
 async fn test_register_request_no_device_name() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     let mut state = setup_mock_app_state();
@@ -83,6 +86,7 @@ async fn test_register_request_no_device_name() {
 async fn test_register_request_db_error() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
@@ -108,6 +112,7 @@ async fn test_register_request_db_error() {
 async fn test_registration_status_found() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst);
@@ -130,6 +135,7 @@ async fn test_registration_status_found() {
 async fn test_registration_status_not_found() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     // return_data=false -> None -> 404
@@ -150,6 +156,7 @@ async fn test_registration_status_not_found() {
 async fn test_registration_status_db_error() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
@@ -174,6 +181,7 @@ async fn test_registration_status_db_error() {
 async fn test_claim_url_flow_success() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst);
@@ -204,6 +212,7 @@ async fn test_claim_url_flow_success() {
 async fn test_claim_not_found() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     // return_data=false -> None -> error
@@ -229,6 +238,7 @@ async fn test_claim_not_found() {
 async fn test_claim_db_error() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
@@ -258,6 +268,7 @@ async fn test_claim_db_error() {
 async fn test_device_settings_found() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst);
@@ -283,6 +294,7 @@ async fn test_device_settings_found() {
 async fn test_device_settings_not_found() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     let mut state = setup_mock_app_state();
@@ -308,6 +320,7 @@ async fn test_device_settings_not_found() {
 async fn test_device_settings_token_match() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst);
@@ -335,6 +348,7 @@ async fn test_device_settings_token_match() {
 async fn test_device_settings_token_mismatch() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst);
@@ -359,6 +373,7 @@ async fn test_device_settings_token_mismatch() {
 async fn test_device_settings_token_sent_but_not_issued() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst);
@@ -383,6 +398,7 @@ async fn test_device_settings_token_sent_but_not_issued() {
 async fn test_device_settings_token_issued_header_missing() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst);
@@ -406,6 +422,7 @@ async fn test_device_settings_token_issued_header_missing() {
 async fn test_registration_status_settings_token_only_when_approved() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst);
@@ -447,6 +464,7 @@ async fn test_registration_status_settings_token_only_when_approved() {
 async fn test_register_fcm_token_success() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst); // lookup_device_tenant returns Some
@@ -471,6 +489,7 @@ async fn test_register_fcm_token_success() {
 async fn test_register_fcm_token_device_not_found() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     // return_data=false -> lookup_device_tenant returns None -> 404
@@ -499,6 +518,7 @@ async fn test_register_fcm_token_device_not_found() {
 async fn test_report_version_success() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst);
@@ -526,6 +546,7 @@ async fn test_report_version_success() {
 async fn test_report_version_device_not_found() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     let mut state = setup_mock_app_state();
@@ -554,6 +575,7 @@ async fn test_report_version_device_not_found() {
 async fn test_report_watchdog_success() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst);
@@ -578,6 +600,7 @@ async fn test_report_watchdog_success() {
 async fn test_report_watchdog_device_not_found() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     let mut state = setup_mock_app_state();
@@ -605,6 +628,7 @@ async fn test_report_watchdog_device_not_found() {
 async fn test_update_last_login_success() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst);
@@ -635,6 +659,7 @@ async fn test_update_last_login_success() {
 async fn test_fcm_notify_call_no_fcm() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     std::env::set_var("FCM_INTERNAL_SECRET", "test-fcm-secret");
 
     let mock = Arc::new(MockDeviceRepository::default());
@@ -661,6 +686,7 @@ async fn test_fcm_notify_call_secret_unset_fail_closed() {
     // FCM_INTERNAL_SECRET 未設定 → fail-closed で 503 (Refs #392)。
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     std::env::remove_var("FCM_INTERNAL_SECRET");
 
     let mock = Arc::new(MockDeviceRepository::default());
@@ -683,6 +709,7 @@ async fn test_fcm_notify_call_secret_unset_fail_closed() {
 async fn test_fcm_notify_call_empty_rooms() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     std::env::set_var("FCM_INTERNAL_SECRET", "test-fcm-secret");
 
     let mock = Arc::new(MockDeviceRepository::default());
@@ -712,6 +739,7 @@ async fn test_fcm_notify_call_empty_rooms() {
 async fn test_fcm_notify_call_with_devices() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     std::env::set_var("FCM_INTERNAL_SECRET", "test-fcm-secret");
 
     let mock = Arc::new(MockDeviceRepository::default());
@@ -741,6 +769,7 @@ async fn test_fcm_notify_call_with_devices() {
 async fn test_fcm_notify_call_with_internal_secret_check() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     std::env::set_var("FCM_INTERNAL_SECRET", "my-secret-123");
 
     let mock = Arc::new(MockDeviceRepository::default());
@@ -781,6 +810,7 @@ async fn test_fcm_notify_call_with_internal_secret_check() {
 async fn test_fcm_dismiss_test_no_fcm() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     let mut state = setup_mock_app_state();
@@ -802,6 +832,7 @@ async fn test_fcm_dismiss_test_no_fcm() {
 async fn test_fcm_dismiss_test_device_not_found() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     // return_data=false -> get_device_tenant_active returns None -> 404
@@ -824,6 +855,7 @@ async fn test_fcm_dismiss_test_device_not_found() {
 async fn test_fcm_dismiss_test_success() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst);
@@ -852,6 +884,7 @@ async fn test_fcm_dismiss_test_success() {
 async fn test_fcm_all_exclude_no_fcm() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     let mut state = setup_mock_app_state();
@@ -877,6 +910,7 @@ async fn test_fcm_all_exclude_no_fcm() {
 async fn test_list_devices_empty() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     let mut state = setup_mock_app_state();
@@ -902,6 +936,7 @@ async fn test_list_devices_empty() {
 async fn test_list_devices_no_auth() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     let mut state = setup_mock_app_state();
@@ -921,6 +956,7 @@ async fn test_list_devices_no_auth() {
 async fn test_list_devices_db_error() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
@@ -946,6 +982,7 @@ async fn test_list_devices_db_error() {
 async fn test_list_pending_empty() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     let mut state = setup_mock_app_state();
@@ -972,6 +1009,7 @@ async fn test_list_pending_empty() {
 async fn test_create_url_token_success() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     let mut state = setup_mock_app_state();
@@ -1002,6 +1040,7 @@ async fn test_create_url_token_success() {
 async fn test_create_url_token_no_auth() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     let mut state = setup_mock_app_state();
@@ -1023,6 +1062,7 @@ async fn test_create_url_token_no_auth() {
 async fn test_create_permanent_qr_success() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     let mut state = setup_mock_app_state();
@@ -1052,6 +1092,7 @@ async fn test_create_permanent_qr_success() {
 async fn test_create_device_owner_token_success() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     let mut state = setup_mock_app_state();
@@ -1081,6 +1122,7 @@ async fn test_create_device_owner_token_success() {
 async fn test_approve_device_success() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst);
@@ -1110,6 +1152,7 @@ async fn test_approve_device_success() {
 async fn test_approve_device_not_found() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     // return_data=false -> find_approve_request returns None -> 404
@@ -1137,6 +1180,7 @@ async fn test_approve_device_not_found() {
 async fn test_approve_by_code_success() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst);
@@ -1163,6 +1207,7 @@ async fn test_approve_by_code_success() {
 async fn test_approve_by_code_not_found() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     let mut state = setup_mock_app_state();
@@ -1187,6 +1232,7 @@ async fn test_approve_by_code_not_found() {
 async fn test_reject_device_success() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst);
@@ -1212,6 +1258,7 @@ async fn test_reject_device_success() {
 async fn test_reject_device_not_found() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     let mut state = setup_mock_app_state();
@@ -1237,6 +1284,7 @@ async fn test_reject_device_not_found() {
 async fn test_disable_device_success() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst);
@@ -1263,6 +1311,7 @@ async fn test_disable_device_success() {
 async fn test_enable_device_success() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst);
@@ -1289,6 +1338,7 @@ async fn test_enable_device_success() {
 async fn test_delete_device_success() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst);
@@ -1314,6 +1364,7 @@ async fn test_delete_device_success() {
 async fn test_delete_device_not_found() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     let mut state = setup_mock_app_state();
@@ -1339,6 +1390,7 @@ async fn test_delete_device_not_found() {
 async fn test_update_call_settings_success() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst);
@@ -1370,6 +1422,7 @@ async fn test_update_call_settings_success() {
 async fn test_update_call_settings_not_found() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     let mut state = setup_mock_app_state();
@@ -1398,6 +1451,7 @@ async fn test_update_call_settings_not_found() {
 async fn test_fcm_single_device_success() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst);
@@ -1426,6 +1480,7 @@ async fn test_fcm_single_device_success() {
 async fn test_fcm_single_device_no_fcm() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     let mut state = setup_mock_app_state();
@@ -1451,6 +1506,7 @@ async fn test_fcm_single_device_no_fcm() {
 async fn test_fcm_single_device_not_found() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     // return_data=false -> get_device_fcm_token returns None -> 404
@@ -1477,6 +1533,7 @@ async fn test_fcm_single_device_not_found() {
 async fn test_fcm_single_device_failing_sender() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst);
@@ -1507,6 +1564,7 @@ async fn test_fcm_single_device_failing_sender() {
 async fn test_fcm_all_success() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst);
@@ -1538,6 +1596,7 @@ async fn test_fcm_all_success() {
 async fn test_fcm_all_no_fcm() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     let mut state = setup_mock_app_state();
@@ -1562,6 +1621,7 @@ async fn test_fcm_all_no_fcm() {
 async fn test_trigger_update_success() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst);
@@ -1594,6 +1654,7 @@ async fn test_trigger_update_success() {
 async fn test_trigger_update_already_updated() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst);
@@ -1628,6 +1689,7 @@ async fn test_trigger_update_already_updated() {
 async fn test_trigger_update_dev_no_secret() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     std::env::remove_var("FCM_INTERNAL_SECRET");
 
     let mock = Arc::new(MockDeviceRepository::default());
@@ -1651,6 +1713,7 @@ async fn test_trigger_update_dev_no_secret() {
 async fn test_trigger_update_dev_wrong_secret() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     std::env::set_var("FCM_INTERNAL_SECRET", "correct-secret");
 
     let mock = Arc::new(MockDeviceRepository::default());
@@ -1675,6 +1738,7 @@ async fn test_trigger_update_dev_wrong_secret() {
 async fn test_trigger_update_dev_success() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     std::env::set_var("FCM_INTERNAL_SECRET", "dev-secret");
 
     let mock = Arc::new(MockDeviceRepository::default());
@@ -1706,6 +1770,7 @@ async fn test_trigger_update_dev_success() {
 async fn test_list_devices_with_x_tenant_id() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     let mut state = setup_mock_app_state();
@@ -1730,6 +1795,7 @@ async fn test_list_devices_with_x_tenant_id() {
 async fn test_list_devices_with_device_rows() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_device_rows.store(true, Ordering::SeqCst);
@@ -1764,6 +1830,7 @@ async fn test_list_devices_with_device_rows() {
 async fn test_list_pending_with_rows() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_pending_rows.store(true, Ordering::SeqCst);
@@ -1797,6 +1864,7 @@ async fn test_list_pending_with_rows() {
 async fn test_registration_status_expired() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst);
@@ -1824,6 +1892,7 @@ async fn test_registration_status_expired() {
 async fn test_registration_status_approved() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst);
@@ -1851,6 +1920,7 @@ async fn test_registration_status_approved() {
 async fn test_registration_status_pending_no_expires() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst);
@@ -1878,6 +1948,7 @@ async fn test_registration_status_pending_no_expires() {
 async fn test_claim_qr_permanent_success() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst);
@@ -1912,6 +1983,7 @@ async fn test_claim_qr_permanent_success() {
 async fn test_claim_used_status() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst);
@@ -1942,6 +2014,7 @@ async fn test_claim_used_status() {
 async fn test_claim_unknown_flow_type() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst);
@@ -1972,6 +2045,7 @@ async fn test_claim_unknown_flow_type() {
 async fn test_list_pending_db_error() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
@@ -1996,6 +2070,7 @@ async fn test_list_pending_db_error() {
 async fn test_create_url_token_db_error() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
@@ -2021,6 +2096,7 @@ async fn test_create_url_token_db_error() {
 async fn test_create_device_owner_token_db_error() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
@@ -2048,6 +2124,7 @@ async fn test_create_device_owner_token_db_error() {
 async fn test_create_permanent_qr_db_error() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
@@ -2075,6 +2152,7 @@ async fn test_create_permanent_qr_db_error() {
 async fn test_approve_device_db_error_lookup() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
@@ -2101,6 +2179,7 @@ async fn test_approve_device_db_error_lookup() {
 async fn test_approve_by_code_db_error() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
@@ -2125,6 +2204,7 @@ async fn test_approve_by_code_db_error() {
 async fn test_reject_device_db_error() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
@@ -2150,6 +2230,7 @@ async fn test_reject_device_db_error() {
 async fn test_disable_device_not_found() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     let mut state = setup_mock_app_state();
@@ -2174,6 +2255,7 @@ async fn test_disable_device_not_found() {
 async fn test_disable_device_db_error() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
@@ -2199,6 +2281,7 @@ async fn test_disable_device_db_error() {
 async fn test_enable_device_not_found() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     let mut state = setup_mock_app_state();
@@ -2223,6 +2306,7 @@ async fn test_enable_device_not_found() {
 async fn test_enable_device_db_error() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
@@ -2248,6 +2332,7 @@ async fn test_enable_device_db_error() {
 async fn test_delete_device_db_error() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
@@ -2273,6 +2358,7 @@ async fn test_delete_device_db_error() {
 async fn test_update_call_settings_db_error() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
@@ -2303,6 +2389,7 @@ async fn test_update_call_settings_db_error() {
 async fn test_update_call_settings_always_on_no_token() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst);
@@ -2338,6 +2425,7 @@ async fn test_update_call_settings_always_on_no_token() {
 async fn test_update_call_settings_always_on_no_fcm_provider() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst);
@@ -2372,6 +2460,7 @@ async fn test_update_call_settings_always_on_no_fcm_provider() {
 async fn test_update_call_settings_no_always_on() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst);
@@ -2403,6 +2492,7 @@ async fn test_update_call_settings_no_always_on() {
 async fn test_update_call_settings_fcm_send_failure() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst);
@@ -2438,6 +2528,7 @@ async fn test_update_call_settings_fcm_send_failure() {
 async fn test_device_settings_db_error() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
@@ -2463,6 +2554,7 @@ async fn test_device_settings_db_error() {
 async fn test_register_fcm_token_db_error_lookup() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
@@ -2491,6 +2583,7 @@ async fn test_register_fcm_token_db_error_lookup() {
 async fn test_update_last_login_not_found() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     // return_data=false -> lookup returns None -> 404
@@ -2517,6 +2610,7 @@ async fn test_update_last_login_not_found() {
 async fn test_update_last_login_db_error() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
@@ -2547,6 +2641,7 @@ async fn test_update_last_login_db_error() {
 async fn test_report_version_db_error() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
@@ -2576,6 +2671,7 @@ async fn test_report_version_db_error() {
 async fn test_report_watchdog_db_error() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
@@ -2604,6 +2700,7 @@ async fn test_report_watchdog_db_error() {
 async fn test_fcm_notify_call_disabled_device_skipped() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     std::env::set_var("FCM_INTERNAL_SECRET", "test-fcm-secret");
 
     let mock = Arc::new(MockDeviceRepository::default());
@@ -2636,6 +2733,7 @@ async fn test_fcm_notify_call_disabled_device_skipped() {
 async fn test_fcm_notify_call_schedule_disabled_skipped() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     std::env::set_var("FCM_INTERNAL_SECRET", "test-fcm-secret");
 
     let mock = Arc::new(MockDeviceRepository::default());
@@ -2668,6 +2766,7 @@ async fn test_fcm_notify_call_schedule_disabled_skipped() {
 async fn test_fcm_notify_call_schedule_with_days_sent() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     std::env::set_var("FCM_INTERNAL_SECRET", "test-fcm-secret");
 
     let mock = Arc::new(MockDeviceRepository::default());
@@ -2699,6 +2798,7 @@ async fn test_fcm_notify_call_schedule_with_days_sent() {
 async fn test_fcm_notify_call_fcm_error() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     std::env::set_var("FCM_INTERNAL_SECRET", "test-fcm-secret");
 
     let mock = Arc::new(MockDeviceRepository::default());
@@ -2730,6 +2830,7 @@ async fn test_fcm_notify_call_fcm_error() {
 async fn test_fcm_notify_call_db_error() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     std::env::set_var("FCM_INTERNAL_SECRET", "test-fcm-secret");
 
     let mock = Arc::new(MockDeviceRepository::default());
@@ -2758,6 +2859,7 @@ async fn test_fcm_notify_call_db_error() {
 async fn test_fcm_notify_call_with_exclude() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     std::env::set_var("FCM_INTERNAL_SECRET", "test-fcm-secret");
 
     let mock = Arc::new(MockDeviceRepository::default());
@@ -2793,6 +2895,7 @@ async fn test_fcm_notify_call_with_exclude() {
 async fn test_fcm_dismiss_test_db_error() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
@@ -2819,6 +2922,7 @@ async fn test_fcm_dismiss_test_db_error() {
 async fn test_fcm_all_exclude_with_devices() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_callable_devices.store(true, Ordering::SeqCst);
@@ -2847,6 +2951,7 @@ async fn test_fcm_all_exclude_with_devices() {
 async fn test_fcm_all_exclude_with_exclude_matching() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_callable_devices.store(true, Ordering::SeqCst);
@@ -2875,6 +2980,7 @@ async fn test_fcm_all_exclude_with_exclude_matching() {
 async fn test_fcm_all_exclude_fcm_error() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_callable_devices.store(true, Ordering::SeqCst);
@@ -2904,6 +3010,7 @@ async fn test_fcm_all_exclude_fcm_error() {
 async fn test_fcm_all_exclude_db_error() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
@@ -2930,6 +3037,7 @@ async fn test_fcm_all_exclude_db_error() {
 async fn test_fcm_single_device_null_token() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst);
@@ -2961,6 +3069,7 @@ async fn test_fcm_single_device_null_token() {
 async fn test_fcm_single_device_db_error() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
@@ -2991,6 +3100,7 @@ async fn test_fcm_single_device_db_error() {
 async fn test_fcm_all_failing_sender() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst);
@@ -3026,6 +3136,7 @@ async fn test_fcm_all_failing_sender() {
 async fn test_fcm_all_db_error() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
@@ -3055,6 +3166,7 @@ async fn test_fcm_all_db_error() {
 async fn test_trigger_update_no_fcm() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     let mut state = setup_mock_app_state();
@@ -3084,6 +3196,7 @@ async fn test_trigger_update_no_fcm() {
 async fn test_trigger_update_with_device_ids_filter() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst);
@@ -3122,6 +3235,7 @@ async fn test_trigger_update_with_device_ids_filter() {
 async fn test_trigger_update_fcm_error() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst);
@@ -3158,6 +3272,7 @@ async fn test_trigger_update_fcm_error() {
 async fn test_trigger_update_db_error() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
@@ -3188,6 +3303,7 @@ async fn test_trigger_update_db_error() {
 async fn test_trigger_update_no_version_code() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst);
@@ -3222,6 +3338,7 @@ async fn test_trigger_update_no_version_code() {
 async fn test_trigger_update_with_version_name_only() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst);
@@ -3254,6 +3371,7 @@ async fn test_trigger_update_with_version_name_only() {
 async fn test_trigger_update_dev_only() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst);
@@ -3287,6 +3405,7 @@ async fn test_trigger_update_dev_only() {
 async fn test_trigger_update_dev_with_tenants() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     std::env::set_var("FCM_INTERNAL_SECRET", "dev-secret-2");
 
     let mock = Arc::new(MockDeviceRepository::default());
@@ -3320,6 +3439,7 @@ async fn test_trigger_update_dev_with_tenants() {
 async fn test_trigger_update_dev_download_url_passthrough() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     std::env::set_var("FCM_INTERNAL_SECRET", "dev-secret-3");
 
     let mock = Arc::new(MockDeviceRepository::default());
@@ -3362,6 +3482,7 @@ async fn test_trigger_update_dev_download_url_passthrough() {
 async fn test_trigger_update_without_download_url() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst);
@@ -3396,6 +3517,7 @@ async fn test_trigger_update_without_download_url() {
 async fn test_trigger_update_dev_db_error() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     std::env::set_var("FCM_INTERNAL_SECRET", "dev-secret-3");
 
     let mock = Arc::new(MockDeviceRepository::default());
@@ -3425,6 +3547,7 @@ async fn test_trigger_update_dev_db_error() {
 async fn test_trigger_update_dev_no_fcm() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     std::env::set_var("FCM_INTERNAL_SECRET", "dev-secret-4");
 
     let mock = Arc::new(MockDeviceRepository::default());
@@ -3456,6 +3579,7 @@ async fn test_trigger_update_dev_no_fcm() {
 async fn test_claim_qr_permanent_no_device_name() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst);
@@ -3487,6 +3611,7 @@ async fn test_claim_qr_permanent_no_device_name() {
 async fn test_claim_device_owner_flow() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst);
@@ -3519,6 +3644,7 @@ async fn test_claim_device_owner_flow() {
 async fn test_fcm_notify_call_correct_secret() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     std::env::set_var("FCM_INTERNAL_SECRET", "correct-secret-2");
 
     let mock = Arc::new(MockDeviceRepository::default());
@@ -3547,6 +3673,7 @@ async fn test_fcm_notify_call_correct_secret() {
 async fn test_approve_device_create_db_error() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst); // find_approve_request returns Some
@@ -3578,6 +3705,7 @@ async fn test_approve_device_create_db_error() {
 async fn test_approve_by_code_create_db_error() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst); // find_approve_by_code_request returns Some
@@ -3607,6 +3735,7 @@ async fn test_approve_by_code_create_db_error() {
 async fn test_report_watchdog_update_db_error() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst); // lookup_device_tenant returns Some
@@ -3636,6 +3765,7 @@ async fn test_report_watchdog_update_db_error() {
 async fn test_register_fcm_token_update_db_error() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst); // lookup_device_tenant returns Some
@@ -3665,6 +3795,7 @@ async fn test_register_fcm_token_update_db_error() {
 async fn test_update_last_login_update_db_error() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst); // lookup_device_tenant returns Some
@@ -3696,6 +3827,7 @@ async fn test_update_last_login_update_db_error() {
 async fn test_report_version_update_db_error() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst); // lookup_device_tenant returns Some
@@ -3726,6 +3858,7 @@ async fn test_report_version_update_db_error() {
 async fn test_fcm_notify_call_schedule_days_mismatch_skipped() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     std::env::set_var("FCM_INTERNAL_SECRET", "test-fcm-secret");
 
     let mock = Arc::new(MockDeviceRepository::default());
@@ -3759,6 +3892,7 @@ async fn test_fcm_notify_call_schedule_days_mismatch_skipped() {
 async fn test_fcm_notify_call_schedule_overnight_sent() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     std::env::set_var("FCM_INTERNAL_SECRET", "test-fcm-secret");
 
     let mock = Arc::new(MockDeviceRepository::default());
@@ -3794,6 +3928,7 @@ async fn test_fcm_notify_call_schedule_overnight_sent() {
 async fn test_fcm_dismiss_test_with_tokens_sent() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDeviceRepository::default());
     mock.return_data.store(true, Ordering::SeqCst); // get_device_tenant_active returns Some

--- a/tests/mock_tests/mock_dtako_scraper_test.rs
+++ b/tests/mock_tests/mock_dtako_scraper_test.rs
@@ -20,6 +20,7 @@ use rust_alc_api::routes::dtako_scraper::ScrapeHistoryItem;
 async fn test_get_scrape_history_success_empty() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDtakoScraperRepository::default());
     let mut state = setup_mock_app_state();
@@ -49,6 +50,7 @@ async fn test_get_scrape_history_success_empty() {
 async fn test_get_scrape_history_with_data() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let item = ScrapeHistoryItem {
         id: Uuid::new_v4(),
@@ -92,6 +94,7 @@ async fn test_get_scrape_history_with_data() {
 async fn test_get_scrape_history_with_query_params() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDtakoScraperRepository::default());
     let mut state = setup_mock_app_state();
@@ -119,6 +122,7 @@ async fn test_get_scrape_history_with_query_params() {
 async fn test_get_scrape_history_db_error() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDtakoScraperRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
@@ -147,6 +151,7 @@ async fn test_get_scrape_history_db_error() {
 async fn test_get_scrape_history_unauthorized() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockDtakoScraperRepository::default());
     let mut state = setup_mock_app_state();
@@ -171,6 +176,7 @@ async fn test_get_scrape_history_unauthorized() {
 async fn test_trigger_scrape_connection_refused() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     // メタデータサーバーへの接続を即座に失敗させる
     std::env::set_var("GCP_METADATA_URL", "http://127.0.0.1:1");
 
@@ -207,6 +213,7 @@ async fn test_trigger_scrape_connection_refused() {
 async fn test_trigger_scrape_with_all_fields() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     std::env::set_var("GCP_METADATA_URL", "http://127.0.0.1:1");
 
     let mock = Arc::new(MockDtakoScraperRepository::default());
@@ -242,6 +249,7 @@ async fn test_trigger_scrape_with_all_fields() {
 async fn test_trigger_scrape_empty_body() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     std::env::set_var("GCP_METADATA_URL", "http://127.0.0.1:1");
 
     let mock = Arc::new(MockDtakoScraperRepository::default());
@@ -272,6 +280,7 @@ async fn test_trigger_scrape_empty_body() {
 async fn test_trigger_scrape_no_body() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     std::env::set_var("GCP_METADATA_URL", "http://127.0.0.1:1");
 
     let mock = Arc::new(MockDtakoScraperRepository::default());
@@ -303,6 +312,7 @@ async fn test_trigger_scrape_no_body() {
 async fn test_trigger_scrape_unauthorized() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     std::env::set_var("GCP_METADATA_URL", "http://127.0.0.1:1");
 
     let mock = Arc::new(MockDtakoScraperRepository::default());
@@ -332,6 +342,7 @@ async fn test_trigger_scrape_unauthorized() {
 async fn test_trigger_scrape_scraper_returns_500() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     // Mock metadata server (returns 404 so get_id_token fails silently)
     let metadata_server = MockServer::start().await;
@@ -378,6 +389,7 @@ async fn test_trigger_scrape_scraper_returns_500() {
 async fn test_trigger_scrape_metadata_server_non_success() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     // Mock metadata server returns 403
     let metadata_server = MockServer::start().await;
@@ -425,6 +437,7 @@ async fn test_trigger_scrape_metadata_server_non_success() {
 async fn test_trigger_scrape_metadata_server_success_bearer_auth() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     // Mock metadata server returns a token
     let metadata_server = MockServer::start().await;
@@ -474,6 +487,7 @@ async fn test_trigger_scrape_metadata_server_success_bearer_auth() {
 async fn test_trigger_scrape_sse_stream_with_results() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     std::env::set_var("GCP_METADATA_URL", "http://127.0.0.1:1");
 
     // Mock scraper returns SSE stream with result events
@@ -544,6 +558,7 @@ async fn test_trigger_scrape_sse_stream_with_results() {
 async fn test_trigger_scrape_sse_stream_no_start_date() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     std::env::set_var("GCP_METADATA_URL", "http://127.0.0.1:1");
 
     let scraper_server = MockServer::start().await;
@@ -597,6 +612,7 @@ async fn test_trigger_scrape_sse_stream_no_start_date() {
 async fn test_trigger_scrape_sse_stream_invalid_date() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     std::env::set_var("GCP_METADATA_URL", "http://127.0.0.1:1");
 
     let scraper_server = MockServer::start().await;
@@ -652,6 +668,7 @@ async fn test_trigger_scrape_sse_stream_invalid_date() {
 async fn test_trigger_scrape_sse_stream_non_json_data() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     std::env::set_var("GCP_METADATA_URL", "http://127.0.0.1:1");
 
     let scraper_server = MockServer::start().await;
@@ -713,6 +730,7 @@ async fn test_trigger_scrape_sse_stream_non_json_data() {
 async fn test_trigger_scrape_sse_stream_progress_only() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     std::env::set_var("GCP_METADATA_URL", "http://127.0.0.1:1");
 
     let scraper_server = MockServer::start().await;
@@ -772,6 +790,7 @@ async fn test_trigger_scrape_sse_stream_progress_only() {
 async fn test_trigger_scrape_sse_result_no_comp_id() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     std::env::set_var("GCP_METADATA_URL", "http://127.0.0.1:1");
 
     let scraper_server = MockServer::start().await;
@@ -829,6 +848,7 @@ async fn test_trigger_scrape_sse_result_no_comp_id() {
 async fn test_trigger_scrape_sse_result_missing_status() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     std::env::set_var("GCP_METADATA_URL", "http://127.0.0.1:1");
 
     let scraper_server = MockServer::start().await;
@@ -886,6 +906,7 @@ async fn test_trigger_scrape_sse_result_missing_status() {
 async fn test_trigger_scrape_sse_stream_empty_data() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     std::env::set_var("GCP_METADATA_URL", "http://127.0.0.1:1");
 
     let scraper_server = MockServer::start().await;
@@ -945,6 +966,7 @@ async fn test_trigger_scrape_sse_stream_empty_data() {
 async fn test_trigger_scrape_full_flow_with_metadata_and_sse() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     // Mock metadata server returns a valid token
     let metadata_server = MockServer::start().await;
@@ -1009,6 +1031,7 @@ async fn test_trigger_scrape_full_flow_with_metadata_and_sse() {
 async fn test_trigger_scrape_sse_stream_with_comments() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     std::env::set_var("GCP_METADATA_URL", "http://127.0.0.1:1");
 
     let scraper_server = MockServer::start().await;
@@ -1067,6 +1090,7 @@ async fn test_trigger_scrape_client_disconnect() {
 
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     std::env::remove_var("GCP_METADATA_URL");
 
     // 生 TCP サーバーでイベントをゆっくり送信 → client が先に drop
@@ -1129,6 +1153,7 @@ async fn test_trigger_scrape_stream_error() {
 
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     std::env::remove_var("METADATA_URL");
 
     // 生 TCP サーバーで不正な chunked レスポンスを返す

--- a/tests/mock_tests/mock_lineworks_internal_test.rs
+++ b/tests/mock_tests/mock_lineworks_internal_test.rs
@@ -37,6 +37,7 @@ async fn test_get_bot_secret_success() {
     test_case!("登録済み bot は暗号化済み bot_secret を返す", {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
         let mut state = setup_mock_app_state();
         let _mock = install_mock(&mut state, Some(sample_bot_cfg()));
         let base_url = crate::common::spawn_test_server(state).await;
@@ -62,6 +63,7 @@ async fn test_get_bot_secret_not_found() {
     test_case!("未登録 bot_id は 404", {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
         let mut state = setup_mock_app_state();
         let _mock = install_mock(&mut state, None);
         let base_url = crate::common::spawn_test_server(state).await;
@@ -85,6 +87,7 @@ async fn test_get_bot_secret_no_secret_configured() {
         {
             let _guard = crate::common::ENV_LOCK.lock().unwrap();
             std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+            std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
             let mut state = setup_mock_app_state();
             let mut cfg = sample_bot_cfg();
             cfg.bot_secret_encrypted = None;
@@ -109,6 +112,7 @@ async fn test_get_bot_secret_unauthorized_without_jwt() {
     test_case!("Authorization ヘッダー無しは 401", {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
         let mut state = setup_mock_app_state();
         let _mock = install_mock(&mut state, Some(sample_bot_cfg()));
         let base_url = crate::common::spawn_test_server(state).await;
@@ -128,6 +132,7 @@ async fn test_get_bot_secret_user_jwt_rejected() {
     test_case!("ユーザー JWT (aud 無し) は 401", {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
         let mut state = setup_mock_app_state();
         let _mock = install_mock(&mut state, Some(sample_bot_cfg()));
         let base_url = crate::common::spawn_test_server(state).await;
@@ -149,6 +154,7 @@ async fn test_get_bot_secret_db_error() {
     test_case!("lookup 失敗時は 500", {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
         let mut state = setup_mock_app_state();
         let mock = install_mock(&mut state, Some(sample_bot_cfg()));
         mock.fail_next.store(true, Ordering::SeqCst);
@@ -185,6 +191,7 @@ async fn test_event_joined_calls_upsert() {
     test_case!("joined イベントで upsert_joined が呼ばれる", {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
         let mut state = setup_mock_app_state();
         let mock = install_mock(&mut state, Some(sample_bot_cfg()));
         let base_url = crate::common::spawn_test_server(state).await;
@@ -214,6 +221,7 @@ async fn test_event_left_calls_mark_left() {
     test_case!("left イベントで mark_left が呼ばれる", {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
         let mut state = setup_mock_app_state();
         let mock = install_mock(&mut state, Some(sample_bot_cfg()));
         let base_url = crate::common::spawn_test_server(state).await;
@@ -241,6 +249,7 @@ async fn test_event_unknown_type_ignored() {
     test_case!("未知の event_type は無視されて 200", {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
         let mut state = setup_mock_app_state();
         let mock = install_mock(&mut state, Some(sample_bot_cfg()));
         let base_url = crate::common::spawn_test_server(state).await;
@@ -270,6 +279,7 @@ async fn test_event_no_channel_id_skipped() {
         {
             let _guard = crate::common::ENV_LOCK.lock().unwrap();
             std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+            std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
             let mut state = setup_mock_app_state();
             let mock = install_mock(&mut state, Some(sample_bot_cfg()));
             let base_url = crate::common::spawn_test_server(state).await;
@@ -296,6 +306,7 @@ async fn test_event_bot_not_found() {
     test_case!("未登録 bot_id は 404", {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
         let mut state = setup_mock_app_state();
         let _mock = install_mock(&mut state, None);
         let base_url = crate::common::spawn_test_server(state).await;
@@ -321,6 +332,7 @@ async fn test_event_unauthorized() {
     test_case!("JWT 無しは 401", {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
         let mut state = setup_mock_app_state();
         let _mock = install_mock(&mut state, Some(sample_bot_cfg()));
         let base_url = crate::common::spawn_test_server(state).await;
@@ -345,6 +357,7 @@ async fn test_event_lookup_db_error() {
     test_case!("lookup 失敗時は 500", {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
         let mut state = setup_mock_app_state();
         let mock = install_mock(&mut state, Some(sample_bot_cfg()));
         mock.fail_next.store(true, Ordering::SeqCst);

--- a/tests/mock_tests/mock_measurements_test.rs
+++ b/tests/mock_tests/mock_measurements_test.rs
@@ -15,6 +15,7 @@ use serde_json::Value;
 async fn test_create_measurement_success() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let state = crate::mock_helpers::app_state::setup_mock_app_state();
     let tenant_id = Uuid::new_v4();
@@ -49,6 +50,7 @@ async fn test_create_measurement_success() {
 async fn test_create_measurement_db_error() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockMeasurementsRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
@@ -86,6 +88,7 @@ async fn test_create_measurement_db_error() {
 async fn test_create_measurement_invalid_result_type() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let state = crate::mock_helpers::app_state::setup_mock_app_state();
     let tenant_id = Uuid::new_v4();
@@ -118,6 +121,7 @@ async fn test_create_measurement_invalid_result_type() {
 async fn test_create_measurement_invalid_json() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let state = crate::mock_helpers::app_state::setup_mock_app_state();
     let tenant_id = Uuid::new_v4();
@@ -145,6 +149,7 @@ async fn test_create_measurement_invalid_json() {
 async fn test_start_measurement_success() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let state = crate::mock_helpers::app_state::setup_mock_app_state();
     let tenant_id = Uuid::new_v4();
@@ -177,6 +182,7 @@ async fn test_start_measurement_success() {
 async fn test_start_measurement_db_error() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockMeasurementsRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
@@ -212,6 +218,7 @@ async fn test_start_measurement_db_error() {
 async fn test_list_measurements_success() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let state = crate::mock_helpers::app_state::setup_mock_app_state();
     let tenant_id = Uuid::new_v4();
@@ -242,6 +249,7 @@ async fn test_list_measurements_success() {
 async fn test_list_measurements_db_error() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockMeasurementsRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
@@ -272,6 +280,7 @@ async fn test_list_measurements_db_error() {
 async fn test_get_measurement_not_found() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let state = crate::mock_helpers::app_state::setup_mock_app_state();
     let tenant_id = Uuid::new_v4();
@@ -298,6 +307,7 @@ async fn test_get_measurement_not_found() {
 async fn test_get_measurement_found() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockMeasurementsRepository::default());
     mock.return_some.store(true, Ordering::SeqCst);
@@ -331,6 +341,7 @@ async fn test_get_measurement_found() {
 async fn test_get_measurement_db_error() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockMeasurementsRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
@@ -362,6 +373,7 @@ async fn test_get_measurement_db_error() {
 async fn test_update_measurement_success() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockMeasurementsRepository::default());
     mock.return_some.store(true, Ordering::SeqCst);
@@ -402,6 +414,7 @@ async fn test_update_measurement_success() {
 async fn test_update_measurement_without_status_success() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockMeasurementsRepository::default());
     mock.return_some.store(true, Ordering::SeqCst);
@@ -441,6 +454,7 @@ async fn test_update_measurement_without_status_success() {
 async fn test_update_measurement_not_found() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     // return_some defaults to false → update returns None → 404
     let state = crate::mock_helpers::app_state::setup_mock_app_state();
@@ -473,6 +487,7 @@ async fn test_update_measurement_not_found() {
 async fn test_update_measurement_db_error() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock = Arc::new(MockMeasurementsRepository::default());
     mock.fail_next.store(true, Ordering::SeqCst);
@@ -509,6 +524,7 @@ async fn test_update_measurement_db_error() {
 async fn test_update_measurement_invalid_result_type() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let state = crate::mock_helpers::app_state::setup_mock_app_state();
     let tenant_id = Uuid::new_v4();
@@ -540,6 +556,7 @@ async fn test_update_measurement_invalid_result_type() {
 async fn test_update_measurement_invalid_status() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let state = crate::mock_helpers::app_state::setup_mock_app_state();
     let tenant_id = Uuid::new_v4();
@@ -571,6 +588,7 @@ async fn test_update_measurement_invalid_status() {
 async fn test_update_measurement_invalid_json() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let state = crate::mock_helpers::app_state::setup_mock_app_state();
     let tenant_id = Uuid::new_v4();
@@ -599,6 +617,7 @@ async fn test_update_measurement_invalid_json() {
 async fn test_get_face_photo_success() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock_storage = Arc::new(MockStorage::new("test-bucket"));
     let photo_key = "tenant123/face-photo/abc.jpg";
@@ -640,6 +659,7 @@ async fn test_get_face_photo_success() {
 async fn test_get_face_photo_no_url() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock_repo = Arc::new(MockMeasurementsRepository::default());
     mock_repo.return_some.store(true, Ordering::SeqCst);
@@ -672,6 +692,7 @@ async fn test_get_face_photo_no_url() {
 async fn test_get_face_photo_measurement_not_found() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     // return_some defaults to false → get returns None → 404
     let state = crate::mock_helpers::app_state::setup_mock_app_state();
@@ -699,6 +720,7 @@ async fn test_get_face_photo_measurement_not_found() {
 async fn test_get_face_photo_db_error() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock_repo = Arc::new(MockMeasurementsRepository::default());
     mock_repo.fail_next.store(true, Ordering::SeqCst);
@@ -730,6 +752,7 @@ async fn test_get_face_photo_db_error() {
 async fn test_get_video_success() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock_storage = Arc::new(MockStorage::new("test-bucket"));
     let video_key = "tenant123/blow-video/abc.webm";
@@ -771,6 +794,7 @@ async fn test_get_video_success() {
 async fn test_get_video_no_url() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock_repo = Arc::new(MockMeasurementsRepository::default());
     mock_repo.return_some.store(true, Ordering::SeqCst);
@@ -803,6 +827,7 @@ async fn test_get_video_no_url() {
 async fn test_get_video_measurement_not_found() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     // return_some defaults to false → get returns None → 404
     let state = crate::mock_helpers::app_state::setup_mock_app_state();
@@ -830,6 +855,7 @@ async fn test_get_video_measurement_not_found() {
 async fn test_get_video_db_error() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock_repo = Arc::new(MockMeasurementsRepository::default());
     mock_repo.fail_next.store(true, Ordering::SeqCst);
@@ -861,6 +887,7 @@ async fn test_get_video_db_error() {
 async fn test_measurements_no_auth() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let state = crate::mock_helpers::app_state::setup_mock_app_state();
     let base_url = crate::common::spawn_test_server(state).await;
@@ -936,6 +963,7 @@ async fn test_measurements_no_auth() {
 async fn test_get_face_photo_storage_download_error() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock_storage = Arc::new(MockStorage::new("test-bucket"));
     // URL points to a key that does NOT exist in storage
@@ -973,6 +1001,7 @@ async fn test_get_face_photo_storage_download_error() {
 async fn test_get_video_storage_download_error() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock_storage = Arc::new(MockStorage::new("test-bucket"));
     let missing_url = "https://mock-storage/test-bucket/nonexistent/video.webm".to_string();
@@ -1010,6 +1039,7 @@ async fn test_get_video_storage_download_error() {
 async fn test_get_face_photo_extract_key_fails() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock_repo = Arc::new(MockMeasurementsRepository::default());
     mock_repo.return_some.store(true, Ordering::SeqCst);
@@ -1044,6 +1074,7 @@ async fn test_get_face_photo_extract_key_fails() {
 async fn test_get_video_extract_key_fails() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let mock_repo = Arc::new(MockMeasurementsRepository::default());
     mock_repo.return_some.store(true, Ordering::SeqCst);
@@ -1077,6 +1108,7 @@ async fn test_get_video_extract_key_fails() {
 async fn test_measurements_with_tenant_header() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
     let state = crate::mock_helpers::app_state::setup_mock_app_state();
     let tenant_id = Uuid::new_v4();

--- a/tests/mock_tests/mock_notify_view_internal_test.rs
+++ b/tests/mock_tests/mock_notify_view_internal_test.rs
@@ -45,6 +45,7 @@ async fn test_internal_view_success() {
     test_case!("有効な token は r2_key + メタを返す", {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
         let mut state = setup_mock_app_state();
         let _mock = install_mock(&mut state);
         let base_url = crate::common::spawn_test_server(state).await;
@@ -75,6 +76,7 @@ async fn test_internal_view_not_found() {
     test_case!("存在しない token は 404", {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
         let mut state = setup_mock_app_state();
         let mock = install_mock(&mut state);
         *mock.view_override.lock().unwrap() = Some(None);
@@ -98,6 +100,7 @@ async fn test_internal_view_expired() {
     test_case!("期限切れ token は 410 Gone", {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
         let mut state = setup_mock_app_state();
         let mock = install_mock(&mut state);
         *mock.view_override.lock().unwrap() = Some(Some(sample_view(-1)));
@@ -121,6 +124,7 @@ async fn test_internal_view_db_error() {
     test_case!("get_for_view が失敗すると 500", {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
         let mut state = setup_mock_app_state();
         let mock = install_mock(&mut state);
         mock.fail_next.store(true, Ordering::SeqCst);
@@ -144,6 +148,7 @@ async fn test_internal_view_requires_internal_jwt() {
     test_case!("internal JWT なしは 401", {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
         let mut state = setup_mock_app_state();
         let _mock = install_mock(&mut state);
         let base_url = crate::common::spawn_test_server(state).await;
@@ -168,6 +173,7 @@ async fn test_internal_mark_read_success() {
     test_case!("有効な token の既読化は 204", {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
         let mut state = setup_mock_app_state();
         let _mock = install_mock(&mut state);
         let base_url = crate::common::spawn_test_server(state).await;
@@ -190,6 +196,7 @@ async fn test_internal_mark_read_not_found() {
     test_case!("存在しない token の既読化は 404", {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
         let mut state = setup_mock_app_state();
         let mock = install_mock(&mut state);
         mock.mark_read_none.store(true, Ordering::SeqCst);
@@ -213,6 +220,7 @@ async fn test_internal_mark_read_db_error() {
     test_case!("mark_read が失敗すると 500", {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
         let mut state = setup_mock_app_state();
         let mock = install_mock(&mut state);
         mock.fail_next.store(true, Ordering::SeqCst);

--- a/tests/mock_tests/mock_sso_admin_test.rs
+++ b/tests/mock_tests/mock_sso_admin_test.rs
@@ -116,9 +116,9 @@ async fn test_upsert_config_with_secret_success() {
     let (base_url, auth_header) = setup().await;
     let client = reqwest::Client::new();
 
-    // Need JWT_SECRET or SSO_ENCRYPTION_KEY for encryption
+    // encryption には SSO_ENCRYPTION_KEY が必須 (Refs #479 — JWT_SECRET fallback 撤去)
     let _lock = crate::common::ENV_LOCK.lock().unwrap();
-    std::env::set_var("JWT_SECRET", "test-encryption-key-for-sso");
+    std::env::set_var("SSO_ENCRYPTION_KEY", "test-encryption-key-for-sso");
 
     let res = client
         .post(format!("{base_url}/api/admin/sso/configs"))
@@ -295,7 +295,7 @@ async fn test_upsert_config_with_secret_db_error() {
     let client = reqwest::Client::new();
 
     let _lock = crate::common::ENV_LOCK.lock().unwrap();
-    std::env::set_var("JWT_SECRET", "test-encryption-key-for-sso");
+    std::env::set_var("SSO_ENCRYPTION_KEY", "test-encryption-key-for-sso");
 
     let res = client
         .post(format!("{base_url}/api/admin/sso/configs"))
@@ -447,6 +447,7 @@ async fn test_export_configs_success() {
     use rust_alc_api::db::repository::sso_admin::{SsoConfigExportRow, TenantInfoForExport};
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     let prev = set_dev_emails(dev_email());
 
     let mock = Arc::new(MockSsoAdminRepository::default());
@@ -508,6 +509,7 @@ async fn test_export_configs_success() {
 async fn test_export_configs_forbidden_for_non_developer() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     let prev = set_dev_emails(dev_email());
 
     let mut state = crate::mock_helpers::app_state::setup_mock_app_state();
@@ -539,6 +541,7 @@ async fn test_export_configs_forbidden_for_non_developer() {
 async fn test_export_configs_tenant_not_found() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     let prev = set_dev_emails(dev_email());
 
     // return_tenant_for_export はデフォルト None → handler 側で 404
@@ -571,6 +574,7 @@ async fn test_export_configs_tenant_not_found() {
 async fn test_export_configs_tenant_db_error() {
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     let prev = set_dev_emails(dev_email());
 
     let mock = Arc::new(MockSsoAdminRepository::default());
@@ -605,6 +609,7 @@ async fn test_export_configs_configs_db_error() {
     use rust_alc_api::db::repository::sso_admin::TenantInfoForExport;
     let _guard = crate::common::ENV_LOCK.lock().unwrap();
     std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+    std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
     let prev = set_dev_emails(dev_email());
 
     let mock = Arc::new(MockSsoAdminRepository::default());

--- a/tests/mock_tests/mock_tenko_call_test.rs
+++ b/tests/mock_tests/mock_tenko_call_test.rs
@@ -18,6 +18,7 @@ async fn test_register_success() {
     test_case!("call_number がマスタに存在し登録成功", {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
         let mock = Arc::new(MockTenkoCallRepository::default());
         mock.return_some.store(true, Ordering::SeqCst);
@@ -52,6 +53,7 @@ async fn test_register_without_employee_code() {
     test_case!("employee_code なしでも登録成功", {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
         let mock = Arc::new(MockTenkoCallRepository::default());
         mock.return_some.store(true, Ordering::SeqCst);
@@ -83,6 +85,7 @@ async fn test_register_unknown_call_number() {
     test_case!("未登録の call_number は 400", {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
         let mock = Arc::new(MockTenkoCallRepository::default());
         // return_some = false (default) → Ok(None) → BAD_REQUEST
@@ -115,6 +118,7 @@ async fn test_register_db_error() {
     test_case!("DB エラー時に 500 を返す", {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
         let mock = Arc::new(MockTenkoCallRepository::default());
         mock.fail_next.store(true, Ordering::SeqCst);
@@ -150,6 +154,7 @@ async fn test_tenko_success() {
     test_case!("登録済みドライバーの点呼が成功", {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
         let mock = Arc::new(MockTenkoCallRepository::default());
         mock.return_some.store(true, Ordering::SeqCst);
@@ -182,6 +187,7 @@ async fn test_tenko_driver_not_found() {
     test_case!("未登録ドライバーの点呼は 404", {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
         let mock = Arc::new(MockTenkoCallRepository::default());
         // return_some = false (default) → Ok(None) → NOT_FOUND
@@ -211,6 +217,7 @@ async fn test_tenko_db_error() {
     test_case!("DB エラー時に 500 を返す", {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
         let mock = Arc::new(MockTenkoCallRepository::default());
         mock.fail_next.store(true, Ordering::SeqCst);
@@ -244,6 +251,7 @@ async fn test_list_numbers_empty() {
     test_case!("空のリストを取得できる", {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
         let mock = Arc::new(MockTenkoCallRepository::default());
         let mut state = setup_mock_app_state();
@@ -272,6 +280,7 @@ async fn test_list_numbers_with_data() {
     test_case!("データがある場合にリストを取得できる", {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
         let mock = Arc::new(MockTenkoCallRepository::default());
         mock.return_data.store(true, Ordering::SeqCst);
@@ -307,6 +316,7 @@ async fn test_list_numbers_with_x_tenant_id() {
     test_case!("X-Tenant-ID ヘッダーでもアクセスできる", {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
         let mock = Arc::new(MockTenkoCallRepository::default());
         let mut state = setup_mock_app_state();
@@ -330,6 +340,7 @@ async fn test_list_numbers_no_auth() {
     test_case!("認証なしは 401", {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
         let mock = Arc::new(MockTenkoCallRepository::default());
         let mut state = setup_mock_app_state();
@@ -352,6 +363,7 @@ async fn test_list_numbers_db_error() {
     test_case!("DB エラー時に 500 を返す", {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
         let mock = Arc::new(MockTenkoCallRepository::default());
         mock.fail_next.store(true, Ordering::SeqCst);
@@ -383,6 +395,7 @@ async fn test_create_number_success() {
     test_case!("電話番号マスタの追加が成功する", {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
         let mock = Arc::new(MockTenkoCallRepository::default());
         let mut state = setup_mock_app_state();
@@ -417,6 +430,7 @@ async fn test_create_number_without_tenant_id() {
     test_case!("tenant_id 省略時はデフォルト値を使用", {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
         let mock = Arc::new(MockTenkoCallRepository::default());
         let mut state = setup_mock_app_state();
@@ -449,6 +463,7 @@ async fn test_create_number_without_label() {
     test_case!("label 省略でも成功", {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
         let mock = Arc::new(MockTenkoCallRepository::default());
         let mut state = setup_mock_app_state();
@@ -481,6 +496,7 @@ async fn test_create_number_no_auth() {
     test_case!("認証なしは 401", {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
         let mock = Arc::new(MockTenkoCallRepository::default());
         let mut state = setup_mock_app_state();
@@ -506,6 +522,7 @@ async fn test_create_number_db_error() {
     test_case!("DB エラー時に 500 を返す", {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
         let mock = Arc::new(MockTenkoCallRepository::default());
         mock.fail_next.store(true, Ordering::SeqCst);
@@ -540,6 +557,7 @@ async fn test_delete_number_success() {
     test_case!("電話番号マスタの削除が成功する", {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
         let mock = Arc::new(MockTenkoCallRepository::default());
         let mut state = setup_mock_app_state();
@@ -566,6 +584,7 @@ async fn test_delete_number_no_auth() {
     test_case!("認証なしは 401", {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
         let mock = Arc::new(MockTenkoCallRepository::default());
         let mut state = setup_mock_app_state();
@@ -588,6 +607,7 @@ async fn test_delete_number_db_error() {
     test_case!("DB エラー時に 500 を返す", {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
         let mock = Arc::new(MockTenkoCallRepository::default());
         mock.fail_next.store(true, Ordering::SeqCst);
@@ -619,6 +639,7 @@ async fn test_list_drivers_empty() {
     test_case!("空のリストを取得できる", {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
         let mock = Arc::new(MockTenkoCallRepository::default());
         let mut state = setup_mock_app_state();
@@ -647,6 +668,7 @@ async fn test_list_drivers_with_data() {
     test_case!("データがある場合にリストを取得できる", {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
         let mock = Arc::new(MockTenkoCallRepository::default());
         mock.return_data.store(true, Ordering::SeqCst);
@@ -684,6 +706,7 @@ async fn test_list_drivers_no_auth() {
     test_case!("認証なしは 401", {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
         let mock = Arc::new(MockTenkoCallRepository::default());
         let mut state = setup_mock_app_state();
@@ -706,6 +729,7 @@ async fn test_list_drivers_db_error() {
     test_case!("DB エラー時に 500 を返す", {
         let _guard = crate::common::ENV_LOCK.lock().unwrap();
         std::env::set_var("JWT_SECRET", crate::common::TEST_JWT_SECRET);
+        std::env::set_var("SSO_ENCRYPTION_KEY", crate::common::TEST_JWT_SECRET);
 
         let mock = Arc::new(MockTenkoCallRepository::default());
         mock.fail_next.store(true, Ordering::SeqCst);


### PR DESCRIPTION
Refs #479 (Stage 2 / PR-1: 暗号鍵用途の JWT_SECRET 依存を切る。[用途分類調査](https://github.com/ippoan/rust-alc-api/issues/479#issuecomment-4860884534) 参照)

## 背景

LINE channel secret / LINE WORKS bot secret / SSO client_secret の保存時暗号化 (AES-256-GCM) は、鍵素材を `SSO_ENCRYPTION_KEY` **or** `JWT_SECRET` の env-presence fallback で取っていた。`JWT_SECRET` 本体撤去 (Stage 2 / PR-3) の前提として、この暗号鍵用途から `JWT_SECRET` 依存を切り離す。

## 安全性の根拠

- fallback は **env の有無での切替** (復号失敗時に両鍵を試すものではない)。main サービスには `render.sh` で `sso-encryption-key` が注入済みのため、**rust は既に常に SSO 鍵で暗号化/復号している** = JWT fallback はデッドパス
- **auth-worker (SSO_ENCRYPTION_KEY のみ、fallback 無し) が同じ保存 ciphertext を prod で現に復号できている** (lineworks webhook DO / sso-config フロー) = 鍵の実効一致は本番挙動で実証済み
- 暗号化経路を実行するのは monolith (backend) のみで注入済み。trouble-api は `notifier: None`、他 per-domain バイナリは該当 route を mount しない → render.sh の変更は不要
- user 確認済み: lockdown 実施済み・LINE 認証/通知の動作確認済み。万一の際は設定再投入で復旧可能

## 変更内容

- **9 call site から `or_else(|_| std::env::var("JWT_SECRET"))` を削除** (fallback 撤去、`SSO_ENCRYPTION_KEY` 未設定は loud に 500):
  - alc-notify: `distribute` / `line_config` / `line_webhook` / `lineworks_channels` / `lineworks_directory`
  - alc-misc: `bot_admin` ×2 / `sso_admin`
  - alc-trouble: `notifier`
- **mock テスト**: encryption fallback 前提の env 設定を `SSO_ENCRYPTION_KEY` に置換/併設 (nextest はテストごと別プロセスなので env 汚染なし)。「両 env remove → 500」のエラー系テストは従来のまま有効。`JWT_SECRET` set 自体の掃除は PR-3 (JWT_SECRET 本体撤去) で実施

## Stage 2 残り

- PR-2: gateway の HS256 ローカル検証 → auth-worker `/auth/introspect` 置換
- PR-3: 認証 JWT (`JwtSecret` 型 / access・internal token 署名) と `JWT_SECRET` env 注入の撤去

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q3N7WtyjxVb1fXnMLy1dCL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q3N7WtyjxVb1fXnMLy1dCL)_