### PR TITLE
test(csv-parser): work_segments の未カバー 3 分岐を crate 内テストで被覆し bazel-test-poc を green に (Refs #515)

### DIFF
--- a/.claude/skills/rust-alc-api-map/SKILL.md
+++ b/.claude/skills/rust-alc-api-map/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rust-alc-api-map
-generated-from: rust-alc-api:d2959cafbde5c46145dd467eeb65df055bf4e9c7
+generated-from: rust-alc-api:3388b2824b5b99d14fad8e52b4d3b2238c1a092b
 paths: [crates/, src/, migrations/]
 description: rust-alc-api (アルコールチェッカー基盤の Rust/Axum Cargo workspace — 13 domain crate + gateway/tenko/carins/dtako/trouble の複数バイナリ、PostgreSQL+RLS、Cloud Run) の構造ナビゲーション。どの crate に何のルートがあるか / monolith(rust-alc-api) と per-domain API + gateway の二系統 / RLS・migration・deploy/release 分離の gotcha を 1 枚にまとめる。トリガー:「rust-alc-api」「alc-api」「alc-notify」「alc-tenko」「alc-trouble」「alc-carins」「alc-dtako」「gateway」「tenko-api」「carins-api」「dtako-api」「trouble-api」「RLS テナント」「sqlx migration」「ts-rs」「Release Wave」「Bazel」等。
 ---

--- a/crates/alc-csv-parser/src/work_segments.rs
+++ b/crates/alc-csv-parser/src/work_segments.rs
@@ -933,4 +933,74 @@ mod tests {
             assert_eq!(result.len(), 2); // 08:00-20:00, 20:00-12:00
         });
     }
+
+    #[test]
+    fn test_split_at_24h_with_workdays_short_segment_passthrough() {
+        test_group!("CSVパーサー");
+        test_case!(
+            "24h以内かつworkday境界なしのセグメントはそのまま通る",
+            {
+                let segments = vec![WorkSegment {
+                    start: dt(2026, 2, 24, 8, 0),
+                    end: dt(2026, 2, 24, 17, 0),
+                    labor_minutes: 300,
+                    drive_minutes: 200,
+                    cargo_minutes: 100,
+                }];
+                let result = split_segments_at_24h_with_workdays(segments, &[]);
+                assert_eq!(result.len(), 1);
+                assert_eq!(result[0].start, dt(2026, 2, 24, 8, 0));
+                assert_eq!(result[0].end, dt(2026, 2, 24, 17, 0));
+                assert_eq!(result[0].labor_minutes, 300);
+            }
+        );
+    }
+
+    #[test]
+    fn test_sum_events_cargo_class() {
+        test_group!("CSVパーサー");
+        test_case!("Cargo分類のイベントがcargoに集計される", {
+            let events = vec![
+                make_event("001", dt(2026, 2, 24, 10, 0), "202", Some(45)), // Cargo
+                make_event("001", dt(2026, 2, 24, 11, 0), "110", Some(60)), // Drive
+            ];
+            let refs: Vec<&KudgivtRow> = events.iter().collect();
+            let double_refs: Vec<&&KudgivtRow> = refs.iter().collect();
+            let cls = make_classifications();
+            let (drive, cargo) = sum_events_in_range(
+                &double_refs,
+                &cls,
+                dt(2026, 2, 24, 9, 0),
+                dt(2026, 2, 24, 12, 0),
+            );
+            assert_eq!(drive, 60);
+            assert_eq!(cargo, 45);
+        });
+    }
+
+    #[test]
+    fn test_split_segments_by_day_zero_minute_tail_skipped() {
+        test_group!("CSVパーサー");
+        test_case!(
+            "日跨ぎ直後数十秒の尻尾は分単位切り捨てで0分になりskipされる",
+            {
+                // 24日23:00〜25日00:00:30: 2日目分は day_start=day_end (分精度) で
+                // work_mins=0 → 行を作らず continue する分岐を踏む
+                let segments = vec![WorkSegment {
+                    start: dt(2026, 2, 24, 23, 0),
+                    end: NaiveDate::from_ymd_opt(2026, 2, 25)
+                        .unwrap()
+                        .and_hms_opt(0, 0, 30)
+                        .unwrap(),
+                    labor_minutes: 60,
+                    drive_minutes: 60,
+                    cargo_minutes: 0,
+                }];
+                let daily = split_segments_by_day(&segments);
+                assert_eq!(daily.len(), 1);
+                assert_eq!(daily[0].date, NaiveDate::from_ymd_opt(2026, 2, 24).unwrap());
+                assert_eq!(daily[0].work_minutes, 60);
+            }
+        );
+    }
 }


### PR DESCRIPTION
## 概要

#517 (Bazel test PoC) の lcov gate が work_segments.rs で検出した **5 行の未カバー**を、crate 内テスト 3 本の追加で解消する。これで main 上の全 PR で赤くなっていた `bazel-test-poc` job が green になる。

## PoC の確定結果 (この修正の根拠)

lcov gate の FAIL は **フォーマット差異ではなかった**。cargo-llvm-cov (`--package alc-csv-parser --lib --text`) で同条件を実測したところ、**まったく同じ 5 行が count=0** — つまり:

- **lcov gate と llvm-cov gate の判定意味論は完全一致** (4 ファイル中 3 ファイルは行数まで一致、これが #515 の分水嶺だった)
- 差異の正体は測定範囲: 現行 CI の combined 測定では**他 crate / integration テスト経由**でこの 5 行が踏まれていたが、Bazel はターゲット単位 (crate 自身のテストのみ) で測るため露呈した

## 変更内容

`work_segments.rs` の tests mod に 3 本追加 (既存イディオム踏襲):

| テスト | 踏む分岐 |
|---|---|
| `test_split_at_24h_with_workdays_short_segment_passthrough` | 24h 以内 + workday 境界なしの早期 passthrough (L340-341) |
| `test_sum_events_cargo_class` | `EventClass::Cargo` 集計 arm (L402) |
| `test_split_segments_by_day_zero_minute_tail_skipped` | 日跨ぎ直後数十秒の尻尾が分単位切り捨てで 0 分 → skip (L440-441) |

「**crate の 100% はその crate のテストで閉じる**」形になり、将来の selective CI / Bazel test 化 (テスト結果キャッシュで影響テストだけ実行) の前提とも整合する。

- `.claude/skills/rust-alc-api-map/SKILL.md` の generated-from を更新 (skills-check enforce=fail 対応、内容変更なし)

## 検証

- ローカル `cargo llvm-cov --package alc-csv-parser --lib --text`: 登録 4 ファイルすべて **missed 0 行** (work_segments 636/636)
- lcov 側は本 PR の `bazel-test-poc` job が検証する (同一意味論を確認済みのため green 見込み)

Refs #515, Related to #513

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CEUnL9oDYaRZYh6gG5z9bX

---
_Generated by [Claude Code](https://claude.ai/code/session_01CEUnL9oDYaRZYh6gG5z9bX)_