### PR TITLE
infra: gateway/per-domain アクセス検知アラートの設定を追加 (Refs #556)

### DIFF
--- a/cloudrun/monitoring/gateway-access-alert.json
+++ b/cloudrun/monitoring/gateway-access-alert.json
@@ -1,0 +1,20 @@
+{
+  "displayName": "rust-alc-api gateway/per-domain access detected",
+  "documentation": {
+    "content": "gateway + per-domain (tenko/carins/dtako/trouble/camera) は廃止予定 (Refs #556)。これらは本番・staging とも休眠のはずで、この policy は「万一 実リクエストが来たら」= 隠れ consumer 検出 or 削除判断の材料として通知する安全網。削除完了後は policy ごと消してよい。",
+    "mimeType": "text/markdown"
+  },
+  "combiner": "OR",
+  "conditions": [
+    {
+      "displayName": "any HTTP request to gateway/per-domain (prod+staging)",
+      "conditionMatchedLog": {
+        "filter": "resource.type=\"cloud_run_revision\" AND resource.labels.service_name=~\"rust-alc-api(-staging)?-(gateway|tenko|carins|dtako|trouble|camera)\" AND httpRequest.requestMethod!=\"\""
+      }
+    }
+  ],
+  "alertStrategy": {
+    "notificationRateLimit": { "period": "3600s" }
+  },
+  "notificationChannels": ["__NOTIFICATION_CHANNEL__"]
+}

--- a/cloudrun/monitoring/setup-gateway-access-alert.sh
+++ b/cloudrun/monitoring/setup-gateway-access-alert.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# gateway + per-domain (tenko/carins/dtako/trouble/camera) への実アクセスを検知して
+# メール通知する Cloud Logging アラートを作成する (Refs ippoan/rust-alc-api#556)。
+#
+# これらの service は廃止予定で本番・staging とも休眠のはず。この安全網は
+# 「万一 実リクエストが来たら」だけ通知する (no news = good news)。日次ダイジェスト
+# ではなく access-on-fire 方式 = ゼロが続く前提の廃止判断に最適。
+# 廃止 (Cloud Run service 削除) 完了後は policy + channel ごと消してよい:
+#   gcloud alpha monitoring policies list --project="$PROJECT" \
+#     --filter='displayName:"rust-alc-api gateway/per-domain access detected"'
+#   gcloud alpha monitoring policies delete <POLICY_ID> --project="$PROJECT"
+#
+# 使い方:
+#   EMAIL=you@example.com bash cloudrun/monitoring/setup-gateway-access-alert.sh
+#
+# べき等: 同名 channel / policy が既にあれば再利用し重複作成しない。
+set -euo pipefail
+
+PROJECT="${PROJECT:-cloudsql-sv}"
+EMAIL="${EMAIL:-m.tama.ramu@gmail.com}"
+CHANNEL_NAME="gateway-retire-alert"
+POLICY_NAME="rust-alc-api gateway/per-domain access detected"
+HERE="$(cd "$(dirname "$0")" && pwd)"
+
+echo "project=$PROJECT  email=$EMAIL"
+
+# 1) email 通知チャネル (同 display-name があれば再利用)
+CHANNEL=$(gcloud beta monitoring channels list --project="$PROJECT" \
+  --filter="displayName=\"$CHANNEL_NAME\"" --format='value(name)' | head -n1)
+if [[ -z "$CHANNEL" ]]; then
+  CHANNEL=$(gcloud beta monitoring channels create --project="$PROJECT" \
+    --display-name="$CHANNEL_NAME" --type=email \
+    --channel-labels=email_address="$EMAIL" --format='value(name)')
+  echo "created channel: $CHANNEL"
+else
+  echo "reuse channel:   $CHANNEL"
+fi
+
+# 2) アラートポリシー (同 display-name があれば skip)
+EXISTING=$(gcloud alpha monitoring policies list --project="$PROJECT" \
+  --filter="displayName=\"$POLICY_NAME\"" --format='value(name)' | head -n1)
+if [[ -n "$EXISTING" ]]; then
+  echo "policy already exists: $EXISTING (skip)"
+  exit 0
+fi
+
+TMP="$(mktemp)"
+trap 'rm -f "$TMP"' EXIT
+# JSON テンプレの channel placeholder を実 channel に差し替え
+sed "s#__NOTIFICATION_CHANNEL__#${CHANNEL}#" \
+  "$HERE/gateway-access-alert.json" > "$TMP"
+
+gcloud alpha monitoring policies create --project="$PROJECT" --policy-from-file="$TMP"
+echo "policy created."


### PR DESCRIPTION
## 概要

廃止予定の gateway + per-domain service（tenko/carins/dtako/trouble/camera、Refs #556）への**実リクエストを検知して email 通知**する Cloud Logging アラートの設定を repo に入れる。これらは本番・staging とも休眠のはずで、削除前の安全網として「万一 誰かが叩いたら」だけ通知する（access-on-fire 方式、no news = good news）。

## 変更点

- `cloudrun/monitoring/gateway-access-alert.json` — アラートポリシー定義。condition は `resource.labels.service_name =~ rust-alc-api(-staging)?-(gateway|tenko|carins|dtako|trouble|camera)` かつ `httpRequest.requestMethod != ""`（prod+staging の 6 service への実 HTTP リクエスト）。`notificationRateLimit: 3600s`。`__NOTIFICATION_CHANNEL__` は setup 時に差し替え
- `cloudrun/monitoring/setup-gateway-access-alert.sh` — べき等セットアップ（同名 channel/policy があれば再利用・skip）。`EMAIL=... bash cloudrun/monitoring/setup-gateway-access-alert.sh`

## 運用

- 既に本番へ手動投入済み（channel `gateway-retire-alert` 作成済み）。本 PR はそれを**再現可能な形で repo に記録**するもの
- 廃止（Cloud Run service 削除）完了後は policy + channel ごと削除してよい（スクリプト冒頭に削除手順コメントあり）

## 動作確認

- [x] `bash -n setup-gateway-access-alert.sh`（構文 OK）
- [x] `json.load()` で policy JSON パース OK
- [ ] 実アラート発火は service 削除までの間に自然検証（休眠なら鳴らない＝正常）

Refs #556

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ijYf11nXsaRsB9hr2ot3e

---
_Generated by [Claude Code](https://claude.ai/code/session_012ijYf11nXsaRsB9hr2ot3e)_