### PR TITLE
refactor(gateway): ユーザー JWT 検証を auth-worker /auth/introspect に委譲 (Refs #479)

### DIFF
--- a/.claude/skills/rust-alc-api-map/SKILL.md
+++ b/.claude/skills/rust-alc-api-map/SKILL.md
@@ -19,7 +19,7 @@ Google OAuth + LINE WORKS。Cloud Run にデプロイ。
 | 系統 | バイナリ | 役割 |
 |---|---|---|
 | **monolith** | `rust-alc-api` (`src/main.rs`) | 全 domain crate の router を `/api` 下に一括 nest。全 repo を 1 プロセスで提供 |
-| **gateway** | `gateway` (`crates/gateway`) | JWT 検証 + reverse proxy。public route 判定 (`routes.rs::is_public_route`) して各 per-domain API へ転送 |
+| **gateway** | `gateway` (`crates/gateway`) | 認証 + reverse proxy。ユーザー JWT の検証は auth-worker `/auth/introspect` に委譲 (#479 PR-2、gateway は JWT_SECRET を持たない)。public route 判定 (`routes.rs::is_public_route`) して各 per-domain API へ転送 |
 | **per-domain API** | `tenko-api` / `carins-api` / `dtako-api` / `trouble-api` | 各 domain crate の router だけを単独で立てる薄い main。`X-Tenant-ID` header 認証 (`require_tenant_header`) |
 | **CLI** | `migrate` (`src/bin/migrate.rs`) / `archive` (`src/bin/archive.rs`) | sqlx migration 実行 / アーカイブ Job |
 
@@ -66,7 +66,13 @@ monolith と per-domain API は同じ domain crate (`alc-tenko` 等) を共有 �
   Bearer JWT → identity ヘッダーに変換し従来テストを無改修で通す。
 - **gateway**: `crates/gateway/src/{main,routes,proxy,auth,config}.rs`。`is_public_route` に
   列挙された path (health / auth/* / tenko-call register / devices register / staging /
-  `/notify/line/webhook` / notify read / access-requests 等) は JWT skip でそのまま proxy。
+  `/notify/line/webhook` / notify read / access-requests 等) は認証 skip でそのまま proxy。
+  非 public path は **auth-worker `/auth/introspect` に検証委譲** (#479 PR-2):
+  `auth.rs::IntrospectClient` が Bearer token + request `Origin` を POST し
+  (`Authorization: <INTERNAL_SHARED_SECRET>` 生値認証)、`active:true` なら
+  `X-Tenant-ID`/`X-User-*` を注入。失敗/不達/Origin 欠落は未認証として素通し
+  (認可は backend 側)。env: `AUTH_WORKER_URL` + `INTERNAL_SHARED_SECRET`
+  (旧 `JWT_SECRET` は gateway から撤去済み)。
   **#434 lockdown**: trouble schedule fire は public 列挙から外し internal 化、LINE webhook の
   判定 path も `/notify/line-webhook` (誤) → `/notify/line/webhook` (実パス) に修正。
   `resolve_backend` は `/api/internal/*` を **dtako_url (fallback backend)** へ振る = internal

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1564,10 +1564,8 @@ name = "gateway"
 version = "0.1.0"
 dependencies = [
  "axum",
- "chrono",
  "http 1.4.0",
  "http-body-util",
- "jsonwebtoken",
  "reqwest",
  "serde",
  "serde_json",
@@ -1576,6 +1574,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+ "wiremock",
 ]
 
 [[package]]

--- a/cloudrun/render.sh
+++ b/cloudrun/render.sh
@@ -312,11 +312,15 @@ emit_env_gateway() {
               value: "PLACEHOLDER_TROUBLE_URL"
             - name: CAMERA_API_URL
               value: "PLACEHOLDER_CAMERA_URL"
-            - name: JWT_SECRET
+            # Refs #479 PR-2: gateway は JWT_SECRET を持たず、ユーザー JWT の
+            # 検証を auth-worker /auth/introspect に委譲する。
+            - name: AUTH_WORKER_URL
+              value: "$( [[ "$ENV" == "staging" ]] && echo "https://auth-worker-staging.m-tama-ramu.workers.dev" || echo "https://auth.ippoan.org" )"
+            - name: INTERNAL_SHARED_SECRET
               valueFrom:
                 secretKeyRef:
                   key: latest
-                  name: $(jwt_secret_name)
+                  name: INTERNAL_SHARED_SECRET
             - name: RUST_LOG
               value: "gateway=info,tower_http=info"
 YAML

--- a/crates/gateway/Cargo.toml
+++ b/crates/gateway/Cargo.toml
@@ -5,11 +5,9 @@ edition = "2021"
 
 [dependencies]
 axum = "0.8"
-chrono = { version = "0.4", features = ["serde"] }
 http = "1"
 http-body-util = "0.1"
-jsonwebtoken = "9"
-reqwest = { version = "0.12", features = ["stream"] }
+reqwest = { version = "0.12", features = ["stream", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }
@@ -17,3 +15,6 @@ tower-http = { version = "0.6", features = ["cors", "trace"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { version = "1", features = ["serde", "v4"] }
+
+[dev-dependencies]
+wiremock = "0.6"

--- a/crates/gateway/src/auth.rs
+++ b/crates/gateway/src/auth.rs
@@ -1,33 +1,91 @@
-use jsonwebtoken::{decode, Algorithm, DecodingKey, Validation};
-use serde::{Deserialize, Serialize};
+//! auth-worker `/auth/introspect` client (Refs #479 Stage 2 PR-2)。
+//!
+//! 旧実装は共有 `JWT_SECRET` でユーザー JWT を gateway 内で HS256 検証していた
+//! (#434 の「proxy が introspect で検証して注入」モデルの旧形)。JWT の署名・
+//! 検証を auth-worker に集約するため、検証を auth-worker `/auth/introspect`
+//! (server-to-server、`INTERNAL_SHARED_SECRET` 認証) への委譲に置換した。
+//! これにより gateway は `JWT_SECRET` を持たない。
+
+use serde::Deserialize;
 use uuid::Uuid;
 
-/// JWT クレーム (alc-core::auth_jwt::AppClaims と同一)
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct AppClaims {
-    pub sub: Uuid,
-    pub email: String,
-    pub name: String,
-    pub tenant_id: Uuid,
-    pub role: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub org_slug: Option<String>,
-    pub iat: i64,
-    pub exp: i64,
+/// auth-worker `/auth/introspect` の 200 response (RFC 7662 風)。
+/// `active: false` の時は他 field は載らない (情報リーク回避)。
+#[derive(Debug, Deserialize)]
+pub struct IntrospectResponse {
+    pub active: bool,
+    pub tenant_id: Option<Uuid>,
+    pub sub: Option<Uuid>,
+    pub email: Option<String>,
+    pub role: Option<String>,
 }
 
-/// JWT を検証してクレームを返す
-pub fn verify_jwt(token: &str, secret: &str) -> Result<AppClaims, jsonwebtoken::errors::Error> {
-    let mut validation = Validation::new(Algorithm::HS256);
-    validation.validate_exp = true;
+/// introspect が返した検証済み identity。backend へ `X-Tenant-ID` /
+/// `X-User-*` として注入する。
+#[derive(Debug, Clone)]
+pub struct Identity {
+    pub tenant_id: Uuid,
+    pub user_id: Uuid,
+    pub email: String,
+    pub role: String,
+}
 
-    let token_data = decode::<AppClaims>(
-        token,
-        &DecodingKey::from_secret(secret.as_bytes()),
-        &validation,
-    )?;
+/// auth-worker introspect の呼び出し client。
+///
+/// 認証は `Authorization: <INTERNAL_SHARED_SECRET>` (生の値、Bearer prefix
+/// なし = auth-worker 側契約)。`origin` は per-app テナント ACL
+/// (`APP_TENANT_ACL`) の判定キーで、auth-worker は origin 欠落を
+/// fail-closed (`active:false`) にする。
+pub struct IntrospectClient {
+    client: reqwest::Client,
+    endpoint: String,
+    shared_secret: String,
+}
 
-    Ok(token_data.claims)
+impl IntrospectClient {
+    pub fn new(client: reqwest::Client, auth_worker_url: &str, shared_secret: String) -> Self {
+        Self {
+            client,
+            endpoint: format!("{}/auth/introspect", auth_worker_url.trim_end_matches('/')),
+            shared_secret,
+        }
+    }
+
+    /// token + origin を auth-worker で検証する。
+    ///
+    /// 失敗 (署名不正 / exp 切れ / ACL 不許可 / auth-worker 不達 / parse 不能)
+    /// は全て `None` = 未認証扱い (identity 注入なし)。旧 `verify_jwt` 失敗時と
+    /// 同じ扱いで、proxy 自体は 5xx にしない (認可判定は backend 側)。
+    pub async fn introspect(&self, token: &str, origin: &str) -> Option<Identity> {
+        let resp = self
+            .client
+            .post(&self.endpoint)
+            .header("Authorization", &self.shared_secret)
+            .json(&serde_json::json!({ "token": token, "origin": origin }))
+            .send()
+            .await
+            .map_err(|e| tracing::warn!("introspect unreachable: {e}"))
+            .ok()?;
+        let status = resp.status();
+        if !status.is_success() {
+            tracing::warn!("introspect returned {status}");
+            return None;
+        }
+        let body: IntrospectResponse = resp
+            .json()
+            .await
+            .map_err(|e| tracing::warn!("introspect parse error: {e}"))
+            .ok()?;
+        if !body.active {
+            return None;
+        }
+        Some(Identity {
+            tenant_id: body.tenant_id?,
+            user_id: body.sub?,
+            email: body.email?,
+            role: body.role?,
+        })
+    }
 }
 
 /// Authorization ヘッダーから Bearer トークンを抽出
@@ -38,54 +96,112 @@ pub fn extract_bearer_token(header_value: &str) -> Option<&str> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chrono::{Duration, Utc};
-    use jsonwebtoken::{encode, EncodingKey, Header};
+    use wiremock::matchers::{body_partial_json, header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
-    fn create_test_token(secret: &str, expired: bool) -> String {
-        let now = Utc::now();
-        let exp = if expired {
-            (now - Duration::hours(1)).timestamp()
-        } else {
-            (now + Duration::hours(1)).timestamp()
-        };
-        let claims = AppClaims {
-            sub: Uuid::new_v4(),
-            email: "test@example.com".to_string(),
-            name: "Test User".to_string(),
-            tenant_id: Uuid::new_v4(),
-            role: "admin".to_string(),
-            org_slug: None,
-            iat: now.timestamp(),
-            exp,
-        };
-        encode(
-            &Header::new(Algorithm::HS256),
-            &claims,
-            &EncodingKey::from_secret(secret.as_bytes()),
+    fn client(server_uri: &str) -> IntrospectClient {
+        IntrospectClient::new(
+            reqwest::Client::new(),
+            server_uri,
+            "test-shared-secret".to_string(),
         )
-        .unwrap()
     }
 
-    #[test]
-    fn test_verify_valid_token() {
-        let secret = "test-secret-key-256-bits-long!!!";
-        let token = create_test_token(secret, false);
-        let claims = verify_jwt(&token, secret).unwrap();
-        assert_eq!(claims.email, "test@example.com");
-        assert_eq!(claims.role, "admin");
+    #[tokio::test]
+    async fn introspect_active_true_returns_identity() {
+        let server = MockServer::start().await;
+        let tenant = Uuid::new_v4();
+        let sub = Uuid::new_v4();
+        Mock::given(method("POST"))
+            .and(path("/auth/introspect"))
+            .and(header("Authorization", "test-shared-secret"))
+            .and(body_partial_json(serde_json::json!({
+                "token": "tok",
+                "origin": "https://alc.ippoan.org"
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "active": true,
+                "tenant_id": tenant,
+                "sub": sub,
+                "email": "u@example.com",
+                "role": "admin",
+                "exp": 9999999999u64
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let id = client(&server.uri())
+            .introspect("tok", "https://alc.ippoan.org")
+            .await
+            .expect("identity");
+        assert_eq!(id.tenant_id, tenant);
+        assert_eq!(id.user_id, sub);
+        assert_eq!(id.email, "u@example.com");
+        assert_eq!(id.role, "admin");
     }
 
-    #[test]
-    fn test_verify_expired_token() {
-        let secret = "test-secret-key-256-bits-long!!!";
-        let token = create_test_token(secret, true);
-        assert!(verify_jwt(&token, secret).is_err());
+    #[tokio::test]
+    async fn introspect_active_false_returns_none() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/auth/introspect"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({ "active": false })),
+            )
+            .mount(&server)
+            .await;
+        assert!(client(&server.uri()).introspect("bad", "o").await.is_none());
     }
 
-    #[test]
-    fn test_verify_wrong_secret() {
-        let token = create_test_token("correct-secret-key!!", false);
-        assert!(verify_jwt(&token, "wrong-secret-key!!!!").is_err());
+    #[tokio::test]
+    async fn introspect_non_200_returns_none() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/auth/introspect"))
+            .respond_with(
+                ResponseTemplate::new(401)
+                    .set_body_json(serde_json::json!({ "error": "unauthorized" })),
+            )
+            .mount(&server)
+            .await;
+        assert!(client(&server.uri()).introspect("tok", "o").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn introspect_malformed_body_returns_none() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/auth/introspect"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("not-json"))
+            .mount(&server)
+            .await;
+        assert!(client(&server.uri()).introspect("tok", "o").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn introspect_active_true_but_missing_fields_returns_none() {
+        // active:true なのに identity field が欠ける異常応答は fail-closed。
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/auth/introspect"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({ "active": true })),
+            )
+            .mount(&server)
+            .await;
+        assert!(client(&server.uri()).introspect("tok", "o").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn introspect_unreachable_returns_none() {
+        // 存在しない port へ接続 → network error → None。
+        let c = IntrospectClient::new(
+            reqwest::Client::new(),
+            "http://127.0.0.1:1",
+            "s".to_string(),
+        );
+        assert!(c.introspect("tok", "o").await.is_none());
     }
 
     #[test]

--- a/crates/gateway/src/config.rs
+++ b/crates/gateway/src/config.rs
@@ -3,7 +3,10 @@ use std::env;
 pub struct Config {
     pub port: u16,
     pub backend_url: String,
-    pub jwt_secret: String,
+    /// auth-worker の base URL (introspect 委譲先、Refs #479 PR-2)。
+    pub auth_worker_url: String,
+    /// auth-worker `/auth/introspect` の server-to-server 認証 secret。
+    pub introspect_shared_secret: String,
     /// tenko-api の URL。未設定時は backend_url にフォールバック。
     pub tenko_url: Option<String>,
     /// carins-api の URL。未設定時は backend_url にフォールバック。
@@ -24,7 +27,9 @@ impl Config {
                 .and_then(|v| v.parse().ok())
                 .unwrap_or(8080),
             backend_url: env::var("BACKEND_URL").expect("BACKEND_URL is required"),
-            jwt_secret: env::var("JWT_SECRET").expect("JWT_SECRET is required"),
+            auth_worker_url: env::var("AUTH_WORKER_URL").expect("AUTH_WORKER_URL is required"),
+            introspect_shared_secret: env::var("INTERNAL_SHARED_SECRET")
+                .expect("INTERNAL_SHARED_SECRET is required"),
             tenko_url: env::var("TENKO_API_URL").ok(),
             carins_url: env::var("CARINS_API_URL").ok(),
             dtako_url: env::var("DTAKO_API_URL").ok(),

--- a/crates/gateway/src/main.rs
+++ b/crates/gateway/src/main.rs
@@ -51,10 +51,16 @@ async fn main() {
         tracing::info!("alc-camera-api: {camera_url}");
     }
 
+    let introspect = std::sync::Arc::new(crate::auth::IntrospectClient::new(
+        client.clone(),
+        &config.auth_worker_url,
+        config.introspect_shared_secret,
+    ));
+
     let proxy_state = ProxyState {
         client,
         backend_url: config.backend_url.clone(),
-        jwt_secret: config.jwt_secret,
+        introspect,
         tenko_url: config.tenko_url,
         carins_url: config.carins_url,
         dtako_url: config.dtako_url,

--- a/crates/gateway/src/proxy.rs
+++ b/crates/gateway/src/proxy.rs
@@ -6,14 +6,18 @@ use axum::{
 };
 use reqwest::Client;
 
-use crate::auth::{extract_bearer_token, verify_jwt, AppClaims};
+use std::sync::Arc;
+
+use crate::auth::{extract_bearer_token, Identity, IntrospectClient};
 use crate::routes::is_public_route;
 
 #[derive(Clone)]
 pub struct ProxyState {
     pub client: Client,
     pub backend_url: String,
-    pub jwt_secret: String,
+    /// auth-worker `/auth/introspect` client (Refs #479 PR-2 — 旧 jwt_secret
+    /// によるローカル HS256 検証を置換)。
+    pub introspect: Arc<IntrospectClient>,
     pub tenko_url: Option<String>,
     pub carins_url: Option<String>,
     pub dtako_url: Option<String>,
@@ -70,11 +74,11 @@ pub async fn proxy_handler(
         .map(|pq| pq.as_str())
         .unwrap_or(path);
 
-    // JWT 検証 (public ルート以外)
-    let claims = if is_public_route(path) {
+    // 認証 (public ルート以外): auth-worker introspect に委譲 (Refs #479 PR-2)。
+    let identity = if is_public_route(path) {
         None
     } else {
-        try_verify_jwt(&parts.headers, &state.jwt_secret)
+        try_introspect(&parts.headers, &state).await
     };
 
     // backend URL 構築 (パスに応じて tenko-api or backend を選択)
@@ -99,9 +103,9 @@ pub async fn proxy_handler(
         }
     }
 
-    // JWT 検証成功時にヘッダー追加
-    if let Some(claims) = &claims {
-        builder = inject_auth_headers(builder, claims);
+    // introspect 成功時に検証済み identity をヘッダー注入
+    if let Some(identity) = &identity {
+        builder = inject_auth_headers(builder, identity);
     }
 
     // Body をストリーミング転送
@@ -141,23 +145,30 @@ pub async fn proxy_handler(
     (status, headers, body).into_response()
 }
 
-/// Authorization ヘッダーから JWT を検証する (失敗時は None)
-fn try_verify_jwt(headers: &HeaderMap, jwt_secret: &str) -> Option<AppClaims> {
+/// Authorization ヘッダーの Bearer token を auth-worker introspect で検証する
+/// (失敗時は None = 未認証としてそのまま proxy)。
+///
+/// `origin` は request の `Origin` ヘッダーをそのまま転送する (auth-worker の
+/// per-app テナント ACL 判定キー)。ブラウザからの cross-origin 呼び出しでは
+/// 常に付与される。`Origin` が無い non-browser クライアントは introspect が
+/// fail-closed になるため identity 注入なし (旧実装で JWT 不正時と同じ扱い)。
+async fn try_introspect(headers: &HeaderMap, state: &ProxyState) -> Option<Identity> {
     let auth_header = headers.get("authorization")?.to_str().ok()?;
     let token = extract_bearer_token(auth_header)?;
-    verify_jwt(token, jwt_secret).ok()
+    let origin = headers.get("origin").and_then(|v| v.to_str().ok())?;
+    state.introspect.introspect(token, origin).await
 }
 
-/// 認証情報をヘッダーとして注入
+/// 検証済み identity をヘッダーとして注入
 fn inject_auth_headers(
     builder: reqwest::RequestBuilder,
-    claims: &AppClaims,
+    identity: &Identity,
 ) -> reqwest::RequestBuilder {
     builder
-        .header("X-Tenant-ID", claims.tenant_id.to_string())
-        .header("X-User-ID", claims.sub.to_string())
-        .header("X-User-Email", &claims.email)
-        .header("X-User-Role", &claims.role)
+        .header("X-Tenant-ID", identity.tenant_id.to_string())
+        .header("X-User-ID", identity.user_id.to_string())
+        .header("X-User-Email", &identity.email)
+        .header("X-User-Role", &identity.role)
 }
 
 #[cfg(test)]
@@ -168,7 +179,11 @@ mod tests {
         ProxyState {
             client: Client::new(),
             backend_url: "http://backend:8081".to_string(),
-            jwt_secret: "secret".to_string(),
+            introspect: Arc::new(IntrospectClient::new(
+                Client::new(),
+                "http://auth-worker.invalid",
+                "test-secret".to_string(),
+            )),
             tenko_url: Some("http://tenko:8082".to_string()),
             carins_url: Some("http://carins:8083".to_string()),
             dtako_url: Some("http://dtako:8084".to_string()),
@@ -295,7 +310,11 @@ mod tests {
         let state = ProxyState {
             client: Client::new(),
             backend_url: "http://backend:8081".to_string(),
-            jwt_secret: "secret".to_string(),
+            introspect: Arc::new(IntrospectClient::new(
+                Client::new(),
+                "http://auth-worker.invalid",
+                "test-secret".to_string(),
+            )),
             tenko_url: None,
             carins_url: None,
             dtako_url: None,
@@ -316,51 +335,56 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_try_verify_jwt_no_header() {
+    #[tokio::test]
+    async fn test_try_introspect_no_auth_header() {
         let headers = HeaderMap::new();
-        assert!(try_verify_jwt(&headers, "secret").is_none());
+        assert!(try_introspect(&headers, &test_state()).await.is_none());
     }
 
-    #[test]
-    fn test_try_verify_jwt_invalid_token() {
+    #[tokio::test]
+    async fn test_try_introspect_missing_origin_skips() {
+        // Origin ヘッダーが無い場合は introspect を呼ばず未認証扱い
+        // (auth-worker 側が origin 欠落を fail-closed にするため呼ぶだけ無駄)。
         let mut headers = HeaderMap::new();
-        headers.insert(
-            "authorization",
-            "Bearer invalid.token.here".parse().unwrap(),
-        );
-        assert!(try_verify_jwt(&headers, "secret").is_none());
+        headers.insert("authorization", "Bearer some-token".parse().unwrap());
+        assert!(try_introspect(&headers, &test_state()).await.is_none());
     }
 
-    #[test]
-    fn test_try_verify_jwt_valid_token() {
-        use chrono::{Duration, Utc};
-        use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
+    #[tokio::test]
+    async fn test_try_introspect_active_true_injects_identity() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
 
-        let secret = "test-secret-key-256-bits-long!!!";
-        let now = Utc::now();
-        let claims = AppClaims {
-            sub: uuid::Uuid::new_v4(),
-            email: "test@example.com".to_string(),
-            name: "Test".to_string(),
-            tenant_id: uuid::Uuid::new_v4(),
-            role: "admin".to_string(),
-            org_slug: None,
-            iat: now.timestamp(),
-            exp: (now + Duration::hours(1)).timestamp(),
-        };
-        let token = encode(
-            &Header::new(Algorithm::HS256),
-            &claims,
-            &EncodingKey::from_secret(secret.as_bytes()),
-        )
-        .unwrap();
+        let server = MockServer::start().await;
+        let tenant = uuid::Uuid::new_v4();
+        let sub = uuid::Uuid::new_v4();
+        Mock::given(method("POST"))
+            .and(path("/auth/introspect"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "active": true,
+                "tenant_id": tenant,
+                "sub": sub,
+                "email": "u@example.com",
+                "role": "admin"
+            })))
+            .mount(&server)
+            .await;
+
+        let mut state = test_state();
+        state.introspect = Arc::new(IntrospectClient::new(
+            Client::new(),
+            &server.uri(),
+            "s".to_string(),
+        ));
 
         let mut headers = HeaderMap::new();
-        headers.insert("authorization", format!("Bearer {token}").parse().unwrap());
+        headers.insert("authorization", "Bearer tok".parse().unwrap());
+        headers.insert("origin", "https://alc.ippoan.org".parse().unwrap());
 
-        let result = try_verify_jwt(&headers, secret);
-        assert!(result.is_some());
-        assert_eq!(result.unwrap().email, "test@example.com");
+        let identity = try_introspect(&headers, &state).await.expect("identity");
+        assert_eq!(identity.tenant_id, tenant);
+        assert_eq!(identity.user_id, sub);
+        assert_eq!(identity.email, "u@example.com");
+        assert_eq!(identity.role, "admin");
     }
 }


### PR DESCRIPTION
Refs #479 (Stage 2 / PR-2: gateway の機能置換。[用途分類調査](https://github.com/ippoan/rust-alc-api/issues/479#issuecomment-4860884534) 参照)

## 背景

gateway は共有 `JWT_SECRET` でユーザー JWT を **HS256 ローカル検証**して `X-Tenant-ID` / `X-User-*` を注入していた — #434 の「proxy が auth-worker introspect で検証して注入」モデルの旧実装。JWT の署名・検証を auth-worker に集約するため、検証を auth-worker `/auth/introspect` への委譲に置換し、**gateway から `JWT_SECRET` を撤去**する。

## 変更内容

- **`auth.rs`**: `verify_jwt` / `AppClaims` → `IntrospectClient` / `Identity` に置換。`POST {AUTH_WORKER_URL}/auth/introspect` (認証: `Authorization: <INTERNAL_SHARED_SECRET>` 生値 = auth-worker 側契約 #290/#189)。`active:false` / 非 200 / 不達 / parse 不能 / field 欠落は全て `None` = 未認証扱い (旧 `verify_jwt` 失敗時と同じ。proxy は 5xx にしない、認可判定は backend)
- **`proxy.rs`**: `try_verify_jwt` → `try_introspect`。`origin` は request の `Origin` ヘッダーを転送 (auth-worker の per-app テナント ACL 判定キー。frontends は別 origin なのでブラウザ呼び出しでは常在。無い場合は introspect を呼ばず未認証扱い)
- **`config.rs` / `main.rs`**: `JWT_SECRET` env → `AUTH_WORKER_URL` + `INTERNAL_SHARED_SECRET`
- **`cloudrun/render.sh`**: gateway の `JWT_SECRET` secretKeyRef を撤去、`AUTH_WORKER_URL` (staging/prod で URL 切替) + `INTERNAL_SHARED_SECRET` secretKeyRef を注入。`INTERNAL_SHARED_SECRET` は backend が同名 secretKeyRef で使用実績あり = runtime SA の per-secret grant 済み (grant 漏れ startup fail の心配なし)
- **`Cargo.toml`**: `jsonwebtoken` / `chrono` 削除、`reqwest` に `json` feature、`wiremock` dev-dep 追加

## 検証

- `cargo test -p gateway` **17 passed** (introspect 成功 / active:false / 401 / malformed / field 欠落 / 不達 / Origin 欠落 skip / resolve_backend 群) — wiremock で auth-worker をモック
- `cargo clippy -p gateway --all-targets -- -D warnings` green

## 挙動変化と運用注意

- **ACL の強制が始まる**: 旧実装は署名 + exp のみ検証。introspect は `APP_TENANT_ACL` (per-app テナント) + org ACL も判定する (未登録 origin は pass = fail-open なので既存アプリは影響なし)
- **Origin ヘッダーの無い non-browser クライアント**は identity 注入されなくなる (kiosk の `X-Tenant-ID` 直接ヘッダー経路は従来どおり pass-through で影響なし)
- **staging E2E では gateway は経路に乗らない** (alc-app staging は Cloud Run 直叩き) — prod 反映 (v* tag + Release Wave flip) 前に gateway の preview URL (pending tag) で認証経由の E2E を確認すること
- レイテンシ: 認証付きリクエストごとに auth-worker への RTT (+数十 ms) が乗る。必要なら token-hash キャッシュを後続で検討

## Stage 2 残り

- PR-3: 認証 JWT 本体撤去 (`JwtSecret` 型 / `create/verify_access_token` / monolith ログイン handler / render.sh の JWT_SECRET 注入 / health_canary)。前提: monolith に残る `google_login` 等の auth-worker 移管完了確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q3N7WtyjxVb1fXnMLy1dCL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q3N7WtyjxVb1fXnMLy1dCL)_