### PR TITLE
ci(bazel): test job を crate 単位 17 shard に分割 (Refs #515)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,17 +112,43 @@ jobs:
   # から読めるのは main scope の cache だけなので、main push でここが `bazel test`
   # を 1 回走らせ、test action の結果込み disk cache を main scope に save する。
   # run 跨ぎ hit の成立は PR #521 で実証済み (1 回目 invocation で '(cached)')。
-  # 注意: invocation の flags は bazel-test-poc job と完全一致させること
+  # shard 分割 (crate 単位) の理由: wall time は最重 shard で bounded になり、
+  # alc-core 変更時の単一 job 4-5 分を shard 並列 ~2-3 分に抑える。shard ごとに
+  # 専用 disk cache key (同一 key 共有は save reserve 競合で全滅する、#506 実測)。
+  # 注意 (1): matrix は bazel-test-poc job と 1:1 で同期させること — 同期漏れは
+  # scripts/check_bazel_test_matrix.sh (csv-parser shard 内) が loud fail させる。
+  # 注意 (2): invocation の flags は bazel-test-poc job と完全一致させること
   # (configuration が違うと action key が変わり、PR 側で '(cached)' にならない)。
   cache-warm-bazel-test-poc:
-    name: "Cache Warm (bazel-test-poc)"
+    name: "Cache Warm (bazel-test-${{ matrix.name }})"
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { name: monolith, target: "//:unit_tests" }
+          - { name: auth, target: "//crates/alc-auth:alc-auth_test" }
+          - { name: auth-jwt, target: "//crates/alc-auth-jwt:alc-auth-jwt_test" }
+          - { name: camera, target: "//crates/alc-camera:alc-camera_test" }
+          - { name: carins, target: "//crates/alc-carins:alc-carins_test" }
+          - { name: compare, target: "//crates/alc-compare:alc-compare_test" }
+          - { name: core, target: "//crates/alc-core:alc-core_test" }
+          - { name: csv-parser, target: "//crates/alc-csv-parser:alc-csv-parser_test" }
+          - { name: devices, target: "//crates/alc-devices:alc-devices_test" }
+          - { name: dtako, target: "//crates/alc-dtako:alc-dtako_test" }
+          - { name: misc, target: "//crates/alc-misc:alc-misc_test" }
+          - { name: notify, target: "//crates/alc-notify:alc-notify_test", pdfium: true }
+          - { name: pdf, target: "//crates/alc-pdf:alc-pdf_test" }
+          - { name: storage, target: "//crates/alc-storage:alc-storage_test" }
+          - { name: tenko, target: "//crates/alc-tenko:alc-tenko_test" }
+          - { name: trouble, target: "//crates/alc-trouble:alc-trouble_test" }
+          - { name: gateway, target: "//crates/gateway:gateway_test" }
     steps:
       - uses: actions/checkout@v4
       - uses: ippoan/setup-bazel@main
         with:
-          disk-cache: "bazel-test-poc"
+          disk-cache: "bazel-test-${{ matrix.name }}"
           r2-endpoint: ${{ vars.BAZEL_R2_ENDPOINT }}
           r2-bucket: ${{ vars.BAZEL_R2_BUCKET }}
           r2-access-key-id: ${{ secrets.BAZEL_R2_ACCESS_KEY_ID }}
@@ -130,13 +156,14 @@ jobs:
       # alc-notify::redact が libpdfium.so を dlopen する (test-matrix と同一 step、
       # processwrapper-sandbox はシステムパスに到達できるので /usr/lib で足りる)
       - name: Install PDFium (for redact tests)
+        if: matrix.pdfium == true
         run: |
           curl -fsSL "https://github.com/bblanchon/pdfium-binaries/releases/download/chromium/7825/pdfium-linux-x64.tgz" \
             | sudo tar -xz -C /tmp
           sudo cp /tmp/lib/libpdfium.so /usr/lib/libpdfium.so
           sudo ldconfig
       - name: Warm test result cache (Bazel)
-        run: bazel test //... --build_tests_only --keep_going --test_output=errors --test_summary=short
+        run: bazel test ${{ matrix.target }} --test_output=errors --test_summary=short
 
   cache-cleanup:
     name: Cache Cleanup
@@ -583,25 +610,49 @@ jobs:
           cache-to: "type=gha,mode=max,scope=${{ matrix.name }}-staging"
 
   # Bazel test 化 PoC (Refs #515): 全 crate の unit test (`<crate>_test` + root
-  # `//:unit_tests`) を `bazel test` で実行し、run 跨ぎ test result cache の効果を
-  # 実測する。alc-csv-parser 1 crate での分水嶺検証 (result cache / lcov gate) は
-  # PR #517-#521 で全て突破済み → 全 unit test に拡大 (2026-07-05)。
+  # `//:unit_tests`) を crate 単位の shard で `bazel test` する。分水嶺検証
+  # (result cache / lcov gate / run 跨ぎ hit / sandbox 環境差) は PR #517-#525 で
+  # 全て突破済み。
   # 独立 job (deploy chain の needs 外) = critical path に乗らず、merge gate でも
   # ない。coverage gate (coverage_100.toml) の SoT は引き続き cargo llvm-cov 側で、
-  # ここの lcov gate は alc-csv-parser 限定の並走検証。
+  # ここの lcov gate は alc-csv-parser 限定の並走検証 (csv-parser shard のみ)。
   # run 跨ぎの test result cache は cache-warm-bazel-test-poc (main push warm) 経由
   # でのみ hit する — PR run 自身の save は refs/pull/N/merge scope に隔離され、
   # 別 PR から読めない (2026-07-05 実測、詳細は #515 のコメント)。
+  # shard 分割の狙い: wall time を最重 shard で bounded にする (alc-core 変更時の
+  # 単一 job 4-5 分 → 並列 ~2-3 分)。matrix / flags は warm 側と 1:1 同期必須
+  # (check_bazel_test_matrix.sh が csv-parser shard で検証)。
   bazel-test-poc:
-    name: "Bazel test PoC (all unit tests)"
+    name: "Bazel test (${{ matrix.name }})"
     needs: [pr-limit]
     if: "always() && github.event_name == 'pull_request' && (needs.pr-limit.result == 'success' || needs.pr-limit.result == 'skipped')"
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { name: monolith, target: "//:unit_tests" }
+          - { name: auth, target: "//crates/alc-auth:alc-auth_test" }
+          - { name: auth-jwt, target: "//crates/alc-auth-jwt:alc-auth-jwt_test" }
+          - { name: camera, target: "//crates/alc-camera:alc-camera_test" }
+          - { name: carins, target: "//crates/alc-carins:alc-carins_test" }
+          - { name: compare, target: "//crates/alc-compare:alc-compare_test" }
+          - { name: core, target: "//crates/alc-core:alc-core_test" }
+          - { name: csv-parser, target: "//crates/alc-csv-parser:alc-csv-parser_test" }
+          - { name: devices, target: "//crates/alc-devices:alc-devices_test" }
+          - { name: dtako, target: "//crates/alc-dtako:alc-dtako_test" }
+          - { name: misc, target: "//crates/alc-misc:alc-misc_test" }
+          - { name: notify, target: "//crates/alc-notify:alc-notify_test", pdfium: true }
+          - { name: pdf, target: "//crates/alc-pdf:alc-pdf_test" }
+          - { name: storage, target: "//crates/alc-storage:alc-storage_test" }
+          - { name: tenko, target: "//crates/alc-tenko:alc-tenko_test" }
+          - { name: trouble, target: "//crates/alc-trouble:alc-trouble_test" }
+          - { name: gateway, target: "//crates/gateway:gateway_test" }
     steps:
       - uses: actions/checkout@v4
       - uses: ippoan/setup-bazel@main
         with:
-          disk-cache: "bazel-test-poc"
+          disk-cache: "bazel-test-${{ matrix.name }}"
           r2-endpoint: ${{ vars.BAZEL_R2_ENDPOINT }}
           r2-bucket: ${{ vars.BAZEL_R2_BUCKET }}
           r2-access-key-id: ${{ secrets.BAZEL_R2_ACCESS_KEY_ID }}
@@ -610,21 +661,27 @@ jobs:
       # alc-notify::redact が libpdfium.so を dlopen する (test-matrix と同一 step、
       # processwrapper-sandbox はシステムパスに到達できるので /usr/lib で足りる)
       - name: Install PDFium (for redact tests)
+        if: matrix.pdfium == true
         run: |
           curl -fsSL "https://github.com/bblanchon/pdfium-binaries/releases/download/chromium/7825/pdfium-linux-x64.tgz" \
             | sudo tar -xz -C /tmp
           sudo cp /tmp/lib/libpdfium.so /usr/lib/libpdfium.so
           sudo ldconfig
 
-      - name: bazel test (全 unit test、result cache は main warm から)
+      - name: bazel test (result cache は main warm から)
         run: |
           set -o pipefail
-          bazel test //... --build_tests_only --keep_going --test_output=errors --test_summary=short 2>&1 | tee /tmp/test_run.txt
-          CACHED=$(grep -c "(cached)" /tmp/test_run.txt || true)
-          TOTAL=$(grep -cE "^//.* PASSED" /tmp/test_run.txt || true)
-          echo "::notice::test result cache: ${CACHED}/${TOTAL} targets が (cached) — ソース/BUILD を触った PR や warm 未反映の初回は少なくて正常"
+          bazel test ${{ matrix.target }} --test_output=errors --test_summary=short 2>&1 | tee /tmp/test_run.txt
+          if grep -q "(cached)" /tmp/test_run.txt; then
+            echo "::notice::${{ matrix.target }} は (cached) — main warm から restore"
+          fi
+
+      - name: matrix 網羅性チェック (rust_test target の追加漏れ検出)
+        if: matrix.name == 'csv-parser'
+        run: bash scripts/check_bazel_test_matrix.sh
 
       - name: bazel coverage (lcov 出力)
+        if: matrix.name == 'csv-parser'
         run: |
           bazel coverage //crates/alc-csv-parser:alc-csv-parser_test \
             --combined_report=lcov \
@@ -635,6 +692,7 @@ jobs:
           head -30 /tmp/lcov.dat
 
       - name: coverage 100% gate の lcov 再現 (coverage_100.toml 突合)
+        if: matrix.name == 'csv-parser'
         run: bash scripts/check_coverage_100_lcov.sh /tmp/lcov.dat crates/alc-csv-parser
 
   # staging の postgres sidecar image。旧 deploy.yml の staging-db job からの

--- a/docs/ci-speed-tracking.md
+++ b/docs/ci-speed-tracking.md
@@ -150,6 +150,17 @@ Build backend (Bazel) job 139s の内訳: setup ~8s / **analysis 60s**
   (残りは loading/analysis 固定費 61s + coverage 29s)
 - 実証を受けて poc を**全 crate の unit test に拡大** (`bazel test //... --build_tests_only`、
   warm も同一 invocation)。lcov gate / coverage gate の SoT は引き続き cargo llvm-cov 側
+- 拡大時に洗い出した bazel 環境差 2 件 (どちらも修正済み): (1) dev-dependencies を持つ
+  crate (alc-misc / alc-notify) の rust_test に `all_crate_deps(normal_dev)` 配線が必要、
+  (2) alc-notify redact テストの libpdfium.so dlopen — cargo Tests と同じ Install PDFium
+  step を bazel job にも配置 (#525)。修正後 17/17 PASSED、warm 定常の単一 job は 2m52s
+- **crate 単位 shard 分割** (17 shard、`bazel-test-<crate>` の専用 disk cache key):
+  重複ビルドが浪費するのは CPU であって wall time ではなく、wall time は最重 shard で
+  bounded になる (alc-core 変更時: 単一 job 4-5 分 → 並列 ~2-3 分、最重は monolith
+  shard の最深チェーン)。leaf shard の定常は analysis 60s + restore ≈ 1.5-2 分。
+  トレードオフ: PR あたり +16 job (Free 20 枠では Tests の queue 悪化 → Team 化推奨) と
+  cache 容量 (17 key、GH 10GB 上限)。matrix の追加漏れ/warm-poc 同期は
+  `scripts/check_bazel_test_matrix.sh` (csv-parser shard 内) が loud fail
 - 残: DB 依存 integration test の Bazel 化設計 (postgres service との接続を bazel test
   サンドボックスからどう張るか)
 

--- a/scripts/check_bazel_test_matrix.sh
+++ b/scripts/check_bazel_test_matrix.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# ci.yml の bazel test matrix (bazel-test-poc / cache-warm-bazel-test-poc) が
+# BUILD ファイルの rust_test target を網羅しているか + 両 job の matrix が
+# 一致しているかを検証する (Refs #515)。
+#
+# crate を追加して rust_test を定義したのに matrix へ足し忘れると、その crate の
+# テストが bazel 側で「無言で対象外」になる。逆に BUILD から消した target が
+# matrix に残ると shard が恒常 fail する。どちらも loud fail させる。
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+python3 - <<'PYEOF'
+import glob
+import re
+import sys
+
+import yaml
+
+ci = yaml.safe_load(open(".github/workflows/ci.yml", encoding="utf-8"))
+
+def matrix_targets(job_name):
+    job = ci["jobs"].get(job_name)
+    if job is None:
+        print(f"::error::ci.yml に job '{job_name}' がありません")
+        sys.exit(1)
+    return {e["target"]: e for e in job["strategy"]["matrix"]["include"]}
+
+poc = matrix_targets("bazel-test-poc")
+warm = matrix_targets("cache-warm-bazel-test-poc")
+
+# --- BUILD ファイルから rust_test target を列挙 ---
+expected = set()
+for f in glob.glob("crates/*/BUILD.bazel") + ["BUILD.bazel"]:
+    src = open(f, encoding="utf-8").read()
+    for m in re.finditer(r'rust_test\(\s*name = "([^"]+)"', src):
+        pkg = "" if f == "BUILD.bazel" else f[: -len("/BUILD.bazel")]
+        expected.add(f"//{pkg}:{m.group(1)}")
+
+fail = 0
+
+missing = expected - set(poc)
+for t in sorted(missing):
+    print(f"::error::rust_test target {t} が ci.yml の bazel-test-poc matrix にありません (追加漏れ = 無言で対象外)")
+    fail += 1
+
+stale = set(poc) - expected
+for t in sorted(stale):
+    print(f"::error::bazel-test-poc matrix の {t} に対応する rust_test が BUILD にありません (削除漏れ)")
+    fail += 1
+
+# --- warm と poc の matrix 一致 (target / name / pdfium) ---
+if poc.keys() != warm.keys():
+    for t in sorted(set(poc) ^ set(warm)):
+        print(f"::error::warm/poc の matrix target 不一致: {t}")
+        fail += 1
+else:
+    for t, e in poc.items():
+        w = warm[t]
+        for k in ("name", "pdfium"):
+            if e.get(k) != w.get(k):
+                print(f"::error::{t} の matrix field '{k}' が warm/poc で不一致 ({e.get(k)} != {w.get(k)})")
+                fail += 1
+
+if fail:
+    print(f"::error::bazel test matrix check: {fail} 件の不整合")
+    sys.exit(1)
+
+print(f"bazel test matrix OK — {len(expected)} rust_test target を網羅、warm/poc 一致")
+PYEOF


### PR DESCRIPTION
## Summary

Refs #515

bazel test の単一 job を **crate 単位 17 shard の matrix に分割**する。重複ビルドが浪費するのは CPU (runner 台数) であって wall time ではなく、wall time は最重 shard で bounded になる:

- alc-core 変更時: 単一 job 4-5 分 → 並列 **~2-3 分** (最重は monolith `//:unit_tests` shard の最深チェーン)
- leaf crate 変更 / 非接触 PR: 各 shard は analysis 60s + restore で **~1.5-2 分**
- org の **Team 化 (20→60 並列) 済み**のため +16 job の queue 懸念は解消

## 変更内容

- **poc / warm を同一 matrix (17 target) に分割**。shard ごとに専用 disk cache key `bazel-test-<name>` (同一 key 共有は save reserve 競合で全滅する #506 実測を回避)
- PDFium install は notify shard のみ、coverage + lcov gate は csv-parser shard のみ
- **`scripts/check_bazel_test_matrix.sh`** (新規): BUILD の rust_test target と ci.yml matrix の突合 + warm/poc の matrix 一致検証。crate 追加時の「無言で対象外」/ 削除漏れ / 同期ズレを csv-parser shard で loud fail
- `docs/ci-speed-tracking.md` に分割判断の根拠と環境差 2 件 (dev deps / PDFium) の記録を追記

## 検証

- 本 PR は shard ごとに cache key が変わる (旧 `bazel-test-poc` → `bazel-test-<name>`) ため、**全 shard 初回フルビルド**になる。ここで「shard 分割時の cold 時間」も実測できる
- merge 後の main warm (17 並列) が各 key を save → 次 PR から非接触 shard は `(cached)` で ~1.5-2 分
- shard 分割の cold/warm 実測は #515 に追記予定

---
_Generated by [Claude Code](https://claude.ai/code/session_01CEUnL9oDYaRZYh6gG5z9bX)_