### PR TITLE
ci(bazel): 集約 coverage gate を全域 warn モードで導入 — gate 移行 PR3b (Refs #515)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,28 +127,28 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: monolith, target: "//:unit_tests" }
-          - { name: mock-carins, target: "//:mock_carins" }
-          - { name: mock-devices, target: "//:mock_devices" }
-          - { name: mock-dtako, target: "//:mock_dtako" }
-          - { name: mock-misc, target: "//:mock_misc" }
-          - { name: mock-tenko, target: "//:mock_tenko" }
-          - { name: mock-trouble, target: "//:mock_trouble" }
+          - { name: monolith, target: "//:unit_tests", coverage: "^//$" }
+          - { name: mock-carins, target: "//:mock_carins", coverage: "//crates/alc-carins" }
+          - { name: mock-devices, target: "//:mock_devices", coverage: "//crates/alc-devices,//crates/alc-core" }
+          - { name: mock-dtako, target: "//:mock_dtako", coverage: "//crates/alc-dtako" }
+          - { name: mock-misc, target: "//:mock_misc", coverage: "//crates/alc-misc,//crates/alc-core,^//$" }
+          - { name: mock-tenko, target: "//:mock_tenko", coverage: "//crates/alc-tenko" }
+          - { name: mock-trouble, target: "//:mock_trouble", coverage: "//crates/alc-trouble" }
           - { name: auth, target: "//crates/alc-auth:alc-auth_test" }
-          - { name: auth-jwt, target: "//crates/alc-auth-jwt:alc-auth-jwt_test" }
+          - { name: auth-jwt, target: "//crates/alc-auth-jwt:alc-auth-jwt_test", coverage: "//crates/alc-auth-jwt" }
           - { name: camera, target: "//crates/alc-camera:alc-camera_test" }
-          - { name: carins, target: "//crates/alc-carins:alc-carins_test" }
-          - { name: compare, target: "//crates/alc-compare:alc-compare_test" }
-          - { name: core, target: "//crates/alc-core:alc-core_test" }
-          - { name: csv-parser, target: "//crates/alc-csv-parser:alc-csv-parser_test" }
-          - { name: devices, target: "//crates/alc-devices:alc-devices_test" }
-          - { name: dtako, target: "//crates/alc-dtako:alc-dtako_test" }
-          - { name: misc, target: "//crates/alc-misc:alc-misc_test" }
-          - { name: notify, target: "//crates/alc-notify:alc-notify_test", pdfium: true }
-          - { name: pdf, target: "//crates/alc-pdf:alc-pdf_test" }
+          - { name: carins, target: "//crates/alc-carins:alc-carins_test", coverage: "//crates/alc-carins" }
+          - { name: compare, target: "//crates/alc-compare:alc-compare_test", coverage: "//crates/alc-compare" }
+          - { name: core, target: "//crates/alc-core:alc-core_test", coverage: "//crates/alc-core" }
+          - { name: csv-parser, target: "//crates/alc-csv-parser:alc-csv-parser_test", coverage: "//crates/alc-csv-parser" }
+          - { name: devices, target: "//crates/alc-devices:alc-devices_test", coverage: "//crates/alc-devices" }
+          - { name: dtako, target: "//crates/alc-dtako:alc-dtako_test", coverage: "//crates/alc-dtako" }
+          - { name: misc, target: "//crates/alc-misc:alc-misc_test", coverage: "//crates/alc-misc" }
+          - { name: notify, target: "//crates/alc-notify:alc-notify_test", pdfium: true, coverage: "//crates/alc-notify" }
+          - { name: pdf, target: "//crates/alc-pdf:alc-pdf_test", coverage: "//crates/alc-pdf" }
           - { name: storage, target: "//crates/alc-storage:alc-storage_test" }
-          - { name: tenko, target: "//crates/alc-tenko:alc-tenko_test" }
-          - { name: trouble, target: "//crates/alc-trouble:alc-trouble_test" }
+          - { name: tenko, target: "//crates/alc-tenko:alc-tenko_test", coverage: "//crates/alc-tenko" }
+          - { name: trouble, target: "//crates/alc-trouble:alc-trouble_test", coverage: "//crates/alc-trouble" }
           - { name: gateway, target: "//crates/gateway:gateway_test" }
     steps:
       - uses: actions/checkout@v4
@@ -171,14 +171,14 @@ jobs:
       - name: Warm test result cache (Bazel)
         run: bazel test ${{ matrix.target }} --test_output=errors --test_summary=short
 
-      # PR3a pilot (Refs #515): coverage の計装ビルドも warm して PR 側を cache hit に
-      # する戦略の実測。mock-trouble 1 shard のみ。flags は poc 側と完全一致必須。
-      - name: Warm coverage build (Bazel, PR3a pilot)
-        if: matrix.name == 'mock-trouble'
+      # PR3b (Refs #515): coverage の計装ビルド + テスト実行も warm し、PR 側を
+      # cache hit にする。flags は poc 側と完全一致必須。
+      - name: Warm coverage build (Bazel)
+        if: matrix.coverage
         run: |
           bazel coverage ${{ matrix.target }} \
             --combined_report=lcov \
-            --instrumentation_filter=//crates/alc-trouble
+            --instrumentation_filter="${{ matrix.coverage }}"
 
   # DB integration テスト用 warm (Refs #515 PR2)。postgres service + TEST_DATABASE_URL
   # を持つ点以外は cache-warm-bazel-test-poc と同じ。matrix / flags は bazel-test-db と
@@ -191,8 +191,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: db-trouble, target: "//:trouble_test" }
-          - { name: db-archive, target: "//:archive_repo_test" }
+          - { name: db-trouble, target: "//:trouble_test", coverage: "//crates/alc-trouble" }
+          - { name: db-archive, target: "//:archive_repo_test", coverage: "^//$" }
     services:
       postgres:
         image: postgres:16
@@ -220,6 +220,14 @@ jobs:
         run: psql "postgresql://postgres:test@localhost:5432/postgres" -f scripts/init_local_db.sql
       - name: Warm test result cache (Bazel)
         run: bazel test ${{ matrix.target }} --test_env=TEST_DATABASE_URL --test_output=errors --test_summary=short
+      # PR3b (Refs #515): coverage も warm (flags は bazel-test-db と一致必須)
+      - name: Warm coverage build (Bazel)
+        if: matrix.coverage
+        run: |
+          bazel coverage ${{ matrix.target }} \
+            --test_env=TEST_DATABASE_URL \
+            --combined_report=lcov \
+            --instrumentation_filter="${{ matrix.coverage }}"
 
   cache-cleanup:
     name: Cache Cleanup
@@ -687,28 +695,28 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: monolith, target: "//:unit_tests" }
-          - { name: mock-carins, target: "//:mock_carins" }
-          - { name: mock-devices, target: "//:mock_devices" }
-          - { name: mock-dtako, target: "//:mock_dtako" }
-          - { name: mock-misc, target: "//:mock_misc" }
-          - { name: mock-tenko, target: "//:mock_tenko" }
-          - { name: mock-trouble, target: "//:mock_trouble" }
+          - { name: monolith, target: "//:unit_tests", coverage: "^//$" }
+          - { name: mock-carins, target: "//:mock_carins", coverage: "//crates/alc-carins" }
+          - { name: mock-devices, target: "//:mock_devices", coverage: "//crates/alc-devices,//crates/alc-core" }
+          - { name: mock-dtako, target: "//:mock_dtako", coverage: "//crates/alc-dtako" }
+          - { name: mock-misc, target: "//:mock_misc", coverage: "//crates/alc-misc,//crates/alc-core,^//$" }
+          - { name: mock-tenko, target: "//:mock_tenko", coverage: "//crates/alc-tenko" }
+          - { name: mock-trouble, target: "//:mock_trouble", coverage: "//crates/alc-trouble" }
           - { name: auth, target: "//crates/alc-auth:alc-auth_test" }
-          - { name: auth-jwt, target: "//crates/alc-auth-jwt:alc-auth-jwt_test" }
+          - { name: auth-jwt, target: "//crates/alc-auth-jwt:alc-auth-jwt_test", coverage: "//crates/alc-auth-jwt" }
           - { name: camera, target: "//crates/alc-camera:alc-camera_test" }
-          - { name: carins, target: "//crates/alc-carins:alc-carins_test" }
-          - { name: compare, target: "//crates/alc-compare:alc-compare_test" }
-          - { name: core, target: "//crates/alc-core:alc-core_test" }
-          - { name: csv-parser, target: "//crates/alc-csv-parser:alc-csv-parser_test" }
-          - { name: devices, target: "//crates/alc-devices:alc-devices_test" }
-          - { name: dtako, target: "//crates/alc-dtako:alc-dtako_test" }
-          - { name: misc, target: "//crates/alc-misc:alc-misc_test" }
-          - { name: notify, target: "//crates/alc-notify:alc-notify_test", pdfium: true }
-          - { name: pdf, target: "//crates/alc-pdf:alc-pdf_test" }
+          - { name: carins, target: "//crates/alc-carins:alc-carins_test", coverage: "//crates/alc-carins" }
+          - { name: compare, target: "//crates/alc-compare:alc-compare_test", coverage: "//crates/alc-compare" }
+          - { name: core, target: "//crates/alc-core:alc-core_test", coverage: "//crates/alc-core" }
+          - { name: csv-parser, target: "//crates/alc-csv-parser:alc-csv-parser_test", coverage: "//crates/alc-csv-parser" }
+          - { name: devices, target: "//crates/alc-devices:alc-devices_test", coverage: "//crates/alc-devices" }
+          - { name: dtako, target: "//crates/alc-dtako:alc-dtako_test", coverage: "//crates/alc-dtako" }
+          - { name: misc, target: "//crates/alc-misc:alc-misc_test", coverage: "//crates/alc-misc" }
+          - { name: notify, target: "//crates/alc-notify:alc-notify_test", pdfium: true, coverage: "//crates/alc-notify" }
+          - { name: pdf, target: "//crates/alc-pdf:alc-pdf_test", coverage: "//crates/alc-pdf" }
           - { name: storage, target: "//crates/alc-storage:alc-storage_test" }
-          - { name: tenko, target: "//crates/alc-tenko:alc-tenko_test" }
-          - { name: trouble, target: "//crates/alc-trouble:alc-trouble_test" }
+          - { name: tenko, target: "//crates/alc-tenko:alc-tenko_test", coverage: "//crates/alc-tenko" }
+          - { name: trouble, target: "//crates/alc-trouble:alc-trouble_test", coverage: "//crates/alc-trouble" }
           - { name: gateway, target: "//crates/gateway:gateway_test" }
     steps:
       - uses: actions/checkout@v4
@@ -742,30 +750,28 @@ jobs:
         if: matrix.name == 'csv-parser'
         run: bash scripts/check_bazel_test_matrix.sh
 
-      # PR3a pilot (Refs #515): mock target 経由の route ファイル coverage を lcov で
-      # 取れるか + 計装ビルドのコスト実測。gate は warn モード (fail させない)。
-      - name: bazel coverage (PR3a pilot, warn モード)
-        if: matrix.name == 'mock-trouble'
+      # PR3b (Refs #515): coverage field を持つ shard は lcov を生成して artifact 化。
+      # bazel-coverage-gate job が全 shard 分を merge して coverage_100.toml 全域を
+      # warn モードで突合する (mock は route / db は Pg repo / unit は crate と、
+      # file ごとに寄与 shard が異なるため merge が必須)。flags は warm 側と一致必須。
+      - name: bazel coverage (lcov 出力)
+        if: matrix.coverage
         run: |
           bazel coverage ${{ matrix.target }} \
             --combined_report=lcov \
-            --instrumentation_filter=//crates/alc-trouble
+            --instrumentation_filter="${{ matrix.coverage }}"
           LCOV="$(bazel info output_path)/_coverage/_coverage_report.dat"
           cp "$LCOV" /tmp/lcov.dat
-          bash scripts/check_coverage_100_lcov.sh /tmp/lcov.dat crates/alc-trouble \
-            || echo "::warning::PR3a pilot: lcov gate (crates/alc-trouble) に差分あり — 里帰りテスト対象として #515 に記録"
 
-      - name: bazel coverage (lcov 出力)
-        if: matrix.name == 'csv-parser'
-        run: |
-          bazel coverage //crates/alc-csv-parser:alc-csv-parser_test \
-            --combined_report=lcov \
-            --instrumentation_filter=//crates/alc-csv-parser
-          LCOV="$(bazel info output_path)/_coverage/_coverage_report.dat"
-          cp "$LCOV" /tmp/lcov.dat
-          echo "=== lcov head ==="
-          head -30 /tmp/lcov.dat
+      - name: upload lcov artifact
+        if: matrix.coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: lcov-${{ matrix.name }}
+          path: /tmp/lcov.dat
+          retention-days: 3
 
+      # csv-parser は PoC で意味論一致を実証済みのため strict gate を維持 (fail する)
       - name: coverage 100% gate の lcov 再現 (coverage_100.toml 突合)
         if: matrix.name == 'csv-parser'
         run: bash scripts/check_coverage_100_lcov.sh /tmp/lcov.dat crates/alc-csv-parser
@@ -784,8 +790,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: db-trouble, target: "//:trouble_test" }
-          - { name: db-archive, target: "//:archive_repo_test" }
+          - { name: db-trouble, target: "//:trouble_test", coverage: "//crates/alc-trouble" }
+          - { name: db-archive, target: "//:archive_repo_test", coverage: "^//$" }
     services:
       postgres:
         image: postgres:16
@@ -818,6 +824,49 @@ jobs:
           if grep -q "(cached)" /tmp/test_run.txt; then
             echo "::notice::${{ matrix.target }} は (cached) — main warm から restore"
           fi
+
+      # PR3b (Refs #515): DB shard の lcov (Pg repo 実装の寄与分)。flags は warm と一致必須。
+      - name: bazel coverage (lcov 出力)
+        if: matrix.coverage
+        run: |
+          bazel coverage ${{ matrix.target }} \
+            --test_env=TEST_DATABASE_URL \
+            --combined_report=lcov \
+            --instrumentation_filter="${{ matrix.coverage }}"
+          LCOV="$(bazel info output_path)/_coverage/_coverage_report.dat"
+          cp "$LCOV" /tmp/lcov.dat
+
+      - name: upload lcov artifact
+        if: matrix.coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: lcov-${{ matrix.name }}
+          path: /tmp/lcov.dat
+          retention-days: 3
+
+  # PR3b (Refs #515): 全 shard の lcov を merge して coverage_100.toml 全域を検証する
+  # 集約 gate。寄与 shard が file ごとに異なる (mock=route / db=Pg repo / unit=crate)
+  # ため per-shard では判定できない。fail 化は差分ゼロを確認してから (現状 warn)。
+  bazel-coverage-gate:
+    name: "Bazel coverage gate (warn)"
+    needs: [bazel-test-poc, bazel-test-db]
+    if: "always() && github.event_name == 'pull_request'"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: lcov-*
+          path: /tmp/lcov
+      - name: merge lcov + coverage_100.toml 全域突合 (warn モード)
+        run: |
+          shopt -s globstar nullglob
+          files=(/tmp/lcov/**/*.dat /tmp/lcov/**/lcov.dat)
+          echo "merged inputs: ${#files[@]}"
+          [ "${#files[@]}" -gt 0 ] || { echo "::warning::lcov artifact が 0 件 (shard 失敗?)"; exit 0; }
+          cat "${files[@]}" > /tmp/merged.dat
+          bash scripts/check_coverage_100_lcov.sh /tmp/merged.dat \
+            || echo "::warning::PR3b: 全域 lcov gate に差分あり — fail 化前に #515 で解消する"
 
   # staging の postgres sidecar image。旧 deploy.yml の staging-db job からの
   # 移設 (Refs #482)。build-image と並列に走らせることで、deploy workflow 側の

--- a/docs/ci-speed-tracking.md
+++ b/docs/ci-speed-tracking.md
@@ -175,8 +175,17 @@ Build backend (Bazel) job 139s の内訳: setup ~8s / **analysis 60s**
   発見: tests/ の他 6 binary (devices_test / employees_test / measurements_test /
   devices_re_pair_test / trouble_task_statuses_test / trouble_tasks_cross_ticket_test)
   は **cargo CI でも走っていない** (test-matrix の `--test` 列挙に無い) — 要別途判断
-- 残: coverage gate の lcov 全域化 (PR3)、cargo Tests matrix 退役 + required checks
-  差し替え (PR4)、dormant な DB テスト 6 binary の扱い
+- **PR3a pilot (mock-trouble)**: mock target 経由の route ファイル lcov は per-target
+  でも 100% (files.rs 160/160 / workflow.rs 126/126、里帰り不要)。計装ビルド初回 +2 分弱、
+  warm/PR-scope cache で以降 hit。Pg repo 実装 (repo/trouble_*.rs) は db shard の寄与が
+  無いと 0% = **per-file gate は shard 別 lcov の merge が必須**と確定。スクリプトの
+  comment-out 誤検出は tomllib 化で修正 (#532)
+- **PR3b**: coverage field を matrix に追加 (21 shard が対象、無登録 crate の 4 shard は
+  対象外)。各 shard が lcov を artifact 化し `bazel-coverage-gate` job が merge して
+  coverage_100.toml **全域**を warn モードで突合。warm も coverage を焼く (PR 側 cache hit)。
+  差分ゼロを確認したら fail 化
+- 残: PR3b の warn → fail 化、cargo Tests matrix 退役 + required checks 差し替え (PR4)、
+  dormant な DB テスト 6 binary の扱い (#530)
 
 ### cache-warm build-only 化の実測 (PR #519、2026-07-05)
 

--- a/scripts/check_bazel_test_matrix.sh
+++ b/scripts/check_bazel_test_matrix.sh
@@ -44,7 +44,7 @@ for run_job, warm_job in PAIRS:
     else:
         for t, e in run_m.items():
             w = warm_m[t]
-            for k in ("name", "pdfium"):
+            for k in ("name", "pdfium", "coverage"):
                 if e.get(k) != w.get(k):
                     print(f"::error::{t} の matrix field '{k}' が {run_job}/{warm_job} で不一致 ({e.get(k)} != {w.get(k)})")
                     fail += 1

--- a/scripts/check_coverage_100_lcov.sh
+++ b/scripts/check_coverage_100_lcov.sh
@@ -6,13 +6,14 @@
 # lcov の DA (line, hit-count) レコードから「登録ファイルの全計装行が hit>0」を検証し、
 # llvm-cov --text ベースの gate と同じ判定が出るかを確かめる。
 #
-# 使い方: check_coverage_100_lcov.sh <lcov.dat> <path-prefix>
-#   <path-prefix> に一致する coverage_100.toml 登録ファイルだけを対象にする
-#   (PoC は crates/alc-csv-parser 限定。全体適用は gate 移行の判断後)。
+# 使い方: check_coverage_100_lcov.sh <lcov.dat> [path-prefix]
+#   <path-prefix> に一致する coverage_100.toml 登録ファイルだけを対象にする。
+#   省略時は全域 (PR3b の集約 gate が merge 済み lcov に対して使う)。
 set -euo pipefail
 
-LCOV_FILE="${1:?usage: $0 <lcov.dat> <path-prefix>}"
-PREFIX="${2:?usage: $0 <lcov.dat> <path-prefix>}"
+LCOV_FILE="${1:?usage: $0 <lcov.dat> [path-prefix]}"
+# prefix 省略時は coverage_100.toml 全域を対象にする (PR3b 集約 gate 用)
+PREFIX="${2-}"
 
 python3 - "$LCOV_FILE" "$PREFIX" <<'PYEOF'
 import re
@@ -28,7 +29,7 @@ with open("coverage_100.toml", "rb") as fh:
 registered = [f["path"] for f in toml.get("files", []) if f["path"].startswith(prefix)]
 
 if not registered:
-    print(f"::error::coverage_100.toml に prefix '{prefix}' の登録ファイルがありません")
+    print(f"::error::coverage_100.toml に prefix '{prefix or '(全域)'}' の登録ファイルがありません")
     sys.exit(1)
 
 # --- lcov をパース: SF -> {line: max(hit)} (複数レコードはマージ) ---
@@ -54,7 +55,7 @@ def find_record(path):
     return None, None
 
 fail = 0
-print(f"=== lcov 100% gate ({prefix}) ===")
+print(f"=== lcov 100% gate ({prefix or 'coverage_100.toml 全域'}) ===")
 for path in registered:
     sf, das = find_record(path)
     if das is None:


### PR DESCRIPTION
## Summary

Refs #515 (bazel gate 移行 PR3b)

coverage_100.toml の per-file 100% gate は **file ごとに寄与 shard が異なる** (mock=route / db=Pg repo / unit=crate、PR3a pilot で確定) ため、shard 別 lcov を merge してから全域で突合する集約 gate を **warn モード**で導入する。

## 変更内容

- **matrix に `coverage` field (instrumentation_filter) を追加** — 登録 file を持つ 21 shard が対象 (auth / camera / storage / gateway の 4 shard は登録なしのため対象外)。src/ (monolith) は `^//$`、alc-core は広く実行される mock-misc / mock-devices に相乗り
- **generic coverage step**: `bazel coverage <target> --instrumentation_filter=<field>` → `lcov-<shard>` artifact (retention 3 日)。pilot の mock-trouble 個別 step と csv-parser 個別 coverage step を置換
- **`bazel-coverage-gate` job (新設)**: 全 artifact を download → concat (`check_coverage_100_lcov.sh` は複数 SF レコードを line 単位 max で merge 済み) → **coverage_100.toml 全域 (63 file)** を warn モードで突合
- **warm (poc/db 両方) も coverage を焼く** — PR 側の計装ビルド + coverage テスト再実行を cache hit にする (pilot で実証済みの戦略)
- `check_coverage_100_lcov.sh`: prefix optional 化 (省略 = 全域)
- `check_bazel_test_matrix.sh`: `coverage` field も warm/poc pair 一致検証に追加
- csv-parser の strict gate (PoC で意味論一致を実証済み) は維持

## 検証 / 次

- 本 PR の `Bazel coverage gate (warn)` の出力が **cargo llvm-cov gate との全域差分一覧**になる。差分 (里帰りテスト or filter 調整が必要な file) を解消したら fail 化 → PR4 (cargo Tests matrix 退役)
- 初回は計装ビルドが全 shard で走るため遅い (merge 後の warm で解消)。`^//$` (root package filter) の効き方は warn 出力の SF パスで確認し、ズレていれば調整

---
_Generated by [Claude Code](https://claude.ai/code/session_01CEUnL9oDYaRZYh6gG5z9bX)_