### PR TITLE
ci: bazel-test-poc の run 跨ぎ test cache 用に main-push warm を追加 (Refs #515)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,29 @@ jobs:
       - name: Build (Bazel)
         run: bazel build -c fastbuild --strip=always ${{ matrix.targets }}
 
+  # bazel-test-poc (PR 限定 job) の run 跨ぎ test result cache 用 warm (Refs #515)。
+  # setup-bazel の disk-cache tar は GH Actions cache 保存で、PR run の save は
+  # refs/pull/N/merge scope に隔離され別 PR から読めない (2026-07-05 実測)。全 PR
+  # から読めるのは main scope の cache だけなので、main push でここが `bazel test`
+  # を 1 回走らせ、test action の結果込み disk cache を main scope に save する。
+  # 注意: invocation の flags は bazel-test-poc job と完全一致させること
+  # (configuration が違うと action key が変わり、PR 側で '(cached)' にならない)。
+  cache-warm-bazel-test-poc:
+    name: "Cache Warm (bazel-test-poc)"
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ippoan/setup-bazel@main
+        with:
+          disk-cache: "bazel-test-poc"
+          r2-endpoint: ${{ vars.BAZEL_R2_ENDPOINT }}
+          r2-bucket: ${{ vars.BAZEL_R2_BUCKET }}
+          r2-access-key-id: ${{ secrets.BAZEL_R2_ACCESS_KEY_ID }}
+          r2-secret-access-key: ${{ secrets.BAZEL_R2_SECRET_ACCESS_KEY }}
+      - name: Warm test result cache (Bazel)
+        run: bazel test //crates/alc-csv-parser:alc-csv-parser_test --test_summary=short
+
   cache-cleanup:
     name: Cache Cleanup
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
@@ -554,6 +577,9 @@ jobs:
   # テスト結果キャッシュ、`bazel coverage` (lcov) による coverage 100% gate の再現
   # 可否を検証する。独立 job (deploy chain の needs 外) = critical path に乗らない。
   # PoC が有効と判断されるまで他 crate へは広げない。
+  # run 跨ぎの test result cache は cache-warm-bazel-test-poc (main push warm) 経由
+  # でのみ hit する — PR run 自身の save は refs/pull/N/merge scope に隔離され、
+  # 別 PR から読めない (2026-07-05 実測、詳細は #515 のコメント)。
   bazel-test-poc:
     name: "Bazel test PoC (alc-csv-parser)"
     needs: [pr-limit]
@@ -575,7 +601,7 @@ jobs:
           echo "=== 2nd invocation (expect cached) ==="
           bazel test //crates/alc-csv-parser:alc-csv-parser_test --test_summary=short 2>&1 | tee /tmp/second_run.txt
           if grep -q "cached" /tmp/second_run.txt; then
-            echo "::notice::bazel test result cache HIT (同一サーバ内)。run 跨ぎの cache は次 push の 1 回目で '(cached)' が出るかで確認する"
+            echo "::notice::bazel test result cache HIT (同一サーバ内)。run 跨ぎは 1 回目の invocation で '(cached)' が出るか (= main warm からの restore) で確認する"
           else
             echo "::warning::2 回目の実行で cached にならなかった (要調査、#515 に記録)"
           fi

--- a/docs/ci-speed-tracking.md
+++ b/docs/ci-speed-tracking.md
@@ -130,8 +130,27 @@ Build backend (Bazel) job 139s の内訳: setup ~8s / **analysis 60s**
 - 検出された差異はフォーマットではなく**測定範囲**: combined 測定 (他 crate のテスト経由) で
   100% だった work_segments.rs の 5 行が、Bazel の per-target 測定で露呈 → crate 内テスト
   3 本追加で解消 (#518)。他 crate へ拡大する際も同種の「里帰りテスト追加」が必要になる見込み
-- 残: run 跨ぎの test result cache 確認 (crates/ 非接触 PR の bazel-test-poc 1 回目で
-  `(cached)` が出るか)、DB 依存 integration test の Bazel 化設計
+- **run 跨ぎの test result cache (2026-07-05 PR #519 で実測 → 原因確定 → warm 追加で解消見込み)**:
+  1 回目 invocation は `Executed 1 out of 1` + restore が `No disk cache found` で不発だった。
+  原因は Bazel のキャッシュ意味論ではなく **GH Actions cache の scope 分離**:
+  - setup-bazel の disk-cache tar は GH Actions cache 保存で、PR run の save は
+    `refs/pull/N/merge` scope に隔離され**別 PR から読めない** (save 自体は毎 run 成功していた)
+  - `bazel-test-poc` job は pull_request 限定 → 全 PR から読める **main scope に save される
+    機会がゼロ** = どの PR の 1 回目も恒常 miss する構造だった
+  - 対照: `Build backend` は main push の cache-warm-bazel が save するので PR から
+    `Cache hit for: ...disk-bazel-backend-tar-...` (488MB、1366 disk cache hit) で復元できている
+  - 対策: `cache-warm-bazel-test-poc` job (main push で `bazel test` を warm) を追加。
+    invocation flags を poc job と一致させるのが必須 (configuration 差 = action key 差)
+- 残: warm 導入後の PR 1 回目で `(cached)` が出るかの再確認、DB 依存 integration test の
+  Bazel 化設計
+
+### cache-warm build-only 化の実測 (PR #519、2026-07-05)
+
+`Cache Warm (test-shared)` が **60 分 → 1 分 54 秒** (run 28742594624)。postgres の無い
+warm job が DB 依存テストを `--ignore-run-fail` で実行し、PoolTimedOut (acquire timeout 30s)
+× 数十本を直列で浪費していたのを `-E 'none()' --no-tests=pass` (build-only) にした効果。
+同 run では tenko 分割 (Phase A) 後の warm 状態で Tests ~3 分・Builds ~3 分、
+PR CI 全体 4 分 44 秒 (run 28742465845) を確認。
 
 ## 施策 log
 


### PR DESCRIPTION
## Summary

Refs #515

PR #519 の実測で、`bazel-test-poc` の run 跨ぎ test result cache が不発だった原因を確定した ([#515 コメント](https://github.com/ippoan/rust-alc-api/issues/515#issuecomment-4886263156)):

- setup-bazel の disk-cache tar は **GH Actions cache 保存**で、PR run の save は `refs/pull/N/merge` scope に隔離され**別 PR から読めない** (save 自体は毎 run 成功していた)
- `bazel-test-poc` job は `pull_request` 限定 → 全 PR から読める **main scope に save される機会がゼロ** = どの PR の 1 回目も恒常 miss する構造だった
- 対照: `Build backend` は main push の `cache-warm-bazel` が save するので PR から 488MB restore + 1366 disk cache hit で復元できている

## 変更内容

- **`cache-warm-bazel-test-poc` job を追加** (main push 限定): `bazel test //crates/alc-csv-parser:alc-csv-parser_test` を 1 回実行し、test action 結果込みの disk cache を main scope に save する。invocation flags は poc job と完全一致させる (configuration 差 = action key 差で hit しなくなるため、コメントで明記)
- poc job のコメント / notice メッセージを実測結果に合わせて更新
- `docs/ci-speed-tracking.md` に原因の実測と、#519 の cache-warm build-only 化の効果 (`Cache Warm (test-shared)` **60 分 → 1 分 54 秒**) を追記

## 検証

- 本 PR の `bazel-test-poc` は従来どおり (warm 未実施なので 1 回目は非 cached の想定)
- **merge 後の main push で `Cache Warm (bazel-test-poc)` が走り、その次の PR の 1 回目 invocation で `(cached) PASSED` が出るかが判定点** (#515 の残タスク)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CEUnL9oDYaRZYh6gG5z9bX)_