### PR TITLE
ci(bazel): mock 統合テスト 6 binary を bazel test shard 化 — gate 移行 PR1 (Refs #515)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,12 @@ jobs:
       matrix:
         include:
           - { name: monolith, target: "//:unit_tests" }
+          - { name: mock-carins, target: "//:mock_carins" }
+          - { name: mock-devices, target: "//:mock_devices" }
+          - { name: mock-dtako, target: "//:mock_dtako" }
+          - { name: mock-misc, target: "//:mock_misc" }
+          - { name: mock-tenko, target: "//:mock_tenko" }
+          - { name: mock-trouble, target: "//:mock_trouble" }
           - { name: auth, target: "//crates/alc-auth:alc-auth_test" }
           - { name: auth-jwt, target: "//crates/alc-auth-jwt:alc-auth-jwt_test" }
           - { name: camera, target: "//crates/alc-camera:alc-camera_test" }
@@ -632,6 +638,12 @@ jobs:
       matrix:
         include:
           - { name: monolith, target: "//:unit_tests" }
+          - { name: mock-carins, target: "//:mock_carins" }
+          - { name: mock-devices, target: "//:mock_devices" }
+          - { name: mock-dtako, target: "//:mock_dtako" }
+          - { name: mock-misc, target: "//:mock_misc" }
+          - { name: mock-tenko, target: "//:mock_tenko" }
+          - { name: mock-trouble, target: "//:mock_trouble" }
           - { name: auth, target: "//crates/alc-auth:alc-auth_test" }
           - { name: auth-jwt, target: "//crates/alc-auth-jwt:alc-auth-jwt_test" }
           - { name: camera, target: "//crates/alc-camera:alc-camera_test" }

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -66,3 +66,102 @@ rust_test(
     deps = all_crate_deps(normal_dev = True),
     proc_macro_deps = all_crate_deps(proc_macro_dev = True),
 )
+
+# --- mock 統合テスト (DB 不要、Refs #515 bazel gate 移行 PR1) ---
+#
+# tests/mock_<domain>/main.rs が #[path] で tests/common + tests/mock_helpers +
+# tests/mock_tests を束ねる dir-style integration test。mock repository で
+# AppState/TenkoState/TroubleState を組み、実 HTTP サーバーを spawn する。
+# postgres には接続しない (pool: None) ので bazel sandbox でそのまま走る。
+# 新しい mock shard を足したら ci.yml の bazel test matrix (warm/poc) にも
+# 追記すること (check_bazel_test_matrix.sh が同期漏れを loud fail する)。
+
+_MOCK_TEST_SRCS = glob([
+    "tests/common/**/*.rs",
+    "tests/mock_helpers/**/*.rs",
+    "tests/mock_tests/**/*.rs",
+])
+
+rust_test(
+    name = "mock_carins",
+    srcs = ["tests/mock_carins/main.rs"] + _MOCK_TEST_SRCS,
+    crate_root = "tests/mock_carins/main.rs",
+    deps = [":rust_alc_api_lib"] + all_crate_deps(
+        normal = True,
+        normal_dev = True,
+    ) + _WORKSPACE_CRATES,
+    proc_macro_deps = all_crate_deps(
+        proc_macro = True,
+        proc_macro_dev = True,
+    ),
+)
+
+rust_test(
+    name = "mock_devices",
+    srcs = ["tests/mock_devices/main.rs"] + _MOCK_TEST_SRCS,
+    crate_root = "tests/mock_devices/main.rs",
+    deps = [":rust_alc_api_lib"] + all_crate_deps(
+        normal = True,
+        normal_dev = True,
+    ) + _WORKSPACE_CRATES,
+    proc_macro_deps = all_crate_deps(
+        proc_macro = True,
+        proc_macro_dev = True,
+    ),
+)
+
+rust_test(
+    name = "mock_dtako",
+    srcs = ["tests/mock_dtako/main.rs"] + _MOCK_TEST_SRCS,
+    crate_root = "tests/mock_dtako/main.rs",
+    deps = [":rust_alc_api_lib"] + all_crate_deps(
+        normal = True,
+        normal_dev = True,
+    ) + _WORKSPACE_CRATES,
+    proc_macro_deps = all_crate_deps(
+        proc_macro = True,
+        proc_macro_dev = True,
+    ),
+)
+
+rust_test(
+    name = "mock_misc",
+    srcs = ["tests/mock_misc/main.rs"] + _MOCK_TEST_SRCS,
+    crate_root = "tests/mock_misc/main.rs",
+    deps = [":rust_alc_api_lib"] + all_crate_deps(
+        normal = True,
+        normal_dev = True,
+    ) + _WORKSPACE_CRATES,
+    proc_macro_deps = all_crate_deps(
+        proc_macro = True,
+        proc_macro_dev = True,
+    ),
+)
+
+rust_test(
+    name = "mock_tenko",
+    srcs = ["tests/mock_tenko/main.rs"] + _MOCK_TEST_SRCS,
+    crate_root = "tests/mock_tenko/main.rs",
+    deps = [":rust_alc_api_lib"] + all_crate_deps(
+        normal = True,
+        normal_dev = True,
+    ) + _WORKSPACE_CRATES,
+    proc_macro_deps = all_crate_deps(
+        proc_macro = True,
+        proc_macro_dev = True,
+    ),
+)
+
+rust_test(
+    name = "mock_trouble",
+    srcs = ["tests/mock_trouble/main.rs"] + _MOCK_TEST_SRCS,
+    crate_root = "tests/mock_trouble/main.rs",
+    deps = [":rust_alc_api_lib"] + all_crate_deps(
+        normal = True,
+        normal_dev = True,
+    ) + _WORKSPACE_CRATES,
+    proc_macro_deps = all_crate_deps(
+        proc_macro = True,
+        proc_macro_dev = True,
+    ),
+)

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -86,6 +86,8 @@ rust_test(
     name = "mock_carins",
     srcs = ["tests/mock_carins/main.rs"] + _MOCK_TEST_SRCS,
     crate_root = "tests/mock_carins/main.rs",
+    # tests/common/mod.rs の sqlx::migrate! が compile 時に migrations/ を読む
+    compile_data = glob(["migrations/**"]),
     deps = [":rust_alc_api_lib"] + all_crate_deps(
         normal = True,
         normal_dev = True,
@@ -100,6 +102,8 @@ rust_test(
     name = "mock_devices",
     srcs = ["tests/mock_devices/main.rs"] + _MOCK_TEST_SRCS,
     crate_root = "tests/mock_devices/main.rs",
+    # tests/common/mod.rs の sqlx::migrate! が compile 時に migrations/ を読む
+    compile_data = glob(["migrations/**"]),
     deps = [":rust_alc_api_lib"] + all_crate_deps(
         normal = True,
         normal_dev = True,
@@ -114,6 +118,8 @@ rust_test(
     name = "mock_dtako",
     srcs = ["tests/mock_dtako/main.rs"] + _MOCK_TEST_SRCS,
     crate_root = "tests/mock_dtako/main.rs",
+    # tests/common/mod.rs の sqlx::migrate! が compile 時に migrations/ を読む
+    compile_data = glob(["migrations/**"]),
     deps = [":rust_alc_api_lib"] + all_crate_deps(
         normal = True,
         normal_dev = True,
@@ -128,6 +134,8 @@ rust_test(
     name = "mock_misc",
     srcs = ["tests/mock_misc/main.rs"] + _MOCK_TEST_SRCS,
     crate_root = "tests/mock_misc/main.rs",
+    # tests/common/mod.rs の sqlx::migrate! が compile 時に migrations/ を読む
+    compile_data = glob(["migrations/**"]),
     deps = [":rust_alc_api_lib"] + all_crate_deps(
         normal = True,
         normal_dev = True,
@@ -142,6 +150,8 @@ rust_test(
     name = "mock_tenko",
     srcs = ["tests/mock_tenko/main.rs"] + _MOCK_TEST_SRCS,
     crate_root = "tests/mock_tenko/main.rs",
+    # tests/common/mod.rs の sqlx::migrate! が compile 時に migrations/ を読む
+    compile_data = glob(["migrations/**"]),
     deps = [":rust_alc_api_lib"] + all_crate_deps(
         normal = True,
         normal_dev = True,
@@ -156,6 +166,8 @@ rust_test(
     name = "mock_trouble",
     srcs = ["tests/mock_trouble/main.rs"] + _MOCK_TEST_SRCS,
     crate_root = "tests/mock_trouble/main.rs",
+    # tests/common/mod.rs の sqlx::migrate! が compile 時に migrations/ を読む
+    compile_data = glob(["migrations/**"]),
     deps = [":rust_alc_api_lib"] + all_crate_deps(
         normal = True,
         normal_dev = True,

--- a/docs/ci-speed-tracking.md
+++ b/docs/ci-speed-tracking.md
@@ -161,8 +161,17 @@ Build backend (Bazel) job 139s の内訳: setup ~8s / **analysis 60s**
   トレードオフ: PR あたり +16 job (Free 20 枠では Tests の queue 悪化 → Team 化推奨) と
   cache 容量 (17 key、GH 10GB 上限)。matrix の追加漏れ/warm-poc 同期は
   `scripts/check_bazel_test_matrix.sh` (csv-parser shard 内) が loud fail
-- 残: DB 依存 integration test の Bazel 化設計 (postgres service との接続を bazel test
-  サンドボックスからどう張るか)
+- **shard 分割の実測 (PR #527 = alc-core を触る最悪ケース)**: 17 shard 全 green、
+  wall **~2.5 分に bounded** (最重 notify 151s、大半 80-90s)。単一 job の cold 5 分から
+  設計どおり
+- **bazel gate 移行 PR1**: mock 統合テスト 6 binary (`tests/mock_<domain>/main.rs`、DB 不要)
+  を rust_test target 化して shard matrix に追加 (17 → 23 shard)。cargo Tests matrix は
+  当面 gate として並走 (PR4 で退役予定)。注意: mock shard は monolith lib 閉包を含むため
+  disk cache が各 ~500MB 級 — GH cache 10GB 上限との兼ね合いで eviction が観測されたら
+  shard 統合で対処する
+- 残: DB 依存 integration test の Bazel 化 (PR2、shard job に postgres service +
+  `--test_env=TEST_DATABASE_URL`)、coverage gate の lcov 全域化 (PR3)、
+  cargo Tests matrix 退役 + required checks 差し替え (PR4)
 
 ### cache-warm build-only 化の実測 (PR #519、2026-07-05)
 


### PR DESCRIPTION
## Summary

Refs #515 (bazel gate 移行 PR1/4)

cargo Tests matrix の主戦力である **mock 統合テスト 6 binary** (`tests/mock_<domain>/main.rs`) を rust_test target 化し、bazel test shard matrix を **17 → 23** に拡張する。mock テストは postgres に接続しない (pool: None、mock repository で実 HTTP サーバーを spawn) ため、bazel sandbox でそのまま走る。

## 変更内容

- **root BUILD.bazel**: `mock_{carins,devices,dtako,misc,tenko,trouble}` の rust_test を追加 (srcs = `main.rs` + common/mock_helpers/mock_tests glob、deps = `rust_alc_api_lib` + normal/dev deps + workspace crates)
- **ci.yml**: warm / poc 両 matrix に 6 entry 追加 (`check_bazel_test_matrix.sh` で 23 target 網羅・warm/poc 一致を検証済み)
- **docs/ci-speed-tracking.md**: #527 の shard 実測 (alc-core 変更で wall ~2.5 分 bounded) と PR1-4 のロードマップを記録

## 位置づけ

| PR | 内容 | 状態 |
|---|---|---|
| **PR1 (本 PR)** | mock テスト (DB 不要) の bazel 化 | ← |
| PR2 | DB integration テスト (shard job に postgres service + `--test_env`) | 予定 |
| PR3 | coverage gate の lcov 全域化 | 予定 |
| PR4 | cargo Tests matrix 退役 + required checks 差し替え | 予定 |

cargo Tests matrix は当面 gate として並走する (本 PR で CI 時間は増えない — shard は merge gate 外の観測 job)。

## 注意 / 検証

- mock shard の disk cache は monolith lib 閉包込みで各 ~500MB 級。**GH cache 10GB 上限で eviction thrash が観測されたら shard 統合で対処** (doc に記録済み)
- 本 PR の poc run で 6 shard が初回フルビルドになる (BUILD 変更で全 shard の cache key も更新)。mock テストが bazel sandbox 環境で全 pass するかがここでの判定点

---
_Generated by [Claude Code](https://claude.ai/code/session_01CEUnL9oDYaRZYh6gG5z9bX)_