### PR TITLE
feat(devices): list_devices に re-pair 状態列を追加 (Refs #495)

### DIFF
--- a/.claude/skills/rust-alc-api-map/SKILL.md
+++ b/.claude/skills/rust-alc-api-map/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rust-alc-api-map
-generated-from: rust-alc-api:c8ad3a7e2db04dcc58c5161f0d523400ef0f5c41
+generated-from: rust-alc-api:595d31d259ad6747f96b08f294c5c4f2a84182a7
 paths: [crates/, src/, migrations/]
 description: rust-alc-api (アルコールチェッカー基盤の Rust/Axum Cargo workspace — 13 domain crate + gateway/tenko/carins/dtako/trouble の複数バイナリ、PostgreSQL+RLS、Cloud Run) の構造ナビゲーション。どの crate に何のルートがあるか / monolith(rust-alc-api) と per-domain API + gateway の二系統 / RLS・migration・deploy/release 分離の gotcha を 1 枚にまとめる。トリガー:「rust-alc-api」「alc-api」「alc-notify」「alc-tenko」「alc-trouble」「alc-carins」「alc-dtako」「gateway」「tenko-api」「carins-api」「dtako-api」「trouble-api」「RLS テナント」「sqlx migration」「ts-rs」「Release Wave」「Bazel」等。
 ---

--- a/crates/alc-core/src/repository/devices.rs
+++ b/crates/alc-core/src/repository/devices.rs
@@ -32,6 +32,11 @@ pub struct DeviceRow {
     pub watchdog_running: Option<bool>,
     pub created_at: String,
     pub updated_at: String,
+    /// re-pair (再認証) 状態。管理者一覧で残り window / 履歴を表示するため (Refs #495)。
+    pub re_pair_authorized_until: Option<String>,
+    pub last_re_pair_at: Option<String>,
+    pub re_pair_count: i32,
+    pub hardware_id: Option<String>,
 }
 
 /// 登録リクエスト情報

--- a/crates/alc-devices/src/devices.rs
+++ b/crates/alc-devices/src/devices.rs
@@ -128,6 +128,10 @@ struct Device {
     watchdog_running: Option<bool>,
     created_at: String,
     updated_at: String,
+    re_pair_authorized_until: Option<String>,
+    last_re_pair_at: Option<String>,
+    re_pair_count: i32,
+    hardware_id: Option<String>,
 }
 
 impl From<DeviceRow> for Device {
@@ -157,6 +161,10 @@ impl From<DeviceRow> for Device {
             watchdog_running: r.watchdog_running,
             created_at: r.created_at,
             updated_at: r.updated_at,
+            re_pair_authorized_until: r.re_pair_authorized_until,
+            last_re_pair_at: r.last_re_pair_at,
+            re_pair_count: r.re_pair_count,
+            hardware_id: r.hardware_id,
         }
     }
 }

--- a/crates/alc-devices/src/repo/devices.rs
+++ b/crates/alc-devices/src/repo/devices.rs
@@ -399,7 +399,8 @@ impl DeviceRepository for PgDeviceRepository {
                    call_enabled, call_schedule, fcm_token,
                    last_login_employee_id, last_login_employee_name, last_login_employee_role,
                    app_version_code, app_version_name, is_device_owner, is_dev_device,
-                   always_on, watchdog_running, created_at::text, updated_at::text
+                   always_on, watchdog_running, created_at::text, updated_at::text,
+                   re_pair_authorized_until::text, last_re_pair_at::text, re_pair_count, hardware_id
             FROM devices
             ORDER BY created_at DESC
             "#,

--- a/tests/mock_helpers/repos_a.rs
+++ b/tests/mock_helpers/repos_a.rs
@@ -1450,6 +1450,10 @@ impl DeviceRepository for MockDeviceRepository {
                 watchdog_running: None,
                 created_at: "2026-01-01T00:00:00Z".to_string(),
                 updated_at: "2026-01-01T00:00:00Z".to_string(),
+                re_pair_authorized_until: None,
+                last_re_pair_at: None,
+                re_pair_count: 0,
+                hardware_id: None,
             }])
         } else {
             Ok(vec![])


### PR DESCRIPTION
## Summary

issue #495 PR1 完了条件「管理者が端末一覧で再認証を許可 → window 残り時間が
UI に出る」に必要な列 (`re_pair_authorized_until` / `last_re_pair_at` /
`re_pair_count` / `hardware_id`) が `list_devices` の SELECT / `DeviceRow` /
`Device` レスポンス構造体に露出していなかった (#497 マージ時の抜け漏れ)。
alc-app 側 (#84、`DeviceRegistrationManager.vue` の window 残り時間表示)
が必要とする値をここで追加する。

- `crates/alc-core/src/repository/devices.rs` — `DeviceRow` に 4 フィールド追加
- `crates/alc-devices/src/repo/devices.rs` — `list_devices` の SELECT に列追加
- `crates/alc-devices/src/devices.rs` — HTTP レスポンス `Device` 構造体 +
  `From<DeviceRow>` に反映
- `tests/mock_helpers/repos_a.rs` — mock `DeviceRow` 構築に新フィールド追加

`migrations/122_devices_re_pair.sql` で追加済みのカラムをそのまま SELECT に
足すだけで、新規ロジック分岐は無い。

## Test plan

- [x] `cargo check --lib --bins --tests` (workspace 全体) green
- [x] `cargo test --test mock_devices` (152 テスト) green
- [x] `cargo fmt --all -- --check` green
- [x] coverage regression 無し (単純フィールドマッピング、既存
      `list_devices` テストの mapping で自動的にカバーされる想定 —
      `devices.rs` は `coverage_100.toml` の `combined` 型 gate 対象、CI で確認)

Refs #495


---
_Generated by [Claude Code](https://claude.ai/code/session_01PxdPi54wqpvCzzFa65jEzt)_