### PR TITLE
ci: build-image に external/repository cache を追加 (Bazel analysis 短縮) [no-issue]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -393,9 +393,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # external-cache / repository-cache は cache-warm-bazel (main push) が保存し、
+      # PR 側の本 job は restore して使う。これが無いと crate_universe の external
+      # repo 構築を毎 run やり直し、analysis だけで ~60s かかる (2026-07-04 実測:
+      # "Analyzed 3 targets (603 packages loaded)" まで 60s、execution は disk/R2
+      # cache hit で 41s)。
       - uses: ippoan/setup-bazel@main
         with:
           disk-cache: "bazel-${{ matrix.name }}"
+          external-cache: true
+          repository-cache: true
           r2-endpoint: ${{ vars.BAZEL_R2_ENDPOINT }}
           r2-bucket: ${{ vars.BAZEL_R2_BUCKET }}
           r2-access-key-id: ${{ secrets.BAZEL_R2_ACCESS_KEY_ID }}


### PR DESCRIPTION
## 背景 (実測)

PR の `build-image` job (Bazel) は 1 job ~139s かかっており、内訳は run 28698773673 / Build backend の実測で:

| 区間 | 時間 | 中身 |
|---|---|---|
| **Bazel analysis** | **~60s** | `Analyzed 3 targets (603 packages loaded, 23369 targets configured)` — crate_universe の external repo 構築 + loading/analysis が毎 run コールド |
| Bazel execution | ~41s | 1824 actions 中 1366 disk cache hit、実行はわずか 15 (Critical Path 37s) |
| docker build/push ×2 | ~20s | |
| checkout + cache restore | ~8s | |

コンパイルはキャッシュでほぼゼロなのに、**analysis の 60s が job 時間の最大要因**。

## 変更

`build-image` の `ippoan/setup-bazel@main` に `external-cache: true` + `repository-cache: true` を追加 (2 input のみ)。

- 保存側は既存の `cache-warm-bazel` (main push) が同 input で温めており、**restore 側の配線だけが欠けていた**
- GitHub Actions cache は main で保存したものが PR ブランチから読めるため、warm → PR restore の非対称設計 (rust-flickr#28-#32 / Refs #426 と同型) がそのまま成立する

## 検証

ローカル PoC は CCoW の egress policy (github.com への generic fetch が 403) で crate_universe の fetch が通らず不成立のため、**この PR の CI 実測を PoC とする**: `Build *` 各 job の `Analyzed N targets` までの時間を before (~60s) と比較。

注意: この PR 自体の 1 回目の run は、main の `cache-warm-bazel` が external cache を保存済みであることが前提 (直近 main push で warm 済みのはず)。効果が出ない場合は cache key の突き合わせを確認する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SNGtpxL29vQrEev4F26ycn

---
_Generated by [Claude Code](https://claude.ai/code/session_01SNGtpxL29vQrEev4F26ycn)_