### PR TITLE
docs(ci): 2026-07-05 調査を追記 + cache-warm の DB timeout 30s×N 浪費を解消 (Refs #513, #515)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,11 +49,14 @@ jobs:
           # だけ save」設計 (Refs #426)。
           # cmd は --workspace --all-targets で全 test binary を 1 cargo invocation で
           # build (cargo の jobs server が内部並列)。--no-report で coverage report
-          # 生成抑制、--ignore-run-fail で DB 必要 test が一部 fail しても許容。
+          # 生成抑制。
           # 注意: cargo-llvm-cov 0.8.4 の --no-run は cargo test の --no-run と意味が
-          # 異なる (report subcommand の旧名で profraw 必須)。build only にしたければ
-          # --no-run を使わず、test 実行 + --ignore-run-fail のパターンを使う。
-          - { name: "test-shared", key: "test-shared", cmd: "cargo llvm-cov nextest --no-report --ignore-run-fail --workspace --all-targets" }
+          # 異なる (report subcommand の旧名で profraw 必須)。build only は
+          # `-E 'none()' --no-tests=pass` で「全 binary を build して 0 本実行」に
+          # する (旧 --ignore-run-fail 方式は postgres service が無いため DB 系
+          # テスト 1 本ごとに接続 timeout 30s を直列に浪費し、warm job が 60 分級に
+          # なっていた。cache に要るのは build 成果物だけで実行は不要)。
+          - { name: "test-shared", key: "test-shared", cmd: "cargo llvm-cov nextest --no-report --workspace --all-targets -E 'none()' --no-tests=pass" }
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.92.0

--- a/docs/ci-speed-tracking.md
+++ b/docs/ci-speed-tracking.md
@@ -80,6 +80,59 @@ Build backend (Bazel) job 139s の内訳: setup ~8s / **analysis 60s**
 - targets 数 (23369) は crate_universe が 1 crate に複数 target を生成するため。
   依存 crate 数にほぼ比例するので依存削減がそのままターゲット削減になる
 
+## 確定した事実 (2026-07-05 調査、Refs #513 / #515)
+
+### runner queue 遅延の真因 = org が GitHub Free plan (同時 20 job)
+
+- run 28698773673 の実測: pr-limit 完了 (gate open) 後、即時に走れたのは 6-7 job のみ。
+  残りは 27〜73s かけて滴下開始 (Tests mock-devices は 66s 待ち = critical path 直撃)
+- gate open 時点で **同一ブランチの 2 分前 push の CI (~17 job) がまだ走行中**で、
+  org 全体の需要は ~35 job。billing 画面で **ippoan org は GitHub Free ($0) = 上限 20 並列**
+  を確認 → 需要 35 > 枠 20 が滴下の説明として整合
+- 対策: org Team 化 ($4/user/月) で 60 並列。cancel-in-progress は「同一ブランチ連続 push」
+  のみ救済 + deploy レース考慮が要るため優先度下げ (経緯は #513 の議論)
+- 注: public repo のため標準 runner の分数は無料。job 統合による「課金削減」効果は無い
+
+### Bazel analysis ~55s/job は「lockfile 全体の固定費」でターゲット閉包に非比例
+
+同 run の 3 job 実測 (loading + analysis):
+
+| job | 閉包 | loading (repo rule) | analysis | 合計 |
+|---|---|---|---|---|
+| backend | 603 pkgs / 23,369 targets | ~34s | ~24s | ~58s |
+| tenko | 373 pkgs / 14,221 targets | ~33s | ~23s | ~56s |
+| gateway | 288 pkgs / 10,174 targets | ~32s | ~21s | ~53s |
+
+- 前半 ~33s は `Loading: 0 packages loaded` のまま = **crate_universe が Cargo.lock 全体
+  (572 crate) を処理する固定費**。どのターゲットでも満額
+- 閉包を半分にしても −5s → **「build を細かく分割して analysis を減らす」は成立しない**
+- 削る手段は CPU 増 (larger runner、ただし public repo でも有料) / 依存削減 /
+  Bazel サーバ常駐 (self-hosted、public repo では不可) / Skycache (OSS 未公開) のみ
+
+### alc-core ドメイン分割 Phase A (#513 / PR #514、merge 済み)
+
+- alc-core (10,495 行、18 crate が依存) の `AppState` が全 ~60 repository を束ねる
+  god-object で、**domain 機能 PR が全 21 crate + 全 test shard を再コンパイル**していた
+  (実例: feat/trouble-field-layout = trouble 専用機能なのに backend 443 actions 再ビルド)
+- 使用行列の実測で「層分割は無効 (全 crate が全層参照)、ドメイン分割が正解」と確定
+- Phase A で tenko の trait 9 本 + models 392 行 + driver_info + overdue を alc-tenko へ移設。
+  再流入は `scripts/check_domain_split.sh` (check job) が loud fail
+- **merge 直後の 1-2 run は cache 焼き直しでむしろ遅い (正常)**。warm 後の効果
+  (tenko 系 PR で他 shard がキャッシュヒット化) は実測して本 doc に追記すること
+- 後続: Phase B trouble (11 repo + 17 struct) → dtako / notify / carins
+
+### Bazel test 化 PoC (#515 / PR #517 #518、merge 済み)
+
+- `bazel-test-poc` job (独立 job、merge gate 外) で alc-csv-parser 1 crate を検証:
+  - bazel test 動作 ✅ / **テスト結果キャッシュ** ✅ (同一サーバ 2 回目 `(cached) PASSED in 0.0s`)
+  - **lcov gate (`scripts/check_coverage_100_lcov.sh`) は llvm-cov --text と判定意味論が一致** ✅
+    (4 ファイル中 3 つは行数まで一致 — gate 移行の最大の壁は突破可能と確定)
+- 検出された差異はフォーマットではなく**測定範囲**: combined 測定 (他 crate のテスト経由) で
+  100% だった work_segments.rs の 5 行が、Bazel の per-target 測定で露呈 → crate 内テスト
+  3 本追加で解消 (#518)。他 crate へ拡大する際も同種の「里帰りテスト追加」が必要になる見込み
+- 残: run 跨ぎの test result cache 確認 (crates/ 非接触 PR の bazel-test-poc 1 回目で
+  `(cached)` が出るか)、DB 依存 integration test の Bazel 化設計
+
 ## 施策 log
 
 ### #482: check job の TS bindings 生成を test-matrix(lib) に統合 (PR #483)


### PR DESCRIPTION
## 概要

2 つの独立した小変更 + **run 跨ぎ test result cache の実験台**:

### 1. `docs/ci-speed-tracking.md` に 2026-07-05 調査の確定事実を追記

- runner queue 遅延の真因 = org GitHub Free plan (20 並列) + 同一ブランチ連続 push (実測 27〜73s の滴下)
- Bazel analysis ~55s/job の内訳 = Cargo.lock 全体の repo rule 固定費 ~33s + analysis ~22s (閉包サイズに非比例、backend 58s vs gateway 53s)
- alc-core ドメイン分割 Phase A (#514) の記録と warm 後実測の TODO
- Bazel test 化 PoC (#515) の結果 (result cache ✅ / lcov gate は llvm-cov と判定一致 ✅)

### 2. cache-warm (test-shared) をビルドのみ (0 テスト実行) に

#514 merge 後のフル焼き直しで露呈: postgres service の無い warm job が `--ignore-run-fail` で DB 系テストを実行し、**1 本 30s の接続 timeout (`PoolTimedOut`) を直列に浪費して job が 60 分級**になっていた。cache に必要なのは build 成果物だけなので `-E 'none()' --no-tests=pass` で全 binary build + 0 実行に変更。次の main push の warm 実測を tracking doc に追記予定。

### 3. (この PR 自体が実験) run 跨ぎ test result cache の確認

本 PR は `crates/` 非接触なので、`bazel-test-poc` job の **1 回目の実行**が R2 disk-cache 経由で `(cached) PASSED` になるか = #515 の残タスクの検証になる。結果は #515 に記録する。

## 検証

- docs のみ + warm cmd 1 行。warm job は main push でしか走らないため、万一 `-E 'none()' --no-tests=pass` が不発でも影響は「warm 1 回分の cache 未更新 + main run の loud fail」に閉じる (次 PR で revert 可能)

Refs #513, #515

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CEUnL9oDYaRZYh6gG5z9bX

---
_Generated by [Claude Code](https://claude.ai/code/session_01CEUnL9oDYaRZYh6gG5z9bX)_