### PR TITLE
feat(role): role に payroll を足す (CHECK と allowlist、挙動は不変) (Refs ohishi-exp/nuxt-dtako-admin#1048)

### DIFF
--- a/.claude/skills/rust-alc-api-map/SKILL.md
+++ b/.claude/skills/rust-alc-api-map/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rust-alc-api-map
-generated-from: rust-alc-api:5df8b032
+generated-from: rust-alc-api:e31d4c59
 paths: [crates/, src/, migrations/]
 description: rust-alc-api (アルコールチェッカー基盤の Rust/Axum Cargo workspace — domain crate 群 + monolith 単一バイナリ、PostgreSQL+RLS、Cloud Run) の構造ナビゲーション。どの crate に何のルートがあるか / monolith (rust-alc-api) 一本化 (gateway + per-domain は #556 で廃止) / RLS・migration・deploy/release 分離の gotcha を 1 枚にまとめる。トリガー:「rust-alc-api」「alc-api」「alc-notify」「alc-tenko」「alc-trouble」「alc-carins」「alc-dtako」「gateway」「tenko-api」「carins-api」「dtako-api」「trouble-api」「RLS テナント」「sqlx migration」「ts-rs」「Release Wave」「Bazel」等。
 ---
@@ -259,7 +259,7 @@ psql "$DB_BASE" -c "VACUUM FULL alc_api.<table_name>;"
   "email": "user@example.com",
   "name": "ユーザー名",
   "tenant_id": "UUID (テナントID)",
-  "role": "admin | viewer",
+  "role": "admin | viewer | payroll",
   "iat": 1234567890,
   "exp": 1234571490
 }
@@ -287,6 +287,7 @@ psql "$DB_BASE" -c "VACUUM FULL alc_api.<table_name>;"
 - HMAC-SHA256 state パラメータで CSRF 防止（`OAUTH_STATE_SECRET` 環境変数）
 - 実装: `src/auth/lineworks.rs`, `src/routes/auth.rs`
 - **新規ユーザーの `role` は `'viewer'`** (`crates/alc-core/src/repo/auth.rs` の `create_user_lineworks`、Refs #599。旧 `'admin'` リテラル)。経路別: Google = 招待 (`tenant_allowed_emails.role`) を bind / LINE WORKS = `'viewer'` / LINE = `'viewer'`。この INSERT は `upsert_lineworks_user` が `find_user_by_lineworks_id` で既存行を引けなかった時だけ走る (= 既存ユーザーの role は動かない)。`users.role` の DB 既定値は `'admin'` (`migrations/003_create_users.sql`) なので退行は静かに管理者が増える形でしか出ず、mock は SQL を通らないため実 DB テスト `tests/auth_user_role_test.rs` (bazel-test-db の `db-auth-user-role` shard) で 3 経路とも縛っている
+- **`role` の取りうる値は `'admin'` / `'viewer'` / `'payroll'`** (`migrations/131_add_payroll_role.sql` で `users.role` と `tenant_allowed_emails.role` の CHECK を同時に広げた)。**招待側 (`tenant_allowed_emails`) とログイン本体 (`users`) は必ず同じ集合にする** — 片方だけ広げると「招待は通るのにログインで CHECK 違反」になる。`'payroll'` は給与の閲覧可否を決める独立した軸で、上流 (rust-ichibanboshi) の email allowlist と **AND** で効く (role が allowlist を上書きすることはない)。**テナント管理系の権限判定 (`role != "admin"` の 22 か所: `access_requests.rs` / `api_tokens.rs` / `bot_admin.rs` / `members.rs` / `sso_admin.rs` / `tenant_users.rs`) は従来どおりで、`'payroll'` はそこでは 403 のまま** — 給与専用 role が SSO 設定 / API トークン / bot 設定 / メンバー管理 / 参加リクエストに触れないのが正しい状態なので緩めない。受け付ける側は `tenant_users::invite_user` の allowlist と `members::is_allowed_role` の 2 か所 (後者は frontend 固有の `'member'` も許す)。**`employees.role` (`migrations/024` / `028`、driver / manager / admin) は別テーブル・別ドメイン**で、同名の `'admin'` が出てくるが無関係
 
 ### ミドルウェア
 

--- a/crates/alc-misc/src/members.rs
+++ b/crates/alc-misc/src/members.rs
@@ -39,7 +39,7 @@ struct UpdateRoleRequest {
 /// frontend から送られてくる role を受け付ける集合。
 /// DB 側は text でゆるいので、`member` などの frontend 固有値もそのまま保存する。
 fn is_allowed_role(role: &str) -> bool {
-    matches!(role, "admin" | "viewer" | "member")
+    matches!(role, "admin" | "viewer" | "member" | "payroll")
 }
 
 pub fn router() -> Router<AppState> {

--- a/crates/alc-misc/src/tenant_users.rs
+++ b/crates/alc-misc/src/tenant_users.rs
@@ -117,7 +117,9 @@ async fn invite_user(
     }
 
     let role = body.role.unwrap_or_else(|| "admin".to_string());
-    if role != "admin" && role != "viewer" {
+    // 'payroll' は給与閲覧用の role。テナント管理の権限判定 (role != "admin") は
+    // 従来どおりなので、招待で受け付けても管理系は 403 のまま。
+    if !matches!(role.as_str(), "admin" | "viewer" | "payroll") {
         return Err(StatusCode::BAD_REQUEST);
     }
 

--- a/migrations/131_add_payroll_role.sql
+++ b/migrations/131_add_payroll_role.sql
@@ -1,0 +1,90 @@
+-- role に 'payroll' (給与閲覧) を追加する。
+--
+-- 広げる先は 2 つで、必ず同時に広げる:
+--   - alc_api.users.role                 (003 で作成) — ログイン本体
+--   - alc_api.tenant_allowed_emails.role (053 で作成) — 招待
+-- 片方だけ広げると「招待は通るのにログインで CHECK 違反」というズレが出るため、
+-- 1 つの migration にまとめている。
+--
+-- この migration は CHECK を広げるだけで、既存行の role は 1 件も書き換えない
+-- (UPDATE を書かない)。この時点で 'payroll' を持つ行は 0 件なので、
+-- API の挙動は変わらない。値を先に受け付けられる状態にするのが目的。
+--
+-- 'payroll' は「給与の実額を見てよいか」を決める独立した軸で、上流の
+-- email allowlist と AND で効く。role が allowlist を上書きすることはない。
+-- テナント管理 (SSO 設定 / API トークン / bot 設定 / メンバー管理 /
+-- 参加リクエスト) の権限判定は従来どおり role = 'admin' のみで、
+-- 'payroll' はそれらでは 403 のまま — ここでは緩めない。
+--
+-- 注意: employees.role (024 / 028) は運行者 / 運行管理者 / システム管理者の
+-- 別テーブル・別ドメイン。同名の 'admin' が出てくるが、ここでは触らない。
+--
+-- ---------------------------------------------------------------------------
+-- なぜ制約名を決め打ちせず pg_constraint から引くのか
+-- ---------------------------------------------------------------------------
+-- 003 / 053 はどちらもインライン CHECK なので、名前は PostgreSQL の既定命名
+-- (<table>_<column>_check) になっているはず。004〜130 に改名・再作成も無い。
+-- それでも決め打ちしないのは、**本番 DB (Supabase) の pg_constraint を
+-- 事前に見る手段が無い**ため。migration 履歴の外で手作業の改名や制約の
+-- 張り直しが行われていた場合、grep では検出できない。
+--
+-- そして、その drift を本番より前に踏む経路が無い:
+--   - staging (PR ごとに deploy) は postgres sidecar の**揮発 DB** で、
+--     cold start ごとに 001 から順に流し直す (staging/entrypoint.sh)。
+--     つまり staging の制約名は migration が作った既定名そのもので、
+--     **定義上ズレようがない** → drift の検出には使えない
+--   - migration-safety-check.yml は SQL の静的検査のみで DB に当てない
+--     (しかも warning only)
+--   - 本番へは deploy.yml の migrate job (Cloud Run Jobs) が
+--     v* タグ push でのみ実行する
+-- ⇒ 名前を決め打ちすると、ズレていた場合に**本番デプロイで初めて**落ちる。
+--
+-- DROP に `IF EXISTS` を付けないのも同じ理由。付けると名前が違ったときに
+-- DROP が黙って no-op になり、旧 CHECK が残ったまま新 CHECK が足されて
+-- 'payroll' が拒否され続ける — 一番気付きにくい壊れ方になる。
+-- 下の DO ブロックは「role 列の CHECK がちょうど 1 個」でなければ
+-- RAISE EXCEPTION で落とすので、沈黙しない性質はそのまま保たれる。
+
+DO $$
+DECLARE
+    v_table   TEXT;
+    v_conname TEXT;
+    v_count   INT;
+BEGIN
+    FOREACH v_table IN ARRAY ARRAY['alc_api.users', 'alc_api.tenant_allowed_emails']
+    LOOP
+        -- role 列に掛かる CHECK 制約を実際に引く。
+        -- contype = 'c' は CHECK のみ (NOT NULL は attnotnull / contype = 'n' で
+        -- 別枠なのでここには出てこない)。conkey に role の attnum を含むものが対象。
+        SELECT count(*), min(c.conname)
+          INTO v_count, v_conname
+          FROM pg_constraint c
+          JOIN pg_attribute a
+            ON a.attrelid = c.conrelid
+           AND a.attnum = ANY (c.conkey)
+         WHERE c.conrelid = v_table::regclass
+           AND c.contype = 'c'
+           AND a.attname = 'role';
+
+        IF v_count <> 1 THEN
+            RAISE EXCEPTION
+                'migration 131: % の role 列に掛かる CHECK 制約が % 個見つかりました (1 個であるはず)。'
+                ' migration 履歴の外で制約が張り替えられている可能性があります。'
+                ' pg_constraint を確認してから再実行してください。',
+                v_table, v_count;
+        END IF;
+
+        RAISE NOTICE 'migration 131: % の role CHECK 制約 "%" を DROP します', v_table, v_conname;
+        EXECUTE format('ALTER TABLE %s DROP CONSTRAINT %I', v_table::regclass, v_conname);
+    END LOOP;
+END
+$$;
+
+-- 張り直しは新規作成なので名前が衝突しない。既定命名に揃えておく。
+ALTER TABLE alc_api.users
+    ADD CONSTRAINT users_role_check
+    CHECK (role IN ('admin', 'viewer', 'payroll'));
+
+ALTER TABLE alc_api.tenant_allowed_emails
+    ADD CONSTRAINT tenant_allowed_emails_role_check
+    CHECK (role IN ('admin', 'viewer', 'payroll'));

--- a/tests/mock_tests/mock_members_test.rs
+++ b/tests/mock_tests/mock_members_test.rs
@@ -448,3 +448,31 @@ async fn test_delete_member_db_error() {
         .unwrap();
     assert_eq!(res.status(), 500);
 }
+
+#[tokio::test]
+async fn test_invite_member_payroll_role() {
+    let (base_url, auth) = setup_admin().await;
+    let client = reqwest::Client::new();
+    let res = client
+        .post(format!("{base_url}/api/members"))
+        .header("Authorization", &auth)
+        .json(&json!({ "email": "x@example.com", "role": "payroll" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+}
+
+#[tokio::test]
+async fn test_update_role_payroll() {
+    let (base_url, auth) = setup_admin().await;
+    let client = reqwest::Client::new();
+    let res = client
+        .patch(format!("{base_url}/api/members/foo@example.com"))
+        .header("Authorization", &auth)
+        .json(&json!({ "role": "payroll" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 204);
+}

--- a/tests/mock_tests/mock_tenant_users_test.rs
+++ b/tests/mock_tests/mock_tenant_users_test.rs
@@ -523,3 +523,24 @@ async fn test_list_users_with_data() {
     assert_eq!(users.len(), 1);
     assert_eq!(users[0]["email"], "test@example.com");
 }
+
+#[tokio::test]
+async fn test_invite_user_success_payroll_role() {
+    let (base_url, auth_header, _, _) = setup().await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/admin/users/invite"))
+        .header("Authorization", &auth_header)
+        .json(&serde_json::json!({
+            "email": "payroll@example.com",
+            "role": "payroll"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    let body: serde_json::Value = res.json().await.unwrap();
+    assert_eq!(body["email"], "payroll@example.com");
+    assert_eq!(body["role"], "payroll");
+}


### PR DESCRIPTION
## 何を・なぜ

`role` に **`payroll`** (給与閲覧) を足せるようにします。**この PR では値を受け付けられる状態にするだけ**で、
**挙動は 1 mm も変わりません** — この時点で `payroll` を持つ行は 0 件だからです。

`payroll` は「給与の実額を**見てよいか**」を決める独立した軸で、**上流の email allowlist と AND** で効きます。
**role が allowlist を上書きすることはありません。** 詳細は ohishi-exp/nuxt-dtako-admin#1048。

Refs ohishi-exp/nuxt-dtako-admin#1048

## 変えたもの

| ファイル | 変更 |
|---|---|
| `migrations/131_add_payroll_role.sql` (新規) | `users.role` と `tenant_allowed_emails.role` の CHECK を**両方同時に** `('admin','viewer','payroll')` へ |
| `crates/alc-misc/src/tenant_users.rs` | `invite_user` のバリデーションに `payroll` |
| `crates/alc-misc/src/members.rs` | `is_allowed_role` に `payroll` |
| `.claude/skills/rust-alc-api-map/SKILL.md` | `crates/`・`migrations/` を触ったので再生成 |
| `tests/mock_tests/mock_{members,tenant_users}_test.rs` | `payroll` の正常系 |

**CHECK は 2 つとも同時に広げます。** 片方だけだと「招待は通るのにログインで CHECK 違反」というズレが出ます。

## 触っていないもの

- **`role != "admin"` の権限判定 22 か所** (`access_requests` / `api_tokens` / `bot_admin` / `members` /
  `sso_admin` / `tenant_users`)。**新 role はそれら 22 か所すべてで 403 のまま**です — 給与専用の role が
  テナント管理に触れないのは正しい状態なので、ここでは緩めません
- `crates/alc-auth/src/internal.rs` の自動テナント作成時の既定 `role="admin"`
- `migrations/024` / `028` の **`employees.role`** — あちらは運行者 / 運行管理者 / システム管理者の
  **別テーブル・別ドメイン**です。同名の `'admin'` が出てきますが無関係
- **既存 migration のバイト列は 1 つも変えていません** (`git diff --name-only origin/main -- migrations/`
  が `131` 以外を出さないことを確認)
- **`UPDATE` / `DELETE` / `INSERT` を 1 行も書いていません** (陽性対照: 同じ grep が `053` には 2 件ヒット)

## ★ 制約名を決め打ちしていません

`003` / `053` はどちらもインライン CHECK なので、名前は既定命名 (`<table>_<column>_check`) に
なっている**はず**です。`004`〜`130` に改名・再作成もありません。**それでも決め打ちしないのは、
本番 DB の `pg_constraint` を事前に見る手段が無いから**です。履歴の外で手作業の改名が行われていた
場合、grep では検出できません。

**そして、その drift を本番より前に踏む経路がありません**:

- **staging** (PR ごとに deploy) は postgres sidecar の**揮発 DB** で、cold start ごとに `001` から
  流し直します (`staging/entrypoint.sh`)。つまり staging の制約名は migration が作った既定名そのもので、
  **定義上ズレようがない** ⇒ **drift の検出には使えません**
- `migration-safety-check.yml` は SQL の**静的検査のみ**で DB に当てません (しかも warning only)
- 本番へは `deploy.yml` の `migrate` job (Cloud Run Jobs) が **`v*` タグ push でのみ**実行します

⇒ 名前を決め打ちすると、ズレていた場合に**本番デプロイで初めて**落ちます。

そこで `pg_constraint` から**実際に引いて** `EXECUTE format(...)` で DROP しています。

**`DROP` に `IF EXISTS` は付けていません。** 付けると名前が違ったときに DROP が黙って no-op になり、
**旧 CHECK が残ったまま新 CHECK が足されて `payroll` が拒否され続ける** — 一番気付きにくい壊れ方に
なります。DO ブロックは「role 列の CHECK がちょうど 1 個」でなければ `RAISE EXCEPTION` で落とすので、
**沈黙しない性質はそのまま保たれます。**

## 検証 — 使い捨ての postgres:16 に実際に当てました

**共有の `make db-up` (固定ポート) は他セッションの持ち物なので使わず**、ユニーク名 +
ループバック限定の高位ポートで 1 個だけ起動し、`003` / `053` の role 列定義を verbatim で写した
fixture に当てています。

まず fixture が既定命名になること (= 履歴からの推定が正しいこと) を確認:

```
alc_api.users                 -> users_role_check
alc_api.tenant_allowed_emails -> tenant_allowed_emails_role_check
```

| CASE | 状況 | 結果 |
|---|---|---|
| **A** | 既定命名のまま (= staging と同じ) | `exit=0`。適用後 `payroll` は入る / `member` は弾かれる / **既存行は不変** |
| **B** | **履歴外で改名されている** (`chk_users_role_legacy` / `tae_role_v2`) | `exit=0` — 引いた名前で DROP して通る。**決め打ち版ならここで本番デプロイが止まっていました** |
| **C** | role の CHECK が **0 個** | `exit=3` — `RAISE EXCEPTION` で落ちる |
| **D** | role の CHECK が **2 個** | `exit=3` — 同上 |
| **E** | 1 つ目が成功し 2 つ目で落ちる | `exit=3`。**`users` の旧 CHECK が健在** = DROP が巻き戻った。DO ブロックは 1 文なので原子的で、**片方だけ DROP された中途半端な状態は残りません** |

その他:

```
cargo fmt --all -- --check     fmt: clean
cargo check --all-targets      exit 0
migration-safety-check.sh      rollback-safe (no contract pattern detected) / 0 unsafe pattern(s)
```

**本番 / staging への手動 migration 適用はしていません。** 当てたのは使い捨てのローカルコンテナだけです。

## ★ 測っていないこと

- **本番 DB の `pg_constraint` の実物は見ていません。** そもそも見る手段が無いのがこの設計の理由です
- `RAISE NOTICE` が Cloud Run のログに出るかは**未確認**です。そこは当てにせず、
  **失敗時は例外メッセージ側にテーブル名と個数が入る**形にしてあります

## この後の順序 (ここを逆にすると業務が止まります)

```
① この PR              CHECK を広げる (誰も payroll を持っていないので挙動は不変)
② dtako 側 1 行         ALLOWED_ROLES に payroll (既存の admin には影響なし)
③ 【人の作業】          対象者に payroll role を配る
④ rust-ichibanboshi     authorize() に role の AND を足す (allowlist 判定の【後】)
```

**①②は互いに独立で、どちらも単独で安全**です。**④だけが③を待ちます。**

## 作業中に見つけた別件 (この PR では触っていません)

`is_allowed_role` が許す **`member`** は、どちらの CHECK にも入っていません。しかも
**`role` 未指定時の既定値**なので、`POST /api/members` を `role` 無しで叩くと CHECK 違反で **500** に
なります。**#601 に切り出しました** — この PR は「挙動を 1 mm も変えない」のが性質なので混ぜていません。
