### PR TITLE
feat(trouble): trouble_tasks に print_page_break_before を追加 (Refs ippoan/nuxt-trouble#150)

### DIFF
--- a/.claude/skills/rust-alc-api-map/SKILL.md
+++ b/.claude/skills/rust-alc-api-map/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rust-alc-api-map
-generated-from: rust-alc-api:b538a62dfe48ef32da88e3fb06c7630e072081dd
+generated-from: rust-alc-api:ac9c29a0811dd7c689523c1212cffaa44b760eea
 paths: [crates/, src/, migrations/]
 description: rust-alc-api (アルコールチェッカー基盤の Rust/Axum Cargo workspace — 13 domain crate + gateway/tenko/carins/dtako/trouble の複数バイナリ、PostgreSQL+RLS、Cloud Run) の構造ナビゲーション。どの crate に何のルートがあるか / monolith(rust-alc-api) と per-domain API + gateway の二系統 / RLS・migration・deploy/release 分離の gotcha を 1 枚にまとめる。トリガー:「rust-alc-api」「alc-api」「alc-notify」「alc-tenko」「alc-trouble」「alc-carins」「alc-dtako」「gateway」「tenko-api」「carins-api」「dtako-api」「trouble-api」「RLS テナント」「sqlx migration」「ts-rs」「Release Wave」「Bazel」等。
 ---

--- a/crates/alc-core/src/models.rs
+++ b/crates/alc-core/src/models.rs
@@ -1881,6 +1881,8 @@ pub struct TroubleTask {
     pub next_action_by: Option<String>,
     pub next_action_due: Option<DateTime<Utc>>,
     pub occurred_at: Option<DateTime<Utc>>,
+    /// 印刷時、この行の直前で改ページするか (ユーザーが任意の位置に手動指定)。
+    pub print_page_break_before: bool,
     pub created_by: Option<Uuid>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
@@ -1967,6 +1969,8 @@ pub struct UpdateTroubleTask {
         deserialize_with = "crate::serde_helpers::empty_string_as_none_option_datetime"
     )]
     pub occurred_at: Option<Option<DateTime<Utc>>>,
+    #[serde(default)]
+    pub print_page_break_before: Option<bool>,
 }
 
 // ============================================================

--- a/crates/alc-trouble/src/repo/trouble_tasks.rs
+++ b/crates/alc-trouble/src/repo/trouble_tasks.rs
@@ -98,6 +98,7 @@ impl TroubleTasksRepository for PgTroubleTasksRepository {
                 next_action_by = CASE WHEN $16::boolean THEN $17 ELSE next_action_by END,
                 next_action_due = CASE WHEN $18::boolean THEN $19 ELSE next_action_due END,
                 occurred_at = CASE WHEN $20::boolean THEN $21 ELSE occurred_at END,
+                print_page_break_before = COALESCE($22, print_page_break_before),
                 updated_at = now()
             WHERE id = $1 AND tenant_id = $2
             RETURNING *"#,
@@ -123,6 +124,7 @@ impl TroubleTasksRepository for PgTroubleTasksRepository {
         .bind(input.next_action_due.as_ref().and_then(|v| *v))
         .bind(input.occurred_at.is_some())
         .bind(input.occurred_at.as_ref().and_then(|v| *v))
+        .bind(input.print_page_break_before)
         .fetch_optional(&mut *tc.conn)
         .await
     }

--- a/migrations/123_trouble_tasks_print_page_break.sql
+++ b/migrations/123_trouble_tasks_print_page_break.sql
@@ -1,0 +1,6 @@
+-- 状況管理 (trouble_tasks) の印刷時、ユーザーが任意の行の直前に手動で改ページを
+-- 指定できるようにする。チケットのタスクデータとして保存するため、どの端末/
+-- ブラウザから印刷しても同じページ割りになる。
+
+ALTER TABLE alc_api.trouble_tasks
+    ADD COLUMN print_page_break_before BOOLEAN NOT NULL DEFAULT false;

--- a/tests/mock_helpers/repos_e.rs
+++ b/tests/mock_helpers/repos_e.rs
@@ -1006,6 +1006,7 @@ impl TroubleTasksRepository for MockTroubleTasksRepository {
             next_action_by: input.next_action_by.clone(),
             next_action_due: input.next_action_due,
             occurred_at: input.occurred_at,
+            print_page_break_before: false,
             created_by,
             created_at: Utc::now(),
             updated_at: Utc::now(),


### PR DESCRIPTION
## Summary

- `trouble_tasks` テーブルに `print_page_break_before BOOLEAN NOT NULL DEFAULT false` を追加するマイグレーションを追加
- `TroubleTask` モデルと `UpdateTroubleTask` にフィールドを追加
- `crates/alc-trouble/src/repo/trouble_tasks.rs` の `update()` SQL に反映（既存の `updateTask` PATCH エンドポイント経由で設定可能、新規エンドポイントは不要）
- mock repository (`tests/mock_helpers/repos_e.rs`) の task 生成にも反映

nuxt-trouble の印刷プレビューで、状況管理の任意の行に手動で改ページを指定できるようにする機能 (ippoan/nuxt-trouble#150) のバックエンド側。タスクのデータとしてサーバーに保存するため、どの端末・ブラウザから印刷しても同じページ割りになる。

Refs ippoan/nuxt-trouble#150

## Test plan

- [x] `cargo fmt --all -- --check` — pass
- [x] `cargo check --workspace --all-targets` — pass
- [x] `cargo test --lib -p alc-trouble -p rust-alc-api` — pass（DB不要、既存分の回帰なし）
- [ ] CI（migration 検証 + staging 自動デプロイ、本リポジトリの方針に従いローカルでは migrate_test.sh を実行していません）
- [ ] staging で `PATCH /trouble/tickets/{ticket_id}/tasks/{id}` に `print_page_break_before` を渡して反映を確認


---
_Generated by [Claude Code](https://claude.ai/code/session_01H9c9UEeap5rQfdYdR3niZX)_