### PR TITLE
docs(ci): cache 上限 20GB 化と budget read-only の罠を追記 (Refs #515)

### DIFF
--- a/docs/ci-speed-tracking.md
+++ b/docs/ci-speed-tracking.md
@@ -219,6 +219,13 @@ Build backend (Bazel) job 139s の内訳: setup ~8s / **analysis 60s**
   lib-only build に縮小。`Bazel tests OK` 集約 job を新設 (required checks は shard 個別
   ではなくこの job + `Bazel coverage gate` の 2 つに張る)。bazel test/gate の if を
   v* tag push にも拡張 (本番 deploy の test gate を cargo から引き継ぐ)
+- **cache 上限を 20GB に引き上げて eviction を根治 (2026-07-05)**: GitHub Actions cache は
+  2025-11 から 10GB/repo 超えが可能 (超過分 $0.07/GB/月、Team plan 以上)。org の maximum →
+  repo の eviction limit を 20GB に設定し、**Billing の budget も $2/月 に設定** —
+  budget が $0 のままだと 10GB 超過時点で cache が **read-only** になり、warm job は
+  success に見えて save だけ無音で失敗する (`Cache reservation failed: You have reached
+  your configured budget` warning、2026-07-05 実害 → budget 設定 + warm re-run で解消)。
+  定常 ~13GB の実使用で課金は ~$0.21/月。無料 10GB は repo ごとなので他 repo には影響なし
 - 残: dormant な DB テスト 6 binary の扱い (#530)、Phase C (notify → dtako → carins
   分割 + mock ハーネスの per-domain 化 = tar 縮小の構造解)
 


### PR DESCRIPTION
## 概要

GitHub Actions cache の 10GB 超え運用 (上限 20GB + budget $2/月) と、**budget $0 のままだと cache が read-only になり warm の save が無音で失敗する罠** (2026-07-05 実害 + 解消手順) を `docs/ci-speed-tracking.md` に記録する。Refs #515

## この PR 自体が定常状態の検証

bazel の cache key (MODULE/BUILD/.bazelrc) に触れない docs-only 変更なので、**全 25 shard が warm hit** (test `(cached)` + coverage 計装 cache hit) になるはず。budget 修正 + 再 warm 後の最初の PR として、定常の wall time を実測する。


---
_Generated by [Claude Code](https://claude.ai/code/session_01CEUnL9oDYaRZYh6gG5z9bX)_