### PR TITLE
fix(ci): 本番 image を tag 対象 commit からビルドする

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,11 @@ jobs:
   build-image:
     name: "Build ${{ matrix.name }}"
     needs: [pr-limit]
-    if: "always() && github.event_name == 'pull_request' && (needs.pr-limit.result == 'success' || needs.pr-limit.result == 'skipped')"
+    # v* tag push でも走る: 本番 image は「タグ対象の commit をこの job がビルド
+    # したもの」でなければならない。以前は deploy.yml の promote-images が :dev を
+    # 貼り直すだけだったため、マージしていない PR のビルドが本番に出ていた
+    # (Refs #609)。
+    if: "always() && (github.event_name == 'pull_request' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))) && (needs.pr-limit.result == 'success' || needs.pr-limit.result == 'skipped')"
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -214,7 +218,16 @@ jobs:
         with:
           context: ctx
           push: true
-          tags: "ghcr.io/${{ github.repository }}${{ matrix.tag-suffix }}:${{ github.sha }}"
+          # tag push のときだけ :${ref_name} も貼る (旧 promote-images の置き換え、
+          # Refs #609)。PR run では 2 行目が空行になるが、build-push-action の
+          # tags は skipEmptyLines + 空要素 filter で空行を落とすため 1 本のまま。
+          tags: |
+            ghcr.io/${{ github.repository }}${{ matrix.tag-suffix }}:${{ github.sha }}
+            ${{ startsWith(github.ref, 'refs/tags/v') && format('ghcr.io/{0}{1}:{2}', github.repository, matrix.tag-suffix, github.ref_name) || '' }}
+          # どの commit から作った image かを image 自身に刻む。deploy.yml の
+          # "Verify image revision == tagged commit" がこれを読んで、本番に出る
+          # image が tag 対象 commit のビルドであることを検算する (Refs #609)。
+          labels: "org.opencontainers.image.revision=${{ github.sha }}"
           cache-from: "type=gha,scope=${{ matrix.name }}"
           cache-to: "type=gha,mode=max,scope=${{ matrix.name }}"
 
@@ -222,7 +235,9 @@ jobs:
       # 旧 staging-images job (deploy.yml) からの移設 (Refs #482)。バイナリは
       # bazel-bin から直接取る (prod image からの docker create/cp 再抽出を廃止)。
       - name: Prepare staging context
-        if: matrix.staging-bin != ''
+        # staging image は PR run 専用。tag push でこの job が走るようになった
+        # (Refs #609) が、production は staging image を使わない。
+        if: matrix.staging-bin != '' && github.event_name == 'pull_request'
         run: |
           mkdir -p ctx-staging/staging
           cp "ctx/${{ matrix.staging-bin }}" ctx-staging/
@@ -234,7 +249,7 @@ jobs:
           cp staging/entrypoint.sh ctx-staging/staging/
 
       - name: Build and push staging image
-        if: matrix.staging-bin != ''
+        if: matrix.staging-bin != '' && github.event_name == 'pull_request'
         uses: docker/build-push-action@v6
         with:
           context: ctx-staging
@@ -540,43 +555,13 @@ jobs:
             docker push "${REPO}${suffix}:dev"
           done
 
-  docker-latest:
-    name: Tag latest
-    # NOTE: main push では check も bazel gate も走らない (coverage-check 時代から
-    # 恒常 skip = 挙動不変)。coverage-check 退役に伴う参照差し替えのみ。
-    if: "always() && github.ref == 'refs/heads/main' && github.event_name == 'push' && needs.check.result == 'success' && needs.bazel-coverage-gate.result == 'success'"
-    needs: [check, bazel-coverage-gate]
-    runs-on: ubuntu-latest
-    permissions:
-      packages: write
-    steps:
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Retag dev → sha + latest (all images)
-        run: |
-          REPO="ghcr.io/${{ github.repository }}"
-          SHA="${{ github.sha }}"
-          # gateway + per-domain 廃止で monolith 1 image のみ (Refs #556)。
-          for suffix in ""; do
-            docker pull "${REPO}${suffix}:dev"
-            docker tag "${REPO}${suffix}:dev" "${REPO}${suffix}:${SHA}"
-            docker tag "${REPO}${suffix}:dev" "${REPO}${suffix}:latest"
-            docker push "${REPO}${suffix}:${SHA}"
-            docker push "${REPO}${suffix}:latest"
-          done
-
   deploy:
     name: Deploy
     needs: [build-image, staging-db, bazel-tests-ok, bazel-coverage-gate]
     if: >-
       always() &&
       (github.event_name == 'pull_request' || (startsWith(github.ref, 'refs/tags/v') && github.event_name == 'push')) &&
-      (needs.build-image.result == 'success' || needs.build-image.result == 'skipped') &&
+      needs.build-image.result == 'success' &&
       (needs.staging-db.result == 'success' || needs.staging-db.result == 'skipped') &&
       needs.bazel-tests-ok.result == 'success' &&
       needs.bazel-coverage-gate.result == 'success'
@@ -782,10 +767,10 @@ jobs:
     # 防ぐ (Refs #405、#391 で 2 回実害)。drift-check 失敗時も merge を止めて
     # cross-store drift を可視化する (Refs #424)。トレードオフとして staging
     # 障害時は全 PR が merge 不能になる。
-    # docker-dev (Tag dev) も needs に含める: merge → branch 削除で :dev への
-    # copy が cancel されると、main push の Tag latest / release の Promote images
-    # が前 PR の :dev image を無音で promote する (同 #405 と同クラスの穴)。
-    needs: [check, bazel-tests-ok, bazel-coverage-gate, build-image, docker-dev, deploy, drift-check-staging]
+    # docker-dev (Tag dev) は needs に入れない: :dev は front repo の
+    # docker-compose.test.yml 用の可変タグでしかなく、本番 image は tag push の
+    # build-image が作る (Refs #609)。したがって :dev の上書き競合は無害。
+    needs: [check, bazel-tests-ok, bazel-coverage-gate, build-image, deploy, drift-check-staging]
     if: >-
       always() &&
       github.event_name == 'pull_request' &&
@@ -793,7 +778,6 @@ jobs:
       needs.bazel-tests-ok.result == 'success' &&
       needs.bazel-coverage-gate.result == 'success' &&
       needs.build-image.result == 'success' &&
-      needs.docker-dev.result == 'success' &&
       needs.deploy.result == 'success' &&
       needs.drift-check-staging.result == 'success'
     uses: ippoan/ci-workflows/.github/workflows/auto-merge.yml@main

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,43 +35,11 @@ jobs:
   # gateway + per-domain は #556 で廃止し、deploy は monolith (backend) 1 本のみ。
   # ---------------------------------------------------------------------------
   # ---------------------------------------------------------------------------
-  # Production: promote dev → version tag
-  # ---------------------------------------------------------------------------
-  promote-images:
-    name: "Promote images"
-    if: startsWith(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-latest
-    permissions:
-      packages: write
-    steps:
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Promote dev → version + sha (all images)
-        run: |
-          REPO="${{ env.REPO }}"
-          TAG="${{ inputs.ref_name }}"
-          SHA="${{ inputs.image_sha }}"
-          # gateway + per-domain 廃止で monolith (backend) の 1 image のみ (Refs #556)。
-          for suffix in ""; do
-            docker pull "${REPO}${suffix}:dev"
-            docker tag "${REPO}${suffix}:dev" "${REPO}${suffix}:${TAG}"
-            docker tag "${REPO}${suffix}:dev" "${REPO}${suffix}:${SHA}"
-            docker push "${REPO}${suffix}:${TAG}"
-            docker push "${REPO}${suffix}:${SHA}"
-          done
-
-  # ---------------------------------------------------------------------------
   # Production: run migrations
   # ---------------------------------------------------------------------------
   migrate:
     name: "Run DB migrations"
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [promote-images]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -112,7 +80,7 @@ jobs:
     name: "Deploy ${{ matrix.service }}"
     # PR (staging): staging image 群は ci.yml (build-image / staging-db) で
     # push 済みなので待つものが無く、即 deploy に入る (Refs #482)。
-    needs: [promote-images, migrate]
+    needs: [migrate]
     if: >-
       always() && (
         github.event_name == 'pull_request' ||
@@ -159,6 +127,19 @@ jobs:
           echo "ROLLBACK_SVC=$SVC" >> "$GITHUB_ENV"
           echo "PREV_REVISION=$PREV" >> "$GITHUB_ENV"
           echo "captured serving revision for rollback: ${PREV:-<none>} (svc=$SVC)"
+
+      # 本番に出る image が「タグ対象の commit のビルド」であることを、image に
+      # 刻まれた revision label (ci.yml build-image が付ける) で検算する。
+      # promote-images (:dev の貼り直し) が、マージしていない PR のビルドを本番へ
+      # 出していた事故の再発検知 (Refs #609)。ghcr は public なので login 不要。
+      - name: Verify image revision == tagged commit (Refs #609)
+        if: github.event_name != 'pull_request'
+        run: |
+          set -euo pipefail
+          IMG="ghcr.io/ippoan/rust-alc-api:${{ inputs.image_sha }}"
+          docker pull -q "$IMG"
+          REV=$(docker inspect --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}' "$IMG")
+          [ "$REV" = "${{ inputs.image_sha }}" ] || { echo "::error::image $IMG was built from '${REV:-<no label>}', not ${{ inputs.image_sha }}"; exit 1; }
 
       - name: Render and deploy
         id: deploy


### PR DESCRIPTION
`#609` の修正。**本番 image が「タグ対象の commit のビルド」になっていなかった**欠陥を直す。

## 何が起きていたか

`deploy.yml` の `promote-images` は、タグ対象の commit をビルドせず
**可変タグ `ghcr.io/ippoan/rust-alc-api:dev` を pull して `${SHA}` / `${TAG}` を貼り直すだけ**だった。
一方 `ci.yml` の `build-image` は `if: github.event_name == 'pull_request'` のみで、
**main push でも tag push でもビルドが走らない**。`docker-dev` は**どの PR の run でも** `:dev` を
上書きし、**re-run は merge-ref を再計算しない**。

⇒ **`v*` タグの中身は「最後に `:dev` を上書きした PR run のビルド」で決まっていた。**

実害 (2026-09-03): DVR ingest (#608) をマージして `v0.0.142` を切った 3 分後に別 PR の CI が
再実行され、その古い base のビルドが `:dev` に乗り、タグ run がそれを本番として promote した。
本番は「DVR 追加前の main」を走り続け、`POST /api/dvr/notifications` が素の 404 を返していた。
経緯と実測タイムラインは #609。

## 変更

| | |
|---|---|
| `ci.yml` `build-image` | **tag push でも走らせる**。`labels` に `org.opencontainers.image.revision=${{ github.sha }}` を付与。tag push のときだけ `:${ref_name}` も push。staging 用の 2 step は `pull_request` のときだけに限定 |
| `ci.yml` `deploy` | `needs.build-image` を **`== 'success'` のみ**に (tag で build が skip されたら deploy させない) |
| `deploy.yml` `promote-images` | **削除**。`migrate` / `deploy-services` の `needs` を繋ぎ直し |
| `deploy.yml` `deploy-services` | production 分岐の `Render and deploy` 直前に **`Verify image revision == tagged commit`** を追加。image の label がタグ対象 commit と一致しなければ loud fail |
| `ci.yml` `docker-latest` | **削除** — `needs.check` が main push で常時 skip のため恒常死。ghcr に `latest` タグを持つ version は **0 件** |
| `ci.yml` `docker-dev` | **残す**。`:dev` は 7 repo の `docker-compose.test.yml` が既定 image として使っている。本番が `:dev` を読まなくなれば上書き競合は無害になる |

`auto-merge` の `needs` から `docker-dev` を外した (`:dev` の flake で merge を止める理由が無くなるため)。

## 収支

```
 .github/workflows/ci.yml     | 24 +++++++--------- 40 ------------
 .github/workflows/deploy.yml | 14 +++++----- 33 ------------
 2 files changed, 38 insertions(+), 73 deletions(-)
```

**純減 35 行。** `crates/` `src/` `migrations/` は無変更なので map 再生成は不要。

## 陰性対照 — 今日の事故を再現して落とす

追加した検算と同じロジックを、実際に本番へ出てしまった image に当てた:

```
$ IMAGE_SHA=a20ee4184dd396c34efc340534664f29c2a51e0e ./verify_rev.sh
::error::image ghcr.io/ippoan/rust-alc-api:a20ee418... was built from '<no label>', not a20ee418...
exit=1
```

**この検算が入っていれば、今日の事故は deploy の手前で止まっていた。**

## `tags:` の空行について

tag push のときだけ 2 本目のタグを足すため `tags:` に条件式を書いており、
PR run では 1 行が空になる。`build-push-action@v6` の dist を読み、
**空行は csv parse の `skipEmptyLines: true` と直後の `.filter(r => r)` で 2 重に落ちる**ことを
確認したので、`metadata-action` や `imagetools create` を挟まず素の形にした。

## 検証

- `actionlint` を base と HEAD で比較 → **新規指摘ゼロ** (既存の SC2086 info 1 件のみ)
- 両ファイル `yaml.safe_load` 通過。job 一覧の diff は **`promote-images` と `docker-latest` が
  消えただけ**で、他は不変
- job グラフの整合を確認: `promote-images` / `docker-latest` の**機能的参照は 0 件**
  (`needs` / `outputs` / `if`。残っているのは旧経緯を説明するコメントのみ)。
  `auto-merge` の `if` 式にも `needs.docker-dev.*` の残骸なし
- `Release Wave` (`report-pending-release`) / `update-archive` / `verify-no-traffic` /
  `render.sh` / staging 経路は**無変更**
- 基点 `a20ee41` に対して `behind_by=0`

**この PR 自身の CI で `Build backend` が回った後に、陽性対照 (自分の build の image の label が
その sha と一致する) と、`Build and push` が push したタグ数を追記する。**
topic branch の push では CI が 1 本も走らない (`ci.yml` の `push` トリガーが main とタグのみ) ため、
PR を立てるまで取得できなかった。

## この PR をマージすると本番に出るもの

**`a20ee41` 以降の main 全部** = DVR ingest の 2 口 (#608) + この直し。
これは意図した結果で、`ohishi-exp/nuxt-dtako-admin#1094` の並行稼働がここから始まる。

Refs #609

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## 追記 — PR の CI run から実測 (本文で「後で追記する」としていた 2 点)

run `33723763435` / `Build backend` = success / merge-ref sha = `3e883f395f30dde018acb2fa790528160b68782c`

### 陽性対照と陰性対照を、同じスクリプトで並べて

```
=== 陽性: この PR の build ===
$ IMAGE_SHA=3e883f395f30dde018acb2fa790528160b68782c ./verify_rev.sh
OK: ghcr.io/ippoan/rust-alc-api:3e883f39... revision=3e883f395f30dde018acb2fa790528160b68782c
exit=0

=== 陰性: 今日 本番に出てしまった image ===
$ IMAGE_SHA=a20ee4184dd396c34efc340534664f29c2a51e0e ./verify_rev.sh
::error::image ghcr.io/ippoan/rust-alc-api:a20ee418... was built from '<no label>', not a20ee418...
exit=1
```

**同一スクリプトで、正しいビルドは通り、事故の image は落ちる。**

### `Build and push` が push したタグは 1 本だけ

```
  tags: ghcr.io/ippoan/rust-alc-api:3e883f395f30dde018acb2fa790528160b68782c
#15 pushing manifest for ghcr.io/ippoan/rust-alc-api:3e883f39...@sha256:f6b52245... done
```

`pushing manifest for` は同 step 内で 1 行だけ (`grep -c` = 1)。
2 本目 (`-staging:…`) は `pull_request` 限定にした別 step の方。

### `tags:` の空行 — 実測でも確認

step の `with:` の raw ログを `cat -A` で見ると、**条件式が `''` に評価された空行が実際に
action の input として渡っており、それでも push されたタグは 1 本**だった。
dist を読んで予測した `skipEmptyLines: true` + `.filter(r => r)` の挙動が実 run で裏付けられた。
tag push 側はこの行が非空になるだけで、同じ経路を通る。

### CI の赤について

`Bazel test (compare)` が 1 本落ちているが、**bazelisk が Bazel 本体を取得できずに切断された**もので
(`connection reset by peer`、テストは 1 件も実行されていない)、この変更とは無関係。
同じ job は `v0.0.142` (同一コード) で success している。他の bazel shard 20 本以上は全て success。
`Bazel tests OK` / `Bazel coverage gate` の赤は、その shard の結果を待つ集約 job の連鎖。
re-run 済み。
