### PR TITLE
ci: Bazel test 化 PoC — alc-csv-parser で bazel test + lcov coverage gate を検証 (Refs #515)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -547,6 +547,49 @@ jobs:
           cache-from: "type=gha,scope=${{ matrix.name }}-staging"
           cache-to: "type=gha,mode=max,scope=${{ matrix.name }}-staging"
 
+  # Bazel test 化 PoC (Refs #515): alc-csv-parser 1 crate で `bazel test` の実行と
+  # テスト結果キャッシュ、`bazel coverage` (lcov) による coverage 100% gate の再現
+  # 可否を検証する。独立 job (deploy chain の needs 外) = critical path に乗らない。
+  # PoC が有効と判断されるまで他 crate へは広げない。
+  bazel-test-poc:
+    name: "Bazel test PoC (alc-csv-parser)"
+    needs: [pr-limit]
+    if: "always() && github.event_name == 'pull_request' && (needs.pr-limit.result == 'success' || needs.pr-limit.result == 'skipped')"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ippoan/setup-bazel@main
+        with:
+          disk-cache: "bazel-test-poc"
+          r2-endpoint: ${{ vars.BAZEL_R2_ENDPOINT }}
+          r2-bucket: ${{ vars.BAZEL_R2_BUCKET }}
+          r2-access-key-id: ${{ secrets.BAZEL_R2_ACCESS_KEY_ID }}
+          r2-secret-access-key: ${{ secrets.BAZEL_R2_SECRET_ACCESS_KEY }}
+
+      - name: bazel test (2 回目で result cache を確認)
+        run: |
+          bazel test //crates/alc-csv-parser:alc-csv-parser_test --test_summary=short
+          echo "=== 2nd invocation (expect cached) ==="
+          bazel test //crates/alc-csv-parser:alc-csv-parser_test --test_summary=short 2>&1 | tee /tmp/second_run.txt
+          if grep -q "cached" /tmp/second_run.txt; then
+            echo "::notice::bazel test result cache HIT (同一サーバ内)。run 跨ぎの cache は次 push の 1 回目で '(cached)' が出るかで確認する"
+          else
+            echo "::warning::2 回目の実行で cached にならなかった (要調査、#515 に記録)"
+          fi
+
+      - name: bazel coverage (lcov 出力)
+        run: |
+          bazel coverage //crates/alc-csv-parser:alc-csv-parser_test \
+            --combined_report=lcov \
+            --instrumentation_filter=//crates/alc-csv-parser
+          LCOV="$(bazel info output_path)/_coverage/_coverage_report.dat"
+          cp "$LCOV" /tmp/lcov.dat
+          echo "=== lcov head ==="
+          head -30 /tmp/lcov.dat
+
+      - name: coverage 100% gate の lcov 再現 (coverage_100.toml 突合)
+        run: bash scripts/check_coverage_100_lcov.sh /tmp/lcov.dat crates/alc-csv-parser
+
   # staging の postgres sidecar image。旧 deploy.yml の staging-db job からの
   # 移設 (Refs #482)。build-image と並列に走らせることで、deploy workflow 側の
   # 直列 hop (staging-db → deploy-services) を消す。staging/ 配下は変更頻度が

--- a/scripts/check_coverage_100_lcov.sh
+++ b/scripts/check_coverage_100_lcov.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# coverage_100.toml の 100% gate を lcov レポートで再現する PoC (Refs #515)
+#
+# 現行 gate (check_coverage_100.sh) は cargo llvm-cov --text の出力を突合するが、
+# Bazel (`bazel coverage --combined_report=lcov`) は lcov 形式を吐く。本スクリプトは
+# lcov の DA (line, hit-count) レコードから「登録ファイルの全計装行が hit>0」を検証し、
+# llvm-cov --text ベースの gate と同じ判定が出るかを確かめる。
+#
+# 使い方: check_coverage_100_lcov.sh <lcov.dat> <path-prefix>
+#   <path-prefix> に一致する coverage_100.toml 登録ファイルだけを対象にする
+#   (PoC は crates/alc-csv-parser 限定。全体適用は gate 移行の判断後)。
+set -euo pipefail
+
+LCOV_FILE="${1:?usage: $0 <lcov.dat> <path-prefix>}"
+PREFIX="${2:?usage: $0 <lcov.dat> <path-prefix>}"
+
+python3 - "$LCOV_FILE" "$PREFIX" <<'PYEOF'
+import re
+import sys
+
+lcov_file, prefix = sys.argv[1], sys.argv[2]
+
+# --- coverage_100.toml から対象ファイルを取る ---
+registered = []
+with open("coverage_100.toml", encoding="utf-8") as fh:
+    for m in re.finditer(r'path\s*=\s*"([^"]+)"', fh.read()):
+        if m.group(1).startswith(prefix):
+            registered.append(m.group(1))
+
+if not registered:
+    print(f"::error::coverage_100.toml に prefix '{prefix}' の登録ファイルがありません")
+    sys.exit(1)
+
+# --- lcov をパース: SF -> {line: max(hit)} (複数レコードはマージ) ---
+files = {}
+cur = None
+with open(lcov_file, encoding="utf-8") as fh:
+    for line in fh:
+        line = line.strip()
+        if line.startswith("SF:"):
+            cur = files.setdefault(line[3:], {})
+        elif line.startswith("DA:") and cur is not None:
+            ln, hit = line[3:].split(",")[:2]
+            ln, hit = int(ln), int(hit)
+            cur[ln] = max(cur.get(ln, 0), hit)
+        elif line == "end_of_record":
+            cur = None
+
+def find_record(path):
+    # bazel の SF は execroot 相対や絶対のことがあるので suffix match
+    for sf, das in files.items():
+        if sf == path or sf.endswith("/" + path):
+            return sf, das
+    return None, None
+
+fail = 0
+print(f"=== lcov 100% gate ({prefix}) ===")
+for path in registered:
+    sf, das = find_record(path)
+    if das is None:
+        print(f"::error::{path}: lcov に見つかりません (instrumentation_filter / SF パス形式を確認)")
+        fail += 1
+        continue
+    total = len(das)
+    missed = sorted(ln for ln, hit in das.items() if hit == 0)
+    if missed:
+        sample = ", ".join(map(str, missed[:10])) + (" …" if len(missed) > 10 else "")
+        print(f"::error::FAIL: {path} — {total - len(missed)}/{total} lines ({len(missed)} lines missed: {sample})")
+        fail += 1
+    else:
+        print(f"  OK: {path} — {total}/{total} instrumented lines (100%) [SF={sf}]")
+
+if fail:
+    print(f"::error::lcov gate: {fail} 件が 100% 未達。llvm-cov gate との行数差異も含め #515 に記録すること")
+    sys.exit(1)
+print("lcov gate OK — 全登録ファイル 100%")
+PYEOF


### PR DESCRIPTION
## 概要

Bazel test 化 (テスト結果キャッシュで「影響を受けたテストだけ実行」する将来構想) の**成否を決める最小 PoC** (Refs #515)。対象は DB 非依存の pure crate `alc-csv-parser` 1 個のみ。既存の cargo テストパイプラインには一切触れません。

## 変更内容

- **ci.yml に独立 job `bazel-test-poc` を追加** — deploy chain の needs 外なので critical path / merge gate に乗らない
  1. `bazel test //crates/alc-csv-parser:alc-csv-parser_test` を 2 回実行し、テスト結果キャッシュ (`(cached) PASSED`) を確認。run 跨ぎのキャッシュは次 push の 1 回目で確認する
  2. `bazel coverage --combined_report=lcov` で lcov レポートを取得
  3. `scripts/check_coverage_100_lcov.sh` (新規) で `coverage_100.toml` の alc-csv-parser 登録 4 ファイルの **100% gate を lcov から再現**
- gate script は合成 lcov でローカル検証済み (100% pass / 行 miss 検出 / SF レコード欠落 = instrumentation 漏れの loud fail、いずれも期待どおり)

## この PoC で判定すること

| 検証項目 | 判定 |
|---|---|
| crate_universe + rules_rust で既存 unit test がそのまま走るか | job step 1 |
| テスト結果キャッシュが効くか (Bazel test 化の価値の源泉) | job step 1 の 2 回目 + 次 push |
| **lcov で coverage 100% gate を再現できるか (計画全体の分水嶺)** | job step 3。llvm-cov --text と計装行の数え方が違う可能性があり、差異が出たらそれ自体が #515 の記録対象 |

## 検証

- `bash -n` + 合成 lcov での gate script 単体検証 green
- CCoW からは github.com への依存アーカイブ取得が proxy で 403 になるためローカル bazel は不成立 — 実検証は本 PR の CI 上で行う (repo の「ローカルテスト不要」方針と同じ)

Refs #515, Related to #513, #482

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CEUnL9oDYaRZYh6gG5z9bX

---
_Generated by [Claude Code](https://claude.ai/code/session_01CEUnL9oDYaRZYh6gG5z9bX)_