### PR TITLE
fix(coverage): gate が crates/* を一度も検証していなかった問題ほか 6 件を修正

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -71,7 +71,13 @@ jobs:
           grep "test result:" /tmp/llvm-cov-stderr.txt || true
 
       - name: Parse coverage → Job Summary
-        run: bash scripts/parse_coverage.sh "${{ inputs.mode }}" "${{ inputs.file_pattern }}" /tmp/llvm-cov-output.txt
+        # inputs.file_pattern は自由入力。run: の本体へ直接展開すると、
+        # workflow_dispatch を起動できる者が任意のシェルコマンドを注入できる。
+        # env 経由なら値は環境変数として渡り、シェルに解釈されない
+        env:
+          COV_MODE: ${{ inputs.mode }}
+          COV_FILE_PATTERN: ${{ inputs.file_pattern }}
+        run: bash scripts/parse_coverage.sh "$COV_MODE" "$COV_FILE_PATTERN" /tmp/llvm-cov-output.txt
 
       - name: Coverage 100% regression check
         run: bash scripts/check_coverage_100.sh --use-cache /tmp/llvm-cov-output.txt

--- a/coverage_100.toml
+++ b/coverage_100.toml
@@ -33,9 +33,10 @@ type = "mock"
 
 # --- alc-core ---
 
-[[files]]
-path = "crates/alc-core/src/auth_jwt.rs"
-type = "mock"
+# crates/alc-core/src/auth_jwt.rs は登録から外した (2026-07-30)。
+# #479 PR-3 で JWT の発行・検証が auth-worker へ移管された結果、doc コメントと
+# `pub use alc_auth_jwt::INTERNAL_AUD;` だけの 10 行 shim になり、実行可能行が
+# ゼロになったため。計測データに現れようがなく、登録しても検証されない
 
 [[files]]
 path = "crates/alc-core/src/models.rs"

--- a/scripts/check_coverage_100.sh
+++ b/scripts/check_coverage_100.sh
@@ -24,7 +24,9 @@ while [[ $# -gt 0 ]]; do
     --mock-only) MOCK_ONLY=true; shift ;;
     --combined) COMBINED=true; shift ;;
     --use-cache) EXTERNAL_CACHE="$2"; shift 2 ;;
-    *) shift ;;
+    # 未知のオプションを黙って捨てない。古い --xxx が script に残っていると
+    # gate が静かに緩くなるため、usage エラーで落とす
+    *) echo "ERROR: unknown option: $1" >&2; sed -n '4,8p' "$0" >&2; exit 2 ;;
   esac
 done
 
@@ -66,13 +68,20 @@ if [ -n "$EXTERNAL_CACHE" ]; then
   CACHE_FILE="$EXTERNAL_CACHE"
 else
   echo "Running cargo llvm-cov --text..."
+  # --workspace が無いと root package しか計測されず、crates/* の登録ファイルが
+  # 丸ごと「not found」になる (実際に kudgivt.rs / kudguri.rs が一度も検証されて
+  # いなかった)。--lib は --workspace と併せて全 package の lib target を見る
   if [ "$UNIT_ONLY" = true ]; then
-    cargo llvm-cov --lib --text > "$CACHE_FILE" 2>&1 || { echo "cargo llvm-cov failed:"; tail -50 "$CACHE_FILE"; exit 101; }
+    cargo llvm-cov --workspace --lib --text > "$CACHE_FILE" 2>&1 || { echo "cargo llvm-cov failed:"; tail -50 "$CACHE_FILE"; exit 101; }
   elif [ "$MOCK_ONLY" = true ]; then
-    cargo llvm-cov --test mock_tenko --test mock_dtako --test mock_devices --test mock_carins --test mock_misc --text > "$CACHE_FILE" 2>&1 || { echo "cargo llvm-cov failed:"; tail -50 "$CACHE_FILE"; exit 101; }
+    # --lib を併せる理由: workspace crate では「unit test は crate 内の lib に在り、
+    # mock test は root package から crate を叩く」ので、--lib を外すと crates/* の
+    # mock 登録ファイルが人工的な部分集合で測られる (例: alc-misc/health.rs が
+    # 124 行中 14 行 = 11.3% に見える。lib を含めれば 355/355 = 100%)
+    cargo llvm-cov --workspace --lib --test mock_tenko --test mock_dtako --test mock_devices --test mock_carins --test mock_misc --text > "$CACHE_FILE" 2>&1 || { echo "cargo llvm-cov failed:"; tail -50 "$CACHE_FILE"; exit 101; }
   else
     [[ -f .test-config ]] && source .test-config
-    cargo llvm-cov --text > "$CACHE_FILE" 2>&1 || { echo "cargo llvm-cov failed:"; tail -50 "$CACHE_FILE"; exit 101; }
+    cargo llvm-cov --workspace --text > "$CACHE_FILE" 2>&1 || { echo "cargo llvm-cov failed:"; tail -50 "$CACHE_FILE"; exit 101; }
   fi
 fi
 
@@ -88,8 +97,16 @@ awk '
     file = $0; sub(/:$/, "", file)
     covered = 0; uncovered = 0; next
 }
-/^[[:space:]]*[0-9]+\|[[:space:]]*0\|/ { uncovered++; next }
-/^[[:space:]]*[0-9]+\|[[:space:]]*[1-9][0-9]*\|/ { covered++; next }
+# ヒット数は 1.98k / 2.50M のようにサフィックス表記されることがある。
+# 純粋な数字だけを見ると、そういう行は covered/uncovered どちらにも掛からず
+# 分母から静かに消える。カウント欄を取り出して "0" かどうかだけで判定する
+/^[[:space:]]*[0-9]+\|[[:space:]]*[0-9][0-9.]*[kMGTE]?[[:space:]]*\|/ {
+    split($0, f, "|")
+    cnt = f[2]
+    gsub(/[[:space:]]/, "", cnt)
+    if (cnt == "0") uncovered++; else covered++
+    next
+}
 END {
     if (file != "") {
         total = covered + uncovered
@@ -121,11 +138,27 @@ for filepath in "${PATHS[@]}"; do
   # combined モードでは全タイプをチェック (lib + mock の combined report を使用)
   # unit, mock, combined すべて対象
 
-  # サマリから該当ファイルを検索 (パス末尾一致)
-  MATCH=$(grep "$filepath" "$SUMMARY_FILE" || true)
+  # サマリから該当ファイルを検索。
+  # 部分一致だと別ファイルに巻き込まれ、複数行ヒットした時に後段の数値比較が壊れる。
+  # "/" 境界での末尾完全一致にし、複数マッチは ambiguous として明示的に落とす
+  MATCH=$(awk -v want="/$filepath" 'index($1, want) == length($1) - length(want) + 1' "$SUMMARY_FILE" || true)
+  MATCH_COUNT=$(printf '%s' "$MATCH" | grep -c . || true)
+
+  if [ "$MATCH_COUNT" -gt 1 ]; then
+    echo "FAIL: $filepath — ambiguous, matched $MATCH_COUNT files in coverage data:"
+    printf '%s\n' "$MATCH" | awk '{print "      " $1}'
+    FAILED=1
+    continue
+  fi
 
   if [ -z "$MATCH" ]; then
-    echo "WARN: $filepath — not found in coverage data"
+    # 黙ってスキップしない。gate が「見ている」と広告する範囲が実際に検証した
+    # 範囲を静かに超えるなら、gate が無いより悪い
+    echo "FAIL: $filepath — not found in coverage data"
+    echo "      考えられる原因: (1) 計測コマンドの対象外 (crates/* は --workspace が要る)"
+    echo "                      (2) パスが coverage_100.toml と実体でずれている"
+    echo "                      (3) ファイルが削除・移動された"
+    FAILED=1
     continue
   fi
 
@@ -134,7 +167,10 @@ for filepath in "${PATHS[@]}"; do
   CHECKED=$((CHECKED + 1))
 
   if [ "$TOTAL" -eq 0 ]; then
-    echo "WARN: $filepath — 0 lines (no executable code)"
+    # 実行可能行ゼロを OK 扱いすると、登録されているのに何も検証していない
+    # ファイルが「維持されている」ように見える
+    echo "FAIL: $filepath — 0 executable lines (登録する意味がない。登録簿から外すこと)"
+    FAILED=1
     continue
   fi
 

--- a/scripts/parse_coverage.sh
+++ b/scripts/parse_coverage.sh
@@ -45,8 +45,12 @@ case "$MODE" in
           file = $0; sub(/:$/, "", file); sub(/.*\/src\//, "src/", file)
           covered = 0; uncovered = 0; next
       }
-      /^[[:space:]]*[0-9]+\|[[:space:]]*0\|/ { uncovered++; next }
-      /^[[:space:]]*[0-9]+\|[[:space:]]*[1-9][0-9]*\|/ { covered++; next }
+      # ヒット数の 1.98k / 2.50M 表記を落とさない (check_coverage_100.sh と同じ規則)
+      /^[[:space:]]*[0-9]+\|[[:space:]]*[0-9][0-9.]*[kMGTE]?[[:space:]]*\|/ {
+        split($0, f, "|"); cnt = f[2]; gsub(/[[:space:]]/, "", cnt)
+        if (cnt == "0") uncovered++; else covered++
+        next
+      }
       END {
           if (file != "") {
               total = covered + uncovered
@@ -83,8 +87,12 @@ case "$MODE" in
           file = $0; sub(/:$/, "", file); sub(/.*\/src\//, "src/", file)
           covered = 0; uncovered = 0; next
       }
-      /^[[:space:]]*[0-9]+\|[[:space:]]*0\|/ { uncovered++; next }
-      /^[[:space:]]*[0-9]+\|[[:space:]]*[1-9][0-9]*\|/ { covered++; next }
+      # ヒット数の 1.98k / 2.50M 表記を落とさない (check_coverage_100.sh と同じ規則)
+      /^[[:space:]]*[0-9]+\|[[:space:]]*[0-9][0-9.]*[kMGTE]?[[:space:]]*\|/ {
+        split($0, f, "|"); cnt = f[2]; gsub(/[[:space:]]/, "", cnt)
+        if (cnt == "0") uncovered++; else covered++
+        next
+      }
       END {
           if (file != "") {
               total = covered + uncovered
@@ -120,8 +128,12 @@ case "$MODE" in
           file = $0; sub(/:$/, "", file); sub(/.*\/src\//, "src/", file)
           covered = 0; uncovered = 0; next
       }
-      /^[[:space:]]*[0-9]+\|[[:space:]]*0\|/ { uncovered++; next }
-      /^[[:space:]]*[0-9]+\|[[:space:]]*[1-9][0-9]*\|/ { covered++; next }
+      # ヒット数の 1.98k / 2.50M 表記を落とさない (check_coverage_100.sh と同じ規則)
+      /^[[:space:]]*[0-9]+\|[[:space:]]*[0-9][0-9.]*[kMGTE]?[[:space:]]*\|/ {
+        split($0, f, "|"); cnt = f[2]; gsub(/[[:space:]]/, "", cnt)
+        if (cnt == "0") uncovered++; else covered++
+        next
+      }
       END {
           if (file != "") {
               total = covered + uncovered


### PR DESCRIPTION
## 何が壊れていたか

`scripts/check_coverage_100.sh` の計測コマンドに `--workspace` が無く、**`crates/*` に在る登録ファイルが全モードで「not found」として黙ってスキップされていた**。登録簿にはあるのに一度も検証されていないファイルが実在した (`kudgivt.rs` / `kudguri.rs`)。

対照実験 — 修正前のスクリプトは、登録済みの 1 件を一度も検証しないまま成功を報告する:

```
WARN: src/routes/mod.rs — not found in coverage data
Checked: 17, Skipped: 0
All registered files maintain 100% coverage.     exit=0
```

## 修正 6 件

| # | 内容 |
|---|---|
| 1 | **計測に `--workspace` を追加。** mock モードは `--lib` も併せる — workspace crate では unit test が crate 内 lib に在るため、外すと人工的な部分集合を測る (`alc-misc/health.rs` が 124 行中 14 行 = 11.3% に見えた。lib 込みで 355/355) |
| 2 | **「登録済みだが計測データに無い」を hard FAIL に。** gate が広告する範囲が検証した範囲を静かに超えるなら、gate が無いより悪い。実行可能行ゼロも同様 |
| 3 | **awk がヒット数のサフィックス表記 (`1.98k` / `2.50M`) を落としていた。** covered / uncovered どちらの正規表現にも掛からず行が分母から消える。実測で **5 ファイル・22 行**が欠落。`parse_coverage.sh` の同じ awk 3 箇所も修正 |
| 4 | **パス照合を非アンカーの `grep` から `/` 境界の末尾完全一致に。** 複数マッチは `ambiguous` として明示的に落とす |
| 5 | **未知のオプションを `*) shift ;;` で握り潰していた。** 古い `--unit-only` 等が残ると gate が静かに緩くなるため usage エラー (exit 2) に |
| 6 | **`coverage.yml` の `inputs.file_pattern` を `run:` 本体への直接展開から `env:` 経由へ。** `workflow_dispatch` を起動できる者による任意コマンド注入の経路だった |

3 について補足: 落ちるのはカバー済みの行だけ (未カバー行はヒット数 `0` でサフィックスが付かない) なので、100% のファイルの判定は変わらない。影響は分母がずれることによるカバレッジ率の報告の不正確さで、`parse_coverage.sh` の not-100 一覧に効く。

## 登録簿から 1 件削除

`crates/alc-core/src/auth_jwt.rs` を外した。#479 PR-3 で JWT の発行・検証が auth-worker へ移管された結果、doc コメントと `pub use alc_auth_jwt::INTERNAL_AUD;` だけの **10 行 shim** になり実行可能行がゼロ。計測データに現れようがなく、登録しても検証されない。2 の hard FAIL がこれを炙り出した。

## 実測で判明したこと

`--workspace` を足した結果、これまで一度も測られていなかった `crates/*` の登録ファイルが検証対象になった。**`kudgivt.rs` / `kudguri.rs` はいずれも 100%** (142/142、173/173) で、CI は赤くならない。

## 検証

- `bash scripts/check_coverage_100.sh --mock-only` → **34/34 OK, exit 0**
- `bash scripts/check_coverage_100.sh --unit-only` → **12/12 OK, exit 0**
- 未知オプション → exit 2 を実測
- `shellcheck` 両スクリプトともクリーン (残るのは `.test-config` の SC1091 info、既存)
- `actionlint` で `coverage.yml` クリーン。指摘があるのは触っていない既存 4 ファイルのみ

🤖 Generated with [Claude Code](https://claude.com/claude-code)