### PR TITLE
docs(cloudrun): render.sh の secretAccessor コメントを per-secret grant の実態に直す (Refs #391)

### DIFF
--- a/cloudrun/render.sh
+++ b/cloudrun/render.sh
@@ -127,8 +127,14 @@ emit_env_backend() {
               value: "info"
 YAML
   # staging のみ: export/import の opt-in 認証 key を注入 (Refs #391)。runtime SA
-  # 747065218280-compute@ は project-level secretAccessor で ALC_STAGING_API_KEY も
-  # 解決できる前提 (既存 GOOGLE_CLIENT_ID 等と同経路)。新 revision 起動で X-Staging-Key 必須化。
+  # 747065218280-compute@ の secretmanager.secretAccessor は **project レベルではなく
+  # per-secret grant** なので、secretKeyRef で参照する新 secret ごとに 1 回
+  #   gcloud secrets add-iam-policy-binding <NAME> --project=cloudsql-sv \
+  #     --member="serviceAccount:747065218280-compute@developer.gserviceaccount.com" \
+  #     --role="roles/secretmanager.secretAccessor"
+  # が必要。漏れると cutover が `Permission denied on secret: <NAME>` で fail する
+  # (ALC_STAGING_API_KEY 自体がその実事例 = #391)。
+  # 詳細: .claude/skills/rust-alc-api-map/SKILL.md:1119。新 revision 起動で X-Staging-Key 必須化。
   if [[ "$ENV" == "staging" ]]; then
     cat <<YAML
             - name: DATABASE_URL


### PR DESCRIPTION
## 何を直したか

`cloudrun/render.sh:130` のコメント:

> runtime SA 747065218280-compute@ は **project-level secretAccessor** で ALC_STAGING_API_KEY も解決できる前提 (既存 GOOGLE_CLIENT_ID 等と同経路)

これが実態と逆。`747065218280-compute@developer.gserviceaccount.com` の `roles/secretmanager.secretAccessor` は **project レベルではなく per-secret grant** で運用している。

## 根拠

- `.claude/skills/rust-alc-api-map/SKILL.md:1119` — 「`747065218280-compute@` への `secretmanager.secretAccessor` は **project レベルではなく per-secret grant**」と明記。新 secret ごとに `gcloud secrets add-iam-policy-binding` が 1 回必要。
- 事例 #391 — まさに `ALC_STAGING_API_KEY` が grant 漏れで staging cutover を `Permission denied on secret: ALC_STAGING_API_KEY ... must be granted roles/secretmanager.secretAccessor` で落とした。**コメントが「解決できる前提」の根拠に挙げていた当の secret が反例**だった。
- 参考 (GCP 公式 Secret Manager access control): `roles/owner` は `secretmanager.versions.access` を含むが `roles/editor` / `roles/viewer` は含まない。つまり「project の editor だから読める」という経路も存在しない。

誤記のまま放置すると「新しい secret を `secretKeyRef` に足すだけで Cloud Run が解決できる」と読めてしまい、#391 と同じ cutover failure を再生産する。

## 変更内容

コメントを実態 (per-secret grant + 必要な `add-iam-policy-binding` コマンド + 参照先 `SKILL.md:1119`) に書き換えた。

**コメントのみの変更で、`render.sh` が出力する YAML は不変。**

## スコープ

同型の誤記は repo 全体でこの 1 か所のみ (確認済み)。スイープはしていない。

## 位置づけ

GCP プロジェクト `cloudsql-sv` の IAM 棚卸し (T-A) の一部。誤った前提が doc に残っていると棚卸しの判断材料が汚染されるため先に潰した。

🤖 Generated with [Claude Code](https://claude.com/claude-code)