### PR TITLE
ci(bazel): coverage 移行 PR3a pilot — mock-trouble 1 shard で計装コスト実測 (Refs #515)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,15 @@ jobs:
       - name: Warm test result cache (Bazel)
         run: bazel test ${{ matrix.target }} --test_output=errors --test_summary=short
 
+      # PR3a pilot (Refs #515): coverage の計装ビルドも warm して PR 側を cache hit に
+      # する戦略の実測。mock-trouble 1 shard のみ。flags は poc 側と完全一致必須。
+      - name: Warm coverage build (Bazel, PR3a pilot)
+        if: matrix.name == 'mock-trouble'
+        run: |
+          bazel coverage ${{ matrix.target }} \
+            --combined_report=lcov \
+            --instrumentation_filter=//crates/alc-trouble
+
   # DB integration テスト用 warm (Refs #515 PR2)。postgres service + TEST_DATABASE_URL
   # を持つ点以外は cache-warm-bazel-test-poc と同じ。matrix / flags は bazel-test-db と
   # 1:1 同期 (check_bazel_test_matrix.sh が poc/db の union で検証)。
@@ -732,6 +741,19 @@ jobs:
       - name: matrix 網羅性チェック (rust_test target の追加漏れ検出)
         if: matrix.name == 'csv-parser'
         run: bash scripts/check_bazel_test_matrix.sh
+
+      # PR3a pilot (Refs #515): mock target 経由の route ファイル coverage を lcov で
+      # 取れるか + 計装ビルドのコスト実測。gate は warn モード (fail させない)。
+      - name: bazel coverage (PR3a pilot, warn モード)
+        if: matrix.name == 'mock-trouble'
+        run: |
+          bazel coverage ${{ matrix.target }} \
+            --combined_report=lcov \
+            --instrumentation_filter=//crates/alc-trouble
+          LCOV="$(bazel info output_path)/_coverage/_coverage_report.dat"
+          cp "$LCOV" /tmp/lcov.dat
+          bash scripts/check_coverage_100_lcov.sh /tmp/lcov.dat crates/alc-trouble \
+            || echo "::warning::PR3a pilot: lcov gate (crates/alc-trouble) に差分あり — 里帰りテスト対象として #515 に記録
 
       - name: bazel coverage (lcov 出力)
         if: matrix.name == 'csv-parser'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -753,7 +753,7 @@ jobs:
           LCOV="$(bazel info output_path)/_coverage/_coverage_report.dat"
           cp "$LCOV" /tmp/lcov.dat
           bash scripts/check_coverage_100_lcov.sh /tmp/lcov.dat crates/alc-trouble \
-            || echo "::warning::PR3a pilot: lcov gate (crates/alc-trouble) に差分あり — 里帰りテスト対象として #515 に記録
+            || echo "::warning::PR3a pilot: lcov gate (crates/alc-trouble) に差分あり — 里帰りテスト対象として #515 に記録"
 
       - name: bazel coverage (lcov 出力)
         if: matrix.name == 'csv-parser'


### PR DESCRIPTION
## Summary

Refs #515 (coverage gate 移行の pilot)

coverage gate をどうするかの分岐点にいる:

- **案 A**: lcov gate を全域化して cargo Tests matrix を完全退役 (PR3 → PR4)
- **案 B**: bazel coverage の計装ビルドが高くつくなら、cargo を coverage 専用に残して PR4 を縮小

判断材料として **mock-trouble 1 shard だけ**で実測する (gate は warn モード = 何も壊さない):

## 変更内容 (ci.yml のみ)

- **poc (mock-trouble)**: `bazel coverage //:mock_trouble --instrumentation_filter=//crates/alc-trouble` + lcov gate (`crates/alc-trouble` prefix、warn)。**mock target 経由で route ファイル (files.rs / workflow.rs、coverage_100.toml 登録) の coverage が取れるか**も同時に検証
- **warm (mock-trouble)**: 同一 invocation の coverage を焼く — PR 側の計装ビルドを cache hit にする戦略のコスト計測

## 測るもの

1. 計装ビルドの追加コスト (shard 時間の増分、warm hit 前後)
2. mock 経由の per-target lcov が cargo combined と一致するか (里帰りテストの規模感)
3. warm への coverage 追加コスト (main push 側)

数字が出たら案 A/B を確定して #515 に記録する。

---
_Generated by [Claude Code](https://claude.ai/code/session_01CEUnL9oDYaRZYh6gG5z9bX)_