### PR TITLE
ci(bazel): instrumentation_filter を修正 — root package は ^//: + shard filter に exercise 先 crate を追加 (Refs #515)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,13 +127,17 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: monolith, target: "//:unit_tests", coverage: "^//$" }
-          - { name: mock-carins, target: "//:mock_carins", coverage: "//crates/alc-carins" }
+          # instrumentation_filter は label 文字列 (例 //:unit_tests) への regex match。
+          # root package は "^//:" (旧 "^//$" はどの label にも一致せず空 lcov になった)。
+          # 各 shard の filter には「そのテストが exercise する他 crate」も含める
+          # (coverage_100.toml の mock/combined type は shard 横断の union で 100% になる)。
+          - { name: monolith, target: "//:unit_tests", coverage: "^//:" }
+          - { name: mock-carins, target: "//:mock_carins", coverage: "//crates/alc-carins,//crates/alc-core" }
           - { name: mock-devices, target: "//:mock_devices", coverage: "//crates/alc-devices,//crates/alc-core" }
-          - { name: mock-dtako, target: "//:mock_dtako", coverage: "//crates/alc-dtako" }
-          - { name: mock-misc, target: "//:mock_misc", coverage: "//crates/alc-misc,//crates/alc-core,^//$" }
-          - { name: mock-tenko, target: "//:mock_tenko", coverage: "//crates/alc-tenko" }
-          - { name: mock-trouble, target: "//:mock_trouble", coverage: "//crates/alc-trouble" }
+          - { name: mock-dtako, target: "//:mock_dtako", coverage: "//crates/alc-dtako,//crates/alc-compare,//crates/alc-pdf,//crates/alc-core" }
+          - { name: mock-misc, target: "//:mock_misc", coverage: "//crates/alc-misc,//crates/alc-core,//crates/alc-tenko,^//:" }
+          - { name: mock-tenko, target: "//:mock_tenko", coverage: "//crates/alc-tenko,//crates/alc-core" }
+          - { name: mock-trouble, target: "//:mock_trouble", coverage: "//crates/alc-trouble,//crates/alc-core" }
           - { name: auth, target: "//crates/alc-auth:alc-auth_test" }
           - { name: auth-jwt, target: "//crates/alc-auth-jwt:alc-auth-jwt_test", coverage: "//crates/alc-auth-jwt" }
           - { name: camera, target: "//crates/alc-camera:alc-camera_test" }
@@ -192,7 +196,7 @@ jobs:
       matrix:
         include:
           - { name: db-trouble, target: "//:trouble_test", coverage: "//crates/alc-trouble" }
-          - { name: db-archive, target: "//:archive_repo_test", coverage: "^//$" }
+          - { name: db-archive, target: "//:archive_repo_test", coverage: "^//:" }
     services:
       postgres:
         image: postgres:16
@@ -695,13 +699,17 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: monolith, target: "//:unit_tests", coverage: "^//$" }
-          - { name: mock-carins, target: "//:mock_carins", coverage: "//crates/alc-carins" }
+          # instrumentation_filter は label 文字列 (例 //:unit_tests) への regex match。
+          # root package は "^//:" (旧 "^//$" はどの label にも一致せず空 lcov になった)。
+          # 各 shard の filter には「そのテストが exercise する他 crate」も含める
+          # (coverage_100.toml の mock/combined type は shard 横断の union で 100% になる)。
+          - { name: monolith, target: "//:unit_tests", coverage: "^//:" }
+          - { name: mock-carins, target: "//:mock_carins", coverage: "//crates/alc-carins,//crates/alc-core" }
           - { name: mock-devices, target: "//:mock_devices", coverage: "//crates/alc-devices,//crates/alc-core" }
-          - { name: mock-dtako, target: "//:mock_dtako", coverage: "//crates/alc-dtako" }
-          - { name: mock-misc, target: "//:mock_misc", coverage: "//crates/alc-misc,//crates/alc-core,^//$" }
-          - { name: mock-tenko, target: "//:mock_tenko", coverage: "//crates/alc-tenko" }
-          - { name: mock-trouble, target: "//:mock_trouble", coverage: "//crates/alc-trouble" }
+          - { name: mock-dtako, target: "//:mock_dtako", coverage: "//crates/alc-dtako,//crates/alc-compare,//crates/alc-pdf,//crates/alc-core" }
+          - { name: mock-misc, target: "//:mock_misc", coverage: "//crates/alc-misc,//crates/alc-core,//crates/alc-tenko,^//:" }
+          - { name: mock-tenko, target: "//:mock_tenko", coverage: "//crates/alc-tenko,//crates/alc-core" }
+          - { name: mock-trouble, target: "//:mock_trouble", coverage: "//crates/alc-trouble,//crates/alc-core" }
           - { name: auth, target: "//crates/alc-auth:alc-auth_test" }
           - { name: auth-jwt, target: "//crates/alc-auth-jwt:alc-auth-jwt_test", coverage: "//crates/alc-auth-jwt" }
           - { name: camera, target: "//crates/alc-camera:alc-camera_test" }
@@ -791,7 +799,7 @@ jobs:
       matrix:
         include:
           - { name: db-trouble, target: "//:trouble_test", coverage: "//crates/alc-trouble" }
-          - { name: db-archive, target: "//:archive_repo_test", coverage: "^//$" }
+          - { name: db-archive, target: "//:archive_repo_test", coverage: "^//:" }
     services:
       postgres:
         image: postgres:16
@@ -861,7 +869,7 @@ jobs:
       - name: merge lcov + coverage_100.toml 全域突合 (warn モード)
         run: |
           shopt -s globstar nullglob
-          files=(/tmp/lcov/**/*.dat /tmp/lcov/**/lcov.dat)
+          files=(/tmp/lcov/**/*.dat)
           echo "merged inputs: ${#files[@]}"
           [ "${#files[@]}" -gt 0 ] || { echo "::warning::lcov artifact が 0 件 (shard 失敗?)"; exit 0; }
           cat "${files[@]}" > /tmp/merged.dat

--- a/docs/ci-speed-tracking.md
+++ b/docs/ci-speed-tracking.md
@@ -184,8 +184,21 @@ Build backend (Bazel) job 139s の内訳: setup ~8s / **analysis 60s**
   対象外)。各 shard が lcov を artifact 化し `bazel-coverage-gate` job が merge して
   coverage_100.toml **全域**を warn モードで突合。warm も coverage を焼く (PR 側 cache hit)。
   差分ゼロを確認したら fail 化
-- 残: PR3b の warn → fail 化、cargo Tests matrix 退役 + required checks 差し替え (PR4)、
-  dormant な DB テスト 6 binary の扱い (#530)
+- **PR3b 初回 warn 結果 (PR #533 run 28747584151)**: 63 file 中 53 OK / 10 差分。
+  **差分は全て instrumentation_filter の配線問題で、テスト不足・意味論不一致はゼロ**
+  (分析全文は #515 コメント)。修正は PR #534:
+  - `^//$` は label 文字列 (`//:unit_tests` 等) への regex match でどれにも一致せず
+    root-package shard (monolith / db-archive) の lcov が空だった → **`^//:` が正**
+  - shard の filter には「そのテストが exercise する**他 crate**」も含める必要がある
+    (driver_info は mock_misc に、compare/pdf は mock_dtako に、alc-core の serde
+    default fn は各 mock shard にテスト実体が居る)。coverage_100.toml の mock/combined
+    type は shard 横断の lcov max-merge union で 100% になる設計
+  - 大物 (devices.rs 1245 行 / dtako_upload.rs 1244 行 / tenko_sessions.rs 851 行) は
+    行数まで cargo llvm-cov gate と一致 — merge 方式の意味論は確定
+  - dormant DB テスト 6 binary (#530) に coverage を依存している file は無し
+    (gate 移行のブロッカーではない)
+- 残: PR #534 で warn 差分ゼロ確認 → fail 化、cargo Tests matrix 退役 + required
+  checks 差し替え (PR4)、dormant な DB テスト 6 binary の扱い (#530)
 
 ### cache-warm build-only 化の実測 (PR #519、2026-07-05)
 


### PR DESCRIPTION
## 概要

PR #533 (PR3b) の全域 warn gate で出た **10 件の差分は全て instrumentation_filter の配線が原因** (テスト不足ではない) だったので修正する。Refs #515

## PR #533 warn 出力の分析

| 差分 | 原因 | 修正 |
|---|---|---|
| `src/*` 6 file「lcov に見つかりません」 | `^//$` は label 文字列 (`//:unit_tests` 等) への regex match のためどの label にも一致せず、monolith / db-archive / mock-misc の lcov が **空 (132 バイト)** だった | `^//:` に修正 |
| `crates/alc-tenko/src/driver_info.rs` 64 行 miss | テスト実体は `tests/mock_tests/mock_driver_info_test.rs` = **mock_misc shard** だが filter に alc-tenko が無い | mock-misc に `//crates/alc-tenko` 追加 |
| `crates/alc-compare/src/lib.rs` 317 miss / `crates/alc-pdf/src/render.rs` 59 miss | 両 crate は `dtako_upload` / `dtako_restraint_report_pdf` 経由で **mock_dtako** から exercise されるが filter が alc-dtako のみ | mock-dtako に `//crates/alc-compare,//crates/alc-pdf,//crates/alc-core` 追加 |
| `crates/alc-core/src/models.rs` 6 行 miss (serde default fn ×2) | alc-core を計装するのが mock-devices / mock-misc だけで、該当 fn を踏む deserialization は他 shard 側 | mock-carins / mock-tenko / mock-trouble にも `//crates/alc-core` 追加 (mock type = mock shard 横断 union) |

あわせて gate job の merge glob 二重カウント (`**/*.dat` と `**/lcov.dat` が同一 file を 2 回拾い 21 artifact → 42 inputs になっていた。max-merge のため結果には無害) も修正。

## 検証

- `scripts/check_bazel_test_matrix.sh` OK (25 rust_test target 網羅、warm/run pair 一致 — coverage field 含む)
- 本 PR の `Bazel coverage gate (warn)` 出力で差分ゼロを確認したら fail 化 → PR4 (cargo Tests matrix 退役) に進む
- 注意: filter 変更で coverage 用 cache key の action graph が変わるため、本 PR の coverage step は初回フルビルドで遅い (merge 後の main warm で解消、#533 と同パターン)


---
_Generated by [Claude Code](https://claude.ai/code/session_01CEUnL9oDYaRZYh6gG5z9bX)_