### PR TITLE
fix(bazel): alc-misc/alc-notify の rust_test に dev deps を配線 + keep_going (Refs #515)

### DIFF
--- a/.claude/skills/rust-alc-api-map/SKILL.md
+++ b/.claude/skills/rust-alc-api-map/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rust-alc-api-map
-generated-from: rust-alc-api:3388b2824b5b99d14fad8e52b4d3b2238c1a092b
+generated-from: rust-alc-api:c8fea07261f4633ccf58a650369e5fffd09dfa48
 paths: [crates/, src/, migrations/]
 description: rust-alc-api (アルコールチェッカー基盤の Rust/Axum Cargo workspace — 13 domain crate + gateway/tenko/carins/dtako/trouble の複数バイナリ、PostgreSQL+RLS、Cloud Run) の構造ナビゲーション。どの crate に何のルートがあるか / monolith(rust-alc-api) と per-domain API + gateway の二系統 / RLS・migration・deploy/release 分離の gotcha を 1 枚にまとめる。トリガー:「rust-alc-api」「alc-api」「alc-notify」「alc-tenko」「alc-trouble」「alc-carins」「alc-dtako」「gateway」「tenko-api」「carins-api」「dtako-api」「trouble-api」「RLS テナント」「sqlx migration」「ts-rs」「Release Wave」「Bazel」等。
 ---
@@ -135,7 +135,12 @@ monolith と per-domain API は同じ domain crate (`alc-tenko` 等) を共有 �
 ## CI / deploy から見た立ち位置
 
 - **Bazel + Cargo の二重ビルド**: `BUILD.bazel` (rust_library `rust_alc_api_lib` + rust_binary 群 + rust_test)
-  と Cargo workspace の両方が存在 (`MODULE.bazel` / `.bazelrc`)。CI は主に Cargo (`cargo llvm-cov nextest`)。
+  と Cargo workspace の両方が存在 (`MODULE.bazel` / `.bazelrc`)。CI の merge gate は Cargo
+  (`cargo llvm-cov nextest`)。`bazel test //... --build_tests_only` は観測用 job
+  (`bazel-test-poc`) + main-push warm で全 unit test を回す (run 跨ぎ result cache、Refs #515)。
+  **dev-dependencies を持つ crate (alc-misc / alc-notify) の rust_test には
+  `all_crate_deps(normal_dev/proc_macro_dev)` の配線が必須** — 無いと `#[tokio::test]` 等が
+  unresolved で FAILED TO BUILD になる。
 - **deploy.yml は deploy/release 分離 (Refs #137)**: PR → staging 自動 deploy、tag(v*) push → production。
   **production の tag release は新 revision を 0% (no-traffic) で deploy するだけ**で traffic は旧 revision に残す。
   実際の切替は **Release Wave flip** が行う。`verify-no-traffic` job がこの不変条件を検証 (latest revision が

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
           r2-access-key-id: ${{ secrets.BAZEL_R2_ACCESS_KEY_ID }}
           r2-secret-access-key: ${{ secrets.BAZEL_R2_SECRET_ACCESS_KEY }}
       - name: Warm test result cache (Bazel)
-        run: bazel test //... --build_tests_only --test_summary=short
+        run: bazel test //... --build_tests_only --keep_going --test_summary=short
 
   cache-cleanup:
     name: Cache Cleanup
@@ -602,7 +602,7 @@ jobs:
       - name: bazel test (全 unit test、result cache は main warm から)
         run: |
           set -o pipefail
-          bazel test //... --build_tests_only --test_summary=short 2>&1 | tee /tmp/test_run.txt
+          bazel test //... --build_tests_only --keep_going --test_summary=short 2>&1 | tee /tmp/test_run.txt
           CACHED=$(grep -c "(cached)" /tmp/test_run.txt || true)
           TOTAL=$(grep -cE "^//.* PASSED" /tmp/test_run.txt || true)
           echo "::notice::test result cache: ${CACHED}/${TOTAL} targets が (cached) — ソース/BUILD を触った PR や warm 未反映の初回は少なくて正常"

--- a/crates/alc-misc/BUILD.bazel
+++ b/crates/alc-misc/BUILD.bazel
@@ -15,4 +15,6 @@ rust_library(
 rust_test(
     name = "alc-misc_test",
     crate = ":alc-misc",
+    deps = all_crate_deps(normal_dev = True),
+    proc_macro_deps = all_crate_deps(proc_macro_dev = True),
 )

--- a/crates/alc-notify/BUILD.bazel
+++ b/crates/alc-notify/BUILD.bazel
@@ -15,4 +15,6 @@ rust_library(
 rust_test(
     name = "alc-notify_test",
     crate = ":alc-notify",
+    deps = all_crate_deps(normal_dev = True),
+    proc_macro_deps = all_crate_deps(proc_macro_dev = True),
 )


### PR DESCRIPTION
## Summary

Refs #515

PR #522 (全 unit test 拡大) の初回実行で `//crates/alc-misc:alc-misc_test` が build 失敗した ([log](https://github.com/ippoan/rust-alc-api/actions/runs/28743541957/job/85230427736))。原因は rust_test target への **dev deps 未配線** (`#[tokio::test]` の `tokio` が dev-dependency のため unresolved)。

- `Executed 4 out of 17: 5 pass (cached 1 含む), 1 fails to build, 11 skipped`
- skipped 11 は `--keep_going` 無しで build が中断された巻き込み (テスト自体の問題ではない)
- workspace で dev-dependencies を持つのは **alc-misc / alc-notify の 2 crate のみ** (Cargo.toml 確認済み)

## 変更内容

- `crates/alc-misc/BUILD.bazel` / `crates/alc-notify/BUILD.bazel` の rust_test に `all_crate_deps(normal_dev/proc_macro_dev)` を配線
- warm / poc 両 invocation に `--keep_going` を追加 (1 build fail で他 target の結果が見えなくなるのを防ぐ。flags 一致は維持)

## 検証

- BUILD.bazel 変更で disk cache key が変わるため、**本 PR の poc job は全 crate フルビルドになる (想定内、初回コストの実測を兼ねる)**
- 17 target 全 PASSED になれば、merge 後の main warm が新 key で全結果を save → 次の PR から `(cached)`

---
_Generated by [Claude Code](https://claude.ai/code/session_01CEUnL9oDYaRZYh6gG5z9bX)_