### PR TITLE
fix(devices): re-pair の shared secret を既存 INTERNAL_SHARED_SECRET に統一 (Refs #495)

### DIFF
--- a/.claude/skills/rust-alc-api-map/SKILL.md
+++ b/.claude/skills/rust-alc-api-map/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rust-alc-api-map
-generated-from: rust-alc-api:595d31d259ad6747f96b08f294c5c4f2a84182a7
+generated-from: rust-alc-api:484233b776142c6414489a781beaea88314cbbc7
 paths: [crates/, src/, migrations/]
 description: rust-alc-api (アルコールチェッカー基盤の Rust/Axum Cargo workspace — 13 domain crate + gateway/tenko/carins/dtako/trouble の複数バイナリ、PostgreSQL+RLS、Cloud Run) の構造ナビゲーション。どの crate に何のルートがあるか / monolith(rust-alc-api) と per-domain API + gateway の二系統 / RLS・migration・deploy/release 分離の gotcha を 1 枚にまとめる。トリガー:「rust-alc-api」「alc-api」「alc-notify」「alc-tenko」「alc-trouble」「alc-carins」「alc-dtako」「gateway」「tenko-api」「carins-api」「dtako-api」「trouble-api」「RLS テナント」「sqlx migration」「ts-rs」「Release Wave」「Bazel」等。
 ---

--- a/cloudrun/render.sh
+++ b/cloudrun/render.sh
@@ -271,6 +271,14 @@ YAML
                 secretKeyRef:
                   key: latest
                   name: INTERNAL_SHARED_SECRET
+            # kiosk 端末 re-pair (再認証、Refs #495)。alc-devices::device_pair_client が
+            # 両方揃っていないと re-pair 機能自体を無効化する (HttpDevicePairClient::from_env
+            # が None を返し re_pair ハンドラは 404 "device_pair_client not configured")。
+            # shared secret は新規発行せず上の INTERNAL_SHARED_SECRET を再利用する
+            # (auth-worker 側で既に ippoan 4 worker と共有済みの binding、新規 secret を
+            # 増やさない方針)。
+            - name: AUTH_WORKER_URL
+              value: "$( [[ "$ENV" == "staging" ]] && echo "https://auth-worker-staging.m-tama-ramu.workers.dev" || echo "https://auth.ippoan.org" )"
 YAML
 }
 

--- a/crates/alc-core/src/device_pair_client.rs
+++ b/crates/alc-core/src/device_pair_client.rs
@@ -90,8 +90,11 @@ impl HttpDevicePairClient {
         }
     }
 
-    /// `AUTH_WORKER_URL` / `RE_PAIR_INTERNAL_SHARED_SECRET` が両方揃っていれば
+    /// `AUTH_WORKER_URL` / `INTERNAL_SHARED_SECRET` が両方揃っていれば
     /// `Some`。片方でも欠けていれば re-pair 機能は未設定 (`None`) とする。
+    /// shared secret は既存 `INTERNAL_SHARED_SECRET` (dtako ingest 等と共用の
+    /// ippoan 4 worker 間 secret) を再利用する。新規 secret は発行しない
+    /// (用途ごとに secret を増やさない方針)。
     pub fn from_env() -> Option<Self> {
         Self::from_env_lookup(|k| std::env::var(k).ok())
     }
@@ -99,7 +102,7 @@ impl HttpDevicePairClient {
     /// env 依存を分離したテスト可能な実装 (`redact_broadcast::from_env_lookup` と同パターン)。
     fn from_env_lookup<F: Fn(&str) -> Option<String>>(getter: F) -> Option<Self> {
         let auth_worker_url = getter("AUTH_WORKER_URL").filter(|s| !s.is_empty())?;
-        let shared_secret = getter("RE_PAIR_INTERNAL_SHARED_SECRET").filter(|s| !s.is_empty())?;
+        let shared_secret = getter("INTERNAL_SHARED_SECRET").filter(|s| !s.is_empty())?;
         Some(Self::new(&auth_worker_url, shared_secret))
     }
 }
@@ -156,7 +159,7 @@ mod tests {
     #[test]
     fn from_env_lookup_none_when_url_missing() {
         assert!(HttpDevicePairClient::from_env_lookup(|k| {
-            if k == "RE_PAIR_INTERNAL_SHARED_SECRET" {
+            if k == "INTERNAL_SHARED_SECRET" {
                 Some("secret".to_string())
             } else {
                 None
@@ -182,7 +185,7 @@ mod tests {
         assert!(HttpDevicePairClient::from_env_lookup(|k| {
             match k {
                 "AUTH_WORKER_URL" => Some(String::new()),
-                "RE_PAIR_INTERNAL_SHARED_SECRET" => Some("secret".to_string()),
+                "INTERNAL_SHARED_SECRET" => Some("secret".to_string()),
                 _ => None,
             }
         })
@@ -194,7 +197,7 @@ mod tests {
         assert!(HttpDevicePairClient::from_env_lookup(|k| {
             match k {
                 "AUTH_WORKER_URL" => Some("https://auth.example.com".to_string()),
-                "RE_PAIR_INTERNAL_SHARED_SECRET" => Some(String::new()),
+                "INTERNAL_SHARED_SECRET" => Some(String::new()),
                 _ => None,
             }
         })
@@ -205,7 +208,7 @@ mod tests {
     fn from_env_lookup_returns_some_when_both_set() {
         let client = HttpDevicePairClient::from_env_lookup(|k| match k {
             "AUTH_WORKER_URL" => Some("https://auth.example.com".to_string()),
-            "RE_PAIR_INTERNAL_SHARED_SECRET" => Some("secret".to_string()),
+            "INTERNAL_SHARED_SECRET" => Some("secret".to_string()),
             _ => None,
         })
         .unwrap();
@@ -227,18 +230,18 @@ mod tests {
         // 唯一実 env を触るテスト。このキーは他テストで使われないため並行
         // 実行下でも安全 (redact_broadcast::from_env_uses_real_env と同パターン)。
         let saved_url = std::env::var("AUTH_WORKER_URL").ok();
-        let saved_secret = std::env::var("RE_PAIR_INTERNAL_SHARED_SECRET").ok();
+        let saved_secret = std::env::var("INTERNAL_SHARED_SECRET").ok();
 
         std::env::remove_var("AUTH_WORKER_URL");
-        std::env::remove_var("RE_PAIR_INTERNAL_SHARED_SECRET");
+        std::env::remove_var("INTERNAL_SHARED_SECRET");
         assert!(HttpDevicePairClient::from_env().is_none());
 
         std::env::set_var("AUTH_WORKER_URL", "https://auth.example.com");
-        std::env::set_var("RE_PAIR_INTERNAL_SHARED_SECRET", "secret");
+        std::env::set_var("INTERNAL_SHARED_SECRET", "secret");
         assert!(HttpDevicePairClient::from_env().is_some());
 
         restore_env("AUTH_WORKER_URL", saved_url);
-        restore_env("RE_PAIR_INTERNAL_SHARED_SECRET", saved_secret);
+        restore_env("INTERNAL_SHARED_SECRET", saved_secret);
     }
 
     #[test]

--- a/crates/alc-core/src/lib.rs
+++ b/crates/alc-core/src/lib.rs
@@ -126,8 +126,9 @@ pub struct AppState {
     pub trouble_task_statuses: Arc<dyn TroubleTaskStatusesRepository>,
     pub trouble_storage: Option<Arc<dyn StorageBackend>>,
     /// kiosk 端末 re-pair (再認証) 用、auth-worker `/device/pair-internal` 呼び出し
-    /// クライアント (Refs #495)。`AUTH_WORKER_URL` / `RE_PAIR_INTERNAL_SHARED_SECRET`
+    /// クライアント (Refs #495)。`AUTH_WORKER_URL` / `INTERNAL_SHARED_SECRET`
     /// が未設定なら None (re-pair endpoint は 404 で "not configured" を表す)。
+    /// shared secret は既存 INTERNAL_SHARED_SECRET (dtako ingest 等と共用) を再利用する。
     pub device_pair_client: Option<Arc<dyn device_pair_client::DevicePairClient>>,
 }
 

--- a/docs/plan-device-repair.md
+++ b/docs/plan-device-repair.md
@@ -208,8 +208,8 @@ Response `201`:
 
 | 変数 | 用途 |
 |---|---|
-| `AUTH_WORKER_URL` | 既存 gateway crate と同名 (rust-alc-api 本体では新規)。auth-worker の base URL |
-| `RE_PAIR_INTERNAL_SHARED_SECRET` | pair-internal 呼び出し用の shared secret (auth-worker 側で allowlist する専用 secret。既存 `INTERNAL_SHARED_SECRET` の再利用ではなく新規 secret を発行する — 用途混在を避ける) |
+| `AUTH_WORKER_URL` | 既存 gateway crate と同名 (rust-alc-api backend では新規)。auth-worker の base URL |
+| `INTERNAL_SHARED_SECRET` | pair-internal 呼び出し用の shared secret。既存 (dtako ingest 等と共用、ippoan 4 worker 間で共有済み) を再利用する — 新規 secret は発行しない (用途ごとに secret を増やさない方針) |
 | `RE_PAIR_REQUIRE_ADMIN` | デフォルト `true`。`false` にすると window 判定をスキップ (段階導入用、本番では常に true 運用) |
 | `RE_PAIR_REQUIRE_TOKEN` | デフォルト `false`。`true` で settings_token 2-factor 化 |
 | `RE_PAIR_WINDOW_SECS` | デフォルト `900` |
@@ -256,6 +256,6 @@ issue #495 の Acceptance Criteria はそのまま本 doc のテスト方針で�
 
 - Cloudflare WAF rate rule の具体的なルール定義はインフラ設定側 (本 repo
   scope 外)
-- staging/prod への `AUTH_WORKER_URL` / `RE_PAIR_INTERNAL_SHARED_SECRET`
-  (auth-worker 側の `INTERNAL_SHARED_SECRET*` binding と同値) の実投入
-  (secrets-inventory 経由、インフラ作業)
+- staging/prod への `AUTH_WORKER_URL` の実投入は `cloudrun/render.sh`
+  (`emit_env_backend`) に組み込み済み。`INTERNAL_SHARED_SECRET` は既存の
+  backend 用 secretKeyRef をそのまま流用するため追加投入は不要


### PR DESCRIPTION
## Summary

**staging E2E で発見したバグの修正 (auth-worker#346 の続き)。** auth-worker
側の allowlist 修正後、`/api/devices/re-pair` は rust-alc-api まで到達する
ようになったが、今度は 404 `"re_pair: device_pair_client not configured"`
になっていた。

原因: 設計 doc (`docs/plan-device-repair.md`) で「既存 `INTERNAL_SHARED_SECRET`
の再利用ではなく新規 secret `RE_PAIR_INTERNAL_SHARED_SECRET` を発行する」と
していたが、その新規 secret を staging Cloud Run / auth-worker のどちらにも
投入していなかった (`HttpDevicePairClient::from_env()` が env var 未設定で
`None` を返し、re-pair 機能自体が無効化される設計)。

## 修正方針 (secret を増やさない)

新規 secret を発行・投入する代わりに、dtako ingest 等で既に
ippoan 4 worker (auth-worker/cdp-relay/hcreaderworker/ref-files-worker) 間で
共有済みの既存 `INTERNAL_SHARED_SECRET` を再利用する:

- rust-alc-api backend は元々この secret を `INTERNAL_SHARED_SECRET` として
  Cloud Run に受け取っている (`cloudrun/render.sh` に既存)
- auth-worker 側もこの secret を `resolveAllSharedSecrets` で既に accept 済み
- そのため Rust コード側の env var 名を `RE_PAIR_INTERNAL_SHARED_SECRET` →
  `INTERNAL_SHARED_SECRET` に統一するだけで、staging への追加 secret 投入
  なしに動く
- `cloudrun/render.sh` (`emit_env_backend`) には `AUTH_WORKER_URL` のみ追加
  (こちらは plain value で secret ではない)

## Test plan

- [x] `cargo check --lib --bins --tests` (workspace 全体) green
- [x] `cargo test --lib -p alc-core` (device_pair_client 含む 173 テスト) green
- [x] `cargo fmt --all -- --check` green
- [x] `bash -n cloudrun/render.sh` green

Refs #495


---
_Generated by [Claude Code](https://claude.ai/code/session_01PxdPi54wqpvCzzFa65jEzt)_