### PR TITLE
fix(ci): bazel test job にも PDFium を配置 — alc-notify redact テストの dlopen 対応 (Refs #515)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,14 @@ jobs:
           r2-bucket: ${{ vars.BAZEL_R2_BUCKET }}
           r2-access-key-id: ${{ secrets.BAZEL_R2_ACCESS_KEY_ID }}
           r2-secret-access-key: ${{ secrets.BAZEL_R2_SECRET_ACCESS_KEY }}
+      # alc-notify::redact が libpdfium.so を dlopen する (test-matrix と同一 step、
+      # processwrapper-sandbox はシステムパスに到達できるので /usr/lib で足りる)
+      - name: Install PDFium (for redact tests)
+        run: |
+          curl -fsSL "https://github.com/bblanchon/pdfium-binaries/releases/download/chromium/7825/pdfium-linux-x64.tgz" \
+            | sudo tar -xz -C /tmp
+          sudo cp /tmp/lib/libpdfium.so /usr/lib/libpdfium.so
+          sudo ldconfig
       - name: Warm test result cache (Bazel)
         run: bazel test //... --build_tests_only --keep_going --test_output=errors --test_summary=short
 
@@ -598,6 +606,15 @@ jobs:
           r2-bucket: ${{ vars.BAZEL_R2_BUCKET }}
           r2-access-key-id: ${{ secrets.BAZEL_R2_ACCESS_KEY_ID }}
           r2-secret-access-key: ${{ secrets.BAZEL_R2_SECRET_ACCESS_KEY }}
+
+      # alc-notify::redact が libpdfium.so を dlopen する (test-matrix と同一 step、
+      # processwrapper-sandbox はシステムパスに到達できるので /usr/lib で足りる)
+      - name: Install PDFium (for redact tests)
+        run: |
+          curl -fsSL "https://github.com/bblanchon/pdfium-binaries/releases/download/chromium/7825/pdfium-linux-x64.tgz" \
+            | sudo tar -xz -C /tmp
+          sudo cp /tmp/lib/libpdfium.so /usr/lib/libpdfium.so
+          sudo ldconfig
 
       - name: bazel test (全 unit test、result cache は main warm から)
         run: |


### PR DESCRIPTION
## Summary

Refs #515

`--test_output=errors` (PR #524) で `alc-notify_test` 14 件失敗の根本原因が確定した:

```
called `Result::unwrap()` on an `Err` value: Pdfium("bind_to_system_library:
LoadLibraryError( DlOpen { source: "libpdfium.so: cannot open shared object file" })")
```

- redact / background_redaction のテストが pdfium-render 経由で **libpdfium.so を実行時 dlopen** する
- cargo の Tests job は「Install PDFium」step (bblanchon/pdfium-binaries chromium/7825 → `/usr/lib/libpdfium.so`) を持つが、bazel の poc / warm job には無かった
- assertion 失敗 2 件 (`GeminiEmpty` / `GeminiStatus` の matches!) も、Gemini 到達前に Pdfium bind で落ちた同根の巻き込み

## 変更内容

- cargo Tests job と同一の「Install PDFium」step を **bazel poc / warm 両 job** に追加
- processwrapper-sandbox はシステムパスに到達できるため `/usr/lib` 配置で足りる

## 検証

本 PR の poc job で **17/17 target PASSED** になれば bazel 移行の環境差は解消。merge 後の main warm が全 target の pass 結果を save → 次の PR から非接触 crate は `(cached)`。

---
_Generated by [Claude Code](https://claude.ai/code/session_01CEUnL9oDYaRZYh6gG5z9bX)_