### PR TITLE
ci: cache-cleanup の PR close 削除漏れと壊れた週次 job を修正 (Refs #515)

### DIFF
--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -1,14 +1,20 @@
 name: Cache Cleanup
 
+# PR close/merge 時にその PR scope の cache を全削除する。
+#
+# 旧構成にあった週次「最新 10 個以外を全削除」job (cleanup-stale-cache) は削除済み:
+# - `--sort last_used` が無効値で gh が即エラー → 作成以来ずっと無音の no-op だった
+# - 仮に「直す」と bazel shard tar 21 個を毎週日曜に全滅させる (cargo 時代に cache が
+#   数個しか無かった頃の遺物)
+# - 世代掃除は ci.yml の cache-cleanup job (base ごと keep 3 / shard tar keep 1) と
+#   GitHub の 7 日未アクセス自動削除が既に担っている
+
 on:
   pull_request:
     types: [closed]
-  schedule:
-    - cron: '0 3 * * 0' # 毎週日曜 03:00 UTC
 
 jobs:
   cleanup-branch-cache:
-    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       actions: write
@@ -17,31 +23,21 @@ jobs:
       - name: Delete caches for closed branch
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          # head.ref は fork の branch 名 = untrusted input。run 内に ${{ }} で
+          # 直接展開すると shell injection になるため env 経由で渡す
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
-          BRANCH="refs/pull/${{ github.event.pull_request.number }}/merge"
+          # --limit 既定は 30。bazel 化後は 1 PR あたり数十〜数百 entry
+          # (shard tar + buildkit blob) あるため、明示しないと大半が残る
+          # (実害: merge 済み PR の cache が数 GB 残留し 30GB 上限を圧迫)。
+          BRANCH="refs/pull/${PR_NUMBER}/merge"
           echo "Deleting caches for: $BRANCH"
-          gh cache list --ref "$BRANCH" --json id -q '.[].id' | while read id; do
+          gh cache list --ref "$BRANCH" --limit 1000 --json id -q '.[].id' | while read id; do
             gh cache delete "$id" || true
           done
-          HEAD_REF="refs/heads/${{ github.event.pull_request.head.ref }}"
+          HEAD_REF="refs/heads/${PR_HEAD_REF}"
           echo "Deleting caches for: $HEAD_REF"
-          gh cache list --ref "$HEAD_REF" --json id -q '.[].id' | while read id; do
-            gh cache delete "$id" || true
-          done
-
-  cleanup-stale-cache:
-    if: github.event_name == 'schedule'
-    runs-on: ubuntu-latest
-    permissions:
-      actions: write
-    steps:
-      - uses: actions/checkout@v4
-      - name: Keep only 10 newest caches
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh cache list --json id --sort last_used --order desc --limit 1000 -q '.[].id' \
-            | tail -n +11 | while read id; do
-            echo "Deleting cache: $id"
+          gh cache list --ref "$HEAD_REF" --limit 1000 --json id -q '.[].id' | while read id; do
             gh cache delete "$id" || true
           done


### PR DESCRIPTION
## 概要

Refs #515

`cache-cleanup.yml` に 2 つの問題を発見・修正する (cache size 日次レポート導入時の調査で発覚)。

## 問題 1: PR close 時の削除が 30 件しか消えない

`gh cache list --ref ...` に `--limit` が無く既定の 30 件しか取得しない。bazel 化後は 1 PR あたり数十〜数百 entry (shard tar + buildkit blob) あるため大半が残留する。実証: merge 済み PR #540 の cache (`[PR 540/merge]` 0.77GB 等) が close 後も残っていた (PR scope 合計 5.81GB / 1884 entries が実測で滞留)。

→ `--limit 1000` を明示。

## 問題 2: 週次「最新 10 個以外を全削除」job は壊れた no-op、直すと危険

`cleanup-stale-cache` (毎週日曜) の `--sort last_used` は無効値 (正: `last_accessed_at`) で、gh がヘルプを出して即エラー → **作成以来ずっと何も削除していない** (2026-07-05 06:37 UTC run のログで確認、pipefail 無しのため step は success)。仮に値を「直す」と bazel shard tar 21 個を毎週全滅させる cargo 時代の遺物。世代掃除は ci.yml の cache-cleanup job (base ごと keep 3 / shard tar keep 1) + GitHub の 7 日未アクセス自動削除が既に担っている。

→ job ごと削除 (schedule trigger も除去)。

## ついで: shell injection 防止

`github.event.pull_request.head.ref` (fork の branch 名 = untrusted input) を `run:` 内に `${{ }}` で直接展開していたのをやめ、env 経由で渡すように変更。

## 検証

- YAML parse OK
- merge 後、次に close される PR の Cache Cleanup run で `Deleting caches for: refs/pull/N/merge` が全件列挙されることを確認する

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CEUnL9oDYaRZYh6gG5z9bX

---
_Generated by [Claude Code](https://claude.ai/code/session_01CEUnL9oDYaRZYh6gG5z9bX)_