### PR TITLE
fix(timecard): card_id を正規化して照合する (Refs ippoan/alc-app-s3#134)

### DIFF
--- a/.claude/skills/rust-alc-api-map/SKILL.md
+++ b/.claude/skills/rust-alc-api-map/SKILL.md
@@ -531,7 +531,8 @@ rust-logi から移行。nuxt-pwa-carins フロントエンドが使用。
 ## タイムカード機能
 
 - **テーブル**: `timecard_cards` (カード:社員 = 多:1) + `time_punches` (打刻記録)
-- **マイグレーション**: `migrations/034_create_timecard.sql`
+- **マイグレーション**: `migrations/034_create_timecard.sql` + `migrations/134_timecard_cards_normalize_card_id.sql` (card_id の正規化移行 + CHECK 制約)
+- **card_id の正規化 (Refs ippoan/alc-app-s3#134)**: `alc_core::repository::timecard::normalize_card_id` = `trim` + **小文字** + `':'` 除去。同じ物理カードでも読み取り側で表記が揺れる (NFC タイムカード端末は `%02X` の大文字 IDm、ローカル NFC ブリッジは小文字、`AA:BB:..` と区切る実装もある) のに照合は完全一致なので、**登録・照合・登録照会の 3 経路すべて**を同じ形に揃える: 登録 = `create_card`、照合 = `resolve_employee_by_card` (ブラウザ版 punch と端末中継の共有 choke point)、登録照会 = `get_card_by_card_id` (choke point を通らない 3 本目)。**小文字**なのは `alc-carins` の `normalize_nfc_uuid` (車検証 NFC タグ) と規約を揃えるため — 1 repo に NFC ID の正規化規約を 2 つ並べない。**読み側だけ正規化してはいけない**: `ABC` と `abc` の 2 行が同時に存在し得ると正規化後の値がどちらにも一致して**打刻が別人に着く**。migration 134 が既存行を移行し、CHECK 制約 `timecard_cards_card_id_normalized` が書き忘れを loud fail させる (既存の `idx_timecard_cards_unique (tenant_id, card_id)` がそのまま正規化後の一意性を保証するので index は増やさない)。`employees.nfc_id` フォールバック (免許証 16 桁の数字) に対しては no-op
 - **バックエンド**: `src/routes/timecard.rs`
   - カード CRUD: `POST/GET /api/timecard/cards`, `DELETE /api/timecard/cards/{id}`, `GET /api/timecard/cards/by-card/{card_id}`
   - 打刻: `POST /api/timecard/punch` (card_id → 社員特定 → 打刻 + 当日一覧返却)

--- a/crates/alc-core/src/repository/timecard.rs
+++ b/crates/alc-core/src/repository/timecard.rs
@@ -119,15 +119,68 @@ pub trait TimecardRepository: Send + Sync {
 /// 2 つあるが、照合はこの 1 か所に閉じる。** 2 実装目を作ると、どちらか片方だけに
 /// フォールバックを足す/外すといったズレが必ず出る。
 ///
-/// 照合は**完全一致**なので、呼び出し側は `card_id` を加工せずに渡すこと
-/// (端末は読み取った生値を送る。接頭辞や正規化を挟むと必ず外れる)。
+/// 照合は**完全一致**だが、その手前で `normalize_card_id` を 1 回だけ通す。
+/// **呼び出し側は読み取った生値をそのまま渡すこと** — 接頭辞を付けたり、
+/// 呼び出し側ごとに別の加工を挟んだりすると、経路ごとに違う値で引くことになる。
 pub async fn resolve_employee_by_card(
     repo: &dyn TimecardRepository,
     tenant_id: Uuid,
     card_id: &str,
 ) -> Result<Option<Uuid>, sqlx::Error> {
-    if let Some(card) = repo.find_card_by_card_id(tenant_id, card_id).await? {
+    let card_id = normalize_card_id(card_id);
+    if let Some(card) = repo.find_card_by_card_id(tenant_id, &card_id).await? {
         return Ok(Some(card.employee_id));
     }
-    repo.find_employee_id_by_nfc(tenant_id, card_id).await
+    repo.find_employee_id_by_nfc(tenant_id, &card_id).await
+}
+
+/// カード ID の正規化。**`timecard_cards` の登録も照合もこの結果で行う。**
+///
+/// 同じ物理カードでも読み取り側で表記が揺れる (IDm を大文字で出す端末、小文字で
+/// 出すローカル NFC ブリッジ、`AA:BB:..` と区切る実装) ため、生値のまま完全一致で
+/// 引くと同じカードが別カードとして扱われる。**小文字**なのは `alc-carins` の
+/// `normalize_nfc_uuid` (車検証 NFC タグ) と規約を揃えるため — 1 つの repo に
+/// NFC ID の正規化規約を 2 つ並べない。
+///
+/// **読み側だけ正規化してはいけない。** `ABC` と `abc` の 2 行が同時に存在し得ると
+/// 打刻が別人に着く。登録側も同じ関数を通し、DB 側の CHECK 制約
+/// (`timecard_cards_card_id_normalized`、migration 134) で書き忘れを loud fail させる。
+///
+/// `employees.nfc_id` フォールバック (免許証の交付日 8 桁 + 有効期限 8 桁 = 16 桁の
+/// 数字) に対しては no-op なので、本番で動いている免許証経路の挙動は変わらない。
+pub fn normalize_card_id(card_id: &str) -> String {
+    card_id.trim().to_lowercase().replace(':', "")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_card_id;
+
+    #[test]
+    fn felica_idm_uppercase_becomes_lowercase() {
+        // 端末は %02X (大文字) で IDm を送る
+        assert_eq!(normalize_card_id("0123456789ABCDEF"), "0123456789abcdef");
+    }
+
+    #[test]
+    fn separators_and_surrounding_space_are_dropped() {
+        assert_eq!(normalize_card_id("  AA:BB:CC:DD  "), "aabbccdd");
+    }
+
+    #[test]
+    fn already_normalized_value_is_unchanged() {
+        assert_eq!(normalize_card_id("0123456789abcdef"), "0123456789abcdef");
+    }
+
+    #[test]
+    fn license_nfc_id_is_untouched() {
+        // employees.nfc_id は交付日 8 桁 + 有効期限 8 桁の数字。
+        // 本番で動いている免許証経路の挙動を変えないことを固定する
+        assert_eq!(normalize_card_id("2023040120280331"), "2023040120280331");
+    }
+
+    #[test]
+    fn empty_input_stays_empty() {
+        assert_eq!(normalize_card_id("   "), "");
+    }
 }

--- a/crates/alc-misc/src/timecard.rs
+++ b/crates/alc-misc/src/timecard.rs
@@ -12,6 +12,7 @@ use alc_core::models::{
     CreateTimePunchByCard, CreateTimecardCard, TimePunchFilter, TimePunchWithEmployee,
     TimePunchesResponse, TimecardCard,
 };
+use alc_core::repository::timecard::normalize_card_id;
 use alc_core::AppState;
 
 pub fn tenant_router() -> Router<AppState> {
@@ -41,7 +42,9 @@ async fn create_card(
         .create_card(
             tenant_id,
             body.employee_id,
-            &body.card_id,
+            // 登録も照合と同じ正規化形で入れる。読み側だけ正規化すると
+            // `ABC` と `abc` が同時に一致し得て打刻が別人に着く
+            &normalize_card_id(&body.card_id),
             body.label.as_deref(),
         )
         .await
@@ -103,7 +106,7 @@ async fn get_card_by_card_id(
 
     let card = state
         .timecard
-        .get_card_by_card_id(tenant_id, &card_id)
+        .get_card_by_card_id(tenant_id, &normalize_card_id(&card_id))
         .await
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
         .ok_or(StatusCode::NOT_FOUND)?;

--- a/migrations/134_timecard_cards_normalize_card_id.sql
+++ b/migrations/134_timecard_cards_normalize_card_id.sql
@@ -1,0 +1,28 @@
+-- timecard_cards.card_id を正規化形 (trim + 小文字 + ':' 除去) に揃える。
+-- Refs ippoan/alc-app-s3#134
+--
+-- 同じ物理カードでも読み取り側で表記が揺れる (IDm を大文字で出す NFC タイムカード
+-- 端末、小文字で出すローカル NFC ブリッジ、`AA:BB:..` と区切る実装) が、照合は
+-- `WHERE tenant_id = $1 AND card_id = $2` の完全一致なので、生値のままだと同じ
+-- カードが別カードとして扱われる。
+--
+-- **読み側 (照合) だけ正規化するのでは足りない。** `ABC` と `abc` の 2 行が同時に
+-- 存在し得ると、正規化後の値がどちらにも一致して**打刻が別人に着く**。登録側
+-- (alc_core::repository::timecard::normalize_card_id 経由) を揃えたうえで、
+-- ここで既存行を移行し、CHECK 制約で「正規化されていない値は書けない」を固定する。
+--
+-- 小文字を採ったのは alc-carins の normalize_nfc_uuid (車検証 NFC タグ、
+-- migration 048 の car_inspection_nfc_tags) と規約を揃えるため。
+
+UPDATE alc_api.timecard_cards
+SET card_id = lower(replace(btrim(card_id), ':', ''))
+WHERE card_id <> lower(replace(btrim(card_id), ':', ''));
+
+-- 既存の idx_timecard_cards_unique (tenant_id, card_id) が、上の UPDATE 以降は
+-- そのまま「正規化後の一意性」を保証する。だから index は増やさない。
+-- 同一テナントに `ABC` と `abc` が両方あった環境ではこの UPDATE が
+-- idx_timecard_cards_unique の一意制約違反で落ちる (= 同じ人か別人かは機械には
+-- 決められないので、黙って畳まず止める。手で片方を消してから再実行すること)。
+ALTER TABLE alc_api.timecard_cards
+    ADD CONSTRAINT timecard_cards_card_id_normalized
+    CHECK (card_id = lower(replace(btrim(card_id), ':', '')));

--- a/tests/mock_helpers/repos_c.rs
+++ b/tests/mock_helpers/repos_c.rs
@@ -1451,6 +1451,10 @@ pub struct MockTimecardRepository {
     /// hub_measurements の打刻中継 (Refs ippoan/alc-app-s3#134) が
     /// 「新規に入った行のときだけ 1 回」打刻することを固定するために使う
     pub punches: std::sync::Mutex<Vec<(Uuid, Uuid, Option<Uuid>)>>,
+    /// find_card_by_card_id が実際に引いた card_id の記録。
+    /// 照合の手前で正規化が 1 回だけ効いていること (Refs ippoan/alc-app-s3#134) を
+    /// ブラウザ版と端末中継の両経路で固定するために使う
+    pub card_lookups: std::sync::Mutex<Vec<String>>,
 }
 
 impl Default for MockTimecardRepository {
@@ -1466,6 +1470,7 @@ impl Default for MockTimecardRepository {
             csv_rows: std::sync::Mutex::new(vec![]),
             cards_list: std::sync::Mutex::new(vec![]),
             punches: std::sync::Mutex::new(vec![]),
+            card_lookups: std::sync::Mutex::new(vec![]),
         }
     }
 }
@@ -1531,8 +1536,9 @@ impl TimecardRepository for MockTimecardRepository {
     async fn find_card_by_card_id(
         &self,
         _tenant_id: Uuid,
-        _card_id: &str,
+        card_id: &str,
     ) -> Result<Option<TimecardCard>, sqlx::Error> {
+        self.card_lookups.lock().unwrap().push(card_id.to_string());
         check_fail!(self);
         Ok(self.find_card_data.lock().unwrap().clone())
     }

--- a/tests/mock_tests/mock_hub_measurements_test.rs
+++ b/tests/mock_tests/mock_hub_measurements_test.rs
@@ -579,6 +579,39 @@ async fn test_timecard_relay_punches_when_card_is_registered() {
     assert_eq!(punches[0], (tenant_id, employee_id, None));
 }
 
+/// 端末が送る大文字 IDm は、照合の手前で正規化されてから引かれる
+/// (Refs ippoan/alc-app-s3#134)。ブラウザ版 punch と同じ choke point
+/// (`resolve_employee_by_card`) を通るので、片方だけ正規化が外れることはない
+#[tokio::test]
+async fn test_timecard_relay_normalizes_card_id_before_lookup() {
+    let (state, _hub, tc) = timecard_state();
+    let tenant_id = Uuid::new_v4();
+    let employee_id = Uuid::new_v4();
+    *tc.find_card_data.lock().unwrap() = Some(rust_alc_api::db::models::TimecardCard {
+        id: Uuid::new_v4(),
+        tenant_id,
+        employee_id,
+        card_id: "01401d0b1d37b660".to_string(),
+        label: None,
+        created_at: chrono::Utc::now(),
+    });
+    let base_url = crate::mock_helpers::app_state::spawn_mock_server(state).await;
+
+    let res = post_timecard(
+        &base_url,
+        tenant_id,
+        vec![timecard_item(1, "01401D0B1D37B660")],
+    )
+    .await;
+    assert_eq!(res.status(), 201);
+
+    assert_eq!(
+        tc.card_lookups.lock().unwrap().as_slice(),
+        ["01401d0b1d37b660"]
+    );
+    assert_eq!(tc.punches.lock().unwrap().len(), 1);
+}
+
 /// カード未登録でも employees.nfc_id にあれば打刻される (免許証 16 桁の経路)
 #[tokio::test]
 async fn test_timecard_relay_falls_back_to_employee_nfc_id() {

--- a/tests/mock_tests/mock_timecard_test.rs
+++ b/tests/mock_tests/mock_timecard_test.rs
@@ -896,7 +896,9 @@ async fn test_create_card_success() {
     assert_eq!(res.status(), 201);
 
     let body: Value = res.json().await.unwrap();
-    assert_eq!(body["card_id"], "NFC-001");
+    // 登録は正規化形 (小文字) で入る — 照合と同じ形にしないと引けない
+    // (Refs ippoan/alc-app-s3#134)
+    assert_eq!(body["card_id"], "nfc-001");
     assert_eq!(body["label"], "Main Card");
     assert_eq!(body["employee_id"], employee_id.to_string());
 }
@@ -1672,4 +1674,92 @@ async fn test_no_auth_returns_401() {
         .await
         .unwrap();
     assert_eq!(res.status(), 401);
+}
+
+// ============================================================
+// card_id の正規化 (Refs ippoan/alc-app-s3#134)
+//
+// 同じ物理カードでも読み取り側で表記が揺れる (端末は %02X の大文字 IDm、
+// ローカル NFC ブリッジは小文字、`AA:BB:..` と区切る実装もある)。照合は
+// 完全一致なので、登録・照合・登録照会の 3 経路すべてを同じ正規化形に
+// 揃えないと「タップしても登録されていません」になる。
+// ============================================================
+
+#[tokio::test]
+async fn test_create_card_normalizes_separators_and_case() {
+    let mock = Arc::new(crate::mock_helpers::MockTimecardRepository::default());
+    let (base_url, jwt) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    let res = client
+        .post(format!("{base_url}/api/timecard/cards"))
+        .header("Authorization", auth(&jwt))
+        .json(&serde_json::json!({
+            "employee_id": Uuid::new_v4(),
+            "card_id": "  AA:BB:CC:DD  "
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 201);
+
+    let body: Value = res.json().await.unwrap();
+    assert_eq!(body["card_id"], "aabbccdd");
+}
+
+#[tokio::test]
+async fn test_punch_normalizes_card_id_before_lookup() {
+    let tenant_id = Uuid::new_v4();
+    let employee_id = Uuid::new_v4();
+    let mock = Arc::new(crate::mock_helpers::MockTimecardRepository::default());
+    *mock.find_card_data.lock().unwrap() =
+        Some(make_card(tenant_id, employee_id, "0123456789abcdef"));
+    *mock.employee_name.lock().unwrap() = "Taro Yamada".to_string();
+
+    let (base_url, jwt) = spawn_with_mock(mock.clone()).await;
+    let client = reqwest::Client::new();
+
+    // 端末が送る生値は大文字 IDm
+    let res = client
+        .post(format!("{base_url}/api/timecard/punch"))
+        .header("Authorization", auth(&jwt))
+        .json(&serde_json::json!({
+            "card_id": "0123456789ABCDEF"
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 201);
+
+    // 引いた値が正規化形になっていること (repo には小文字で届く)
+    assert_eq!(
+        mock.card_lookups.lock().unwrap().as_slice(),
+        ["0123456789abcdef"]
+    );
+}
+
+#[tokio::test]
+async fn test_get_card_by_card_id_normalizes_path_param() {
+    let tenant_id = Uuid::new_v4();
+    let employee_id = Uuid::new_v4();
+    let mock = Arc::new(crate::mock_helpers::MockTimecardRepository::default());
+    *mock.card_data.lock().unwrap() = Some(make_card(tenant_id, employee_id, "0123456789abcdef"));
+
+    let (base_url, jwt) = spawn_with_mock(mock).await;
+    let client = reqwest::Client::new();
+
+    // 登録照会は punch と同じ choke point を通らない 3 本目の経路。
+    // ここが漏れると「登録済みなのに管理画面で引けない」になる
+    let res = client
+        .get(format!(
+            "{base_url}/api/timecard/cards/by-card/0123456789ABCDEF"
+        ))
+        .header("Authorization", auth(&jwt))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+
+    let body: Value = res.json().await.unwrap();
+    assert_eq!(body["card_id"], "0123456789abcdef");
 }


### PR DESCRIPTION
`timecard_cards.card_id` の照合が**完全一致**なため、大文字小文字や区切りが違うと外れる。専用のタイムカード端末 (ippoan/alc-app-s3#134) は FeliCa IDm を **大文字** (`%02X`) で送るので、別形式で登録されたカードと当たらなくなる。

## 方式 — 既存の規約に合わせて **小文字**

この repo には既に NFC ID の正規化がある: `crates/alc-carins/src/nfc_tags.rs:24` の `normalize_nfc_uuid` = `to_lowercase()` + `':'` 除去。検索 (`:45`) / 登録 (`:96`) / 削除 (`:115`) の全経路に掛かり、`UNIQUE (tenant_id, nfc_uuid)` が正規化後の一意性を担保している。

**同じ repo に NFC ID の正規化規約を 2 つ作らない**ため、`card_id` も同じ形 (trim + 小文字 + `':'` 除去) に揃える。

## 変更

- `crates/alc-core/src/repository/timecard.rs` — `normalize_card_id` を新設し、`resolve_employee_by_card` で **1 回だけ**適用。同ファイルの doc にあった設計契約 (「呼び出し側は `card_id` を加工せずに渡すこと」) も書き換え
- `crates/alc-misc/src/timecard.rs` — `create_card` (登録) と `get_card_by_card_id` (登録照会) に適用。**この 2 つは `resolve_employee_by_card` を通らない**ので個別に必要
- `migrations/134_...` — 既存行の UPDATE + CHECK 制約。**index は増やさない** (既存の `idx_timecard_cards_unique` が UPDATE 以降そのまま正規化後の一意性を保証する)

## マージの前提 — `timecard_cards` が 0 件であること

同一テナントに `ABC` と `abc` が両方あると、migration の UPDATE が `idx_timecard_cards_unique` 違反で**止まる** (意図的な loud fail、対処は migration のコメント参照)。本番は 0 件であることを確認済み。

## セットで入れる PR

**ippoan/alc-app#155 と一緒に。** あちらの `TimecardManager.vue` は「API 由来 (正規化形) をキーにした Map を、端末の生値で引く」形になっており、サーバだけ直すと**登録済みカードが「未登録カード」表示**になる (現状は 0 件で `employees.nfc_id` 側が拾うため表面化していない)。

## 検証

**両 repo とも `on: push: branches: [main]` + `pull_request` のみで、feature branch の push では CI が 1 本も回らない。この PR が初検証。** 手元では:

- `cargo test --test mock_misc -- timecard` 36 pass / `--test mock_devices -- timecard_relay` 7 pass / `-p alc-core --lib -- repository::timecard` 5 pass
- `cargo fmt --all` / `cargo clippy` — 変更ファイルに新規指摘なし

`crates/alc-misc/src/timecard.rs` は `coverage_100.toml:225` 登録済みだが、正規化は式に埋めただけで分岐が増えていないため gate は通る見込み (未実測)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)