### PR TITLE
docs(ci): bazel-test-poc の main warm 初回完了を追記 + run 跨ぎ cache 検証 (Refs #515)

### DIFF
--- a/docs/ci-speed-tracking.md
+++ b/docs/ci-speed-tracking.md
@@ -141,6 +141,10 @@ Build backend (Bazel) job 139s の内訳: setup ~8s / **analysis 60s**
     `Cache hit for: ...disk-bazel-backend-tar-...` (488MB、1366 disk cache hit) で復元できている
   - 対策: `cache-warm-bazel-test-poc` job (main push で `bazel test` を warm) を追加。
     invocation flags を poc job と一致させるのが必須 (configuration 差 = action key 差)
+  - PR #520 merge 後の main push で初回 warm 完了 (test PASSED → disk cache 60MB を
+    main scope に save、run 28743114702)。warm は `bazel test` のみなので poc job の
+    `bazel coverage` action は含まれない (coverage ~30s は PR 側で毎回実行、判定点の
+    test result cache には影響しない)
 - 残: warm 導入後の PR 1 回目で `(cached)` が出るかの再確認、DB 依存 integration test の
   Bazel 化設計
 


### PR DESCRIPTION
## Summary

Refs #515

docs のみの変更 (ci-speed-tracking.md に #520 の main warm 初回完了を追記)。

## この PR 自体が検証

本 PR は **run 跨ぎ test result cache の検証 PR を兼ねる**:

- BUILD / MODULE.bazel / .bazelrc に触れない = disk cache key が main warm と一致する
- `bazel-test-poc` job の **1 回目の invocation で `(cached) PASSED` が出れば**、main scope warm (run [28743114702](https://github.com/ippoan/rust-alc-api/actions/runs/28743114702)、60MB save 済み) からの restore が機能している証明 = **#515 の残タスク (run 跨ぎ test result cache) 完了**
- 出なければ warm 設計の見直しに戻る (結果はどちらでも #515 に記録する)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CEUnL9oDYaRZYh6gG5z9bX)_