### PR TITLE
ci(bazel): dtako unit shard の coverage filter に alc-compare を追加 (Refs #515)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,9 @@ jobs:
           - { name: core, target: "//crates/alc-core:alc-core_test", coverage: "//crates/alc-core" }
           - { name: csv-parser, target: "//crates/alc-csv-parser:alc-csv-parser_test", coverage: "//crates/alc-csv-parser" }
           - { name: devices, target: "//crates/alc-devices:alc-devices_test", coverage: "//crates/alc-devices" }
-          - { name: dtako, target: "//crates/alc-dtako:alc-dtako_test", coverage: "//crates/alc-dtako" }
+          # alc-dtako の unit テスト (dtako_upload / dtako_restraint_report) は alc_compare を
+          # 直接呼ぶ — compare/lib.rs の残り ~314 行はこの shard 経由でしか踏まれない
+          - { name: dtako, target: "//crates/alc-dtako:alc-dtako_test", coverage: "//crates/alc-dtako,//crates/alc-compare" }
           - { name: misc, target: "//crates/alc-misc:alc-misc_test", coverage: "//crates/alc-misc" }
           - { name: notify, target: "//crates/alc-notify:alc-notify_test", pdfium: true, coverage: "//crates/alc-notify" }
           - { name: pdf, target: "//crates/alc-pdf:alc-pdf_test", coverage: "//crates/alc-pdf" }
@@ -718,7 +720,9 @@ jobs:
           - { name: core, target: "//crates/alc-core:alc-core_test", coverage: "//crates/alc-core" }
           - { name: csv-parser, target: "//crates/alc-csv-parser:alc-csv-parser_test", coverage: "//crates/alc-csv-parser" }
           - { name: devices, target: "//crates/alc-devices:alc-devices_test", coverage: "//crates/alc-devices" }
-          - { name: dtako, target: "//crates/alc-dtako:alc-dtako_test", coverage: "//crates/alc-dtako" }
+          # alc-dtako の unit テスト (dtako_upload / dtako_restraint_report) は alc_compare を
+          # 直接呼ぶ — compare/lib.rs の残り ~314 行はこの shard 経由でしか踏まれない
+          - { name: dtako, target: "//crates/alc-dtako:alc-dtako_test", coverage: "//crates/alc-dtako,//crates/alc-compare" }
           - { name: misc, target: "//crates/alc-misc:alc-misc_test", coverage: "//crates/alc-misc" }
           - { name: notify, target: "//crates/alc-notify:alc-notify_test", pdfium: true, coverage: "//crates/alc-notify" }
           - { name: pdf, target: "//crates/alc-pdf:alc-pdf_test", coverage: "//crates/alc-pdf" }


### PR DESCRIPTION
## 概要

PR #534 後の全域 warn gate (run 28747942205) は **62/63 OK** まで到達。最後の 1 件を修正する。Refs #515

## 残り 1 件の分析

- `crates/alc-compare/src/lib.rs` — 3908/4222 (314 行 miss)
- alc-compare は tests/ ディレクトリを持たず、crate 単体 shard (compare) は既に走っている
- 消費者を洗うと `alc_compare` を直接呼ぶのは **alc-dtako の unit テスト** (`dtako_upload.rs` / `dtako_restraint_report.rs`) のみ — dtako shard の filter が `//crates/alc-dtako` 単独だったため、この経路の compare 行が計装されていなかった
- mock-dtako 経由 (#534 で追加済み) の回復は +3 行だけで、残りは dtako unit テスト側に居ることが warn 出力で裏付けられた

## 変更

- dtako shard (warm/run 両方) の coverage filter を `//crates/alc-dtako,//crates/alc-compare` に

`scripts/check_bazel_test_matrix.sh` OK。本 PR の `Bazel coverage gate (warn)` で **63/63 OK** になれば fail 化 → PR4 (cargo Tests matrix 退役 + required checks 差し替え) へ進む。


---
_Generated by [Claude Code](https://claude.ai/code/session_01CEUnL9oDYaRZYh6gG5z9bX)_