### PR TITLE
fix(auth): LINE WORKS の新規ユーザーを viewer で作る (Refs #599)

### DIFF
--- a/.claude/skills/rust-alc-api-map/SKILL.md
+++ b/.claude/skills/rust-alc-api-map/SKILL.md
@@ -286,10 +286,7 @@ psql "$DB_BASE" -c "VACUUM FULL alc_api.<table_name>;"
 - `resolve_sso_config()` は SECURITY DEFINER 関数（認証前アクセス用）
 - HMAC-SHA256 state パラメータで CSRF 防止（`OAUTH_STATE_SECRET` 環境変数）
 - 実装: `src/auth/lineworks.rs`, `src/routes/auth.rs`
-- **新規ユーザーの `role` は `'viewer'`** (`crates/alc-core/src/repo/auth.rs` の `create_user_lineworks`、Refs #599)。以前は `'admin'` リテラルで、LINE WORKS で ログインできる人が全員自動で管理者になっていた (`role == "admin"` は `crates/alc-misc/src/{tenant_users,access_requests,api_tokens,bot_admin,members,sso_admin}.rs` の 403 判定そのもの)。昇格は既存の管理 UI (招待 / 権限変更) 経由。
-  **経路ごとの決まり方**: Google = 招待 (`tenant_allowed_emails.role`) を bind (可変) / LINE WORKS = `'viewer'` / LINE = `'viewer'`。
-  この INSERT は `upsert_lineworks_user` (`crates/alc-auth/src/internal.rs`) が `find_user_by_lineworks_id` で既存行を引けなかったときだけ走る ⇒ **既存ユーザーの role は動かない** (既に admin で作られた人の是正は別件)。
-  `users.role` の DB 既定値は `'admin'` (`migrations/003_create_users.sql`) なので、リテラルを戻しても列を落としても退行は「静かに管理者が増える」形でしか出ない。実 DB テスト `tests/auth_user_role_test.rs` (bazel-test-db の `db-auth-user-role` shard) が 3 経路とも縛っている — mock (`tests/mock_helpers/repos_a.rs`) は SQL を通らないのでここは実 DB でしか測れない。
+- **新規ユーザーの `role` は `'viewer'`** (`crates/alc-core/src/repo/auth.rs` の `create_user_lineworks`、Refs #599。旧 `'admin'` リテラル)。経路別: Google = 招待 (`tenant_allowed_emails.role`) を bind / LINE WORKS = `'viewer'` / LINE = `'viewer'`。この INSERT は `upsert_lineworks_user` が `find_user_by_lineworks_id` で既存行を引けなかった時だけ走る (= 既存ユーザーの role は動かない)。`users.role` の DB 既定値は `'admin'` (`migrations/003_create_users.sql`) なので退行は静かに管理者が増える形でしか出ず、mock は SQL を通らないため実 DB テスト `tests/auth_user_role_test.rs` (bazel-test-db の `db-auth-user-role` shard) で 3 経路とも縛っている
 
 ### ミドルウェア
 

--- a/.claude/skills/rust-alc-api-map/SKILL.md
+++ b/.claude/skills/rust-alc-api-map/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rust-alc-api-map
-generated-from: rust-alc-api:3c222246
+generated-from: rust-alc-api:5df8b032
 paths: [crates/, src/, migrations/]
 description: rust-alc-api (アルコールチェッカー基盤の Rust/Axum Cargo workspace — domain crate 群 + monolith 単一バイナリ、PostgreSQL+RLS、Cloud Run) の構造ナビゲーション。どの crate に何のルートがあるか / monolith (rust-alc-api) 一本化 (gateway + per-domain は #556 で廃止) / RLS・migration・deploy/release 分離の gotcha を 1 枚にまとめる。トリガー:「rust-alc-api」「alc-api」「alc-notify」「alc-tenko」「alc-trouble」「alc-carins」「alc-dtako」「gateway」「tenko-api」「carins-api」「dtako-api」「trouble-api」「RLS テナント」「sqlx migration」「ts-rs」「Release Wave」「Bazel」等。
 ---
@@ -286,6 +286,10 @@ psql "$DB_BASE" -c "VACUUM FULL alc_api.<table_name>;"
 - `resolve_sso_config()` は SECURITY DEFINER 関数（認証前アクセス用）
 - HMAC-SHA256 state パラメータで CSRF 防止（`OAUTH_STATE_SECRET` 環境変数）
 - 実装: `src/auth/lineworks.rs`, `src/routes/auth.rs`
+- **新規ユーザーの `role` は `'viewer'`** (`crates/alc-core/src/repo/auth.rs` の `create_user_lineworks`、Refs #599)。以前は `'admin'` リテラルで、LINE WORKS で ログインできる人が全員自動で管理者になっていた (`role == "admin"` は `crates/alc-misc/src/{tenant_users,access_requests,api_tokens,bot_admin,members,sso_admin}.rs` の 403 判定そのもの)。昇格は既存の管理 UI (招待 / 権限変更) 経由。
+  **経路ごとの決まり方**: Google = 招待 (`tenant_allowed_emails.role`) を bind (可変) / LINE WORKS = `'viewer'` / LINE = `'viewer'`。
+  この INSERT は `upsert_lineworks_user` (`crates/alc-auth/src/internal.rs`) が `find_user_by_lineworks_id` で既存行を引けなかったときだけ走る ⇒ **既存ユーザーの role は動かない** (既に admin で作られた人の是正は別件)。
+  `users.role` の DB 既定値は `'admin'` (`migrations/003_create_users.sql`) なので、リテラルを戻しても列を落としても退行は「静かに管理者が増える」形でしか出ない。実 DB テスト `tests/auth_user_role_test.rs` (bazel-test-db の `db-auth-user-role` shard) が 3 経路とも縛っている — mock (`tests/mock_helpers/repos_a.rs`) は SQL を通らないのでここは実 DB でしか測れない。
 
 ### ミドルウェア
 

--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -172,6 +172,10 @@ jobs:
           # (読取日 OR 運行日) を実 DB で固定する。ci.yml の bazel-test-db と
           # 同じ内容にすること (check_bazel_test_matrix.sh が pair 一致を検査する)
           - { name: db-dtako-operation-window, target: "//:dtako_operation_window_test" }
+          # Refs #599: 新規ユーザーの role を実 DB で固定する。ci.yml の
+          # bazel-test-db と同じ内容にすること
+          # (check_bazel_test_matrix.sh が pair 一致を検査する)
+          - { name: db-auth-user-role, target: "//:auth_user_role_test" }
     services:
       postgres:
         image: postgres:16

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -383,6 +383,10 @@ jobs:
           # (読取日 OR 運行日) を実 DB で固定する。SQL は実行時クエリなので
           # コンパイル時検査が効かず、窓が縮む退行は静かにデータが減る形で出る
           - { name: db-dtako-operation-window, target: "//:dtako_operation_window_test" }
+          # Refs #599: ログイン経路ごとの新規ユーザーの role (LINE WORKS = viewer)
+          # を実 DB で固定する。role は実行時 SQL のリテラル / bind で決まり、
+          # users.role の DB 既定値が 'admin' なので退行は静かに管理者を増やす
+          - { name: db-auth-user-role, target: "//:auth_user_role_test" }
     services:
       postgres:
         image: postgres:16

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -151,6 +151,21 @@ rust_test(
 )
 
 rust_test(
+    name = "auth_user_role_test",
+    srcs = ["tests/auth_user_role_test.rs"] + glob(["tests/common/**/*.rs"]),
+    crate_root = "tests/auth_user_role_test.rs",
+    compile_data = glob(["migrations/**"]),
+    deps = [":rust_alc_api_lib"] + all_crate_deps(
+        normal = True,
+        normal_dev = True,
+    ) + _WORKSPACE_CRATES,
+    proc_macro_deps = all_crate_deps(
+        proc_macro = True,
+        proc_macro_dev = True,
+    ),
+)
+
+rust_test(
     name = "mock_carins",
     srcs = ["tests/mock_carins/main.rs"] + _MOCK_TEST_SRCS,
     crate_root = "tests/mock_carins/main.rs",

--- a/crates/alc-core/src/repo/auth.rs
+++ b/crates/alc-core/src/repo/auth.rs
@@ -161,6 +161,15 @@ impl AuthRepository for PgAuthRepository {
         .await
     }
 
+    /// LINE WORKS ログインで **新規に** user 行を作る (既存ヒット時は
+    /// `upsert_lineworks_user` 側が `find_user_by_lineworks_id` の結果を返すため
+    /// ここには来ない = 既存ユーザーの role はこの SQL では変わらない)。
+    ///
+    /// role は `'viewer'` 固定 (Refs #599)。以前は `'admin'` リテラルだったため、
+    /// LINE WORKS でログインできる人が全員自動で管理者になっていた。昇格は既存の
+    /// 管理 UI (招待 / 権限変更) 経由に寄せる。LINE 経路 (`create_user_line`) と
+    /// 揃った形で、招待の role を bind する Google 経路 (`create_user_google`) は
+    /// これまでどおり。
     async fn create_user_lineworks(
         &self,
         tenant_id: Uuid,
@@ -170,7 +179,7 @@ impl AuthRepository for PgAuthRepository {
     ) -> Result<User, sqlx::Error> {
         sqlx::query_as::<_, User>(
             r#"INSERT INTO users (tenant_id, lineworks_id, email, name, role)
-               VALUES ($1, $2, $3, $4, 'admin') RETURNING *"#,
+               VALUES ($1, $2, $3, $4, 'viewer') RETURNING *"#,
         )
         .bind(tenant_id)
         .bind(lineworks_id)

--- a/tests/auth_user_role_test.rs
+++ b/tests/auth_user_role_test.rs
@@ -1,0 +1,135 @@
+//! ログイン経路ごとの「新規ユーザーに付く role」を実 DB で固定する (Refs #599)。
+//!
+//! `role` は SQL 文字列リテラル / bind で決まる実行時クエリなので、コンパイル時
+//! 検査が効かない。しかも `users.role` の DB 既定値は `'admin'`
+//! (`migrations/003_create_users.sql`) なので、**リテラルを書き換えても列を
+//! 落としても、退行は「静かに管理者が増える」形でしか現れない**。
+//!
+//! mock (`tests/mock_helpers/repos_a.rs`) は `create_user_lineworks` を Rust 側で
+//! 組み立てて返すため、この SQL を 1 文字も通らない = ここは実 DB でしか縛れない。
+
+mod common;
+
+use rust_alc_api::db::repository::{AuthRepository, PgAuthRepository};
+use sqlx::postgres::PgPoolOptions;
+use uuid::Uuid;
+
+async fn setup() -> (sqlx::PgPool, PgAuthRepository) {
+    let pool = PgPoolOptions::new()
+        .max_connections(2)
+        .connect(&common::test_database_url())
+        .await
+        .expect("Failed to connect to test DB");
+    sqlx::migrate!("./migrations")
+        .run(&pool)
+        .await
+        .expect("Failed to run migrations");
+    let repo = PgAuthRepository::new(pool.clone());
+    (pool, repo)
+}
+
+/// 本題 (Refs #599): LINE WORKS の新規ユーザーは `viewer` で作られる。
+///
+/// リテラルを `'admin'` に戻すとこのテストが落ちる (陰性対照は PR 本文に実測)。
+#[tokio::test]
+async fn lineworks_new_user_gets_viewer_role() {
+    let (pool, repo) = setup().await;
+    let tenant = common::create_test_tenant(&pool, "LW Role").await;
+    let lineworks_id = format!("lw-{}", Uuid::new_v4().simple());
+
+    let user = repo
+        .create_user_lineworks(
+            tenant,
+            &lineworks_id,
+            "lw-role@example.test",
+            "LW Role User",
+        )
+        .await
+        .expect("create_user_lineworks failed");
+
+    assert_eq!(
+        user.role, "viewer",
+        "LINE WORKS の新規ユーザーは viewer であること (SQL リテラル / 列の抜け落ちで admin に戻る)"
+    );
+    assert_eq!(user.lineworks_id.as_deref(), Some(lineworks_id.as_str()));
+    assert_eq!(user.tenant_id, tenant);
+
+    // DB に書かれた値そのものも見る (RETURNING * の取り違えではないこと)
+    let stored: String = sqlx::query_scalar("SELECT role FROM users WHERE id = $1")
+        .bind(user.id)
+        .fetch_one(&pool)
+        .await
+        .expect("select role failed");
+    assert_eq!(stored, "viewer");
+}
+
+/// 既存ユーザーの role は #599 の変更では動かない。
+///
+/// `upsert_lineworks_user` (`crates/alc-auth/src/internal.rs`) は
+/// `find_user_by_lineworks_id` がヒットしたらその行をそのまま返し、
+/// `create_user_lineworks` を呼ばない。その分岐条件そのものを固定する。
+#[tokio::test]
+async fn existing_lineworks_user_is_found_and_role_untouched() {
+    let (pool, repo) = setup().await;
+    let tenant = common::create_test_tenant(&pool, "LW Existing").await;
+    let lineworks_id = format!("lw-{}", Uuid::new_v4().simple());
+
+    let created = repo
+        .create_user_lineworks(tenant, &lineworks_id, "lw-exist@example.test", "Existing")
+        .await
+        .expect("create_user_lineworks failed");
+
+    // 既に admin に昇格済みの人を模す
+    sqlx::query("UPDATE users SET role = 'admin' WHERE id = $1")
+        .bind(created.id)
+        .execute(&pool)
+        .await
+        .expect("promote failed");
+
+    let found = repo
+        .find_user_by_lineworks_id(&lineworks_id)
+        .await
+        .expect("find_user_by_lineworks_id failed")
+        .expect("既存ユーザーが引けること");
+
+    assert_eq!(found.id, created.id);
+    assert_eq!(
+        found.role, "admin",
+        "既存行がヒットする限り role は据え置き (create 側の変更は効かない)"
+    );
+}
+
+/// 触っていない 2 経路の role が動いていないこと。
+/// LINE = `viewer` リテラル / Google = 招待の role を bind (可変)。
+#[tokio::test]
+async fn line_stays_viewer_and_google_still_binds_role() {
+    let (pool, repo) = setup().await;
+    let tenant = common::create_test_tenant(&pool, "Other Routes Role").await;
+
+    let line_user = repo
+        .create_user_line(
+            tenant,
+            &format!("line-{}", Uuid::new_v4().simple()),
+            "LINE User",
+        )
+        .await
+        .expect("create_user_line failed");
+    assert_eq!(line_user.role, "viewer");
+
+    for role in ["admin", "viewer"] {
+        let google_user = repo
+            .create_user_google(
+                tenant,
+                &format!("gsub-{}", Uuid::new_v4().simple()),
+                "google-role@example.test",
+                "Google User",
+                role,
+            )
+            .await
+            .expect("create_user_google failed");
+        assert_eq!(
+            google_user.role, role,
+            "Google 経路は招待の role をそのまま bind する"
+        );
+    }
+}


### PR DESCRIPTION
## 何を・なぜ

LINE WORKS でログインして**新規に作られる** user 行が、SQL のリテラルで無条件に
`role = 'admin'` になっていました (`crates/alc-core/src/repo/auth.rs` の `create_user_lineworks`)。

`role == "admin"` は各所で管理操作の可否そのもの
(`crates/alc-misc/src/{tenant_users,access_requests,api_tokens,bot_admin,members,sso_admin}.rs`
がいずれも `auth_user.role != "admin"` で 403) なので、**ログイン経路が管理者権限を自動で
付与する**形になっていました。

3 経路で扱いが揃っていなかったのを揃えます:

| 経路 | role の決まり方 |
|---|---|
| Google (`create_user_google`) | 招待 (`tenant_allowed_emails.role`) を bind (可変) — **無変更** |
| LINE WORKS (`create_user_lineworks`) | `'admin'` リテラル → **`'viewer'`** (本 PR) |
| LINE (`create_user_line`) | `'viewer'` リテラル — **無変更** |

昇格が要る人は既存の管理 UI (招待 / 権限変更) で上げる運用に寄せます。

## ★ 効き方の範囲 (誤読されやすいので明記)

- **この INSERT は新規作成時だけ走ります。既存ユーザーの role は 1 件も変わりません。**
  根拠: `upsert_lineworks_user` (`crates/alc-auth/src/internal.rs`) は
  `find_user_by_lineworks_id` を先に引き、`Some(u) => u` でその行をそのまま返します。
  `create_user_lineworks` が呼ばれるのは `None` の分岐だけです。
  この分岐は `existing_lineworks_user_is_found_and_role_untouched` テストでも固定しました
  (admin に昇格済みの既存行が admin のまま引けること)。
- **既に `admin` で作られた既存ユーザーの是正は本 PR の範囲外**です (別の判断)。
  **この PR で DB は更新していません。**

## 触っていないもの

- Google 経路 `create_user_google` / LINE 経路 `create_user_line`
- `migrations/` (**この変更に migration は不要**。変更 0 行)
- `role` の CHECK 制約 (`'admin' | 'viewer'` の 2 値。3 値目は別の議論)
- `crates/alc-misc/src/*.rs` の `role != "admin"` 判定群 (変更 0 行)

## 検証

`role` は実行時 SQL のリテラル / bind で決まるためコンパイル時検査が効かず、しかも
`users.role` の DB 既定値が `'admin'` (`migrations/003_create_users.sql`) なので、
**退行は「静かに管理者が増える」形でしか現れません。** よって実 DB テストで縛ります
(`tests/auth_user_role_test.rs`、3 本)。

`#588` の `dtako_operation_window_test` と同じ形で、CI の `bazel-test-db` に
`db-auth-user-role` shard として登録しています (BUILD.bazel / ci.yml / cache-warm.yml の
3 箇所)。**登録しないと `tests/*.rs` は bazel 一本の CI で 1 回も走りません** —
`scripts/check_bazel_test_matrix.sh` が pair 一致を loud fail させる理由がこれです。
実行結果: `bazel test matrix OK — 27 rust_test target を網羅、各 job pair の warm 一致`。

**測定条件**: base = `5df8b032b85999527ab35c534fbf165805a39367`。
`source .test-config && cargo test --test auth_user_role_test` (docker の test-db)。

- green: `3 passed; 0 failed`
- **陰性対照**: リテラルを `'admin'` に戻すと `lineworks_new_user_gets_viewer_role` が
  `left: "admin" / right: "viewer"` で落ちる (`2 passed; 1 failed`)。
  戻したあと `'viewer'` に直して再 green を確認済み。
- `cargo fmt --check --all` → clean。

テストは値を実際に検査しています (定数同士の assert ではありません):
`user.role` と `SELECT role FROM users WHERE id = $1` の**DB 側の実値**の両方を見ており、
Google 経路は `["admin","viewer"]` の両方を回して bind 値と一致することを確認しています。

**「登録した」と「走った」は別**なので、skip できない作りであることも測りました。
`tests/common/mod.rs` の `test_database_url()` は接続に失敗すると `expect` で落ちるため、
**DB を落として走らせると 3 本とも `FAILED` (`0 ignored; 0 filtered out`)** になります。
緑のまま検証ゼロになる経路はありません。

陰性対照は **BUILD.bazel / ci.yml / cache-warm.yml の登録が既に在る状態**で取り直しています
(登録前に取ると「テストが落ちる」は示せても「CI で走る」は示せないため)。

## 測れなかった範囲

repo 層のメソッドまでの検証で、**LINE WORKS OAuth → auth-worker →
`/api/internal/auth/users/upsert-lineworks` の end-to-end は通していません。**
ハンドラが新規時だけ `create_user_lineworks` を呼ぶことは**コード読みが根拠**です。
mock (`tests/mock_helpers/repos_a.rs`) は SQL を通らず上流の挙動を証明できないため
使っていません。

**手元に bazel が無いため、上記の実測は cargo の `--test auth_user_role_test` 経路で
取っています。** `//:auth_user_role_test` が `bazel-test-db` shard として実際に走ることは
**この PR の `Bazel test (db-auth-user-role)` の結果で確認**してください
(`scripts/check_bazel_test_matrix.sh` は green ですが、それは登録の整合までしか保証しません)。

Refs #599
