### PR TITLE
fix: trouble_tasks.next_action_by の null 送信でクリアできないバグを修正 (Refs #572)

### DIFF
--- a/.claude/skills/rust-alc-api-map/SKILL.md
+++ b/.claude/skills/rust-alc-api-map/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rust-alc-api-map
-generated-from: rust-alc-api:69f46917e03f06968ad8b9b19fec649180d7eabf
+generated-from: rust-alc-api:5c6cc1b1cc3cd64e7469c12a595a3470f67bc7b3
 paths: [crates/, src/, migrations/]
 description: rust-alc-api (アルコールチェッカー基盤の Rust/Axum Cargo workspace — domain crate 群 + monolith 単一バイナリ、PostgreSQL+RLS、Cloud Run) の構造ナビゲーション。どの crate に何のルートがあるか / monolith (rust-alc-api) 一本化 (gateway + per-domain は #556 で廃止) / RLS・migration・deploy/release 分離の gotcha を 1 枚にまとめる。トリガー:「rust-alc-api」「alc-api」「alc-notify」「alc-tenko」「alc-trouble」「alc-carins」「alc-dtako」「gateway」「tenko-api」「carins-api」「dtako-api」「trouble-api」「RLS テナント」「sqlx migration」「ts-rs」「Release Wave」「Bazel」等。
 ---

--- a/crates/alc-trouble/src/models.rs
+++ b/crates/alc-trouble/src/models.rs
@@ -531,7 +531,10 @@ pub struct UpdateTroubleTask {
     pub next_action: Option<String>,
     #[serde(default)]
     pub next_action_detail: Option<String>,
-    #[serde(default)]
+    #[serde(
+        default,
+        deserialize_with = "alc_core::serde_helpers::empty_string_as_none_option_string"
+    )]
     pub next_action_by: Option<Option<String>>,
     #[serde(
         default,
@@ -545,4 +548,28 @@ pub struct UpdateTroubleTask {
     pub occurred_at: Option<Option<DateTime<Utc>>>,
     #[serde(default)]
     pub print_page_break_before: Option<bool>,
+}
+
+#[cfg(test)]
+mod update_trouble_task_tests {
+    use super::UpdateTroubleTask;
+
+    #[test]
+    fn next_action_by_absent_does_not_update() {
+        let t: UpdateTroubleTask = serde_json::from_str(r#"{}"#).unwrap();
+        assert!(t.next_action_by.is_none());
+    }
+
+    #[test]
+    fn next_action_by_null_clears() {
+        let t: UpdateTroubleTask = serde_json::from_str(r#"{"next_action_by": null}"#).unwrap();
+        assert_eq!(t.next_action_by, Some(None));
+    }
+
+    #[test]
+    fn next_action_by_value_updates() {
+        let t: UpdateTroubleTask =
+            serde_json::from_str(r#"{"next_action_by": "青井 健"}"#).unwrap();
+        assert_eq!(t.next_action_by, Some(Some("青井 健".to_string())));
+    }
 }


### PR DESCRIPTION
## Summary

- `UpdateTroubleTask::next_action_by` に `empty_string_as_none_option_string` の `deserialize_with` を付与
- 標準の `Option<Option<T>>` deserialize は JSON `null` を外側 `Option` ごと `None` にフラット化するため、`next_action_by: null` の送信が「フィールド省略 = 更新しない」と誤判定され、値をクリアできないバグがあった
- 同じ double-Option パターンの他フィールド (`assigned_to` / `due_date` / `completed_at` / `next_action_due`) は既に専用 deserializer を使っており、`next_action_by` だけ対応漏れだった

## Test plan

- [x] `models.rs` に `next_action_by` の absent/null/value 各ケースのユニットテストを追加、green
- [x] `cargo test -p alc-core -p alc-trouble` green (128 + 48 tests)
- [x] `cargo fmt --all -- --check` green

Refs #572

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nft47cAkNzLMynQatdc4ed)_