### PR TITLE
ci: 依存グラフ監視を導入 (dep-check reusable + deny.toml + BEP metrics) [no-issue]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,6 +187,15 @@ jobs:
       # (coverage 計装は出力内容に影響しない、diff 検証済み)。check job で
       # test profile のビルドを重複させない。
 
+  # 依存グラフ監視: cargo-deny (重複バージョン warn、設定 SoT は deny.toml) +
+  # cargo-machete (未使用依存 warn)。経緯と削減方針は docs/ci-performance.md の
+  # 「依存グラフ削減」参照 (rust-s3 の旧 hyper スタック二重等)。
+  dep-check:
+    name: Dep Check
+    needs: [pr-limit]
+    if: "always() && !(github.ref == 'refs/heads/main' && github.event_name == 'push') && (needs.pr-limit.result == 'success' || needs.pr-limit.result == 'skipped')"
+    uses: ippoan/ci-workflows/.github/workflows/rust-dep-check.yml@main
+
   test-matrix:
     name: Tests (${{ matrix.group.name }})
     needs: [pr-limit]

--- a/.github/workflows/dep-graph.yml
+++ b/.github/workflows/dep-graph.yml
@@ -79,6 +79,43 @@ jobs:
             -Nfontsize=11 \
             -Eweight=2
 
+      - name: Extract Bazel graph metrics (BEP)
+        # 依存グラフ肥大の監視 (docs/ci-performance.md「依存グラフ削減」参照)。
+        # analysis 対象の targets / packages 数と analysis 時間を BEP の
+        # BuildMetrics から抽出し、Job Summary + しきい値超過で ::warning:: を出す。
+        # しきい値は 2026-07-05 実測 (23369 targets / 603 packages) の約 1 割増。
+        run: |
+          set -euo pipefail
+          bazel build --nobuild \
+            --build_event_json_file=out/bep.json \
+            //:rust-alc-api //:migrate //:archive
+          jq -s '(map(select(.buildMetrics != null)) | last // {}) as $e |
+            ($e.buildMetrics // {}) as $m |
+            { targetsConfigured: (($m.targetMetrics.targetsConfigured // 0) | tonumber),
+              packagesLoaded: (($m.packageMetrics.packagesLoaded // 0) | tonumber),
+              analysisPhaseMs: (($m.timingMetrics.analysisPhaseTimeInMs // 0) | tonumber) }' \
+            out/bep.json > out/graph-metrics.json
+          rm -f out/bep.json
+          cat out/graph-metrics.json
+          TARGETS=$(jq -r '.targetsConfigured' out/graph-metrics.json)
+          PACKAGES=$(jq -r '.packagesLoaded' out/graph-metrics.json)
+          ANALYSIS_MS=$(jq -r '.analysisPhaseMs' out/graph-metrics.json)
+          {
+            echo "## Bazel graph metrics"
+            echo ""
+            echo "| metric | value | warn threshold |"
+            echo "|---|---|---|"
+            echo "| targets configured | $TARGETS | 26000 |"
+            echo "| packages loaded | $PACKAGES | 660 |"
+            echo "| analysis phase | ${ANALYSIS_MS} ms | - |"
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [ "$TARGETS" -gt 26000 ]; then
+            echo "::warning::Bazel targets configured が $TARGETS (> 26000)。依存グラフ肥大 — docs/ci-performance.md「依存グラフ削減」参照"
+          fi
+          if [ "$PACKAGES" -gt 660 ]; then
+            echo "::warning::Bazel packages loaded が $PACKAGES (> 660)。依存グラフ肥大 — docs/ci-performance.md「依存グラフ削減」参照"
+          fi
+
       - name: Write metadata
         env:
           REPO: ${{ github.repository }}

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,11 @@
+# cargo-deny 設定 — 現状は bans (重複バージョン検知) のみ使用。
+# CI: ci.yml の check job が `cargo deny check bans` を実行する。
+#
+# multiple-versions = "warn" — 同一 crate の複数バージョン共存を PR ごとに警告する
+# (CI は fail させない)。既知の重複 (rust-s3 0.35 が hyper 0.14 / http 0.2 の
+# 旧スタックを引き込む等、2026-07-05 時点で 53 crate) の詳細と削減方針は
+# docs/ci-performance.md の「依存グラフ削減」を参照。
+# 重複を解消していき、warn が出なくなった時点で "deny" への引き上げを検討する。
+
+[bans]
+multiple-versions = "warn"

--- a/docs/ci-performance.md
+++ b/docs/ci-performance.md
@@ -84,6 +84,13 @@ CI ビルド時間の実測ベースライン・改善施策の履歴・確定�
    - **期待値**: analysis はグラフサイズ比例なので 1 割減で 60s → ~54s 程度。ただし rust-cache 795MB 縮小 / fingerprint 検証対象減 / コンパイル総量減と全レイヤーに薄く効く
    - targets 数 (23369) は crate_universe が 1 crate に複数 target (lib + build script + env vars) を生成するため。`annotations` の `gen_build_script = False` 個別指定は管理コストの割に効果薄 → 依存削減の方が筋が良い
 
+## CI 常設ガード (2026-07-05 導入)
+
+- **`ci.yml` の `dep-check` job** — `ippoan/ci-workflows` の `rust-dep-check.yml` reusable を呼ぶ:
+  - cargo-deny `check bans`: 重複バージョン警告。設定 SoT は repo root の `deny.toml` (`multiple-versions = "warn"`)。既知重複が解消され warn ゼロになったら `"deny"` 引き上げを検討
+  - cargo-machete: 未使用依存の警告 (`machete_enforce: warn`)。false positive は `[package.metadata.cargo-machete] ignored` で除外
+- **`dep-graph.yml` の BEP metrics step** (main push 毎) — Bazel BuildMetrics から targets configured / packages loaded / analysis 時間を Job Summary に出力し、しきい値 (26000 targets / 660 packages) 超過で `::warning::`
+
 ## 計測方法 (再現手順)
 
 - job 一覧と started_at/completed_at: `gh api repos/ippoan/rust-alc-api/actions/runs/<run_id>/jobs` (または ci-dashboard)


### PR DESCRIPTION
## 概要

`docs/ci-performance.md`「依存グラフ削減」で特定した問題(rust-s3 の旧 hyper スタック二重、53 crate の重複バージョン等)を CI で常時監視する 3 点セット。実装は reusable 化済み(ippoan/ci-workflows#153、merge 済み)。

## 変更

1. **`deny.toml` 新設** — cargo-deny `[bans] multiple-versions = "warn"`。既知重複が解消され warn ゼロになったら `"deny"` 引き上げを検討する旨をコメントに記載
2. **`ci.yml` に `dep-check` job 追加** — `ippoan/ci-workflows/.github/workflows/rust-dep-check.yml@main` を呼ぶ caller(cargo-deny check bans + cargo-machete warn モード)。auto-merge の needs には含めない(warn 専用 job のため merge gate にしない)
3. **`dep-graph.yml` に BEP metrics step 追加**(main push 毎)— `bazel build --nobuild --build_event_json_file` の BuildMetrics から **targets configured / packages loaded / analysis 時間**を Job Summary に出力し、しきい値超過(26000 targets / 660 packages、2026-07-05 実測 23369 / 603 の約 1 割増)で `::warning::`

4. `docs/ci-performance.md` に「CI 常設ガード」節を追記

## 検証

- YAML は python yaml で parse 確認済み
- dep-check の実挙動(既知の重複 53 crate に対する warn 出力、machete の findings)はこの PR の CI run で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SNGtpxL29vQrEev4F26ycn

---
_Generated by [Claude Code](https://claude.ai/code/session_01SNGtpxL29vQrEev4F26ycn)_