### PR TITLE
ci: auto-merge の needs に docker-dev (Tag dev) を追加 (Refs #515)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1061,7 +1061,10 @@ jobs:
     # 防ぐ (Refs #405、#391 で 2 回実害)。drift-check 失敗時も merge を止めて
     # cross-store drift を可視化する (Refs #424)。トレードオフとして staging
     # 障害時は全 PR が merge 不能になる。
-    needs: [check, bazel-tests-ok, bazel-coverage-gate, build-image, deploy, drift-check-staging]
+    # docker-dev (Tag dev) も needs に含める: merge → branch 削除で :dev への
+    # copy が cancel されると、main push の Tag latest / release の Promote images
+    # が前 PR の :dev image を無音で promote する (同 #405 と同クラスの穴)。
+    needs: [check, bazel-tests-ok, bazel-coverage-gate, build-image, docker-dev, deploy, drift-check-staging]
     if: >-
       always() &&
       github.event_name == 'pull_request' &&
@@ -1069,6 +1072,7 @@ jobs:
       needs.bazel-tests-ok.result == 'success' &&
       needs.bazel-coverage-gate.result == 'success' &&
       needs.build-image.result == 'success' &&
+      needs.docker-dev.result == 'success' &&
       needs.deploy.result == 'success' &&
       needs.drift-check-staging.result == 'success'
     uses: ippoan/ci-workflows/.github/workflows/auto-merge.yml@main


### PR DESCRIPTION
## 概要

Refs #515

`auto-merge` の needs に `docker-dev` (Tag dev) が入っていない穴を閉じる。

## 背景

Tag dev は build-image が push した `${sha}` イメージを `:dev` タグへ copy する job で、後段の promote (`Tag latest` on main push / `Promote images` on v* tag) の入力になる。deploy 自体は `-staging:${sha}` を使うので deploy の needs には不要だが、auto-merge が Tag dev を待たないと:

- merge → branch 削除で走行中の Tag dev が cancel される
- `:dev` が**前の PR の image のまま**残る
- main push の `Tag latest` / release の `Promote images` が**古い image を無音で promote** する

#405 (deploy cutover が merge で cancel され無音失敗) と同クラスの穴。Tag dev (~23s) は deploy (数分) より先に終わるのが通常なので実コスト増はゼロ。

## 変更内容

- `auto-merge` の `needs` に `docker-dev` を追加 + `if` に `needs.docker-dev.result == 'success'` を追加

## 検証

- YAML parse OK / `scripts/check_bazel_test_matrix.sh` green
- `docker-dev` は PR event でのみ走る (`if: github.event_name == 'pull_request'`) — auto-merge も同条件なので needs 充足の整合は取れている

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CEUnL9oDYaRZYh6gG5z9bX

---
_Generated by [Claude Code](https://claude.ai/code/session_01CEUnL9oDYaRZYh6gG5z9bX)_