### PR TITLE
fix(scripts): lcov gate の toml パースを tomllib 化 — comment-out 行の誤検出を修正 (Refs #515)

### DIFF
--- a/scripts/check_coverage_100_lcov.sh
+++ b/scripts/check_coverage_100_lcov.sh
@@ -20,12 +20,12 @@ import sys
 
 lcov_file, prefix = sys.argv[1], sys.argv[2]
 
-# --- coverage_100.toml から対象ファイルを取る ---
-registered = []
-with open("coverage_100.toml", encoding="utf-8") as fh:
-    for m in re.finditer(r'path\s*=\s*"([^"]+)"', fh.read()):
-        if m.group(1).startswith(prefix):
-            registered.append(m.group(1))
+# --- coverage_100.toml から対象ファイルを取る (tomllib: comment-out 行を拾わない) ---
+import tomllib
+
+with open("coverage_100.toml", "rb") as fh:
+    toml = tomllib.load(fh)
+registered = [f["path"] for f in toml.get("files", []) if f["path"].startswith(prefix)]
 
 if not registered:
     print(f"::error::coverage_100.toml に prefix '{prefix}' の登録ファイルがありません")


### PR DESCRIPTION
## Summary

Refs #515

PR3a pilot (#531) の warn 出力で発覚したスクリプトバグの修正。`check_coverage_100_lcov.sh` の登録ファイル抽出が正規表現ベースだったため、coverage_100.toml の **comment-out 行** (`# path = "crates/alc-trouble/src/tickets.rs"` 等) まで拾って偽 FAIL を出していた。tomllib で正規にパースする。

修正後の対象抽出 (ローカル検証済み):
```
crates/alc-trouble: files.rs, workflow.rs, repo/trouble_tickets.rs, repo/trouble_files.rs, repo/trouble_workflow.rs
```
(tickets.rs / comments.rs の comment-out 行は含まれない)

## pilot 判定への影響

これで pilot の残る FAIL は `repo/trouble_*.rs` 3 件のみになる — これは**バグではなく測定スコープの正しい指摘** (Pg 実装は db-trouble shard の trouble_test が実行するため、mock shard 単独の lcov では 0%)。PR3 本番は shard 別 lcov を artifact merge してから gate する設計が必要、という結論の裏付け (詳細は #515 に記録)。

---
_Generated by [Claude Code](https://claude.ai/code/session_01CEUnL9oDYaRZYh6gG5z9bX)_