### PR TITLE
feat(infra): Cloud Run runtime SA を既定 Compute SA から専用 SA へ (Refs #606)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -84,6 +84,19 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
 
+      # runtime SA は cloudrun/render.sh が single source of truth (Refs #606)。
+      # ここで値を再掲すると render.sh と drift し、T-E で compute SA から
+      # roles/editor を剥がした時に job だけ黙って動かなくなるので、render.sh の
+      # production 出力から読み出す (image_sha は SA 選択に影響しないので dummy)。
+      - name: Resolve runtime service account
+        run: |
+          set -euo pipefail
+          SA=$(bash cloudrun/render.sh backend production dummy \
+                 | awk '/serviceAccountName:/{print $2; exit}')
+          test -n "$SA"
+          echo "RUNTIME_SA=$SA" >> "$GITHUB_ENV"
+          echo "::notice ::runtime SA for Cloud Run jobs: $SA"
+
       - name: Run migrations
         run: |
           AR_IMAGE="${{ env.AR_PREFIX }}/${{ env.REPO }}:${{ inputs.image_sha }}"
@@ -92,11 +105,13 @@ jobs:
           if gcloud run jobs describe $JOB_NAME --region ${{ env.REGION }} --project ${{ env.PROJECT }} &>/dev/null; then
             gcloud run jobs update $JOB_NAME \
               --region ${{ env.REGION }} --project ${{ env.PROJECT }} \
-              --image "$AR_IMAGE"
+              --image "$AR_IMAGE" \
+              --service-account "$RUNTIME_SA"
           else
             gcloud run jobs create $JOB_NAME \
               --region ${{ env.REGION }} --project ${{ env.PROJECT }} \
               --image "$AR_IMAGE" \
+              --service-account "$RUNTIME_SA" \
               --set-secrets "DATABASE_URL=alc-app-database-url:latest" \
               --command "migrate" \
               --memory 512Mi --task-timeout 120s --max-retries 0
@@ -358,6 +373,8 @@ jobs:
     needs: [migrate]
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+
       - name: Authenticate to GCP
         uses: google-github-actions/auth@v2
         with:
@@ -366,13 +383,27 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
 
+      # runtime SA は cloudrun/render.sh が single source of truth (Refs #606)。
+      # ここで値を再掲すると render.sh と drift し、T-E で compute SA から
+      # roles/editor を剥がした時に job だけ黙って動かなくなるので、render.sh の
+      # production 出力から読み出す (image_sha は SA 選択に影響しないので dummy)。
+      - name: Resolve runtime service account
+        run: |
+          set -euo pipefail
+          SA=$(bash cloudrun/render.sh backend production dummy \
+                 | awk '/serviceAccountName:/{print $2; exit}')
+          test -n "$SA"
+          echo "RUNTIME_SA=$SA" >> "$GITHUB_ENV"
+          echo "::notice ::runtime SA for Cloud Run jobs: $SA"
+
       - name: Update archive Job image
         run: |
           AR_IMAGE="${{ env.AR_PREFIX }}/${{ env.REPO }}:${{ inputs.image_sha }}"
           gcloud run jobs update rust-alc-api-archive \
             --region ${{ env.REGION }} --project ${{ env.PROJECT }} \
-            --image "$AR_IMAGE"
-          echo "::notice ::Archive Job updated"
+            --image "$AR_IMAGE" \
+            --service-account "$RUNTIME_SA"
+          echo "::notice ::Archive Job updated (runtime SA: $RUNTIME_SA)"
 
   # ---------------------------------------------------------------------------
   # Production: verify the tag release did NOT flip traffic

--- a/archive.sh
+++ b/archive.sh
@@ -23,18 +23,31 @@ else
   GCLOUD_ARGS="$COMMAND"
 fi
 
+# runtime SA は cloudrun/render.sh が single source of truth (Refs #606)。
+# ここで値を再掲すると render.sh と drift するので production 出力から読む
+# (image_sha は SA 選択に影響しないので dummy)。
+RUNTIME_SA=$(bash "$(dirname "$0")/cloudrun/render.sh" backend production dummy \
+               | awk '/serviceAccountName:/{print $2; exit}')
+if [ -z "$RUNTIME_SA" ]; then
+  echo "failed to resolve runtime service account from cloudrun/render.sh" >&2
+  exit 1
+fi
+echo "runtime SA: $RUNTIME_SA"
+
 # Create or update the job
 if gcloud run jobs describe $ARCHIVE_JOB_NAME --region $REGION --project $PROJECT_ID &>/dev/null; then
   gcloud run jobs update $ARCHIVE_JOB_NAME \
     --region $REGION \
     --project $PROJECT_ID \
     --image $IMAGE:latest \
+    --service-account "$RUNTIME_SA" \
     --args "$GCLOUD_ARGS"
 else
   gcloud run jobs create $ARCHIVE_JOB_NAME \
     --region $REGION \
     --project $PROJECT_ID \
     --image $IMAGE:latest \
+    --service-account "$RUNTIME_SA" \
     --set-secrets "DATABASE_URL=alc-app-database-url:latest,DTAKO_R2_ACCESS_KEY=dtako-r2-access-key:latest,DTAKO_R2_SECRET_KEY=dtako-r2-secret-key:latest" \
     --set-env-vars "R2_ACCOUNT_ID=24b45709d060d957340180e995f0d373,DTAKO_R2_BUCKET=ohishi-dtako" \
     --command "archive" \

--- a/cloudrun/render.sh
+++ b/cloudrun/render.sh
@@ -40,8 +40,28 @@ while [[ $# -gt 0 ]]; do
 done
 
 REPO="ghcr.io/ippoan/rust-alc-api"
-AR_PREFIX="asia-northeast1-docker.pkg.dev/cloudsql-sv/ghcr"
+PROJECT="cloudsql-sv"
+AR_PREFIX="asia-northeast1-docker.pkg.dev/${PROJECT}/ghcr"
 REGION="asia-northeast1"
+
+# ---------------------------------------------------------------------------
+# Runtime service account (Refs #606)
+# ---------------------------------------------------------------------------
+# 以前は serviceAccountName を一切書かず、Cloud Run 既定の Compute SA
+# (747065218280-compute@developer.gserviceaccount.com、roles/editor 保持) が
+# 暗黙で runtime SA になっていた。専用 SA に移して editor の巻き添え権限を切る。
+#
+# NOTE: rust-alc-api だけ ci-workflows の reusable deploy を経由せず
+# `gcloud run services replace` で service YAML を丸ごと置き換えるため
+# (.github/workflows/deploy.yml)、reusable 側の runtime_service_account
+# enforce が効かない。したがって runtime SA の指定はこの render.sh が
+# single source of truth になる。reusable に寄せる話は #556 の monolith 化とは
+# 別軸で、YAML replace をやめない限り成立しない。
+if [[ "$ENV" == "staging" ]]; then
+  RUNTIME_SA="alc-api-runtime-staging@${PROJECT}.iam.gserviceaccount.com"
+else
+  RUNTIME_SA="alc-api-runtime@${PROJECT}.iam.gserviceaccount.com"
+fi
 
 # ---------------------------------------------------------------------------
 # Service name and image
@@ -362,6 +382,7 @@ spec:
         autoscaling.knative.dev/maxScale: "${MAX_SCALE}"
         autoscaling.knative.dev/minScale: "${MIN_SCALE}"
     spec:
+      serviceAccountName: ${RUNTIME_SA}
       containerConcurrency: 80
       timeoutSeconds: 300
       containers:

--- a/deploy.sh
+++ b/deploy.sh
@@ -8,6 +8,17 @@ REPOSITORY="alc-app"
 IMAGE="$REGION-docker.pkg.dev/$PROJECT_ID/$REPOSITORY/$SERVICE_NAME"
 MIGRATION_JOB_NAME="rust-alc-api-migrate"
 
+# runtime SA は cloudrun/render.sh が single source of truth (Refs #606)。
+# ここで指定を落とすと、手動 deploy を 1 回流しただけで runtime SA が既定の
+# Compute SA に黙って巻き戻る (= T-D の cutover が無音で剥がれる)。
+RUNTIME_SA=$(bash "$(dirname "$0")/cloudrun/render.sh" backend production dummy \
+               | awk '/serviceAccountName:/{print $2; exit}')
+if [ -z "$RUNTIME_SA" ]; then
+  echo "failed to resolve runtime service account from cloudrun/render.sh" >&2
+  exit 1
+fi
+echo "runtime SA: $RUNTIME_SA"
+
 echo "=== Building Docker image ==="
 docker build -t $IMAGE:latest .
 
@@ -19,12 +30,14 @@ if gcloud run jobs describe $MIGRATION_JOB_NAME --region $REGION --project $PROJ
   gcloud run jobs update $MIGRATION_JOB_NAME \
     --region $REGION \
     --project $PROJECT_ID \
-    --image $IMAGE:latest
+    --image $IMAGE:latest \
+    --service-account "$RUNTIME_SA"
 else
   gcloud run jobs create $MIGRATION_JOB_NAME \
     --region $REGION \
     --project $PROJECT_ID \
     --image $IMAGE:latest \
+    --service-account "$RUNTIME_SA" \
     --set-secrets "DATABASE_URL=alc-app-database-url:latest" \
     --command "migrate" \
     --memory 512Mi \
@@ -43,6 +56,7 @@ gcloud run deploy $SERVICE_NAME \
   --region $REGION \
   --platform managed \
   --allow-unauthenticated \
+  --service-account "$RUNTIME_SA" \
   --set-secrets "DATABASE_URL=alc-app-database-url:latest,GOOGLE_CLIENT_ID=GOOGLE_CLIENT_ID:latest,GOOGLE_DEVICE_CLIENT_ID=GOOGLE_DEVICE_CLIENT_ID:latest,R2_ACCESS_KEY=alc-r2-access-key:latest,R2_SECRET_KEY=alc-r2-secret-key:latest,OAUTH_STATE_SECRET=alc-oauth-state-secret:latest,CARINS_R2_ACCESS_KEY=carins-r2-access-key:latest,CARINS_R2_SECRET_KEY=carins-r2-secret-key:latest,DTAKO_R2_ACCESS_KEY=dtako-r2-access-key:latest,DTAKO_R2_SECRET_KEY=dtako-r2-secret-key:latest,NOTIFY_R2_ACCESS_KEY=carins-r2-access-key:latest,NOTIFY_R2_SECRET_KEY=carins-r2-secret-key:latest,LINE_LOGIN_CHANNEL_ID=line-login-channel-id:latest,LINE_LOGIN_CHANNEL_SECRET=line-login-channel-secret:latest,NOTIFY_WORKER_SECRET=notify-worker-secret:latest,NOTIFY_REDACT_BROADCAST_SECRET=notify-redact-broadcast-secret:latest,GEMINI_API_KEY=gemini-api-key:latest" \
   --set-env-vars "STORAGE_BACKEND=r2,R2_BUCKET=alc-face-photos,R2_ACCOUNT_ID=24b45709d060d957340180e995f0d373,FCM_PROJECT_ID=alc-fcm,API_ORIGIN=https://alc-api.ippoan.org,CARINS_R2_BUCKET=carins-files,DTAKO_R2_BUCKET=ohishi-dtako,NOTIFY_R2_BUCKET=notify-files,NOTIFY_REDACT_BROADCAST_URL=https://realtime.notify.ippoan.org/broadcast,NOTIFY_REDACT_2STAGE=1,RUST_LOG=info,rust_alc_api=info,alc_notify=info" \
   --port 8080 \

--- a/scripts/provision-runtime-sa.sh
+++ b/scripts/provision-runtime-sa.sh
@@ -18,9 +18,15 @@
 # 1 件でも漏れると cutover が `Permission denied on secret: <NAME>` で落ちる
 # ため (Refs #391 で実際に踏んだ失敗)。
 #
-# やらないこと (T-B の実測が要るので別途手動):
-#   - 別 project alc-fcm 側の FCM 送信 role (末尾に手順を出力する)
-#   - service の run.invoker binding (compute SA が bind されていれば維持。T-E 担当)
+# やらないこと:
+#   - rust-alc-api service の run.invoker binding。compute SA は **サービス単位で
+#     明示 bind** されており (T-B 実測: 747065218280-compute@ と
+#     alc-api-proxy-invoker@)、editor 由来ではないので T-E の editor 剥奪では
+#     壊れない。呼び出し側 (rust-ichibanboshi) の SA 移行は T-E の担当で、
+#     その際は **新 SA を invoker に足してから compute SA を外す** こと。
+#   - compute SA からの accessor 剥奪。rust-alc-api を移しても compute SA は
+#     kintai-push-database-url / rust-logi-* / RELEASE_WAVE_GCP_API_KEY 等を
+#     他 service のために使い続ける (T-B 実測: accessor 41 件、実使用 27 件)。
 set -euo pipefail
 
 ENV="${1:?Usage: provision-runtime-sa.sh <staging|production> [--apply]}"
@@ -47,6 +53,13 @@ FCM_PROJECT="alc-fcm"
 PROJECT_ROLES=(
   roles/logging.logWriter
 )
+
+# 別 project alc-fcm 側の role。T-B 実測で compute SA の alc-fcm binding は
+# roles/firebase.sdkAdminServiceAgent の 1 本のみ。prod / staging 双方の新 SA に
+# 同じものを付ける (FCM_PROJECT_ID=alc-fcm は render.sh が env 分岐の外で
+# 無条件に出しており、staging でも FcmSender が生きているため)。
+# 実行者が alc-fcm 側にも IAM 編集権限を持っている必要がある。
+FCM_ROLE="roles/firebase.sdkAdminServiceAgent"
 
 # ---------------------------------------------------------------------------
 # render.sh から runtime SA と secret 一覧を取り出す (single source of truth)
@@ -123,6 +136,10 @@ done
 # 4. deployer に actAs。DEPLOYER_SA は GCP_SA_KEY の client_email。
 #    これが無いと `gcloud run services replace` が
 #    "Permission 'iam.serviceaccounts.actAs' denied" で落ちる。
+#    T-B 実測では GCP_SA_KEY = staging-deploy@ で、この SA は既に **project
+#    レベルで** roles/iam.serviceAccountUser を持っているため要件は充足済み。
+#    以下は SA 単位で明示的に付け直す冪等な念押し (project レベルの grant を
+#    将来絞った時に落ちないようにする) なので、任意。
 if [[ -n "${DEPLOYER_SA:-}" ]]; then
   run gcloud iam service-accounts add-iam-policy-binding "$RUNTIME_SA" \
     --project "$PROJECT" \
@@ -130,25 +147,24 @@ if [[ -n "${DEPLOYER_SA:-}" ]]; then
     --role roles/iam.serviceAccountUser \
     --condition=None
 else
-  cat <<MSG
-
-!! DEPLOYER_SA 未設定 — actAs の grant を skip した。
-   GCP_SA_KEY の client_email を渡して再実行すること:
-     DEPLOYER_SA=<ci-deployer>@${PROJECT}.iam.gserviceaccount.com \\
-       bash scripts/provision-runtime-sa.sh $ENV --apply
-MSG
+  echo
+  echo "DEPLOYER_SA 未設定 — SA 単位の actAs grant は skip (staging-deploy@ が"
+  echo "project レベルで iam.serviceAccountUser を持つため要件自体は充足済み)。"
 fi
+
+# 5. 別 project alc-fcm 側の FCM 送信 role
+run gcloud projects add-iam-policy-binding "$FCM_PROJECT" \
+  --member "serviceAccount:${RUNTIME_SA}" \
+  --role "$FCM_ROLE" \
+  --condition=None
 
 cat <<MSG
 
---- 手動で残っているもの ---
-1) 別 project ${FCM_PROJECT} の FCM 送信 role。T-B が確認した compute SA と
-   **同じ role** を付けること (推測で firebasemessaging.admin 等を付けない):
-     gcloud projects add-iam-policy-binding ${FCM_PROJECT} \\
-       --member serviceAccount:${RUNTIME_SA} \\
-       --role <T-B で確認した role> --condition=None
-   FCM は失敗しても push が届かないだけでエラーが目立たない。flip 後に
-   実機で push 到達を明示的に確認すること。
-2) run.invoker: T-B で rust-alc-api service の invoker に compute SA が
-   bind されていた場合はそのまま維持 (ichibanboshi 側の移行は T-E)。
+--- 手作業で残っているもの ---
+- FCM は送信に失敗しても push が届かないだけでエラーが目立たない。cutover 後に
+  実機で push 到達を明示的に確認すること。
+- rust-alc-api service の run.invoker binding はこの script では触らない。
+  compute SA はサービス単位で明示 bind されており editor 剥奪では壊れないが、
+  **この binding を消すと即死する**。呼び出し側の SA 移行 (T-E) では新 SA を
+  invoker に足してから compute SA を外すこと。
 MSG

--- a/scripts/provision-runtime-sa.sh
+++ b/scripts/provision-runtime-sa.sh
@@ -1,0 +1,154 @@
+#!/bin/bash
+# provision-runtime-sa.sh — Cloud Run 専用 runtime SA の作成と grant (Refs #606)
+#
+# Usage:
+#   bash scripts/provision-runtime-sa.sh <staging|production> [--apply]
+#
+# 既定は dry-run (実行する gcloud コマンドを出力するだけ)。--apply で実際に流す。
+#
+# 何をするか:
+#   1. runtime SA を作る (既にあれば skip)
+#   2. その env の render.sh 出力に現れる **全 secret** に per-secret
+#      roles/secretmanager.secretAccessor を付ける
+#   3. project レベルの role を付ける (下の PROJECT_ROLES)
+#   4. CI deployer SA に roles/iam.serviceAccountUser を付ける
+#      (非デフォルト SA を指定して deploy するのに actAs が要る)
+#
+# secret の一覧は **render.sh の出力から機械的に**取る。手打ちしないのは、
+# 1 件でも漏れると cutover が `Permission denied on secret: <NAME>` で落ちる
+# ため (Refs #391 で実際に踏んだ失敗)。
+#
+# やらないこと (T-B の実測が要るので別途手動):
+#   - 別 project alc-fcm 側の FCM 送信 role (末尾に手順を出力する)
+#   - service の run.invoker binding (compute SA が bind されていれば維持。T-E 担当)
+set -euo pipefail
+
+ENV="${1:?Usage: provision-runtime-sa.sh <staging|production> [--apply]}"
+APPLY=0
+[[ "${2:-}" == "--apply" ]] && APPLY=1
+
+case "$ENV" in
+  staging|production) ;;
+  *) echo "env must be staging or production" >&2; exit 1 ;;
+esac
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+PROJECT="cloudsql-sv"
+FCM_PROJECT="alc-fcm"
+
+# project レベルの role。
+#   - logging.logWriter: Cloud Run の stdout 取り込み自体は service agent 経由なので
+#     runtime SA には不要な可能性が高いが、Google の Cloud Run least-privilege 推奨に
+#     従って付ける。外せるかは flip 後 24h のログで判断する。
+#   - cloudsql.client / cloudsql.instanceUser は **付けない**: render.sh に
+#     run.googleapis.com/cloudsql-instances annotation が無く、DB は
+#     DATABASE_URL (secret) の接続文字列で直接繋いでいる = Cloud SQL connector
+#     経路を使っていない。Recommender に使用実績が出た場合のみ追加すること。
+PROJECT_ROLES=(
+  roles/logging.logWriter
+)
+
+# ---------------------------------------------------------------------------
+# render.sh から runtime SA と secret 一覧を取り出す (single source of truth)
+# ---------------------------------------------------------------------------
+RENDER_ARGS=(backend "$ENV" dummy)
+if [[ "$ENV" == "staging" ]]; then
+  RENDER_ARGS+=(--staging-url https://example.invalid --db-image dummy)
+fi
+YAML="$(bash "$ROOT/cloudrun/render.sh" "${RENDER_ARGS[@]}")"
+
+RUNTIME_SA="$(printf '%s\n' "$YAML" | awk '/serviceAccountName:/{print $2; exit}')"
+[[ -n "$RUNTIME_SA" ]] || { echo "failed to resolve runtime SA from render.sh" >&2; exit 1; }
+
+# secretKeyRef: の 2 行下が secret 名 (key: latest を挟む)。
+mapfile -t SECRETS < <(printf '%s\n' "$YAML" \
+  | awk '/secretKeyRef:/{f=3} f&&/^ *name: /{print $2; f=0} f{f--}' \
+  | sort -u)
+(( ${#SECRETS[@]} > 0 )) || { echo "no secretKeyRef found in rendered YAML" >&2; exit 1; }
+
+# production の Cloud Run jobs (rust-alc-api-migrate / -archive) が参照する secret。
+# service 側の一覧に含まれているはずだが、含まれていなければ足す (drift 検出も兼ねる)。
+if [[ "$ENV" == "production" ]]; then
+  for s in alc-app-database-url dtako-r2-access-key dtako-r2-secret-key; do
+    if ! printf '%s\n' "${SECRETS[@]}" | grep -qx "$s"; then
+      echo "::warning:: job secret '$s' が service の secretKeyRef に無い — 追加して grant する"
+      SECRETS+=("$s")
+    fi
+  done
+fi
+
+SA_ID="${RUNTIME_SA%%@*}"
+
+echo "=== env=$ENV  runtime SA=$RUNTIME_SA  secrets=${#SECRETS[@]} ==="
+printf '  - %s\n' "${SECRETS[@]}"
+echo
+
+run() {
+  if (( APPLY )); then
+    echo "+ $*"
+    "$@"
+  else
+    printf '  '; printf '%q ' "$@"; printf '\n'
+  fi
+}
+
+(( APPLY )) || echo "--- DRY RUN (--apply で実行) ---"
+
+# 1. SA
+if gcloud iam service-accounts describe "$RUNTIME_SA" --project "$PROJECT" &>/dev/null; then
+  echo "service account already exists: $RUNTIME_SA"
+else
+  run gcloud iam service-accounts create "$SA_ID" \
+    --project "$PROJECT" \
+    --display-name "rust-alc-api Cloud Run runtime ($ENV)"
+fi
+
+# 2. per-secret secretAccessor
+for s in "${SECRETS[@]}"; do
+  run gcloud secrets add-iam-policy-binding "$s" \
+    --project "$PROJECT" \
+    --member "serviceAccount:${RUNTIME_SA}" \
+    --role roles/secretmanager.secretAccessor \
+    --condition=None
+done
+
+# 3. project roles
+for r in "${PROJECT_ROLES[@]}"; do
+  run gcloud projects add-iam-policy-binding "$PROJECT" \
+    --member "serviceAccount:${RUNTIME_SA}" \
+    --role "$r" \
+    --condition=None
+done
+
+# 4. deployer に actAs。DEPLOYER_SA は GCP_SA_KEY の client_email。
+#    これが無いと `gcloud run services replace` が
+#    "Permission 'iam.serviceaccounts.actAs' denied" で落ちる。
+if [[ -n "${DEPLOYER_SA:-}" ]]; then
+  run gcloud iam service-accounts add-iam-policy-binding "$RUNTIME_SA" \
+    --project "$PROJECT" \
+    --member "serviceAccount:${DEPLOYER_SA}" \
+    --role roles/iam.serviceAccountUser \
+    --condition=None
+else
+  cat <<MSG
+
+!! DEPLOYER_SA 未設定 — actAs の grant を skip した。
+   GCP_SA_KEY の client_email を渡して再実行すること:
+     DEPLOYER_SA=<ci-deployer>@${PROJECT}.iam.gserviceaccount.com \\
+       bash scripts/provision-runtime-sa.sh $ENV --apply
+MSG
+fi
+
+cat <<MSG
+
+--- 手動で残っているもの ---
+1) 別 project ${FCM_PROJECT} の FCM 送信 role。T-B が確認した compute SA と
+   **同じ role** を付けること (推測で firebasemessaging.admin 等を付けない):
+     gcloud projects add-iam-policy-binding ${FCM_PROJECT} \\
+       --member serviceAccount:${RUNTIME_SA} \\
+       --role <T-B で確認した role> --condition=None
+   FCM は失敗しても push が届かないだけでエラーが目立たない。flip 後に
+   実機で push 到達を明示的に確認すること。
+2) run.invoker: T-B で rust-alc-api service の invoker に compute SA が
+   bind されていた場合はそのまま維持 (ichibanboshi 側の移行は T-E)。
+MSG


### PR DESCRIPTION
> [!IMPORTANT]
> **凍結中 (2026-09-03)。** ユーザーが GCP 書き込み (`provision-runtime-sa.sh --apply`) の可否を dismiss したため、この PR は draft のまま停止している。**ready 化しないこと。** 再開はユーザーの指示待ち。
>
> 再開時の前提は [この順序コメント](https://github.com/ippoan/rust-alc-api/pull/607#issuecomment-5519598711) のとおり: **staging → production を連続で、両方とも ready 化の前**。「staging だけ先に」は罠 (PR run では migrate 等が skip されるので staging だけで CI が緑 → auto-merge まで通り、production SA 不在のまま本番経路が武装する)。

Refs #606 (T-D)。GCP 側の実測はすべて T-B の全数調査 [ippoan/auth-worker#502](https://github.com/ippoan/auth-worker/issues/502) が出典。

Cloud Run の runtime SA を、既定の Compute SA `747065218280-compute@developer.gserviceaccount.com` (roles/editor 保持) から専用 SA へ移す。

**draft で出している。** staging 側の SA が存在して 20 件の secret に grant が揃うまで、この PR の staging deploy が `Permission denied on secret: <NAME>` で落ちる (= CI が赤で auto-merge されない)。GCP 側の手順が終わってから ready にする。

## なぜ render.sh 側に持たせるか (設計差の明記)

**rust-alc-api だけ ci-workflows の reusable deploy を経由しない。** `.github/workflows/deploy.yml` の deploy-services が `gcloud run services replace` で service YAML を丸ごと置き換えるため、reusable 側の `runtime_service_account` enforce が効かない。したがって runtime SA の指定は `cloudrun/render.sh` が single source of truth になる。

「reusable に寄せればよい」は YAML replace をやめない限り成立しない — no-traffic release の `--pin-traffic-revision` / `--pending-tag` (render.sh:437-459) が replace 前提だから。後から同じ issue が再発しないよう、コード側のコメントと #606 の両方に残した。

jobs / 手動 deploy 側は render.sh の production 出力から SA を**読み出す**。値を再掲すると render.sh と drift し、T-E で compute SA から editor を剥がした時に job だけ黙って動かなくなる。

## 変更

| file | 変更 |
|---|---|
| `cloudrun/render.sh` | `PROJECT` を変数化し、`spec.template.spec.serviceAccountName` を emit (staging/production で切替) |
| `.github/workflows/deploy.yml` | migrate / update-archive に「Resolve runtime service account」step を足し、jobs create/update へ `--service-account`。update-archive に `actions/checkout@v4` を追加 (render.sh を読むため) |
| `deploy.sh` / `archive.sh` | 同上。落とすと**手動 deploy を 1 回流しただけで runtime SA が既定 SA に黙って巻き戻る** |
| `scripts/provision-runtime-sa.sh` (新規) | SA 作成 + per-secret grant + project role + deployer actAs。既定 dry-run、`--apply` で実行 |

`provision-runtime-sa.sh` は grant 対象の secret 一覧を **render.sh の出力から機械的に抽出**する。手打ちして 1 件漏らすと cutover が `Permission denied on secret: <NAME>` で落ちるため (#391 と同じ失敗)。dry-run の実測で prod / staging とも 20 件、T-B の独立実測 (render.sh を両 env で実際に実行) と数も名前も一致した。

## ADC 経路の要否判定 (元タスクの [BLOCKER])

metadata server 経由でデフォルト SA のトークンを取る経路の**実サイトは 4 か所** (6 ではない)。`crates/alc-misc/src/health.rs:213` と `:397` は `#[cfg(test)] mod tests` (health.rs:195 以降) の中の wiremock mock で runtime 経路ではない。

| 経路 | site | prod | staging | jobs |
|---|---|---|---|---|
| GCS | `alc-storage/src/gcs.rs:18` | 不要 | 不要 | 不要 |
| Cloud Tasks | `alc-trouble/src/cloud_tasks.rs:57` | 不要 | 不要 | 不要 |
| FCM v1 send | `alc-notify/src/fcm.rs:90` | **必要** | **必要** | 不要 |
| Secret Manager (`/health/secret-fingerprint`) | `alc-misc/src/health.rs:67` | **必要** | **必要** | 不要 |

元タスクの推定と食い違った 2 点:

- **FCM は staging でも生きている。** render.sh は `FCM_PROJECT_ID: "alc-fcm"` を env 分岐の**外**で無条件に出しており、`src/main.rs:212` はそれがあれば `FcmSender` を作る。「prod だけ」ではないので **staging SA にも alc-fcm 側の grant が要る**。
- **Cloud Tasks は「env 未配線」ではなく dead code。** `GcpCloudTasksClient` の構築サイトが repo 全体でゼロ (`from_env()` はどこからも呼ばれていない)。

GCS が全環境で到達不能な根拠: `main.rs:130` は `STORAGE_BACKEND` 未設定なら `"gcs"` に fallback するが、render.sh が `emit_env_backend` の先頭で `STORAGE_BACKEND: "r2"` を無条件に出すので両 env とも `"r2"` 腕に入る。jobs は `main.rs` を通らない別 bin で、`archive.rs:83-90` は R2 のみ、`migrate.rs:5` は `DATABASE_URL` だけ。

判定の全文と根拠は #606 に記録した。

## 確定したロール

- per-secret `roles/secretmanager.secretAccessor` × 20 件 × 2 env
- project `cloudsql-sv`: `roles/logging.logWriter` のみ
- project `alc-fcm` (別 project): `roles/firebase.sdkAdminServiceAgent` (T-B 実測。compute SA の alc-fcm binding はこの 1 本のみ)。prod / staging 双方の新 SA に付ける

**`cloudsql.client` / `cloudsql.instanceUser` は付けない。** render.sh に `run.googleapis.com/cloudsql-instances` annotation が無く、DB は `DATABASE_URL` (secret) の接続文字列で直接繋いでいる = Cloud SQL connector 経路を使っていない。Recommender に使用実績が出た場合のみ追加する。

`logging.logWriter` も確定ではない: Cloud Run の stdout 取り込みは service agent 経由なので runtime SA には不要な可能性が高い。least-privilege の定番として付けておき、flip 後 24h のログで外せるか判断する。

## 追加で判明した前提 — deployer の actAs

非デフォルト SA を指定して deploy するには、**deployer (`secrets.GCP_SA_KEY` の SA) が runtime SA に対して `roles/iam.serviceAccountUser` を持っている必要がある**。無いと `gcloud run services replace` が `Permission 'iam.serviceaccounts.actAs' denied` で落ちる。元の手順に無かったので明記する。

T-B 実測で `GCP_SA_KEY` = `staging-deploy@` と確定し、この SA は **project レベルで** `iam.serviceAccountUser` を持っているため**要件は現状すでに充足済み**。provision script の該当処理は、project レベルの grant を将来絞った時に落ちないための冪等な念押し (`DEPLOYER_SA` を渡した時のみ実行) として残してある。

## invoker はこの PR では触らない (T-B で確定)

`rust-alc-api` service の `roles/run.invoker` には compute SA (と `alc-api-proxy-invoker@`) が**サービス単位で明示 bind**されている。editor 由来ではないので **T-E の editor 剥奪では壊れない** — 当初懸念していた経路は否定された。

逆に **この binding を消すと即死する**。呼び出し側 (rust-ichibanboshi) の SA 移行は T-E の担当で、その際は**新 SA を invoker に足してから compute SA を外す**順序にすること (同時入れ替えは窓が開く)。

## スコープの線引き — compute SA からの accessor 剥奪は含まない

T-B 実測で compute SA の per-secret accessor は 41 件 (実使用 27 / 剥がせる 14)。**「render.sh が参照しているのに grant が無い」は 0 件**で、この PR の 20 件は全部 grant 済み。

ただし **rust-alc-api を専用 SA に移しても compute SA の accessor は剥がせない** — `kintai-push-database-url` (rust-ichibanboshi / ichibanboshi-sync)、`rust-logi-database-url` / `rust-logi-jwt-secret` (rust-logi)、`RELEASE_WAVE_GCP_API_KEY` (release-wave-gcp-staging) が compute SA で動き続けるため。剥奪は後続フェーズ。

## merge 前に必要なこと

1. `DEPLOYER_SA=... bash scripts/provision-runtime-sa.sh staging --apply`
2. 同 production
3. alc-fcm の grant は上記 script が一緒に流す (実行者が alc-fcm 側にも IAM 編集権限を持っていること)
4. ~~invoker~~ 触らない (上記のとおり T-B で確定)
5. staging 検証 — **新 revision が cold start で起動することを必ず確認**。既存 instance は起動時にキャッシュした secret 値で動き続けるので「動いて見える」偽陽性になる
6. prod は tag release の no-traffic revision で pending tag URL を検証してから、**AskUserQuestion で確認した上で** flip
7. flip 後 24h: `protoPayload.status.code=7` が 0 件 + FCM push の到達を実機で確認 (失敗しても目立たない経路のため)

## 気づいたが直していないこと

`deploy.sh` の `--set-secrets` が render.sh から大きく drift している (`INTERNAL_SHARED_SECRET` / `sso-encryption-key` / `developer-emails` / `trouble-r2-*` が無い、custom audiences も no-traffic pinning も無い)。この PR では runtime SA の指定だけ足した。drift 自体の是正は別件。

## ロールバック

```
gcloud run services update-traffic rust-alc-api --region asia-northeast1 --to-revisions <前revision>=100
```
前 revision は compute SA のまま残るので即座に戻る。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
