### PR TITLE
ci(bazel): test 失敗の詳細をログに出す --test_output=errors を追加 (Refs #515)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
           r2-access-key-id: ${{ secrets.BAZEL_R2_ACCESS_KEY_ID }}
           r2-secret-access-key: ${{ secrets.BAZEL_R2_SECRET_ACCESS_KEY }}
       - name: Warm test result cache (Bazel)
-        run: bazel test //... --build_tests_only --keep_going --test_summary=short
+        run: bazel test //... --build_tests_only --keep_going --test_output=errors --test_summary=short
 
   cache-cleanup:
     name: Cache Cleanup
@@ -602,7 +602,7 @@ jobs:
       - name: bazel test (全 unit test、result cache は main warm から)
         run: |
           set -o pipefail
-          bazel test //... --build_tests_only --keep_going --test_summary=short 2>&1 | tee /tmp/test_run.txt
+          bazel test //... --build_tests_only --keep_going --test_output=errors --test_summary=short 2>&1 | tee /tmp/test_run.txt
           CACHED=$(grep -c "(cached)" /tmp/test_run.txt || true)
           TOTAL=$(grep -cE "^//.* PASSED" /tmp/test_run.txt || true)
           echo "::notice::test result cache: ${CACHED}/${TOTAL} targets が (cached) — ソース/BUILD を触った PR や warm 未反映の初回は少なくて正常"


### PR DESCRIPTION
## Summary

Refs #515

PR #523 の run で全 17 target 中 **16 PASSED**、`//crates/alc-notify:alc-notify_test` のみ Exit 101 (実行時失敗) だった ([log](https://github.com/ippoan/rust-alc-api/actions/runs/28743862810/job/85231288508))。しかし default の `--test_output=summary` では失敗テストの出力 (test.log) が CI ログに出ず、**どのテストがなぜ落ちたか特定できない**。

## 変更内容

- warm / poc 両 invocation に `--test_output=errors` を追加 — 失敗した test の出力を inline 表示する
- UI flag のため action cache key には影響しない (flags 一致の規約上、両 job に同時追加)

## 検証

本 PR の poc job のログに alc-notify_test の失敗詳細 (どのテスト・どの assertion / panic か) が出るので、それを見て根本修正の PR を切る。cargo (`Tests (mock-*)` / `Tests (lib)`) では同テストが green のため、bazel sandbox 環境差 (env / cwd / runfiles) 起因の可能性が高い。

---
_Generated by [Claude Code](https://claude.ai/code/session_01CEUnL9oDYaRZYh6gG5z9bX)_