### PR TITLE
ci(bazel): DB integration テスト 2 binary を bazel 化 — gate 移行 PR2 (Refs #515)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,47 @@ jobs:
       - name: Warm test result cache (Bazel)
         run: bazel test ${{ matrix.target }} --test_output=errors --test_summary=short
 
+  # DB integration テスト用 warm (Refs #515 PR2)。postgres service + TEST_DATABASE_URL
+  # を持つ点以外は cache-warm-bazel-test-poc と同じ。matrix / flags は bazel-test-db と
+  # 1:1 同期 (check_bazel_test_matrix.sh が poc/db の union で検証)。
+  cache-warm-bazel-test-db:
+    name: "Cache Warm (bazel-test-${{ matrix.name }})"
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { name: db-trouble, target: "//:trouble_test" }
+          - { name: db-archive, target: "//:archive_repo_test" }
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_PASSWORD: test
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+    env:
+      TEST_DATABASE_URL: "postgresql://postgres:test@localhost:5432/postgres?options=-c search_path=alc_api"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ippoan/setup-bazel@main
+        with:
+          disk-cache: "bazel-test-${{ matrix.name }}"
+          r2-endpoint: ${{ vars.BAZEL_R2_ENDPOINT }}
+          r2-bucket: ${{ vars.BAZEL_R2_BUCKET }}
+          r2-access-key-id: ${{ secrets.BAZEL_R2_ACCESS_KEY_ID }}
+          r2-secret-access-key: ${{ secrets.BAZEL_R2_SECRET_ACCESS_KEY }}
+      - name: Init test DB (alc_api schema + roles)
+        run: psql "postgresql://postgres:test@localhost:5432/postgres" -f scripts/init_local_db.sql
+      - name: Warm test result cache (Bazel)
+        run: bazel test ${{ matrix.target }} --test_env=TEST_DATABASE_URL --test_output=errors --test_summary=short
+
   cache-cleanup:
     name: Cache Cleanup
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
@@ -706,6 +747,55 @@ jobs:
       - name: coverage 100% gate の lcov 再現 (coverage_100.toml 突合)
         if: matrix.name == 'csv-parser'
         run: bash scripts/check_coverage_100_lcov.sh /tmp/lcov.dat crates/alc-csv-parser
+
+  # DB integration テストの bazel shard (Refs #515 PR2)。postgres service +
+  # TEST_DATABASE_URL + init_local_db.sql を持つ点以外は bazel-test-poc と同じ。
+  # sandbox (processwrapper) はネットワークを遮断しないので localhost:5432 に届く。
+  # DB を挟むため test result は入力不変でも DB 状態に依存し得るが、テスト自体が
+  # 冪等設計 (tenant 分離 + 専用ロック) なので cache hit を許容する。
+  bazel-test-db:
+    name: "Bazel test (${{ matrix.name }})"
+    needs: [pr-limit]
+    if: "always() && github.event_name == 'pull_request' && (needs.pr-limit.result == 'success' || needs.pr-limit.result == 'skipped')"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { name: db-trouble, target: "//:trouble_test" }
+          - { name: db-archive, target: "//:archive_repo_test" }
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_PASSWORD: test
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+    env:
+      TEST_DATABASE_URL: "postgresql://postgres:test@localhost:5432/postgres?options=-c search_path=alc_api"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ippoan/setup-bazel@main
+        with:
+          disk-cache: "bazel-test-${{ matrix.name }}"
+          r2-endpoint: ${{ vars.BAZEL_R2_ENDPOINT }}
+          r2-bucket: ${{ vars.BAZEL_R2_BUCKET }}
+          r2-access-key-id: ${{ secrets.BAZEL_R2_ACCESS_KEY_ID }}
+          r2-secret-access-key: ${{ secrets.BAZEL_R2_SECRET_ACCESS_KEY }}
+      - name: Init test DB (alc_api schema + roles)
+        run: psql "postgresql://postgres:test@localhost:5432/postgres" -f scripts/init_local_db.sql
+      - name: bazel test (result cache は main warm から)
+        run: |
+          set -o pipefail
+          bazel test ${{ matrix.target }} --test_env=TEST_DATABASE_URL --test_output=errors --test_summary=short 2>&1 | tee /tmp/test_run.txt
+          if grep -q "(cached)" /tmp/test_run.txt; then
+            echo "::notice::${{ matrix.target }} は (cached) — main warm から restore"
+          fi
 
   # staging の postgres sidecar image。旧 deploy.yml の staging-db job からの
   # 移設 (Refs #482)。build-image と並列に走らせることで、deploy workflow 側の

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -82,6 +82,43 @@ _MOCK_TEST_SRCS = glob([
     "tests/mock_tests/**/*.rs",
 ])
 
+# --- DB integration テスト (postgres 必須、Refs #515 bazel gate 移行 PR2) ---
+#
+# ci.yml の bazel-test-db job (postgres service + TEST_DATABASE_URL) で走らせる。
+# sqlx::migrate! は compile 時に migrations/ を埋め込む (runtime 再読込なし) ので
+# compile_data だけで足りる。新 target を足したら ci.yml の db matrix にも追記
+# (check_bazel_test_matrix.sh が poc/db の union で同期を検証する)。
+
+rust_test(
+    name = "trouble_test",
+    srcs = ["tests/trouble_test.rs"] + glob(["tests/common/**/*.rs"]),
+    crate_root = "tests/trouble_test.rs",
+    compile_data = glob(["migrations/**"]),
+    deps = [":rust_alc_api_lib"] + all_crate_deps(
+        normal = True,
+        normal_dev = True,
+    ) + _WORKSPACE_CRATES,
+    proc_macro_deps = all_crate_deps(
+        proc_macro = True,
+        proc_macro_dev = True,
+    ),
+)
+
+rust_test(
+    name = "archive_repo_test",
+    srcs = ["tests/archive_repo_test.rs"] + glob(["tests/common/**/*.rs"]),
+    crate_root = "tests/archive_repo_test.rs",
+    compile_data = glob(["migrations/**"]),
+    deps = [":rust_alc_api_lib"] + all_crate_deps(
+        normal = True,
+        normal_dev = True,
+    ) + _WORKSPACE_CRATES,
+    proc_macro_deps = all_crate_deps(
+        proc_macro = True,
+        proc_macro_dev = True,
+    ),
+)
+
 rust_test(
     name = "mock_carins",
     srcs = ["tests/mock_carins/main.rs"] + _MOCK_TEST_SRCS,

--- a/docs/ci-speed-tracking.md
+++ b/docs/ci-speed-tracking.md
@@ -169,9 +169,14 @@ Build backend (Bazel) job 139s の内訳: setup ~8s / **analysis 60s**
   当面 gate として並走 (PR4 で退役予定)。注意: mock shard は monolith lib 閉包を含むため
   disk cache が各 ~500MB 級 — GH cache 10GB 上限との兼ね合いで eviction が観測されたら
   shard 統合で対処する
-- 残: DB 依存 integration test の Bazel 化 (PR2、shard job に postgres service +
-  `--test_env=TEST_DATABASE_URL`)、coverage gate の lcov 全域化 (PR3)、
-  cargo Tests matrix 退役 + required checks 差し替え (PR4)
+- **PR2**: CI が実際に走らせている DB integration 2 binary (`trouble_test` /
+  `archive_repo_test`) を bazel 化 (25 shard)。postgres service + `--test_env=
+  TEST_DATABASE_URL` + init_local_db.sql を持つ別 job (`bazel-test-db` とその warm)。
+  発見: tests/ の他 6 binary (devices_test / employees_test / measurements_test /
+  devices_re_pair_test / trouble_task_statuses_test / trouble_tasks_cross_ticket_test)
+  は **cargo CI でも走っていない** (test-matrix の `--test` 列挙に無い) — 要別途判断
+- 残: coverage gate の lcov 全域化 (PR3)、cargo Tests matrix 退役 + required checks
+  差し替え (PR4)、dormant な DB テスト 6 binary の扱い
 
 ### cache-warm build-only 化の実測 (PR #519、2026-07-05)
 

--- a/scripts/check_bazel_test_matrix.sh
+++ b/scripts/check_bazel_test_matrix.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-# ci.yml の bazel test matrix (bazel-test-poc / cache-warm-bazel-test-poc) が
-# BUILD ファイルの rust_test target を網羅しているか + 両 job の matrix が
-# 一致しているかを検証する (Refs #515)。
+# ci.yml の bazel test matrix (bazel-test-poc / bazel-test-db とその warm) が
+# BUILD ファイルの rust_test target を網羅しているか + 各 job pair (poc↔warm)
+# の matrix が一致しているかを検証する (Refs #515)。
 #
 # crate を追加して rust_test を定義したのに matrix へ足し忘れると、その crate の
 # テストが bazel 側で「無言で対象外」になる。逆に BUILD から消した target が
@@ -26,8 +26,33 @@ def matrix_targets(job_name):
         sys.exit(1)
     return {e["target"]: e for e in job["strategy"]["matrix"]["include"]}
 
-poc = matrix_targets("bazel-test-poc")
-warm = matrix_targets("cache-warm-bazel-test-poc")
+# (実行 job, 対応する warm job) の pair。db 系は postgres service 付きの別 job。
+PAIRS = [
+    ("bazel-test-poc", "cache-warm-bazel-test-poc"),
+    ("bazel-test-db", "cache-warm-bazel-test-db"),
+]
+
+fail = 0
+listed = {}
+for run_job, warm_job in PAIRS:
+    run_m = matrix_targets(run_job)
+    warm_m = matrix_targets(warm_job)
+    if run_m.keys() != warm_m.keys():
+        for t in sorted(set(run_m) ^ set(warm_m)):
+            print(f"::error::{run_job}/{warm_job} の matrix target 不一致: {t}")
+            fail += 1
+    else:
+        for t, e in run_m.items():
+            w = warm_m[t]
+            for k in ("name", "pdfium"):
+                if e.get(k) != w.get(k):
+                    print(f"::error::{t} の matrix field '{k}' が {run_job}/{warm_job} で不一致 ({e.get(k)} != {w.get(k)})")
+                    fail += 1
+    for t in run_m:
+        if t in listed:
+            print(f"::error::{t} が複数 job の matrix に重複しています ({listed[t]} と {run_job})")
+            fail += 1
+        listed[t] = run_job
 
 # --- BUILD ファイルから rust_test target を列挙 ---
 expected = set()
@@ -37,34 +62,19 @@ for f in glob.glob("crates/*/BUILD.bazel") + ["BUILD.bazel"]:
         pkg = "" if f == "BUILD.bazel" else f[: -len("/BUILD.bazel")]
         expected.add(f"//{pkg}:{m.group(1)}")
 
-fail = 0
-
-missing = expected - set(poc)
+missing = expected - set(listed)
 for t in sorted(missing):
-    print(f"::error::rust_test target {t} が ci.yml の bazel-test-poc matrix にありません (追加漏れ = 無言で対象外)")
+    print(f"::error::rust_test target {t} が ci.yml のどの bazel test matrix にもありません (追加漏れ = 無言で対象外)")
     fail += 1
 
-stale = set(poc) - expected
+stale = set(listed) - expected
 for t in sorted(stale):
-    print(f"::error::bazel-test-poc matrix の {t} に対応する rust_test が BUILD にありません (削除漏れ)")
+    print(f"::error::matrix の {t} に対応する rust_test が BUILD にありません (削除漏れ)")
     fail += 1
-
-# --- warm と poc の matrix 一致 (target / name / pdfium) ---
-if poc.keys() != warm.keys():
-    for t in sorted(set(poc) ^ set(warm)):
-        print(f"::error::warm/poc の matrix target 不一致: {t}")
-        fail += 1
-else:
-    for t, e in poc.items():
-        w = warm[t]
-        for k in ("name", "pdfium"):
-            if e.get(k) != w.get(k):
-                print(f"::error::{t} の matrix field '{k}' が warm/poc で不一致 ({e.get(k)} != {w.get(k)})")
-                fail += 1
 
 if fail:
     print(f"::error::bazel test matrix check: {fail} 件の不整合")
     sys.exit(1)
 
-print(f"bazel test matrix OK — {len(expected)} rust_test target を網羅、warm/poc 一致")
+print(f"bazel test matrix OK — {len(expected)} rust_test target を網羅、各 job pair の warm 一致")
 PYEOF


### PR DESCRIPTION
## Summary

Refs #515 (bazel gate 移行 PR2/4)

CI が実際に走らせている DB integration テスト (`trouble_test` / `archive_repo_test`) を rust_test 化し、**postgres service + `TEST_DATABASE_URL` + `init_local_db.sql`** を持つ専用 job (`bazel-test-db` とその warm) で回す。shard は **23 → 25**。

## 変更内容

- **BUILD.bazel**: `trouble_test` / `archive_repo_test` の rust_test (srcs = 本体 + `tests/common/**`、`compile_data = migrations/**`)。`sqlx::migrate!` は compile 時に埋め込むため runtime の migrations 同梱は不要
- **ci.yml**: `bazel-test-db` + `cache-warm-bazel-test-db` job を新設 (postgres service container、`--test_env=TEST_DATABASE_URL` で sandbox に伝播。processwrapper sandbox はネットワーク非遮断なので localhost:5432 に届く)
- **check_bazel_test_matrix.sh**: job pair (poc/db × run/warm) の **union 検証**に拡張 — target の重複配置、pair 間の name/pdfium 不一致も loud fail

## 発見 (別途判断が必要)

`tests/` の他 6 binary (`devices_test` / `employees_test` / `measurements_test` / `devices_re_pair_test` / `trouble_task_statuses_test` / `trouble_tasks_cross_ticket_test`) は **cargo CI の `--test` 列挙にも入っておらず PR CI で走っていない** (dormant)。bazel 化の対象からも外した。復活させるか退役させるかは別 issue で判断 (doc に記録済み)。

## 検証

本 PR の `Bazel test (db-trouble)` / `(db-archive)` が green になれば、**bazel gate 移行の技術的な壁は coverage (PR3) を残すのみ**。DB 状態依存の test result cache は、テスト自体が冪等設計 (tenant 分離 + 専用ロック) なので hit を許容する。

---
_Generated by [Claude Code](https://claude.ai/code/session_01CEUnL9oDYaRZYh6gG5z9bX)_