### PR TITLE
ci: closed PR の cache 残骸を一括掃除する workflow_dispatch job を追加 (Refs #515)

### DIFF
--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -12,9 +12,14 @@ name: Cache Cleanup
 on:
   pull_request:
     types: [closed]
+  # closed PR の残骸一括掃除 (下の cleanup-closed-prs)。close 時削除は closed
+  # イベントの瞬間に 1 回だけ走るため、削除が不完全なまま close された PR
+  # (--limit 30 バグ時代の #540-#545 等) には遡って効かない。手動で回収する。
+  workflow_dispatch:
 
 jobs:
   cleanup-branch-cache:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       actions: write
@@ -41,3 +46,47 @@ jobs:
           gh cache list --ref "$HEAD_REF" --limit 1000 --json id -q '.[].id' | while read id; do
             gh cache delete "$id" || true
           done
+
+  # 全 cache を列挙し、refs/pull/N/merge のうち PR が closed のものを一括削除する。
+  # open PR の cache は残す (走行中 CI の cache hit を壊さない)。
+  cleanup-closed-prs:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Delete caches of closed PRs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh cache list -R "$REPO" --limit 5000 \
+            --json id,ref,sizeInBytes > /tmp/caches.json
+          # open PR の番号一覧 (これ以外の pull ref は closed とみなす)
+          gh pr list -R "$REPO" --state open --limit 500 --json number \
+            -q '.[].number' > /tmp/open_prs.txt
+          python3 - <<'PY'
+          import json, re
+
+          caches = json.load(open("/tmp/caches.json"))
+          open_prs = {line.strip() for line in open("/tmp/open_prs.txt") if line.strip()}
+
+          to_delete = []
+          total = 0
+          for e in caches:
+              m = re.fullmatch(r"refs/pull/(\d+)/merge", e["ref"])
+              if m and m.group(1) not in open_prs:
+                  to_delete.append(e)
+                  total += e["sizeInBytes"]
+
+          with open("/tmp/ids.txt", "w") as f:
+              for e in to_delete:
+                  f.write(f"{e['id']}\n")
+          print(f"closed-PR 残骸: {len(to_delete)} entries / {total / 1024**3:.2f}GB を削除します")
+          PY
+          while read -r id; do
+            gh cache delete "$id" || true
+          done < /tmp/ids.txt
+          echo "done"


### PR DESCRIPTION
## 概要

Refs #515

PR close 時の cache 削除は closed イベントの瞬間に 1 回だけ走るため、`--limit 30` バグ時代 (#546 より前) に close された PR の残骸 (~6GB / ~1900 entries、#540/#543/#544/#545 分) には遡って効かない。放置でも GitHub の 7 日未アクセス eviction で消えるが、手動で即回収できる job を用意する。

## 変更内容

- `cache-cleanup.yml` に `workflow_dispatch` トリガー + `cleanup-closed-prs` job を追加
  - 全 cache を列挙 (`--limit 5000`) → `refs/pull/N/merge` のうち **open PR 一覧に無い N** の分を一括削除
  - open PR の cache は温存 (走行中 CI の cache hit を壊さない)
  - 削除対象の件数 / 合計 GB をログに出してから削除
- 既存 `cleanup-branch-cache` に `if: github.event_name == 'pull_request'` を追加 (トリガー追加に伴うガード)

## 検証

- YAML parse OK
- merge 後に workflow_dispatch で実行し、直後の Cache Size Report で「PR 等」が open PR 分だけに減ることを確認する

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CEUnL9oDYaRZYh6gG5z9bX

---
_Generated by [Claude Code](https://claude.ai/code/session_01CEUnL9oDYaRZYh6gG5z9bX)_