### PR TITLE
fix(scripts): coverage gate の見出し判定を /home 決め打ちからパス非依存にする (Refs ohishi-exp/rust-ichibanboshi#205 の 35)

### DIFF
--- a/scripts/check_coverage_100.sh
+++ b/scripts/check_coverage_100.sh
@@ -87,9 +87,16 @@ fi
 
 # --- --text 出力から全ファイルの Lines/Miss を awk で集計 ---
 # 結果を一時ファイルに出力: "ファイル名 total miss"
+#
+# ファイル見出し行の判定は「絶対パス (先頭 /) + '.rs:' で終わる」でのみ行う。
+# 以前は ^/home 決め打ちだったため、CI (/home/runner/...) 以外の場所
+# (例: /tmp 配下に worktree を作るローカル運用) では 1 行もマッチせず、
+# 登録簿の全ファイルが「見つからない」= 全 FAIL に見えていた。
+# `/src/` を必須にしないのも意図的: 将来 src/ 以外に登録ファイルが増えたときに
+# 静かに取りこぼさないため (この gate は取りこぼしたら fail、握り潰さない設計)
 SUMMARY_FILE=$(mktemp)
 awk '
-/^\/home.*\/src\/.*\.rs:$/ {
+/^\/.*\.rs:$/ {
     if (file != "") {
         total = covered + uncovered
         printf "%s %d %d\n", file, total, uncovered
@@ -114,6 +121,18 @@ END {
     }
 }
 ' "$CACHE_FILE" > "$SUMMARY_FILE"
+
+# 登録簿の全ファイルが "not found" になるのは大抵「カバレッジ不足」ではなく
+# 「このスクリプトが --text の出力を 1 行も読めていない」。区別できるよう、
+# ファイル見出しが 1 件も拾えていない場合は先に ERROR を出す
+if [ ! -s "$SUMMARY_FILE" ]; then
+  echo "ERROR: cargo llvm-cov --text の出力からファイル見出し行を 1 件も拾えませんでした。" >&2
+  echo "       これから登録簿の全ファイルが FAIL しますが、原因はカバレッジ不足ではなく" >&2
+  echo "       このスクリプトが出力形式を読めていないことです。" >&2
+  echo "       考えられる原因: cargo-llvm-cov のバージョン差で --text の書式が変わった / $CACHE_FILE が空・壊れている" >&2
+  echo "       $CACHE_FILE の中身を確認してください" >&2
+  echo "" >&2
+fi
 
 # --- Check each file ---
 FAILED=0


### PR DESCRIPTION
`scripts/check_coverage_100.sh` の awk が、`cargo llvm-cov --text` の**ファイル見出し行を `^/home` 決め打ちで拾っていた**のを直す。

```diff
-/^\/home.*\/src\/.*\.rs:$/ {
+/^\/.*\.rs:$/ {
```

## 症状

`/tmp/...` 配下の worktree で回すと**見出し行が 1 件も一致せず、登録簿の全ファイルが "not found" = 全 FAIL に見える**。CI は `/home/runner/...` で走るので**本番の gate は正しく効いていた**が、worktree を scratchpad に作る運用と噛み合っていなかった。実害として、担当者が正規表現だけ緩めた複製を手で作って回す羽目になった。

## 直し方

**絶対パス + `.rs:` 終端**だけで判定する。姉妹リポ `ohishi-exp/rust-ichibanboshi` の同名スクリプト (Python 実装) が既に採っている `^(/.*\.rs):$` と同じ思想。

**`/src/` は必須にしない。** 判定を狭めると将来 `src/` 以外に登録ファイルが増えたときに静かに取りこぼす。この gate の設計思想は「**取りこぼしたら fail、握り潰さない**」なので、狭める方向は思想に逆行する。

あわせて、**見出し行が 1 件も拾えなかった場合に「カバレッジ不足ではなくスクリプトが出力を読めていない」旨の ERROR を先出し**するようにした (同じ診断を姉妹リポにも `ohishi-exp/rust-ichibanboshi#252` で入れている。**本 PR がこの系統の実バグを直す側**)。

## 変えていないこと

- `coverage_100.toml` の登録内容
- `crates/` 配下のコード (よって map 再生成は不要)
- 「登録簿にあるのに計測データに現れないファイルは fail する (スキップしない)」既存の安全性

## 確認

1. **`/tmp` 配下の worktree で正しく判定** — 実際にこの worktree で `cargo llvm-cov --workspace` を回し、`--mock-only` 35 files / `--unit-only` 12 files とも全 OK (全ファイルが path 一致)
2. **`/home` (CI 同形) でも従来どおり** — カバレッジ出力の worktree パスを `/home/runner/work/...` に置換した cache で `--use-cache` 検証、12/12 OK
3. **本当に未達なら fail する** — `redact_broadcast.rs` の 1 行を意図的に 0 hit にした cache で検証し、正しく FAIL (99.4%, 1 lines missing)。他ファイルへの影響なし。確認用 cache は使い捨てで本体には未反映
4. `shellcheck --severity=warning scripts/check_coverage_100.sh` → 0 件

なお本リポの `coverage_100.toml` の登録ファイルはすべて unit/mock/combined 型で、姉妹リポにあった「pg が無いと 100% に届かない登録ファイル」の罠には該当しないことも確認済み。

Refs ohishi-exp/rust-ichibanboshi#205 の 35

🤖 Generated with [Claude Code](https://claude.com/claude-code)
