### PR TITLE
fix(csv-parser): KUDGIVT も 対象乗務員CD を優先して読む

### DIFF
--- a/crates/alc-csv-parser/src/kudgivt.rs
+++ b/crates/alc-csv-parser/src/kudgivt.rs
@@ -48,7 +48,16 @@ fn build_column_index(headers: &[&str]) -> Result<ColumnIndex, String> {
 
     let unko_no = require_col(headers, "運行NO", &mut missing);
     let reading_date = require_col(headers, "読取日", &mut missing);
-    let driver_cd = require_col(headers, "乗務員CD1", &mut missing);
+    // 「乗務員CD1」は運行 primary driver で、KUDGIVT の全行で同じ値になる。
+    // 行ごとの「対象」は「対象乗務員CD」 (subject driver of this row) で、これを
+    // 採用しないと crew_role=2 副運転手の行も primary driver のイベントとして
+    // 集計されてしまう (KUDGURI 側は既に対象乗務員CD を採用しているため、
+    // dtako_daily_work_hours の休息集計でキーが食い違う)。
+    // 対象乗務員CD が無い古い CSV (1人乗務) は乗務員CD1 にフォールバック。
+    let driver_cd = find_col(headers, "対象乗務員CD").or_else(|| find_col(headers, "乗務員CD1"));
+    if driver_cd.is_none() {
+        missing.push("対象乗務員CD or 乗務員CD1");
+    }
     let driver_name = require_col(headers, "乗務員名１", &mut missing);
     let crew_role = require_col(headers, "対象乗務員区分", &mut missing);
     let start_at = require_col(headers, "開始日時", &mut missing);
@@ -178,6 +187,41 @@ mod tests {
             assert_eq!(row.duration_minutes, Some(1123));
             assert!((row.section_distance.unwrap() - 1.2).abs() < 0.01);
             assert_eq!(row.driver_cd, "2");
+        });
+    }
+
+    #[test]
+    fn test_parse_kudgivt_prefers_taisho_driver_cd() {
+        test_group!("CSVパーサー");
+        test_case!("対象乗務員CDを乗務員CD1より優先", {
+            // 乗務員CD1 は運行の primary driver (全行同じ)、対象乗務員CD が行ごとの対象。
+            // crew_role=2 の副運転手の行は対象乗務員CD 側を採らないと primary に寄ってしまう。
+            let csv = "運行NO,読取日,乗務員CD1,乗務員名１,対象乗務員CD,対象乗務員区分,開始日時,イベントCD,イベント名\n\
+                       1001,2026/03/01,2,梅津　政弘,2,1,2026/03/01 08:00:00,100,出庫\n\
+                       1001,2026/03/01,2,梅津　政弘,77,2,2026/03/01 09:00:00,302,休息\n";
+            let rows = parse_kudgivt(csv).unwrap();
+            assert_eq!(rows.len(), 2);
+            assert_eq!(rows[0].driver_cd, "2");
+            assert_eq!(rows[0].crew_role, 1);
+            // 副運転手の行は対象乗務員CD が採用される (乗務員CD1 の "2" ではない)
+            assert_eq!(rows[1].driver_cd, "77");
+            assert_eq!(rows[1].crew_role, 2);
+            // raw_data には両方の列がそのまま残る
+            assert_eq!(rows[1].raw_data["乗務員CD1"], "2");
+            assert_eq!(rows[1].raw_data["対象乗務員CD"], "77");
+        });
+    }
+
+    #[test]
+    fn test_parse_kudgivt_falls_back_to_driver_cd1() {
+        test_group!("CSVパーサー");
+        test_case!("対象乗務員CD が無ければ乗務員CD1にフォールバック", {
+            // 対象乗務員CD を持たない古い CSV (1人乗務)
+            let csv = "運行NO,読取日,乗務員CD1,乗務員名１,対象乗務員区分,開始日時,イベントCD,イベント名\n\
+                       1001,2026/03/01,DR01,テスト運転者,1,2026/03/01 08:00:00,100,出庫\n";
+            let rows = parse_kudgivt(csv).unwrap();
+            assert_eq!(rows.len(), 1);
+            assert_eq!(rows[0].driver_cd, "DR01");
         });
     }
 


### PR DESCRIPTION
Refs ohishi-exp/rust-ichibanboshi#205 の実装計画 08。`kudguri.rs:84` は既にこの対応が入っており、KUDGIVT を揃える。

```rust
let driver_cd = find_col(headers, "対象乗務員CD").or_else(|| find_col(headers, "乗務員CD1"));
```

## 単なる列の読み違いではなく、キーの不一致だった

`KudgivtRow.driver_cd` は常に `乗務員CD1` (運行の主運転者。運行内の全行で同じ値) を返していた。この値の唯一の production 消費者は `dtako_upload.rs:371` で、`rest_event_map` を `(driver_cd, work_date)` で張っている。

ところが `:507` でそのマップを引くときの driver_cd は `alc_compare::build_day_map` 由来 — つまり `KudguriRow.driver_cd` で、**そちらは既に `対象乗務員CD`**。張る側と引く側で別のコードを使っていた。

結果として **2 名乗務の運行では、2 人目の休息時間が主運転者に付くか、落ちていた**。この修正で両側が同じコードで揃う。

## 影響範囲

- `KudgivtRow.driver_cd` を読む production コードは `dtako_upload.rs:371` のみ。`work_segments.rs` / `csv_aggregator.rs` / `alc-compare` / `dtako_y_time_export` はテスト fixture 以外で読んでいない
- 既存 fixture に `対象乗務員CD` 列を持つものが 1 つも無いため、**既存テストは全てフォールバック側を通り無影響**
- 実データでの規模: 2026-06 の 33,028 行のうち、2 列が食い違うのは 41 行

## テスト

追加 2 件 — `test_parse_kudgivt_prefers_taisho_driver_cd` (両列があり crew_role=2 の行が `対象乗務員CD` を取る) / `test_parse_kudgivt_falls_back_to_driver_cd1` (列が無い旧 CSV)。

- `make test` → **679 passed, 0 failed**
- `make mock-test` → **1092 passed, 0 failed**

## 未決 (この PR では触っていない)

**`対象乗務員CD = 0` の行** (2026-06 で 214 行) は、修正後 `driver_cd == "0"` になり主運転者へフォールバックしない。`kudguri.rs` にも同種のガードが無く、片側だけ足すとこの PR が消したキーの不一致が再発するため、**両 parser 同時に決めるべき別件**として残した。

## 補足

`dtako_daily_work_hours` はデジタコ運行データの集計であって賃金計算向きではないため、この修正は #205 の速度改善 (01) とも賃金の正しさとも独立している。

🤖 Generated with [Claude Code](https://claude.com/claude-code)