### PR TITLE
fix: staging seed に auth-staging operator テナントを追加

### DIFF
--- a/staging/entrypoint.sh
+++ b/staging/entrypoint.sh
@@ -29,13 +29,25 @@ DATABASE_URL="postgresql://postgres:staging@localhost:5432/postgres?options=-c s
 echo "Seeding staging default tenant..."
 PGPASSWORD=staging psql -h localhost -p 5432 -U postgres -d postgres -v ON_ERROR_STOP=1 <<'SQL'
 INSERT INTO alc_api.tenants (id, name, slug, email_domain, created_at)
-VALUES (
-  '11111111-1111-1111-1111-111111111111',
-  'Staging Default',
-  'staging-default',
-  'example.com',
-  NOW()
-)
+VALUES
+  (
+    '11111111-1111-1111-1111-111111111111',
+    'Staging Default',
+    'staging-default',
+    'example.com',
+    NOW()
+  ),
+  -- auth-staging の operator テナント。CoreS3 (alc-app-s3) の device credential は
+  -- operator の org に束縛され、device JWT の tenant_id claim がそのまま
+  -- /api/hub/measurements の INSERT に使われるため、無いと FK 違反で 500
+  -- (Refs ippoan/alc-app-s3#21 — 2026-07-12 実機 e2e で踏んだ。上と同型)。
+  (
+    '24e4265b-d8bf-409c-9eed-23c368462373',
+    'Auth Staging Operator',
+    'auth-staging-operator',
+    'example.com',
+    NOW()
+  )
 ON CONFLICT (id) DO NOTHING;
 SQL
 echo "Staging default tenant seeded"


### PR DESCRIPTION
## 概要

CoreS3 (alc-app-s3) → cf-alc-recorder → `POST /api/hub/measurements` の実機 E2E (ippoan/alc-app-s3#21) で、INSERT が FK 違反 500 になった:

```
violates foreign key constraint hub_measurements_tenant_id_fkey
DETAIL: Key (tenant_id)=(24e4265b-...) is not present in table tenants.
```

device credential は auth-staging の operator org に束縛され、device JWT の `tenant_id` claim がそのまま INSERT に使われるため、staging の揮発 DB (cold start seed) に operator テナントが必要 (email-receiver#1 で踏んだ既知パターンと同型)。`staging/entrypoint.sh` の seed に追加する。

UUID はテナント識別子のみで、書き込みには device JWT (credential) が必要。

## テスト

- staging デプロイ後、実機 CoreS3 の送信キュー (未 ack 4 件、接続中 15 秒毎に自動再送) が ack されて `WS STATUS QUEUE=0` になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)