### PR TITLE
fix(timecard): 時計未同期の端末が残した 1970 年の打刻を削除する (Refs ippoan/alc-app-s3#134)

### DIFF
--- a/.claude/skills/rust-alc-api-map/SKILL.md
+++ b/.claude/skills/rust-alc-api-map/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rust-alc-api-map
-generated-from: rust-alc-api:32df349f
+generated-from: rust-alc-api:62ffaf62
 paths: [crates/, src/, migrations/]
 description: rust-alc-api (アルコールチェッカー基盤の Rust/Axum Cargo workspace — domain crate 群 + monolith 単一バイナリ、PostgreSQL+RLS、Cloud Run) の構造ナビゲーション。どの crate に何のルートがあるか / monolith (rust-alc-api) 一本化 (gateway + per-domain は #556 で廃止) / RLS・migration・deploy/release 分離の gotcha を 1 枚にまとめる。トリガー:「rust-alc-api」「alc-api」「alc-notify」「alc-tenko」「alc-trouble」「alc-carins」「alc-dtako」「gateway」「tenko-api」「carins-api」「dtako-api」「trouble-api」「RLS テナント」「sqlx migration」「ts-rs」「Release Wave」「Bazel」等。
 ---
@@ -531,7 +531,8 @@ rust-logi から移行。nuxt-pwa-carins フロントエンドが使用。
 ## タイムカード機能
 
 - **テーブル**: `timecard_cards` (カード:社員 = 多:1)。**`time_punches` は書き手も読み手も無い** (Refs ippoan/alc-app-s3#134 で打刻の一次表を `hub_measurements` へ寄せた)。DROP はしていないので、過去の行は SQL でだけ見える
-- **マイグレーション**: `migrations/034_create_timecard.sql` + `migrations/134_timecard_cards_normalize_card_id.sql` (card_id の正規化移行 + CHECK 制約)
+- **マイグレーション**: `migrations/034_create_timecard.sql` + `migrations/134_timecard_cards_normalize_card_id.sql` (card_id の正規化移行 + CHECK 制約) + `migrations/138_delete_prehistoric_timecard_punches.sql` (1970 年の打刻を削除)
+- **★ `recorded_at` が 1970 になるのは時計未同期の端末が稼働時間を送ったため (Refs ippoan/alc-app-s3#144)**。NFC タイムカード端末は SNTP 起動より前、`recorded_at_ms` に**起動からの稼働時間**を入れていたので 1970 起点になる。送信時に稼働時間の差で補正する仕組み (ippoan/alc-app-s3#124) は「あとで同期したら過去ぶんを補正する」形で、**1 度も同期しなかった端末の行には永久に発火しない**。一覧の絞り込みと並びは `COALESCE(recorded_at, created_at)` なので、これらは 1970 年の打刻として並ぶ。migration 138 が `kind='timecard' AND recorded_at < 2020-01-01 AND created_at < 2026-09-05` の 3 条件で削除した (賃金データなのでオーナー判断で削除)。**device_id / tenant_id はハードコードしない** (public repo に本番の device credential を残さない / device_id は `UNIQUE (tenant_id, device_id, seq)` で全体一意ではない)、**`created_at` の上限が「測定時点で既にあった行だけ」を意味する**、**`recorded_at IS NULL` と他 kind は巻き込まない**。20 件超で `RAISE EXCEPTION` する guard 付き — 発火すると `_sqlx_migrations` に dirty 行が残るので、消してから新 version で作り直す
 - **card_id の正規化 (Refs ippoan/alc-app-s3#134)**: `alc_core::repository::timecard::normalize_card_id` = `trim` + **小文字** + `':'` 除去。同じ物理カードでも読み取り側で表記が揺れる (NFC タイムカード端末は `%02X` の大文字 IDm、ローカル NFC ブリッジは小文字、`AA:BB:..` と区切る実装もある) のに照合は完全一致なので、**登録・照合・登録照会の 3 経路すべて**を同じ形に揃える: 登録 = `create_card`、照合 = `resolve_employee_by_card` (ブラウザ版 punch と端末中継の共有 choke point)、登録照会 = `get_card_by_card_id` (choke point を通らない 3 本目)。**小文字**なのは `alc-carins` の `normalize_nfc_uuid` (車検証 NFC タグ) と規約を揃えるため — 1 repo に NFC ID の正規化規約を 2 つ並べない。**読み側だけ正規化してはいけない**: `ABC` と `abc` の 2 行が同時に存在し得ると正規化後の値がどちらにも一致して**打刻が別人に着く**。migration 134 が既存行を移行し、CHECK 制約 `timecard_cards_card_id_normalized` が書き忘れを loud fail させる (既存の `idx_timecard_cards_unique (tenant_id, card_id)` がそのまま正規化後の一意性を保証するので index は増やさない)。`employees.nfc_id` フォールバック (免許証 16 桁の数字) に対しては no-op
 - **バックエンド**: `src/routes/timecard.rs`
   - カード CRUD: `POST/GET /api/timecard/cards`, `DELETE /api/timecard/cards/{id}`, `GET /api/timecard/cards/by-card/{card_id}`

--- a/migrations/138_delete_prehistoric_timecard_punches.sql
+++ b/migrations/138_delete_prehistoric_timecard_punches.sql
@@ -1,0 +1,74 @@
+-- 1970 年に並ぶ打刻 (hub_measurements の kind='timecard') を削除する。
+-- Refs ippoan/alc-app-s3#134, ippoan/alc-app-s3#144
+--
+-- NFC タイムカード端末が SNTP 起動 (ippoan/alc-app-s3#144) より前に送った行は、
+-- `recorded_at_ms` に**起動からの稼働時間**が入っていたため 1970 起点になっている。
+-- 送信時に稼働時間の差で補正する仕組み (ippoan/alc-app-s3#124) は「あとで同期したら
+-- 過去ぶんを補正する」形なので、**当時 1 度も同期しなかった端末の行には永久に発火しない**。
+-- 打刻一覧の絞り込みと並びは `COALESCE(recorded_at, created_at)`
+-- (`crates/alc-misc/src/repo/timecard.rs` の `PUNCHES_CTE`) なので、これらは
+-- 1970 年の打刻として並び続ける。賃金データなので消す (オーナー判断)。
+-- 実測 2026-09-04 時点で 13 件。
+--
+-- 削除条件は `kind` / `recorded_at` / `created_at` の 3 つの AND。この形にした理由:
+--
+--   * **`device_id` / `tenant_id` をハードコードしない。** この repo は public で、
+--     本番の device credential (auth-worker が発行する JWT の sub) を書くと
+--     git 履歴に恒久的に残る。
+--   * **`device_id` だけでは絞りにならない。** 一意制約は `UNIQUE (tenant_id, device_id, seq)`
+--     (`migrations/126_create_hub_measurements.sql:29`) で device_id は全体一意ではなく、
+--     `migrations/122_devices_re_pair.sql` の re-pair で同じ端末が別テナントに付く形がある。
+--   * **`created_at` の上限が「測定時点で既にあった行だけ」を意味する。** これ以降に入る行には
+--     構造的に当たらない (端末は #144 で SNTP 起動済みなので、以後同じ壊れ方はしない)。
+--   * **`recorded_at IS NULL` は消さない。** あちらは「端末計時を送らなかった」正常な形で、
+--     一覧では `created_at` (到着時刻) に倒れる。
+--   * **他 kind (alcohol / temperature / blood_pressure / license) は巻き込まない。**
+--     アルコールチェックは法定記録。
+--
+-- **`hub_measurements` の RLS は `ENABLE` のみで `FORCE` ではない**
+-- (`migrations/126_create_hub_measurements.sql:34-38`) ため、オーナー実行のこの migration は
+-- RLS をバイパスして全テナントの行に届く。**だから上の条件そのものが唯一の歯止め**である。
+--
+-- guard: DELETE と同じ 3 条件で数え、20 件を超えたら中止する (実測 13 件。桁が違うなら
+-- 前提が変わっているので黙って消さない)。あわせて `created_at` の条件を外した件数を
+-- NOTICE で出す — 測定時点より後にも同種の行が入っていないかを deploy ログで知るため
+-- (**そちらは消さない**)。
+--
+-- **中止すると `src/bin/migrate.rs` が落ちて deploy が止まり、`_sqlx_migrations` に
+-- dirty 行 (success=false) が残る。** 復旧は
+-- `DELETE FROM _sqlx_migrations WHERE version = 138;` で dirty 行を消してから、
+-- 条件を見直した migration を**新しい version 番号で作り直す** (適用済みファイルは変更しない)。
+
+DO $$
+DECLARE
+    target_count    BIGINT;
+    unbounded_count BIGINT;
+BEGIN
+    SELECT count(*) INTO target_count
+    FROM alc_api.hub_measurements
+    WHERE kind = 'timecard'
+      AND recorded_at < TIMESTAMPTZ '2020-01-01'
+      AND created_at  < TIMESTAMPTZ '2026-09-05';
+
+    -- created_at の上限を外した件数。測定時点 (2026-09-04) より後に同種の行が
+    -- 増えていないかの観測用で、削除対象ではない。
+    SELECT count(*) INTO unbounded_count
+    FROM alc_api.hub_measurements
+    WHERE kind = 'timecard'
+      AND recorded_at < TIMESTAMPTZ '2020-01-01';
+
+    RAISE NOTICE 'migration 138: 削除対象 % 件 / created_at 上限を外した 1970 年の timecard 行 % 件',
+        target_count, unbounded_count;
+
+    IF target_count > 20 THEN
+        RAISE EXCEPTION
+            'migration 138: 削除対象が % 件で想定 (実測 13 件、上限 20) を超えたため中止した。前提が変わっている可能性があるので、条件を見直してから新しい migration で消すこと',
+            target_count;
+    END IF;
+
+    DELETE FROM alc_api.hub_measurements
+    WHERE kind = 'timecard'
+      AND recorded_at < TIMESTAMPTZ '2020-01-01'
+      AND created_at  < TIMESTAMPTZ '2026-09-05';
+END
+$$;


### PR DESCRIPTION
本番の打刻一覧に **1970 年の打刻が 13 件**並んでいる。端末が SNTP 起動
(ippoan/alc-app-s3#144) より前に送ったもので、`recorded_at_ms` に**起動からの稼働時間**が
入っていたため 1970 起点になった。送信時に稼働時間の差で補正する仕組み
(alc-app-s3#124) は「あとで同期したら過去ぶんを補正する」形なので、**当時 1 度も同期しなかった
端末の行には永久に発火しない**。

打刻一覧の絞り込みと並びは `COALESCE(recorded_at, created_at)`
(`crates/alc-misc/src/repo/timecard.rs` の `PUNCHES_CTE`) なので、これらは**1970 年の打刻として
並ぶ**。賃金データなので消す (オーナー判断)。

## 本番の実測 (2026-09-05、マージ前に確認)

```
kind=timecard 全 19 件 / recorded_at < 2020 が 13 件
13 件はすべて同じ 1 台の検証端末・同じ 1 テナント (識別子はここに書かない)
seq     1〜13            ← その端末が最初に送った 13 件
created 2026-09-04 11:49:20Z 〜 14:16:27Z
recorded_at が NULL の行: 0 件
```

`seq` が 1〜13 の連番であることが「端末が最初に送ったぶん = SNTP 対応前のテスト打刻」
(alc-app-s3#103 の実機検証でタップしたもの) という説明と整合する。

## 削除条件 — 3 つの AND

```sql
kind = 'timecard'
AND recorded_at < TIMESTAMPTZ '2020-01-01'
AND created_at  < TIMESTAMPTZ '2026-09-05'
```

- **`device_id` / `tenant_id` をハードコードしない。** この repo は public で、本番の
  device credential を書くと git 履歴に恒久的に残る。`device_id` は
  `UNIQUE (tenant_id, device_id, seq)` で全体一意でもなく、`migrations/122` の re-pair で
  端末のテナントが移る
- **`created_at` の上限が「測定時点で既にあった行だけ」を意味する。** これ以降に入る行には
  構造的に当たらない
- **`recorded_at IS NULL` は消さない。** 端末計時を送らなかった正常な形で、一覧では
  `created_at` に倒れる
- **他 kind (alcohol / temperature / blood_pressure / license) は巻き込まない。**
  アルコールチェックは法定記録

`hub_measurements` の RLS は `ENABLE` のみで `FORCE` ではない
(`migrations/126:34-38`) ため migration はオーナー実行で RLS をバイパスする。
**条件そのものが唯一の歯止め**なので guard を付けた:

- **DELETE と同じ 3 条件で数え、20 件超なら `RAISE EXCEPTION` で中止**
- `created_at` 条件を外した件数は `RAISE NOTICE` で出すだけ (**消さない**)。
  他テナントに同種の行があるかを deploy ログで知るため
- `RAISE EXCEPTION` 時の復旧手順をコメントに記載

## ローカル実測 (postgres 16)

7 行のフィクスチャで適用:

| 行 | 結果 |
|---|---|
| timecard / 1970 / created 09-04 (2 台ぶん) | **消えた** |
| timecard / recorded 2026 | 残った |
| timecard / recorded NULL | 残った |
| alcohol / 1970 | 残った |
| license / 1970 | 残った |
| timecard / 1970 / **created 09-10** | 残った (測定時点より後) |

対象を 21 件にすると `RAISE EXCEPTION` で中止し、**1 行も消えなかった** (適用前後とも 21 件)。

## 裏取り (親が実測)

- `compare 62ffaf62...` = `ahead_by 1 / behind_by 0`、変更は **2 ファイル (+77 / -2)**
- **DELETE と guard の COUNT が文字通り同じ 3 条件**であることを SQL 全文で確認
- `NOTICE` 用の 2 条件版カウントは **DELETE に使われていない**
- `crates/` / `src/` / `tests/` / `coverage_100.toml` / `BUILD.bazel` / 既存 migration は**無変更**
- migration 番号 138 は既存最大 137 の次で衝突なし

## 未確認

読み出しに使った API は**テナント絞り**なので、対象テナント以外に同種の行があるかは
**確認できていない**。だから条件に `created_at` の上限を入れ、スコープ無しの件数は
`NOTICE` で出すだけにしてある。

Refs ippoan/alc-app-s3#134, ippoan/alc-app-s3#144

🤖 Generated with [Claude Code](https://claude.com/claude-code)
