### PR TITLE
ci: coverage 付き bazel shard の plain bazel test 段を省略 (Refs #568)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,11 @@ jobs:
             | sudo tar -xz -C /tmp
           sudo cp /tmp/lib/libpdfium.so /usr/lib/libpdfium.so
           sudo ldconfig
+      # coverage 付き shard は PR 側 (bazel-test-poc) が plain `bazel test` を
+      # 走らせない (coverage が test gate を兼ねる、Refs #568) ため、plain config の
+      # warm も不要 — coverage 無し shard に限定して warm 時間と tar サイズを削る。
       - name: Warm test result cache (Bazel)
+        if: ${{ !matrix.coverage }}
         run: bazel test ${{ matrix.target }} --test_output=errors --test_summary=short
 
       # PR3b (Refs #515): coverage の計装ビルド + テスト実行も warm し、PR 側を
@@ -164,7 +168,7 @@ jobs:
       - name: Warm coverage build (Bazel)
         if: matrix.coverage
         run: |
-          bazel coverage ${{ matrix.target }} --config=${{ matrix.coverage }}
+          bazel coverage ${{ matrix.target }} --config=${{ matrix.coverage }} --test_output=errors --test_summary=short
 
   # DB integration テスト用 warm (Refs #515 PR2)。postgres service + TEST_DATABASE_URL
   # を持つ点以外は cache-warm-bazel-test-poc と同じ。matrix / flags は bazel-test-db と
@@ -205,13 +209,17 @@ jobs:
           r2-secret-access-key: ${{ secrets.BAZEL_R2_SECRET_ACCESS_KEY }}
       - name: Init test DB (alc_api schema + roles)
         run: psql "postgresql://postgres:test@localhost:5432/postgres" -f scripts/init_local_db.sql
+      # coverage 付き shard は plain test warm を skip — PR 側 (bazel-test-db) が
+      # plain `bazel test` を走らせなくなったため (cache-warm-bazel-test-poc と同じ
+      # 理由、Refs #568)
       - name: Warm test result cache (Bazel)
+        if: ${{ !matrix.coverage }}
         run: bazel test ${{ matrix.target }} --test_env=TEST_DATABASE_URL --test_output=errors --test_summary=short
       # PR3b (Refs #515): coverage も warm (flags は bazel-test-db と一致必須)
       - name: Warm coverage build (Bazel)
         if: matrix.coverage
         run: |
-          bazel coverage ${{ matrix.target }} --test_env=TEST_DATABASE_URL --config=${{ matrix.coverage }}
+          bazel coverage ${{ matrix.target }} --test_env=TEST_DATABASE_URL --config=${{ matrix.coverage }} --test_output=errors --test_summary=short
 
   cache-cleanup:
     name: Cache Cleanup
@@ -603,7 +611,12 @@ jobs:
           sudo cp /tmp/lib/libpdfium.so /usr/lib/libpdfium.so
           sudo ldconfig
 
+      # coverage 付き shard では skip する (Refs #568): 後段の bazel coverage が
+      # 同じテストを計装ビルドで実行し、失敗すれば job を fail させる (test gate と
+      # して同等)。coverage は別 configuration で bazel test の結果を再利用しない
+      # ため、両方走らせると mock 系 shard (モノリス全体をリンク) で特に高くつく。
       - name: bazel test (result cache は main warm から)
+        if: ${{ !matrix.coverage }}
         run: |
           set -o pipefail
           bazel test ${{ matrix.target }} --test_output=errors --test_summary=short 2>&1 | tee /tmp/test_run.txt
@@ -619,10 +632,15 @@ jobs:
       # bazel-coverage-gate job が全 shard 分を merge して coverage_100.toml 全域を
       # warn モードで突合する (mock は route / db は Pg repo / unit は crate と、
       # file ごとに寄与 shard が異なるため merge が必須)。flags は warm 側と一致必須。
+      # coverage 付き shard の test gate はこの step が兼ねる (Refs #568)。
       - name: bazel coverage (lcov 出力)
         if: matrix.coverage
         run: |
-          bazel coverage ${{ matrix.target }} --config=${{ matrix.coverage }}
+          set -o pipefail
+          bazel coverage ${{ matrix.target }} --config=${{ matrix.coverage }} --test_output=errors --test_summary=short 2>&1 | tee /tmp/test_run.txt
+          if grep -q "(cached)" /tmp/test_run.txt; then
+            echo "::notice::${{ matrix.target }} は (cached) — main warm から restore"
+          fi
           LCOV="$(bazel info output_path)/_coverage/_coverage_report.dat"
           cp "$LCOV" /tmp/lcov.dat
 
@@ -682,7 +700,9 @@ jobs:
           r2-secret-access-key: ${{ secrets.BAZEL_R2_SECRET_ACCESS_KEY }}
       - name: Init test DB (alc_api schema + roles)
         run: psql "postgresql://postgres:test@localhost:5432/postgres" -f scripts/init_local_db.sql
+      # coverage 付き shard では skip する (bazel-test-poc 側と同じ理由、Refs #568)
       - name: bazel test (result cache は main warm から)
+        if: ${{ !matrix.coverage }}
         run: |
           set -o pipefail
           bazel test ${{ matrix.target }} --test_env=TEST_DATABASE_URL --test_output=errors --test_summary=short 2>&1 | tee /tmp/test_run.txt
@@ -691,10 +711,15 @@ jobs:
           fi
 
       # PR3b (Refs #515): DB shard の lcov (Pg repo 実装の寄与分)。flags は warm と一致必須。
+      # coverage 付き shard の test gate はこの step が兼ねる (Refs #568)。
       - name: bazel coverage (lcov 出力)
         if: matrix.coverage
         run: |
-          bazel coverage ${{ matrix.target }} --test_env=TEST_DATABASE_URL --config=${{ matrix.coverage }}
+          set -o pipefail
+          bazel coverage ${{ matrix.target }} --test_env=TEST_DATABASE_URL --config=${{ matrix.coverage }} --test_output=errors --test_summary=short 2>&1 | tee /tmp/test_run.txt
+          if grep -q "(cached)" /tmp/test_run.txt; then
+            echo "::notice::${{ matrix.target }} は (cached) — main warm から restore"
+          fi
           LCOV="$(bazel info output_path)/_coverage/_coverage_report.dat"
           cp "$LCOV" /tmp/lcov.dat
 


### PR DESCRIPTION
Refs #568

## 背景

bazel test matrix の mock 系 shard (mock-carins 2m40s / mock-devices 3m22s / mock-misc 3m47s 等) が非 mock 系 (1m19s〜1m44s) の約 2 倍かかっていた。coverage field を持つ shard は `bazel test` → `bazel coverage --config=cov-<shard>` の 2 段を実行しており、coverage は別 configuration のため `bazel test` の結果・成果物を再利用せず同じテストを 2 回フル実行している。モノリス全体 (`:rust_alc_api_lib`) をリンクする mock 系でこの二重化が特に高くつく。

## 変更内容

`bazel coverage` はテスト失敗時に job を fail させる (test gate として `bazel test` と同等) ため、coverage field を持つ shard では plain `bazel test` を skip する。

- **bazel-test-poc / bazel-test-db**: `bazel test` step に `if: ${{ !matrix.coverage }}` を付与。coverage step に `--test_output=errors --test_summary=short` と "(cached)" notice を追加し、失敗時出力・cache hit の可観測性を `bazel test` step と同等に維持
- **cache-warm-bazel-test-poc / cache-warm-bazel-test-db**: PR 側が plain config を使わなくなるため、plain test warm も coverage 無し shard に限定 (warm 時間と disk-cache tar サイズ削減)。coverage warm の flags は PR 側と一致

matrix 定義は非変更 — `scripts/check_bazel_test_matrix.sh` はローカルで green を確認済み (25 target 網羅・poc↔warm 一致)。

## 影響しないもの

- coverage 無し shard (auth / camera / storage / db-hub-measurements) は従来どおり `bazel test` が走る
- csv-parser の lcov strict gate、bazel-coverage-gate の merge 判定 (lcov 生成は coverage step のまま)
- v* tag run (bazel-test-poc / db は同 step 構成で動作)

## 期待効果

coverage 付き全 shard で非計装ビルド + テスト 1 実行分が浮く。mock 系 6 shard は 3m 台 → 2m 前後を見込む (本 PR の CI で実測確認)。

---
_Generated by [Claude Code](https://claude.ai/code/session_01BGffL4nHk4Xbnq1jLE76rp)_