### PR TITLE
ci(bazel): coverage filter を .bazelrc config 化 + cfg(coverage) 注入 (Refs #515)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -2,3 +2,47 @@
 build --incompatible_strict_action_env
 build --action_env=PATH
 build --jobs=auto
+
+# --- coverage: shard 別 instrumentation_filter (Refs #515) ---
+#
+# filter を ci.yml ではなくここに置く理由: setup-bazel の disk-cache tar key は
+# MODULE/BUILD/.bazelrc の hash のみで ci.yml を含まない。filter を ci.yml に
+# 書くと、filter 変更時に cache key が変わらず main warm が「Disk cache hit,
+# skipping save」で新計装 action を保存できない (GH Actions cache は同一 key へ
+# 上書き不可) = 全 PR が毎回 coverage 再ビルドを払い続ける (2026-07-05 実測)。
+# ここに置けば filter 変更 = key 変更となり warm が新 key で save できる。
+#
+# 規約:
+# - config 名は "cov-<shard名>" (ci.yml の matrix coverage field と 1:1。
+#   check_bazel_test_matrix.sh が対応を検証する)
+# - instrumentation_filter は label 文字列 (例 //:unit_tests) への regex match。
+#   root package は "^//:"。各 shard は「そのテストが exercise する crate」を
+#   全て列挙する (coverage_100.toml の mock/combined type は shard 横断の
+#   lcov max-merge union で 100% になる)
+coverage --combined_report=lcov
+# cargo-llvm-cov は --cfg=coverage を自動注入する。これに合わせないと
+# `#[cfg_attr(not(coverage), ignore)]` の里帰りテスト (alc-compare の 21 本) が
+# bazel coverage では ignore されたまま走らず、対応する deep branch 行が
+# DA=0 になる (2026-07-05 実測: compare/lib.rs 313 行 miss の根本原因)。
+coverage --@rules_rust//rust/settings:extra_rustc_flag=--cfg=coverage
+coverage:cov-monolith --instrumentation_filter=^//:
+coverage:cov-mock-carins --instrumentation_filter=//crates/alc-carins,//crates/alc-core
+coverage:cov-mock-devices --instrumentation_filter=//crates/alc-devices,//crates/alc-core
+coverage:cov-mock-dtako --instrumentation_filter=//crates/alc-dtako,//crates/alc-compare,//crates/alc-pdf,//crates/alc-core
+coverage:cov-mock-misc --instrumentation_filter=//crates/alc-misc,//crates/alc-core,//crates/alc-tenko,^//:
+coverage:cov-mock-tenko --instrumentation_filter=//crates/alc-tenko,//crates/alc-core
+coverage:cov-mock-trouble --instrumentation_filter=//crates/alc-trouble,//crates/alc-core
+coverage:cov-auth-jwt --instrumentation_filter=//crates/alc-auth-jwt
+coverage:cov-carins --instrumentation_filter=//crates/alc-carins
+coverage:cov-compare --instrumentation_filter=//crates/alc-compare
+coverage:cov-core --instrumentation_filter=//crates/alc-core
+coverage:cov-csv-parser --instrumentation_filter=//crates/alc-csv-parser
+coverage:cov-devices --instrumentation_filter=//crates/alc-devices
+coverage:cov-dtako --instrumentation_filter=//crates/alc-dtako,//crates/alc-compare
+coverage:cov-misc --instrumentation_filter=//crates/alc-misc
+coverage:cov-notify --instrumentation_filter=//crates/alc-notify
+coverage:cov-pdf --instrumentation_filter=//crates/alc-pdf
+coverage:cov-tenko --instrumentation_filter=//crates/alc-tenko
+coverage:cov-trouble --instrumentation_filter=//crates/alc-trouble
+coverage:cov-db-trouble --instrumentation_filter=//crates/alc-trouble
+coverage:cov-db-archive --instrumentation_filter=^//:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,34 +127,32 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # instrumentation_filter は label 文字列 (例 //:unit_tests) への regex match。
-          # root package は "^//:" (旧 "^//$" はどの label にも一致せず空 lcov になった)。
-          # 各 shard の filter には「そのテストが exercise する他 crate」も含める
-          # (coverage_100.toml の mock/combined type は shard 横断の union で 100% になる)。
-          - { name: monolith, target: "//:unit_tests", coverage: "^//:" }
-          - { name: mock-carins, target: "//:mock_carins", coverage: "//crates/alc-carins,//crates/alc-core" }
-          - { name: mock-devices, target: "//:mock_devices", coverage: "//crates/alc-devices,//crates/alc-core" }
-          - { name: mock-dtako, target: "//:mock_dtako", coverage: "//crates/alc-dtako,//crates/alc-compare,//crates/alc-pdf,//crates/alc-core" }
-          - { name: mock-misc, target: "//:mock_misc", coverage: "//crates/alc-misc,//crates/alc-core,//crates/alc-tenko,^//:" }
-          - { name: mock-tenko, target: "//:mock_tenko", coverage: "//crates/alc-tenko,//crates/alc-core" }
-          - { name: mock-trouble, target: "//:mock_trouble", coverage: "//crates/alc-trouble,//crates/alc-core" }
+          # coverage field は .bazelrc の config 名 (cov-<shard名>)。instrumentation_filter の
+          # 実体は .bazelrc に置く — ci.yml に書くと setup-bazel の cache key (MODULE/BUILD/
+          # .bazelrc の hash) が filter 変更で変わらず、warm が save skip して全 PR が毎回
+          # coverage 再ビルドになる (詳細は .bazelrc のコメント、Refs #515)。
+          - { name: monolith, target: "//:unit_tests", coverage: "cov-monolith" }
+          - { name: mock-carins, target: "//:mock_carins", coverage: "cov-mock-carins" }
+          - { name: mock-devices, target: "//:mock_devices", coverage: "cov-mock-devices" }
+          - { name: mock-dtako, target: "//:mock_dtako", coverage: "cov-mock-dtako" }
+          - { name: mock-misc, target: "//:mock_misc", coverage: "cov-mock-misc" }
+          - { name: mock-tenko, target: "//:mock_tenko", coverage: "cov-mock-tenko" }
+          - { name: mock-trouble, target: "//:mock_trouble", coverage: "cov-mock-trouble" }
           - { name: auth, target: "//crates/alc-auth:alc-auth_test" }
-          - { name: auth-jwt, target: "//crates/alc-auth-jwt:alc-auth-jwt_test", coverage: "//crates/alc-auth-jwt" }
+          - { name: auth-jwt, target: "//crates/alc-auth-jwt:alc-auth-jwt_test", coverage: "cov-auth-jwt" }
           - { name: camera, target: "//crates/alc-camera:alc-camera_test" }
-          - { name: carins, target: "//crates/alc-carins:alc-carins_test", coverage: "//crates/alc-carins" }
-          - { name: compare, target: "//crates/alc-compare:alc-compare_test", coverage: "//crates/alc-compare" }
-          - { name: core, target: "//crates/alc-core:alc-core_test", coverage: "//crates/alc-core" }
-          - { name: csv-parser, target: "//crates/alc-csv-parser:alc-csv-parser_test", coverage: "//crates/alc-csv-parser" }
-          - { name: devices, target: "//crates/alc-devices:alc-devices_test", coverage: "//crates/alc-devices" }
-          # alc-dtako の unit テスト (dtako_upload / dtako_restraint_report) は alc_compare を
-          # 直接呼ぶ — compare/lib.rs の残り ~314 行はこの shard 経由でしか踏まれない
-          - { name: dtako, target: "//crates/alc-dtako:alc-dtako_test", coverage: "//crates/alc-dtako,//crates/alc-compare" }
-          - { name: misc, target: "//crates/alc-misc:alc-misc_test", coverage: "//crates/alc-misc" }
-          - { name: notify, target: "//crates/alc-notify:alc-notify_test", pdfium: true, coverage: "//crates/alc-notify" }
-          - { name: pdf, target: "//crates/alc-pdf:alc-pdf_test", coverage: "//crates/alc-pdf" }
+          - { name: carins, target: "//crates/alc-carins:alc-carins_test", coverage: "cov-carins" }
+          - { name: compare, target: "//crates/alc-compare:alc-compare_test", coverage: "cov-compare" }
+          - { name: core, target: "//crates/alc-core:alc-core_test", coverage: "cov-core" }
+          - { name: csv-parser, target: "//crates/alc-csv-parser:alc-csv-parser_test", coverage: "cov-csv-parser" }
+          - { name: devices, target: "//crates/alc-devices:alc-devices_test", coverage: "cov-devices" }
+          - { name: dtako, target: "//crates/alc-dtako:alc-dtako_test", coverage: "cov-dtako" }
+          - { name: misc, target: "//crates/alc-misc:alc-misc_test", coverage: "cov-misc" }
+          - { name: notify, target: "//crates/alc-notify:alc-notify_test", pdfium: true, coverage: "cov-notify" }
+          - { name: pdf, target: "//crates/alc-pdf:alc-pdf_test", coverage: "cov-pdf" }
           - { name: storage, target: "//crates/alc-storage:alc-storage_test" }
-          - { name: tenko, target: "//crates/alc-tenko:alc-tenko_test", coverage: "//crates/alc-tenko" }
-          - { name: trouble, target: "//crates/alc-trouble:alc-trouble_test", coverage: "//crates/alc-trouble" }
+          - { name: tenko, target: "//crates/alc-tenko:alc-tenko_test", coverage: "cov-tenko" }
+          - { name: trouble, target: "//crates/alc-trouble:alc-trouble_test", coverage: "cov-trouble" }
           - { name: gateway, target: "//crates/gateway:gateway_test" }
     steps:
       - uses: actions/checkout@v4
@@ -182,9 +180,7 @@ jobs:
       - name: Warm coverage build (Bazel)
         if: matrix.coverage
         run: |
-          bazel coverage ${{ matrix.target }} \
-            --combined_report=lcov \
-            --instrumentation_filter="${{ matrix.coverage }}"
+          bazel coverage ${{ matrix.target }} --config=${{ matrix.coverage }}
 
   # DB integration テスト用 warm (Refs #515 PR2)。postgres service + TEST_DATABASE_URL
   # を持つ点以外は cache-warm-bazel-test-poc と同じ。matrix / flags は bazel-test-db と
@@ -197,8 +193,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: db-trouble, target: "//:trouble_test", coverage: "//crates/alc-trouble" }
-          - { name: db-archive, target: "//:archive_repo_test", coverage: "^//:" }
+          - { name: db-trouble, target: "//:trouble_test", coverage: "cov-db-trouble" }
+          - { name: db-archive, target: "//:archive_repo_test", coverage: "cov-db-archive" }
     services:
       postgres:
         image: postgres:16
@@ -230,10 +226,7 @@ jobs:
       - name: Warm coverage build (Bazel)
         if: matrix.coverage
         run: |
-          bazel coverage ${{ matrix.target }} \
-            --test_env=TEST_DATABASE_URL \
-            --combined_report=lcov \
-            --instrumentation_filter="${{ matrix.coverage }}"
+          bazel coverage ${{ matrix.target }} --test_env=TEST_DATABASE_URL --config=${{ matrix.coverage }}
 
   cache-cleanup:
     name: Cache Cleanup
@@ -701,34 +694,32 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # instrumentation_filter は label 文字列 (例 //:unit_tests) への regex match。
-          # root package は "^//:" (旧 "^//$" はどの label にも一致せず空 lcov になった)。
-          # 各 shard の filter には「そのテストが exercise する他 crate」も含める
-          # (coverage_100.toml の mock/combined type は shard 横断の union で 100% になる)。
-          - { name: monolith, target: "//:unit_tests", coverage: "^//:" }
-          - { name: mock-carins, target: "//:mock_carins", coverage: "//crates/alc-carins,//crates/alc-core" }
-          - { name: mock-devices, target: "//:mock_devices", coverage: "//crates/alc-devices,//crates/alc-core" }
-          - { name: mock-dtako, target: "//:mock_dtako", coverage: "//crates/alc-dtako,//crates/alc-compare,//crates/alc-pdf,//crates/alc-core" }
-          - { name: mock-misc, target: "//:mock_misc", coverage: "//crates/alc-misc,//crates/alc-core,//crates/alc-tenko,^//:" }
-          - { name: mock-tenko, target: "//:mock_tenko", coverage: "//crates/alc-tenko,//crates/alc-core" }
-          - { name: mock-trouble, target: "//:mock_trouble", coverage: "//crates/alc-trouble,//crates/alc-core" }
+          # coverage field は .bazelrc の config 名 (cov-<shard名>)。instrumentation_filter の
+          # 実体は .bazelrc に置く — ci.yml に書くと setup-bazel の cache key (MODULE/BUILD/
+          # .bazelrc の hash) が filter 変更で変わらず、warm が save skip して全 PR が毎回
+          # coverage 再ビルドになる (詳細は .bazelrc のコメント、Refs #515)。
+          - { name: monolith, target: "//:unit_tests", coverage: "cov-monolith" }
+          - { name: mock-carins, target: "//:mock_carins", coverage: "cov-mock-carins" }
+          - { name: mock-devices, target: "//:mock_devices", coverage: "cov-mock-devices" }
+          - { name: mock-dtako, target: "//:mock_dtako", coverage: "cov-mock-dtako" }
+          - { name: mock-misc, target: "//:mock_misc", coverage: "cov-mock-misc" }
+          - { name: mock-tenko, target: "//:mock_tenko", coverage: "cov-mock-tenko" }
+          - { name: mock-trouble, target: "//:mock_trouble", coverage: "cov-mock-trouble" }
           - { name: auth, target: "//crates/alc-auth:alc-auth_test" }
-          - { name: auth-jwt, target: "//crates/alc-auth-jwt:alc-auth-jwt_test", coverage: "//crates/alc-auth-jwt" }
+          - { name: auth-jwt, target: "//crates/alc-auth-jwt:alc-auth-jwt_test", coverage: "cov-auth-jwt" }
           - { name: camera, target: "//crates/alc-camera:alc-camera_test" }
-          - { name: carins, target: "//crates/alc-carins:alc-carins_test", coverage: "//crates/alc-carins" }
-          - { name: compare, target: "//crates/alc-compare:alc-compare_test", coverage: "//crates/alc-compare" }
-          - { name: core, target: "//crates/alc-core:alc-core_test", coverage: "//crates/alc-core" }
-          - { name: csv-parser, target: "//crates/alc-csv-parser:alc-csv-parser_test", coverage: "//crates/alc-csv-parser" }
-          - { name: devices, target: "//crates/alc-devices:alc-devices_test", coverage: "//crates/alc-devices" }
-          # alc-dtako の unit テスト (dtako_upload / dtako_restraint_report) は alc_compare を
-          # 直接呼ぶ — compare/lib.rs の残り ~314 行はこの shard 経由でしか踏まれない
-          - { name: dtako, target: "//crates/alc-dtako:alc-dtako_test", coverage: "//crates/alc-dtako,//crates/alc-compare" }
-          - { name: misc, target: "//crates/alc-misc:alc-misc_test", coverage: "//crates/alc-misc" }
-          - { name: notify, target: "//crates/alc-notify:alc-notify_test", pdfium: true, coverage: "//crates/alc-notify" }
-          - { name: pdf, target: "//crates/alc-pdf:alc-pdf_test", coverage: "//crates/alc-pdf" }
+          - { name: carins, target: "//crates/alc-carins:alc-carins_test", coverage: "cov-carins" }
+          - { name: compare, target: "//crates/alc-compare:alc-compare_test", coverage: "cov-compare" }
+          - { name: core, target: "//crates/alc-core:alc-core_test", coverage: "cov-core" }
+          - { name: csv-parser, target: "//crates/alc-csv-parser:alc-csv-parser_test", coverage: "cov-csv-parser" }
+          - { name: devices, target: "//crates/alc-devices:alc-devices_test", coverage: "cov-devices" }
+          - { name: dtako, target: "//crates/alc-dtako:alc-dtako_test", coverage: "cov-dtako" }
+          - { name: misc, target: "//crates/alc-misc:alc-misc_test", coverage: "cov-misc" }
+          - { name: notify, target: "//crates/alc-notify:alc-notify_test", pdfium: true, coverage: "cov-notify" }
+          - { name: pdf, target: "//crates/alc-pdf:alc-pdf_test", coverage: "cov-pdf" }
           - { name: storage, target: "//crates/alc-storage:alc-storage_test" }
-          - { name: tenko, target: "//crates/alc-tenko:alc-tenko_test", coverage: "//crates/alc-tenko" }
-          - { name: trouble, target: "//crates/alc-trouble:alc-trouble_test", coverage: "//crates/alc-trouble" }
+          - { name: tenko, target: "//crates/alc-tenko:alc-tenko_test", coverage: "cov-tenko" }
+          - { name: trouble, target: "//crates/alc-trouble:alc-trouble_test", coverage: "cov-trouble" }
           - { name: gateway, target: "//crates/gateway:gateway_test" }
     steps:
       - uses: actions/checkout@v4
@@ -769,9 +760,7 @@ jobs:
       - name: bazel coverage (lcov 出力)
         if: matrix.coverage
         run: |
-          bazel coverage ${{ matrix.target }} \
-            --combined_report=lcov \
-            --instrumentation_filter="${{ matrix.coverage }}"
+          bazel coverage ${{ matrix.target }} --config=${{ matrix.coverage }}
           LCOV="$(bazel info output_path)/_coverage/_coverage_report.dat"
           cp "$LCOV" /tmp/lcov.dat
 
@@ -802,8 +791,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: db-trouble, target: "//:trouble_test", coverage: "//crates/alc-trouble" }
-          - { name: db-archive, target: "//:archive_repo_test", coverage: "^//:" }
+          - { name: db-trouble, target: "//:trouble_test", coverage: "cov-db-trouble" }
+          - { name: db-archive, target: "//:archive_repo_test", coverage: "cov-db-archive" }
     services:
       postgres:
         image: postgres:16
@@ -841,10 +830,7 @@ jobs:
       - name: bazel coverage (lcov 出力)
         if: matrix.coverage
         run: |
-          bazel coverage ${{ matrix.target }} \
-            --test_env=TEST_DATABASE_URL \
-            --combined_report=lcov \
-            --instrumentation_filter="${{ matrix.coverage }}"
+          bazel coverage ${{ matrix.target }} --test_env=TEST_DATABASE_URL --config=${{ matrix.coverage }}
           LCOV="$(bazel info output_path)/_coverage/_coverage_report.dat"
           cp "$LCOV" /tmp/lcov.dat
 

--- a/scripts/check_bazel_test_matrix.sh
+++ b/scripts/check_bazel_test_matrix.sh
@@ -54,6 +54,24 @@ for run_job, warm_job in PAIRS:
             fail += 1
         listed[t] = run_job
 
+# --- matrix の coverage config が .bazelrc に定義されているか ---
+# (filter 実体は .bazelrc の "coverage:cov-<shard>" config。ci.yml 側は config 名のみ)
+rc_src = open(".bazelrc", encoding="utf-8").read()
+rc_configs = set(re.findall(r"^coverage:(\S+) --instrumentation_filter=", rc_src, re.M))
+used_configs = set()
+for run_job, _ in PAIRS:
+    for e in matrix_targets(run_job).values():
+        cov = e.get("coverage")
+        if cov is None:
+            continue
+        used_configs.add(cov)
+        if cov not in rc_configs:
+            print(f"::error::matrix の coverage config '{cov}' が .bazelrc に定義されていません (coverage:{cov} --instrumentation_filter=... を追加)")
+            fail += 1
+for stale_cfg in sorted(rc_configs - used_configs):
+    print(f"::error::.bazelrc の coverage config '{stale_cfg}' を使う matrix entry がありません (削除漏れ)")
+    fail += 1
+
 # --- BUILD ファイルから rust_test target を列挙 ---
 expected = set()
 for f in glob.glob("crates/*/BUILD.bazel") + ["BUILD.bazel"]:


### PR DESCRIPTION
## 概要

PR #534/#535 の後に残った 2 つの独立した問題を修正する。Refs #515

## 1. filter を ci.yml に書くと cache が恒久 stale (「また残ってる」の正体)

- setup-bazel の disk-cache tar key は **MODULE/BUILD/.bazelrc の hash のみ**で ci.yml を含まない
- #534 の filter 変更でも key が変わらず、main warm は旧 tar を exact hit で restore → `Disk cache hit, skipping save` で**新計装 action を保存できない** (GH Actions cache は同一 key へ上書き不可、warm 28748025870 の実ログで確認)
- 結果、全 PR が毎回 mock shard の coverage 再ビルド (~2.5 分/shard) を払い続ける構造だった

**修正**: instrumentation_filter を `.bazelrc` の `coverage:cov-<shard>` config に移し、ci.yml は `--config=cov-<shard>` を呼ぶだけにする。filter 変更 = .bazelrc 変更 = key 変更となり warm が新 key で save できる。`check_bazel_test_matrix.sh` が matrix の config 名 ↔ .bazelrc 定義の 1:1 (未定義/削除漏れ両方向) を検証する。

## 2. compare/lib.rs 313 行 miss の根本原因 = cfg(coverage) 不一致

- alc-compare の里帰りテスト 21 本は `#[cfg_attr(not(coverage), ignore)]` 付き
- **cargo-llvm-cov は `--cfg=coverage` を自動注入する**のでこれらが走るが、**bazel coverage は注入しない**ため全て ignore → deep branch 行が DA=0 (coverage 実行が 0.7s で終わっていたのも ignored だらけのため)
- 検証過程: rustc 1.93.1 (rules_rust 0.69.0 default) をローカルに入れて同一テストを cargo-llvm-cov で実行 → **全行 covered** = コンパイラ版差説を棄却。shard artifact (lcov-compare) の DA と突き合わせて「local=1 の行 267 本が bazel=0」= テスト実行差と特定

**修正**: `.bazelrc` に `coverage --@rules_rust//rust/settings:extra_rustc_flag=--cfg=coverage` を追加し cargo-llvm-cov と同じ意味論に揃える。

## 注意

- `.bazelrc` 変更で**全 shard の cache key が変わる**ため、本 PR の bazel job は test/coverage ともフルビルド (一回性、merge 後の main warm が新 key で焼き直す — 今回はこの仕組み自体の検証になる)
- 本 PR の `Bazel coverage gate (warn)` で **63/63 OK** を確認したら fail 化 → PR4 (cargo Tests matrix 退役) へ


---
_Generated by [Claude Code](https://claude.ai/code/session_01CEUnL9oDYaRZYh6gG5z9bX)_