### PR TITLE
chore(deps): cargo-machete 検出の未使用依存 7 件を削除 + rust-s3 を ignored 登録 [no-issue]

### DIFF
--- a/.claude/skills/rust-alc-api-map/SKILL.md
+++ b/.claude/skills/rust-alc-api-map/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rust-alc-api-map
-generated-from: rust-alc-api:d7313fba7dbd3fd0daf5f0b296d9f7466bcf1c26
+generated-from: rust-alc-api:af2c361d88281e672dfe95d5049843d2cf3b5e60
 paths: [crates/, src/, migrations/]
 description: rust-alc-api (アルコールチェッカー基盤の Rust/Axum Cargo workspace — 13 domain crate + gateway/tenko/carins/dtako/trouble の複数バイナリ、PostgreSQL+RLS、Cloud Run) の構造ナビゲーション。どの crate に何のルートがあるか / monolith(rust-alc-api) と per-domain API + gateway の二系統 / RLS・migration・deploy/release 分離の gotcha を 1 枚にまとめる。トリガー:「rust-alc-api」「alc-api」「alc-notify」「alc-tenko」「alc-trouble」「alc-carins」「alc-dtako」「gateway」「tenko-api」「carins-api」「dtako-api」「trouble-api」「RLS テナント」「sqlx migration」「ts-rs」「Release Wave」「Bazel」等。
 ---
@@ -124,9 +124,9 @@ monolith と per-domain API は同じ domain crate (`alc-tenko` 等) を共有 �
   pre-commit (`.githooks`) + CI `snapshot-check` job が drift/stale-sha を検出。`SKIP_CLIPPY=1` で commit 時 clippy skip 可。
 - **ts-rs**: 各 crate が `#[ts(export)]` で TS 型を生成 (`cargo test export_bindings`)。フロント
   (nuxt-*) が型同期する。型変更時は export_bindings を回す。生成元は alc-core / alc-misc /
-  alc-carins の 3 crate のみ (alc-auth は ts-rs 依存だけあって derive 未使用)。CI での
-  `ts-bindings-${sha}` artifact は **test-matrix(lib) shard が生成** する (check job ではない、
-  Refs #482 / 下記 CI 節)。
+  alc-carins の 3 crate のみ (alc-auth の未使用だった ts-rs 依存は削除済み)。CI での
+  `ts-bindings-${sha}` artifact は **test-lib job が生成** する (check job ではない。lib shard は
+  #507 で test-matrix から DB なしの test-lib job に分離。Refs #482 / 下記 CI 節)。
 - **長時間 compute と Cloud Run**: `tokio::spawn` で background compute → fire-and-forget broadcast は
   やらない (Cloud Run は応答後に CPU を絞る)。`RealtimeBus` / `RedactBroadcaster` で対処。CLAUDE.md 該当節参照。
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -11,7 +11,6 @@ _WORKSPACE_CRATES = [
     "//crates/alc-dtako",
     "//crates/alc-misc",
     "//crates/alc-notify",
-    "//crates/alc-pdf",
     "//crates/alc-storage",
     "//crates/alc-tenko",
     "//crates/alc-trouble",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,9 +46,7 @@ dependencies = [
  "chrono",
  "serde",
  "serde_json",
- "sqlx",
  "tracing",
- "ts-rs",
  "uuid",
 ]
 
@@ -188,11 +186,9 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "chrono",
- "csv",
  "flate2",
  "futures",
  "rand 0.8.5",
- "reqwest",
  "serde",
  "serde_json",
  "sqlx",
@@ -200,7 +196,6 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "uuid",
- "zip",
 ]
 
 [[package]]
@@ -311,7 +306,6 @@ dependencies = [
  "serde_json",
  "sqlx",
  "thiserror 2.0.18",
- "tokio",
  "tracing",
  "uuid",
 ]
@@ -1552,7 +1546,6 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "http 1.4.0",
- "http-body-util",
  "reqwest",
  "serde",
  "serde_json",
@@ -3550,7 +3543,6 @@ dependencies = [
  "alc-dtako",
  "alc-misc",
  "alc-notify",
- "alc-pdf",
  "alc-storage",
  "alc-tenko",
  "alc-trouble",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,6 @@ alc-trouble = { path = "crates/alc-trouble" }
 alc-storage = { path = "crates/alc-storage" }
 alc-csv-parser = { path = "crates/alc-csv-parser" }
 alc-compare = { path = "crates/alc-compare" }
-alc-pdf = { path = "crates/alc-pdf" }
 anyhow = "1"
 async-trait = "0.1"
 axum = { version = "0.8", features = ["multipart"] }

--- a/crates/alc-auth/Cargo.toml
+++ b/crates/alc-auth/Cargo.toml
@@ -11,7 +11,5 @@ axum = "0.8"
 chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-sqlx = { version = "0.8", features = ["postgres", "chrono", "uuid"] }
 tracing = "0.1"
-ts-rs = { version = "10", features = ["chrono-impl", "uuid-impl"] }
 uuid = { version = "1", features = ["v4", "serde"] }

--- a/crates/alc-dtako/Cargo.toml
+++ b/crates/alc-dtako/Cargo.toml
@@ -18,14 +18,11 @@ axum = { version = "0.8", features = ["multipart"] }
 flate2 = "1"
 base64 = "0.22"
 chrono = { version = "0.4", features = ["serde"] }
-csv = "1"
 futures = "0.3"
 rand = "0.8"
-reqwest = { version = "0.12", features = ["json", "stream"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = "1"
 tokio-stream = "0.1"
 tracing = "0.1"
 uuid = { version = "1", features = ["v4", "serde"] }
-zip = "2"

--- a/crates/alc-storage/Cargo.toml
+++ b/crates/alc-storage/Cargo.toml
@@ -10,3 +10,9 @@ reqwest = { version = "0.12", features = ["json", "stream"] }
 rust-s3 = { version = "0.35", default-features = false, features = ["tokio-rustls-tls"] }
 serde_json = "1"
 tracing = "0.1"
+
+# cargo-machete は rust-s3 を未使用と誤検知する (lib 名が `s3` で
+# `use s3::...` がパッケージ名の text match に掛からないため)。実際は
+# src/r2.rs が使用中。
+[package.metadata.cargo-machete]
+ignored = ["rust-s3"]

--- a/crates/alc-trouble/Cargo.toml
+++ b/crates/alc-trouble/Cargo.toml
@@ -15,6 +15,5 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sqlx = { version = "0.8", features = ["postgres", "chrono", "uuid"] }
 thiserror = "2"
-tokio = "1"
 tracing = "0.1"
 uuid = { version = "1", features = ["v4", "serde"] }

--- a/crates/gateway/Cargo.toml
+++ b/crates/gateway/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 [dependencies]
 axum = "0.8"
 http = "1"
-http-body-util = "0.1"
 reqwest = { version = "0.12", features = ["stream", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"


### PR DESCRIPTION
## 概要

#510 で導入した `dep-check` の初回検出([run 28731233448](https://github.com/ippoan/rust-alc-api/actions/runs/28731233448/job/85197086497))の後始末。**各検出は crate 全体の grep で裏取り**した上で処理した。

## 削除(crate 内に使用箇所なし)

| crate | 削除した依存 |
|---|---|
| rust-alc-api (root) | alc-pdf 直接依存(alc-dtako 経由では引き続き使用、crate 自体は残る)。root BUILD.bazel の `_WORKSPACE_CRATES` からも除去 |
| alc-dtako | csv / reqwest / zip |
| alc-trouble | tokio |
| alc-auth | sqlx / ts-rs |
| gateway | http-body-util |

## false positive(使用中)→ ignored 登録

- **alc-storage: rust-s3** — lib 名が `s3` のため machete の text match に掛からないが `src/r2.rs` が `use s3::` で使用中。`[package.metadata.cargo-machete] ignored` に登録

## Cargo.lock

`cargo metadata` で再生成(エッジ 8 行のみの削除)。**削除した依存はすべて他 crate が使用中のため package 数は 572 のまま** — グラフ削減効果はゼロで、効果はマニフェスト衛生 + machete warning の解消。グラフ削減の本丸(rust-s3 の旧 hyper スタック二重)は別対応(`docs/ci-performance.md` 参照)。

## 検証

- 削除対象の使用箇所ゼロは grep で確認済み(src / tests / examples)
- feature unification の影響(削除した feature 宣言に他 crate が暗黙依存していないか)は本 PR の CI(clippy -D warnings + 全テスト + Bazel build ×7)で最終確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SNGtpxL29vQrEev4F26ycn

---
_Generated by [Claude Code](https://claude.ai/code/session_01SNGtpxL29vQrEev4F26ycn)_